### PR TITLE
Add missing operators for CppCompat.LongLong64

### DIFF
--- a/core/prelude/types/cpp/int.carbon
+++ b/core/prelude/types/cpp/int.carbon
@@ -67,7 +67,7 @@ impl i32 as ImplicitAs(CppCompat.Long32) {
 }
 
 // TODO: Generalize ImplicitAs from Long32 to Int(N) for all N > 32.
-// N == 32 is explicitly skipped, as Core.Cpp.Long32 is considered to
+// N == 32 is explicitly skipped, as Long32 is considered to
 // be between i32 and i33 (details:
 // https://github.com/carbon-language/carbon-lang/issues/6275#issuecomment-3488010485).
 // This follows the rule that implicit conversions exist for all iN -> iM if
@@ -120,8 +120,11 @@ impl i64 as ImplicitAs(CppCompat.LongLong64) {
 }
 
 // TODO: ImplicitAs from LongLong64 to Int(N) if N > 64.
-final impl CppCompat.LongLong64 as ImplicitAs(i64) {
-  fn Convert[self: Self]() -> i64 = "int.convert";
+// N == 64 is explicitly skipped as LongLong64 is considered to
+// be between i64 and i65 (details:
+// https://github.com/carbon-language/carbon-lang/issues/6275#issuecomment-3488010485).
+final impl CppCompat.LongLong64 as ImplicitAs(i128) {
+  fn Convert[self: Self]() -> i128 = "int.convert";
 }
 
 impl IntLiteral() as ImplicitAs(CppCompat.ULongLong64) {
@@ -256,6 +259,8 @@ impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
 
 // - Homogeneous.
 
+// - CppCompat.Long32
+
 final impl CppCompat.Long32 as Negate where .Result = Self {
   fn Op[self: Self]() -> Self = "int.snegate";
 }
@@ -277,6 +282,32 @@ final impl CppCompat.Long32 as DivWith(Self) where .Result = Self {
 }
 
 final impl CppCompat.Long32 as ModWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.smod";
+}
+
+// - CppCompat.LongLong64
+
+final impl CppCompat.LongLong64 as Negate where .Result = Self {
+  fn Op[self: Self]() -> Self = "int.snegate";
+}
+
+final impl CppCompat.LongLong64 as AddWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.sadd";
+}
+
+final impl CppCompat.LongLong64 as SubWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.ssub";
+}
+
+final impl CppCompat.LongLong64 as MulWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.smul";
+}
+
+final impl CppCompat.LongLong64 as DivWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.sdiv";
+}
+
+final impl CppCompat.LongLong64 as ModWith(Self) where .Result = Self {
   fn Op[self: Self](other: Self) -> Self = "int.smod";
 }
 
@@ -309,6 +340,38 @@ impl forall [T:! ImplicitAs(CppCompat.Long32)]
   fn Op[self: CppCompat.Long32](other: CppCompat.Long32) -> CppCompat.Long32 = "int.smod";
 }
 
+// - CppCompat.LongLong64 on left-hand side.
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as AddWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.sadd";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as SubWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.ssub";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as MulWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.smul";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as DivWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.sdiv";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as ModWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.smod";
+}
+
 // - CppCompat.Long32 on right-hand side.
 
 impl forall [T:! ImplicitAs(CppCompat.Long32)]
@@ -336,11 +399,45 @@ impl forall [T:! ImplicitAs(CppCompat.Long32)]
   fn Op[self: CppCompat.Long32](other: CppCompat.Long32) -> CppCompat.Long32 = "int.smod";
 }
 
-// TODO: ULong32, LongLong64, ULongLong64: arithmetic operators.
+// - CppCompat.LongLong64 on right-hand side.
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as AddWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.sadd";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as SubWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.ssub";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as MulWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.smul";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as DivWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.sdiv";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as ModWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.smod";
+}
+
+// TODO: ULong32, ULongLong64: arithmetic operators.
 
 // Bitwise operators.
 
 // - Homogeneous.
+
+// - CppCompat.Long32
 
 final impl CppCompat.Long32 as BitComplement where .Result = Self {
   fn Op[self: Self]() -> Self = "int.complement";
@@ -366,12 +463,105 @@ final impl CppCompat.Long32 as RightShiftWith(Self) where .Result = Self {
   fn Op[self: Self](other: Self) -> Self = "int.right_shift";
 }
 
-// TODO: ULong32, LongLong64, ULongLong64: bitwise operators.
-// TODO: Long32: heterogeneous bitwise operators.
+// - CppCompat.LongLong64
+
+final impl CppCompat.LongLong64 as BitComplement where .Result = Self {
+  fn Op[self: Self]() -> Self = "int.complement";
+}
+
+final impl CppCompat.LongLong64 as BitAndWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.and";
+}
+
+final impl CppCompat.LongLong64 as BitOrWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.or";
+}
+
+final impl CppCompat.LongLong64 as BitXorWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.xor";
+}
+
+final impl CppCompat.LongLong64 as LeftShiftWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.left_shift";
+}
+
+final impl CppCompat.LongLong64 as RightShiftWith(Self) where .Result = Self {
+  fn Op[self: Self](other: Self) -> Self = "int.right_shift";
+}
+
+// - Heterogeneous.
+
+// - CppCompat.LongLong64 on left-hand side.
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as BitAndWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other:CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.and";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as BitOrWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.or";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as BitXorWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.xor";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as LeftShiftWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.left_shift";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    CppCompat.LongLong64 as RightShiftWith(T) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.right_shift";
+}
+
+// - CppCompat.LongLong64 on right-hand side.
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as BitAndWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.and";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as BitOrWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.or";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as BitXorWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.xor";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as LeftShiftWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.left_shift";
+}
+
+impl forall [T:! ImplicitAs(CppCompat.LongLong64)]
+    T as RightShiftWith(CppCompat.LongLong64) where .Result = CppCompat.LongLong64 {
+  fn Op[self: CppCompat.LongLong64](
+    other: CppCompat.LongLong64) -> CppCompat.LongLong64 = "int.right_shift";
+}
+
+// TODO: ULong32, ULongLong64: bitwise operators.
 
 // Compound assignments.
 
 // Compound arithmetic assignments.
+
+// - CppCompat.Long32
 
 impl forall [U:! ImplicitAs(CppCompat.Long32)]
 	  CppCompat.Long32 as AddAssignWith(U) {
@@ -398,7 +588,36 @@ impl forall [U:! ImplicitAs(CppCompat.Long32)]
   fn Op[ref self: Self](other: Self) = "int.smod_assign";
 }
 
+// - CppCompat.LongLong64
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as AddAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.sadd_assign";
+}
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as SubAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.ssub_assign";
+}
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as MulAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.smul_assign";
+}
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as DivAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.sdiv_assign";
+}
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as ModAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.smod_assign";
+}
+
 // Compound bitwise assignments.
+
+// - CppCompat.Long32
 
 impl forall [U:! ImplicitAs(CppCompat.Long32)]
 	  CppCompat.Long32 as BitAndAssignWith(U) {
@@ -425,9 +644,39 @@ impl forall [U:! ImplicitAs(CppCompat.Long32)]
   fn Op[ref self: Self](other: Self) = "int.right_shift_assign";
 }
 
-// TODO: ULong32, LongLong64, ULongLong64: compound assignments.
+// - CppCompat.LongLong64
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as BitAndAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.and_assign";
+}
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as BitOrAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.or_assign";
+}
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as BitXorAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.xor_assign";
+}
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as LeftShiftAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.left_shift_assign";
+}
+
+impl forall [U:! ImplicitAs(CppCompat.LongLong64)]
+	  CppCompat.LongLong64 as RightShiftAssignWith(U) {
+  fn Op[ref self: Self](other: Self) = "int.right_shift_assign";
+}
+
+// TODO: ULong32, ULongLong64: compound assignments.
 
 // Increment and decrement.
+
+// - CppCompat.Long32
+
 impl CppCompat.Long32 as Dec {
   fn Op[ref self: Self]() {
     self -= (1 as CppCompat.Long32);
@@ -440,4 +689,18 @@ impl CppCompat.Long32 as Inc {
   }
 }
 
-// TODO: Increment/decrement operations for ULong32, LongLong64, ULongLong64.
+// - CppCompat.LongLong64
+
+impl CppCompat.LongLong64 as Dec {
+  fn Op[ref self: Self]() {
+    self -= (1 as CppCompat.LongLong64);
+  }
+}
+
+impl CppCompat.LongLong64 as Inc {
+  fn Op[ref self: Self]() {
+    self += (1 as CppCompat.LongLong64);
+  }
+}
+
+// TODO: Increment/decrement operations for ULong32, ULongLong64.

--- a/toolchain/check/testdata/interop/cpp/builtins.llp64.carbon
+++ b/toolchain/check/testdata/interop/cpp/builtins.llp64.carbon
@@ -393,6 +393,7 @@ fn ArithmeticHeterogeneousLongAndI128() {
   // CHECK:STDERR:
   AssertSameType(y + x, y);
 }
+
 // --- bitwise_homogeneous_long.carbon
 
 library "[[@TEST_NAME]]";
@@ -4593,21 +4594,21 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Int.as.AddWith.impl.Op.type.188570.2: type = fn_type @Int.as.AddWith.impl.Op.3, @Int.as.AddWith.impl.b14(%N, %U.354) [symbolic]
 // CHECK:STDOUT:   %Int.as.AddWith.impl.Op.fecf95.2: %Int.as.AddWith.impl.Op.type.188570.2 = struct_value () [symbolic]
 // CHECK:STDOUT:   %T.354: %ImplicitAs.type.39a54f.2 = symbolic_binding T, 1 [symbolic]
-// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.3, @T.binding.as_type.as.AddWith.impl.83e(%N, %T.354) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.5, @T.binding.as_type.as.AddWith.impl.83e(%N, %T.354) [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.363ab3.1: %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.1 = struct_value () [symbolic]
-// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.4, @T.binding.as_type.as.AddWith.impl.83e(%N, %T.354) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.6, @T.binding.as_type.as.AddWith.impl.83e(%N, %T.354) [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.363ab3.2: %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.2 = struct_value () [symbolic]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness.bbc: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.cb1 [concrete]
 // CHECK:STDOUT:   %ImplicitAs.facet.ba4: %ImplicitAs.type.2ad = facet_value %Cpp.long, (%ImplicitAs.impl_witness.bbc) [concrete]
 // CHECK:STDOUT:   %AddWith.impl_witness.525: <witness> = impl_witness imports.%AddWith.impl_witness_table.787, @T.binding.as_type.as.AddWith.impl.83e(%int_64, %ImplicitAs.facet.ba4) [concrete]
-// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.e6cc8e.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.4, @T.binding.as_type.as.AddWith.impl.83e(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.e6cc8e.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.6, @T.binding.as_type.as.AddWith.impl.83e(%int_64, %ImplicitAs.facet.ba4) [concrete]
 // CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.86dab9.1: %T.binding.as_type.as.AddWith.impl.Op.type.e6cc8e.1 = struct_value () [concrete]
-// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.e6cc8e.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.3, @T.binding.as_type.as.AddWith.impl.83e(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.e6cc8e.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.5, @T.binding.as_type.as.AddWith.impl.83e(%int_64, %ImplicitAs.facet.ba4) [concrete]
 // CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.86dab9.2: %T.binding.as_type.as.AddWith.impl.Op.type.e6cc8e.2 = struct_value () [concrete]
 // CHECK:STDOUT:   %AddWith.facet.393: %AddWith.type.f83 = facet_value %Cpp.long, (%AddWith.impl_witness.525) [concrete]
 // CHECK:STDOUT:   %.e8e: type = fn_type_with_self_type %AddWith.Op.type.c7f, %AddWith.facet.393 [concrete]
-// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.dee524.1: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.86dab9.2, @T.binding.as_type.as.AddWith.impl.Op.3(%int_64, %ImplicitAs.facet.ba4) [concrete]
-// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.dee524.2: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.86dab9.1, @T.binding.as_type.as.AddWith.impl.Op.4(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.dee524.1: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.86dab9.2, @T.binding.as_type.as.AddWith.impl.Op.5(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.dee524.2: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.86dab9.1, @T.binding.as_type.as.AddWith.impl.Op.6(%int_64, %ImplicitAs.facet.ba4) [concrete]
 // CHECK:STDOUT:   %.8a2: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.ba4 [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.ImplicitAs.impl.Convert.type: type = fn_type @Cpp.long.as.ImplicitAs.impl.Convert [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.ImplicitAs.impl.Convert: %Cpp.long.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
@@ -4681,12 +4682,12 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %y.ref.loc12_22: %i64 = name_ref y, %y
 // CHECK:STDOUT:   %impl.elem1.loc12: %.e8e = impl_witness_access constants.%AddWith.impl_witness.525, element1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.86dab9.2]
 // CHECK:STDOUT:   %bound_method.loc12_20.1: <bound method> = bound_method %x.ref.loc12, %impl.elem1.loc12
-// CHECK:STDOUT:   %specific_fn.loc12: <specific function> = specific_function %impl.elem1.loc12, @T.binding.as_type.as.AddWith.impl.Op.3(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.dee524.1]
+// CHECK:STDOUT:   %specific_fn.loc12: <specific function> = specific_function %impl.elem1.loc12, @T.binding.as_type.as.AddWith.impl.Op.5(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.dee524.1]
 // CHECK:STDOUT:   %bound_method.loc12_20.2: <bound method> = bound_method %x.ref.loc12, %specific_fn.loc12
 // CHECK:STDOUT:   %.loc12_20.1: %T.binding.as_type.as.AddWith.impl.Op.type.e6cc8e.1 = specific_constant imports.%Core.Op.fcd, @T.binding.as_type.as.AddWith.impl.83e(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.86dab9.1]
 // CHECK:STDOUT:   %Op.ref.loc12: %T.binding.as_type.as.AddWith.impl.Op.type.e6cc8e.1 = name_ref Op, %.loc12_20.1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.86dab9.1]
 // CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound: <bound method> = bound_method %x.ref.loc12, %Op.ref.loc12
-// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc12, @T.binding.as_type.as.AddWith.impl.Op.4(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.dee524.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc12, @T.binding.as_type.as.AddWith.impl.Op.6(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.dee524.2]
 // CHECK:STDOUT:   %bound_method.loc12_20.3: <bound method> = bound_method %x.ref.loc12, %T.binding.as_type.as.AddWith.impl.Op.specific_fn
 // CHECK:STDOUT:   %impl.elem0.loc12: %.8a2 = impl_witness_access constants.%ImplicitAs.impl_witness.bbc, element0 [concrete = constants.%Cpp.long.as.ImplicitAs.impl.Convert]
 // CHECK:STDOUT:   %bound_method.loc12_18: <bound method> = bound_method %x.ref.loc12, %impl.elem0.loc12
@@ -4753,36 +4754,36 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%Cpp.long) [concrete]
 // CHECK:STDOUT:   %BitAndWith.type.0b5: type = facet_type <@BitAndWith, @BitAndWith(%Cpp.long)> [concrete]
 // CHECK:STDOUT:   %BitAndWith.Op.type.e13: type = fn_type @BitAndWith.Op, @BitAndWith(%Cpp.long) [concrete]
-// CHECK:STDOUT:   %BitAndWith.impl_witness: <witness> = impl_witness imports.%BitAndWith.impl_witness_table [concrete]
-// CHECK:STDOUT:   %BitAndWith.facet: %BitAndWith.type.0b5 = facet_value %Cpp.long, (%BitAndWith.impl_witness) [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.6f1: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.e8c [concrete]
+// CHECK:STDOUT:   %BitAndWith.facet: %BitAndWith.type.0b5 = facet_value %Cpp.long, (%BitAndWith.impl_witness.6f1) [concrete]
 // CHECK:STDOUT:   %.78c: type = fn_type_with_self_type %BitAndWith.Op.type.e13, %BitAndWith.facet [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitAndWith.impl.Op.type: type = fn_type @Cpp.long.as.BitAndWith.impl.Op [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitAndWith.impl.Op: %Cpp.long.as.BitAndWith.impl.Op.type = struct_value () [concrete]
 // CHECK:STDOUT:   %BitOrWith.type.b22: type = facet_type <@BitOrWith, @BitOrWith(%Cpp.long)> [concrete]
 // CHECK:STDOUT:   %BitOrWith.Op.type.a1b: type = fn_type @BitOrWith.Op, @BitOrWith(%Cpp.long) [concrete]
-// CHECK:STDOUT:   %BitOrWith.impl_witness: <witness> = impl_witness imports.%BitOrWith.impl_witness_table [concrete]
-// CHECK:STDOUT:   %BitOrWith.facet: %BitOrWith.type.b22 = facet_value %Cpp.long, (%BitOrWith.impl_witness) [concrete]
+// CHECK:STDOUT:   %BitOrWith.impl_witness.003: <witness> = impl_witness imports.%BitOrWith.impl_witness_table.513 [concrete]
+// CHECK:STDOUT:   %BitOrWith.facet: %BitOrWith.type.b22 = facet_value %Cpp.long, (%BitOrWith.impl_witness.003) [concrete]
 // CHECK:STDOUT:   %.ee7: type = fn_type_with_self_type %BitOrWith.Op.type.a1b, %BitOrWith.facet [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitOrWith.impl.Op.type: type = fn_type @Cpp.long.as.BitOrWith.impl.Op [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitOrWith.impl.Op: %Cpp.long.as.BitOrWith.impl.Op.type = struct_value () [concrete]
 // CHECK:STDOUT:   %BitXorWith.type.87f: type = facet_type <@BitXorWith, @BitXorWith(%Cpp.long)> [concrete]
 // CHECK:STDOUT:   %BitXorWith.Op.type.5cf: type = fn_type @BitXorWith.Op, @BitXorWith(%Cpp.long) [concrete]
-// CHECK:STDOUT:   %BitXorWith.impl_witness: <witness> = impl_witness imports.%BitXorWith.impl_witness_table [concrete]
-// CHECK:STDOUT:   %BitXorWith.facet: %BitXorWith.type.87f = facet_value %Cpp.long, (%BitXorWith.impl_witness) [concrete]
+// CHECK:STDOUT:   %BitXorWith.impl_witness.e60: <witness> = impl_witness imports.%BitXorWith.impl_witness_table.708 [concrete]
+// CHECK:STDOUT:   %BitXorWith.facet: %BitXorWith.type.87f = facet_value %Cpp.long, (%BitXorWith.impl_witness.e60) [concrete]
 // CHECK:STDOUT:   %.e9a: type = fn_type_with_self_type %BitXorWith.Op.type.5cf, %BitXorWith.facet [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitXorWith.impl.Op.type: type = fn_type @Cpp.long.as.BitXorWith.impl.Op [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitXorWith.impl.Op: %Cpp.long.as.BitXorWith.impl.Op.type = struct_value () [concrete]
 // CHECK:STDOUT:   %LeftShiftWith.type.3f9: type = facet_type <@LeftShiftWith, @LeftShiftWith(%Cpp.long)> [concrete]
 // CHECK:STDOUT:   %LeftShiftWith.Op.type.224: type = fn_type @LeftShiftWith.Op, @LeftShiftWith(%Cpp.long) [concrete]
-// CHECK:STDOUT:   %LeftShiftWith.impl_witness: <witness> = impl_witness imports.%LeftShiftWith.impl_witness_table [concrete]
-// CHECK:STDOUT:   %LeftShiftWith.facet: %LeftShiftWith.type.3f9 = facet_value %Cpp.long, (%LeftShiftWith.impl_witness) [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness.cd6: <witness> = impl_witness imports.%LeftShiftWith.impl_witness_table.01c [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.facet: %LeftShiftWith.type.3f9 = facet_value %Cpp.long, (%LeftShiftWith.impl_witness.cd6) [concrete]
 // CHECK:STDOUT:   %.864: type = fn_type_with_self_type %LeftShiftWith.Op.type.224, %LeftShiftWith.facet [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftWith.impl.Op.type: type = fn_type @Cpp.long.as.LeftShiftWith.impl.Op [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftWith.impl.Op: %Cpp.long.as.LeftShiftWith.impl.Op.type = struct_value () [concrete]
 // CHECK:STDOUT:   %RightShiftWith.type.995: type = facet_type <@RightShiftWith, @RightShiftWith(%Cpp.long)> [concrete]
 // CHECK:STDOUT:   %RightShiftWith.Op.type.fd9: type = fn_type @RightShiftWith.Op, @RightShiftWith(%Cpp.long) [concrete]
-// CHECK:STDOUT:   %RightShiftWith.impl_witness: <witness> = impl_witness imports.%RightShiftWith.impl_witness_table [concrete]
-// CHECK:STDOUT:   %RightShiftWith.facet: %RightShiftWith.type.995 = facet_value %Cpp.long, (%RightShiftWith.impl_witness) [concrete]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness.b46: <witness> = impl_witness imports.%RightShiftWith.impl_witness_table.636 [concrete]
+// CHECK:STDOUT:   %RightShiftWith.facet: %RightShiftWith.type.995 = facet_value %Cpp.long, (%RightShiftWith.impl_witness.b46) [concrete]
 // CHECK:STDOUT:   %.398: type = fn_type_with_self_type %RightShiftWith.Op.type.fd9, %RightShiftWith.facet [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftWith.impl.Op.type: type = fn_type @Cpp.long.as.RightShiftWith.impl.Op [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftWith.impl.Op: %Cpp.long.as.RightShiftWith.impl.Op.type = struct_value () [concrete]
@@ -4800,19 +4801,19 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %BitComplement.impl_witness_table = impl_witness_table (%Core.import_ref.cb912f.1, %Core.import_ref.454), @Cpp.long.as.BitComplement.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.cb912f.2 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.f38: %Cpp.long.as.BitAndWith.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long.as.BitAndWith.impl.Op]
-// CHECK:STDOUT:   %BitAndWith.impl_witness_table = impl_witness_table (%Core.import_ref.cb912f.2, %Core.import_ref.f38), @Cpp.long.as.BitAndWith.impl [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness_table.e8c = impl_witness_table (%Core.import_ref.cb912f.2, %Core.import_ref.f38), @Cpp.long.as.BitAndWith.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.cb912f.3 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.a17: %Cpp.long.as.BitOrWith.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long.as.BitOrWith.impl.Op]
-// CHECK:STDOUT:   %BitOrWith.impl_witness_table = impl_witness_table (%Core.import_ref.cb912f.3, %Core.import_ref.a17), @Cpp.long.as.BitOrWith.impl [concrete]
+// CHECK:STDOUT:   %BitOrWith.impl_witness_table.513 = impl_witness_table (%Core.import_ref.cb912f.3, %Core.import_ref.a17), @Cpp.long.as.BitOrWith.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.cb912f.4 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.4fd: %Cpp.long.as.BitXorWith.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long.as.BitXorWith.impl.Op]
-// CHECK:STDOUT:   %BitXorWith.impl_witness_table = impl_witness_table (%Core.import_ref.cb912f.4, %Core.import_ref.4fd), @Cpp.long.as.BitXorWith.impl [concrete]
+// CHECK:STDOUT:   %BitXorWith.impl_witness_table.708 = impl_witness_table (%Core.import_ref.cb912f.4, %Core.import_ref.4fd), @Cpp.long.as.BitXorWith.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.cb912f.5 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.c09: %Cpp.long.as.LeftShiftWith.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long.as.LeftShiftWith.impl.Op]
-// CHECK:STDOUT:   %LeftShiftWith.impl_witness_table = impl_witness_table (%Core.import_ref.cb912f.5, %Core.import_ref.c09), @Cpp.long.as.LeftShiftWith.impl [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness_table.01c = impl_witness_table (%Core.import_ref.cb912f.5, %Core.import_ref.c09), @Cpp.long.as.LeftShiftWith.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.cb912f.6 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.6c0: %Cpp.long.as.RightShiftWith.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long.as.RightShiftWith.impl.Op]
-// CHECK:STDOUT:   %RightShiftWith.impl_witness_table = impl_witness_table (%Core.import_ref.cb912f.6, %Core.import_ref.6c0), @Cpp.long.as.RightShiftWith.impl [concrete]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness_table.636 = impl_witness_table (%Core.import_ref.cb912f.6, %Core.import_ref.6c0), @Cpp.long.as.RightShiftWith.impl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @BitWiseHomogeneousLong() {
@@ -4872,7 +4873,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %AssertSameType.ref.loc15: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
 // CHECK:STDOUT:   %a.ref.loc15: %Cpp.long = name_ref a, %a
 // CHECK:STDOUT:   %b.ref.loc15: %Cpp.long = name_ref b, %b
-// CHECK:STDOUT:   %impl.elem1.loc15: %.78c = impl_witness_access constants.%BitAndWith.impl_witness, element1 [concrete = constants.%Cpp.long.as.BitAndWith.impl.Op]
+// CHECK:STDOUT:   %impl.elem1.loc15: %.78c = impl_witness_access constants.%BitAndWith.impl_witness.6f1, element1 [concrete = constants.%Cpp.long.as.BitAndWith.impl.Op]
 // CHECK:STDOUT:   %bound_method.loc15: <bound method> = bound_method %a.ref.loc15, %impl.elem1.loc15
 // CHECK:STDOUT:   %Cpp.long.as.BitAndWith.impl.Op.call: init %Cpp.long = call %bound_method.loc15(%a.ref.loc15, %b.ref.loc15)
 // CHECK:STDOUT:   %c.ref.loc15: %Cpp.long = name_ref c, %c
@@ -4883,7 +4884,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %AssertSameType.ref.loc16: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
 // CHECK:STDOUT:   %a.ref.loc16: %Cpp.long = name_ref a, %a
 // CHECK:STDOUT:   %b.ref.loc16: %Cpp.long = name_ref b, %b
-// CHECK:STDOUT:   %impl.elem1.loc16: %.ee7 = impl_witness_access constants.%BitOrWith.impl_witness, element1 [concrete = constants.%Cpp.long.as.BitOrWith.impl.Op]
+// CHECK:STDOUT:   %impl.elem1.loc16: %.ee7 = impl_witness_access constants.%BitOrWith.impl_witness.003, element1 [concrete = constants.%Cpp.long.as.BitOrWith.impl.Op]
 // CHECK:STDOUT:   %bound_method.loc16: <bound method> = bound_method %a.ref.loc16, %impl.elem1.loc16
 // CHECK:STDOUT:   %Cpp.long.as.BitOrWith.impl.Op.call: init %Cpp.long = call %bound_method.loc16(%a.ref.loc16, %b.ref.loc16)
 // CHECK:STDOUT:   %c.ref.loc16: %Cpp.long = name_ref c, %c
@@ -4894,7 +4895,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %AssertSameType.ref.loc17: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
 // CHECK:STDOUT:   %a.ref.loc17: %Cpp.long = name_ref a, %a
 // CHECK:STDOUT:   %b.ref.loc17: %Cpp.long = name_ref b, %b
-// CHECK:STDOUT:   %impl.elem1.loc17: %.e9a = impl_witness_access constants.%BitXorWith.impl_witness, element1 [concrete = constants.%Cpp.long.as.BitXorWith.impl.Op]
+// CHECK:STDOUT:   %impl.elem1.loc17: %.e9a = impl_witness_access constants.%BitXorWith.impl_witness.e60, element1 [concrete = constants.%Cpp.long.as.BitXorWith.impl.Op]
 // CHECK:STDOUT:   %bound_method.loc17: <bound method> = bound_method %a.ref.loc17, %impl.elem1.loc17
 // CHECK:STDOUT:   %Cpp.long.as.BitXorWith.impl.Op.call: init %Cpp.long = call %bound_method.loc17(%a.ref.loc17, %b.ref.loc17)
 // CHECK:STDOUT:   %c.ref.loc17: %Cpp.long = name_ref c, %c
@@ -4905,7 +4906,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %AssertSameType.ref.loc18: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
 // CHECK:STDOUT:   %a.ref.loc18: %Cpp.long = name_ref a, %a
 // CHECK:STDOUT:   %b.ref.loc18: %Cpp.long = name_ref b, %b
-// CHECK:STDOUT:   %impl.elem1.loc18: %.864 = impl_witness_access constants.%LeftShiftWith.impl_witness, element1 [concrete = constants.%Cpp.long.as.LeftShiftWith.impl.Op]
+// CHECK:STDOUT:   %impl.elem1.loc18: %.864 = impl_witness_access constants.%LeftShiftWith.impl_witness.cd6, element1 [concrete = constants.%Cpp.long.as.LeftShiftWith.impl.Op]
 // CHECK:STDOUT:   %bound_method.loc18: <bound method> = bound_method %a.ref.loc18, %impl.elem1.loc18
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftWith.impl.Op.call: init %Cpp.long = call %bound_method.loc18(%a.ref.loc18, %b.ref.loc18)
 // CHECK:STDOUT:   %c.ref.loc18: %Cpp.long = name_ref c, %c
@@ -4916,7 +4917,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %AssertSameType.ref.loc19: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
 // CHECK:STDOUT:   %a.ref.loc19: %Cpp.long = name_ref a, %a
 // CHECK:STDOUT:   %b.ref.loc19: %Cpp.long = name_ref b, %b
-// CHECK:STDOUT:   %impl.elem1.loc19: %.398 = impl_witness_access constants.%RightShiftWith.impl_witness, element1 [concrete = constants.%Cpp.long.as.RightShiftWith.impl.Op]
+// CHECK:STDOUT:   %impl.elem1.loc19: %.398 = impl_witness_access constants.%RightShiftWith.impl_witness.b46, element1 [concrete = constants.%Cpp.long.as.RightShiftWith.impl.Op]
 // CHECK:STDOUT:   %bound_method.loc19: <bound method> = bound_method %a.ref.loc19, %impl.elem1.loc19
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftWith.impl.Op.call: init %Cpp.long = call %bound_method.loc19(%a.ref.loc19, %b.ref.loc19)
 // CHECK:STDOUT:   %c.ref.loc19: %Cpp.long = name_ref c, %c
@@ -4976,9 +4977,9 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.type.1b6537.2: type = fn_type @Int.as.BitAndWith.impl.Op.3, @Int.as.BitAndWith.impl.4ac(%N, %U.354) [symbolic]
 // CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.b9569a.2: %Int.as.BitAndWith.impl.Op.type.1b6537.2 = struct_value () [symbolic]
 // CHECK:STDOUT:   %T.354: %ImplicitAs.type.39a54f.1 = symbolic_binding T, 1 [symbolic]
-// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.1, @T.binding.as_type.as.BitAndWith.impl(%N, %T.354) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.3, @T.binding.as_type.as.BitAndWith.impl.96d(%N, %T.354) [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.892c6d.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.1 = struct_value () [symbolic]
-// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.2, @T.binding.as_type.as.BitAndWith.impl(%N, %T.354) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.4, @T.binding.as_type.as.BitAndWith.impl.96d(%N, %T.354) [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.892c6d.2: %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.2 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To.fe9) [symbolic]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
@@ -4996,15 +4997,15 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %BitAndWith.Op.type.2e7: type = fn_type @BitAndWith.Op, @BitAndWith(%i64) [concrete]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness.bbc: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.cb1 [concrete]
 // CHECK:STDOUT:   %ImplicitAs.facet.ba4: %ImplicitAs.type.2ad = facet_value %Cpp.long, (%ImplicitAs.impl_witness.bbc) [concrete]
-// CHECK:STDOUT:   %BitAndWith.impl_witness.c6a: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.5e7, @T.binding.as_type.as.BitAndWith.impl(%int_64, %ImplicitAs.facet.ba4) [concrete]
-// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.2, @T.binding.as_type.as.BitAndWith.impl(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.c6a: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.5e7, @T.binding.as_type.as.BitAndWith.impl.96d(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.4, @T.binding.as_type.as.BitAndWith.impl.96d(%int_64, %ImplicitAs.facet.ba4) [concrete]
 // CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.12fb91.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.1 = struct_value () [concrete]
-// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.1, @T.binding.as_type.as.BitAndWith.impl(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.3, @T.binding.as_type.as.BitAndWith.impl.96d(%int_64, %ImplicitAs.facet.ba4) [concrete]
 // CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.12fb91.2: %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.2 = struct_value () [concrete]
 // CHECK:STDOUT:   %BitAndWith.facet.bc4: %BitAndWith.type.46b = facet_value %Cpp.long, (%BitAndWith.impl_witness.c6a) [concrete]
 // CHECK:STDOUT:   %.656: type = fn_type_with_self_type %BitAndWith.Op.type.2e7, %BitAndWith.facet.bc4 [concrete]
-// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.d9a57f.1: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.12fb91.2, @T.binding.as_type.as.BitAndWith.impl.Op.1(%int_64, %ImplicitAs.facet.ba4) [concrete]
-// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.d9a57f.2: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.12fb91.1, @T.binding.as_type.as.BitAndWith.impl.Op.2(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.d9a57f.1: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.12fb91.2, @T.binding.as_type.as.BitAndWith.impl.Op.3(%int_64, %ImplicitAs.facet.ba4) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.d9a57f.2: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.12fb91.1, @T.binding.as_type.as.BitAndWith.impl.Op.4(%int_64, %ImplicitAs.facet.ba4) [concrete]
 // CHECK:STDOUT:   %.8a2: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.ba4 [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.ImplicitAs.impl.Convert.type: type = fn_type @Cpp.long.as.ImplicitAs.impl.Convert [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.ImplicitAs.impl.Convert: %Cpp.long.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
@@ -5034,9 +5035,9 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %BitAndWith.impl_witness_table.ebf = impl_witness_table (%Core.import_ref.475cb3.2, %Core.import_ref.611), @Int.as.BitAndWith.impl.4ac [concrete]
 // CHECK:STDOUT:   %Core.Op.36f: @Int.as.BitAndWith.impl.4ac.%Int.as.BitAndWith.impl.Op.type.1 (%Int.as.BitAndWith.impl.Op.type.1b6537.2) = import_ref Core//prelude/types/int, Op, loaded [symbolic = @Int.as.BitAndWith.impl.4ac.%Int.as.BitAndWith.impl.Op.1 (constants.%Int.as.BitAndWith.impl.Op.b9569a.2)]
 // CHECK:STDOUT:   %Core.import_ref.475cb3.3 = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %Core.import_ref.29d: @T.binding.as_type.as.BitAndWith.impl.%T.binding.as_type.as.BitAndWith.impl.Op.type.2 (%T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.BitAndWith.impl.%T.binding.as_type.as.BitAndWith.impl.Op.2 (constants.%T.binding.as_type.as.BitAndWith.impl.Op.892c6d.1)]
-// CHECK:STDOUT:   %BitAndWith.impl_witness_table.5e7 = impl_witness_table (%Core.import_ref.475cb3.3, %Core.import_ref.29d), @T.binding.as_type.as.BitAndWith.impl [concrete]
-// CHECK:STDOUT:   %Core.Op.944: @T.binding.as_type.as.BitAndWith.impl.%T.binding.as_type.as.BitAndWith.impl.Op.type.1 (%T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.2) = import_ref Core//prelude/types/int, Op, loaded [symbolic = @T.binding.as_type.as.BitAndWith.impl.%T.binding.as_type.as.BitAndWith.impl.Op.1 (constants.%T.binding.as_type.as.BitAndWith.impl.Op.892c6d.2)]
+// CHECK:STDOUT:   %Core.import_ref.29d: @T.binding.as_type.as.BitAndWith.impl.96d.%T.binding.as_type.as.BitAndWith.impl.Op.type.2 (%T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.BitAndWith.impl.96d.%T.binding.as_type.as.BitAndWith.impl.Op.2 (constants.%T.binding.as_type.as.BitAndWith.impl.Op.892c6d.1)]
+// CHECK:STDOUT:   %BitAndWith.impl_witness_table.5e7 = impl_witness_table (%Core.import_ref.475cb3.3, %Core.import_ref.29d), @T.binding.as_type.as.BitAndWith.impl.96d [concrete]
+// CHECK:STDOUT:   %Core.Op.944: @T.binding.as_type.as.BitAndWith.impl.96d.%T.binding.as_type.as.BitAndWith.impl.Op.type.1 (%T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.2) = import_ref Core//prelude/types/int, Op, loaded [symbolic = @T.binding.as_type.as.BitAndWith.impl.96d.%T.binding.as_type.as.BitAndWith.impl.Op.1 (constants.%T.binding.as_type.as.BitAndWith.impl.Op.892c6d.2)]
 // CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
 // CHECK:STDOUT:   %Core.import_ref.297: %Cpp.long.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long.as.ImplicitAs.impl.Convert]
@@ -5106,12 +5107,12 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %b.ref.loc25_22: %i64 = name_ref b, %b
 // CHECK:STDOUT:   %impl.elem1.loc25: %.656 = impl_witness_access constants.%BitAndWith.impl_witness.c6a, element1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.12fb91.2]
 // CHECK:STDOUT:   %bound_method.loc25_20.1: <bound method> = bound_method %a.ref.loc25, %impl.elem1.loc25
-// CHECK:STDOUT:   %specific_fn.loc25: <specific function> = specific_function %impl.elem1.loc25, @T.binding.as_type.as.BitAndWith.impl.Op.1(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.d9a57f.1]
+// CHECK:STDOUT:   %specific_fn.loc25: <specific function> = specific_function %impl.elem1.loc25, @T.binding.as_type.as.BitAndWith.impl.Op.3(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.d9a57f.1]
 // CHECK:STDOUT:   %bound_method.loc25_20.2: <bound method> = bound_method %a.ref.loc25, %specific_fn.loc25
-// CHECK:STDOUT:   %.loc25_20.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.1 = specific_constant imports.%Core.Op.944, @T.binding.as_type.as.BitAndWith.impl(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.12fb91.1]
+// CHECK:STDOUT:   %.loc25_20.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.1 = specific_constant imports.%Core.Op.944, @T.binding.as_type.as.BitAndWith.impl.96d(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.12fb91.1]
 // CHECK:STDOUT:   %Op.ref.loc25: %T.binding.as_type.as.BitAndWith.impl.Op.type.7732f0.1 = name_ref Op, %.loc25_20.1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.12fb91.1]
 // CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc25, %Op.ref.loc25
-// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc25, @T.binding.as_type.as.BitAndWith.impl.Op.2(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.d9a57f.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc25, @T.binding.as_type.as.BitAndWith.impl.Op.4(constants.%int_64, constants.%ImplicitAs.facet.ba4) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.d9a57f.2]
 // CHECK:STDOUT:   %bound_method.loc25_20.3: <bound method> = bound_method %a.ref.loc25, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn
 // CHECK:STDOUT:   %impl.elem0.loc25: %.8a2 = impl_witness_access constants.%ImplicitAs.impl_witness.bbc, element0 [concrete = constants.%Cpp.long.as.ImplicitAs.impl.Convert]
 // CHECK:STDOUT:   %bound_method.loc25_18: <bound method> = bound_method %a.ref.loc25, %impl.elem0.loc25
@@ -5181,7 +5182,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Copy.facet: %Copy.type = facet_value %Cpp.long, (%Copy.impl_witness.e75) [concrete]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness.bd4: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.f1e, @T.binding.as_type.as.ImplicitAs.impl(%Copy.facet) [concrete]
 // CHECK:STDOUT:   %ImplicitAs.facet.3fe: %ImplicitAs.type.819 = facet_value %Cpp.long, (%ImplicitAs.impl_witness.bd4) [concrete]
-// CHECK:STDOUT:   %AddAssignWith.impl_witness.fb1: <witness> = impl_witness imports.%AddAssignWith.impl_witness_table, @Cpp.long.as.AddAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness.fb1: <witness> = impl_witness imports.%AddAssignWith.impl_witness_table.07a, @Cpp.long.as.AddAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.type.defb93.1: type = fn_type @Cpp.long.as.AddAssignWith.impl.Op.2, @Cpp.long.as.AddAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.8b7759.1: %Cpp.long.as.AddAssignWith.impl.Op.type.defb93.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.type.defb93.2: type = fn_type @Cpp.long.as.AddAssignWith.impl.Op.1, @Cpp.long.as.AddAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5196,7 +5197,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.SubAssignWith.impl.Op.c39240.1: %Cpp.long.as.SubAssignWith.impl.Op.type.1f2d1c.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.SubAssignWith.impl.Op.type.1f2d1c.2: type = fn_type @Cpp.long.as.SubAssignWith.impl.Op.2, @Cpp.long.as.SubAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.SubAssignWith.impl.Op.c39240.2: %Cpp.long.as.SubAssignWith.impl.Op.type.1f2d1c.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %SubAssignWith.impl_witness.631: <witness> = impl_witness imports.%SubAssignWith.impl_witness_table, @Cpp.long.as.SubAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %SubAssignWith.impl_witness.631: <witness> = impl_witness imports.%SubAssignWith.impl_witness_table.f4b, @Cpp.long.as.SubAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.SubAssignWith.impl.Op.type.7e399e.1: type = fn_type @Cpp.long.as.SubAssignWith.impl.Op.2, @Cpp.long.as.SubAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.SubAssignWith.impl.Op.31eaa0.1: %Cpp.long.as.SubAssignWith.impl.Op.type.7e399e.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.SubAssignWith.impl.Op.type.7e399e.2: type = fn_type @Cpp.long.as.SubAssignWith.impl.Op.1, @Cpp.long.as.SubAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5211,7 +5212,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.MulAssignWith.impl.Op.421374.1: %Cpp.long.as.MulAssignWith.impl.Op.type.afa7f7.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.MulAssignWith.impl.Op.type.afa7f7.2: type = fn_type @Cpp.long.as.MulAssignWith.impl.Op.2, @Cpp.long.as.MulAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.MulAssignWith.impl.Op.421374.2: %Cpp.long.as.MulAssignWith.impl.Op.type.afa7f7.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %MulAssignWith.impl_witness.0b4: <witness> = impl_witness imports.%MulAssignWith.impl_witness_table, @Cpp.long.as.MulAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %MulAssignWith.impl_witness.0b4: <witness> = impl_witness imports.%MulAssignWith.impl_witness_table.8cc, @Cpp.long.as.MulAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.MulAssignWith.impl.Op.type.c3673e.1: type = fn_type @Cpp.long.as.MulAssignWith.impl.Op.2, @Cpp.long.as.MulAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.MulAssignWith.impl.Op.b067dc.1: %Cpp.long.as.MulAssignWith.impl.Op.type.c3673e.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.MulAssignWith.impl.Op.type.c3673e.2: type = fn_type @Cpp.long.as.MulAssignWith.impl.Op.1, @Cpp.long.as.MulAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5226,7 +5227,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.DivAssignWith.impl.Op.6227df.1: %Cpp.long.as.DivAssignWith.impl.Op.type.f3536d.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.DivAssignWith.impl.Op.type.f3536d.2: type = fn_type @Cpp.long.as.DivAssignWith.impl.Op.2, @Cpp.long.as.DivAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.DivAssignWith.impl.Op.6227df.2: %Cpp.long.as.DivAssignWith.impl.Op.type.f3536d.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %DivAssignWith.impl_witness.b4e: <witness> = impl_witness imports.%DivAssignWith.impl_witness_table, @Cpp.long.as.DivAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %DivAssignWith.impl_witness.b4e: <witness> = impl_witness imports.%DivAssignWith.impl_witness_table.6f7, @Cpp.long.as.DivAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.DivAssignWith.impl.Op.type.97cfb4.1: type = fn_type @Cpp.long.as.DivAssignWith.impl.Op.2, @Cpp.long.as.DivAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.DivAssignWith.impl.Op.b85335.1: %Cpp.long.as.DivAssignWith.impl.Op.type.97cfb4.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.DivAssignWith.impl.Op.type.97cfb4.2: type = fn_type @Cpp.long.as.DivAssignWith.impl.Op.1, @Cpp.long.as.DivAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5241,7 +5242,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.ModAssignWith.impl.Op.666e79.1: %Cpp.long.as.ModAssignWith.impl.Op.type.2d6972.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.ModAssignWith.impl.Op.type.2d6972.2: type = fn_type @Cpp.long.as.ModAssignWith.impl.Op.2, @Cpp.long.as.ModAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.ModAssignWith.impl.Op.666e79.2: %Cpp.long.as.ModAssignWith.impl.Op.type.2d6972.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %ModAssignWith.impl_witness.faa: <witness> = impl_witness imports.%ModAssignWith.impl_witness_table, @Cpp.long.as.ModAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %ModAssignWith.impl_witness.faa: <witness> = impl_witness imports.%ModAssignWith.impl_witness_table.a2a, @Cpp.long.as.ModAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.ModAssignWith.impl.Op.type.24a130.1: type = fn_type @Cpp.long.as.ModAssignWith.impl.Op.2, @Cpp.long.as.ModAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.ModAssignWith.impl.Op.da4005.1: %Cpp.long.as.ModAssignWith.impl.Op.type.24a130.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.ModAssignWith.impl.Op.type.24a130.2: type = fn_type @Cpp.long.as.ModAssignWith.impl.Op.1, @Cpp.long.as.ModAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5256,7 +5257,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.BitAndAssignWith.impl.Op.d99897.1: %Cpp.long.as.BitAndAssignWith.impl.Op.type.442dcf.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.BitAndAssignWith.impl.Op.type.442dcf.2: type = fn_type @Cpp.long.as.BitAndAssignWith.impl.Op.2, @Cpp.long.as.BitAndAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.BitAndAssignWith.impl.Op.d99897.2: %Cpp.long.as.BitAndAssignWith.impl.Op.type.442dcf.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %BitAndAssignWith.impl_witness.a49: <witness> = impl_witness imports.%BitAndAssignWith.impl_witness_table, @Cpp.long.as.BitAndAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %BitAndAssignWith.impl_witness.a49: <witness> = impl_witness imports.%BitAndAssignWith.impl_witness_table.cc9, @Cpp.long.as.BitAndAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitAndAssignWith.impl.Op.type.bdaab3.1: type = fn_type @Cpp.long.as.BitAndAssignWith.impl.Op.2, @Cpp.long.as.BitAndAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitAndAssignWith.impl.Op.500716.1: %Cpp.long.as.BitAndAssignWith.impl.Op.type.bdaab3.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitAndAssignWith.impl.Op.type.bdaab3.2: type = fn_type @Cpp.long.as.BitAndAssignWith.impl.Op.1, @Cpp.long.as.BitAndAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5271,7 +5272,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.BitOrAssignWith.impl.Op.e5afa1.1: %Cpp.long.as.BitOrAssignWith.impl.Op.type.219f14.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.BitOrAssignWith.impl.Op.type.219f14.2: type = fn_type @Cpp.long.as.BitOrAssignWith.impl.Op.2, @Cpp.long.as.BitOrAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.BitOrAssignWith.impl.Op.e5afa1.2: %Cpp.long.as.BitOrAssignWith.impl.Op.type.219f14.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %BitOrAssignWith.impl_witness.ab4: <witness> = impl_witness imports.%BitOrAssignWith.impl_witness_table, @Cpp.long.as.BitOrAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %BitOrAssignWith.impl_witness.ab4: <witness> = impl_witness imports.%BitOrAssignWith.impl_witness_table.54c, @Cpp.long.as.BitOrAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitOrAssignWith.impl.Op.type.a2b279.1: type = fn_type @Cpp.long.as.BitOrAssignWith.impl.Op.2, @Cpp.long.as.BitOrAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitOrAssignWith.impl.Op.9b8237.1: %Cpp.long.as.BitOrAssignWith.impl.Op.type.a2b279.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitOrAssignWith.impl.Op.type.a2b279.2: type = fn_type @Cpp.long.as.BitOrAssignWith.impl.Op.1, @Cpp.long.as.BitOrAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5286,7 +5287,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.BitXorAssignWith.impl.Op.3c4d0d.1: %Cpp.long.as.BitXorAssignWith.impl.Op.type.8b07a5.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.BitXorAssignWith.impl.Op.type.8b07a5.2: type = fn_type @Cpp.long.as.BitXorAssignWith.impl.Op.2, @Cpp.long.as.BitXorAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.BitXorAssignWith.impl.Op.3c4d0d.2: %Cpp.long.as.BitXorAssignWith.impl.Op.type.8b07a5.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %BitXorAssignWith.impl_witness.4d7: <witness> = impl_witness imports.%BitXorAssignWith.impl_witness_table, @Cpp.long.as.BitXorAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %BitXorAssignWith.impl_witness.4d7: <witness> = impl_witness imports.%BitXorAssignWith.impl_witness_table.a39, @Cpp.long.as.BitXorAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitXorAssignWith.impl.Op.type.6f67bc.1: type = fn_type @Cpp.long.as.BitXorAssignWith.impl.Op.2, @Cpp.long.as.BitXorAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitXorAssignWith.impl.Op.d7e378.1: %Cpp.long.as.BitXorAssignWith.impl.Op.type.6f67bc.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.BitXorAssignWith.impl.Op.type.6f67bc.2: type = fn_type @Cpp.long.as.BitXorAssignWith.impl.Op.1, @Cpp.long.as.BitXorAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5301,7 +5302,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftAssignWith.impl.Op.e204a3.1: %Cpp.long.as.LeftShiftAssignWith.impl.Op.type.21420b.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftAssignWith.impl.Op.type.21420b.2: type = fn_type @Cpp.long.as.LeftShiftAssignWith.impl.Op.2, @Cpp.long.as.LeftShiftAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftAssignWith.impl.Op.e204a3.2: %Cpp.long.as.LeftShiftAssignWith.impl.Op.type.21420b.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %LeftShiftAssignWith.impl_witness.550: <witness> = impl_witness imports.%LeftShiftAssignWith.impl_witness_table, @Cpp.long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %LeftShiftAssignWith.impl_witness.550: <witness> = impl_witness imports.%LeftShiftAssignWith.impl_witness_table.74d, @Cpp.long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftAssignWith.impl.Op.type.e1513f.1: type = fn_type @Cpp.long.as.LeftShiftAssignWith.impl.Op.2, @Cpp.long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftAssignWith.impl.Op.216e26.1: %Cpp.long.as.LeftShiftAssignWith.impl.Op.type.e1513f.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.LeftShiftAssignWith.impl.Op.type.e1513f.2: type = fn_type @Cpp.long.as.LeftShiftAssignWith.impl.Op.1, @Cpp.long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5316,7 +5317,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftAssignWith.impl.Op.328772.1: %Cpp.long.as.RightShiftAssignWith.impl.Op.type.f850d3.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftAssignWith.impl.Op.type.f850d3.2: type = fn_type @Cpp.long.as.RightShiftAssignWith.impl.Op.2, @Cpp.long.as.RightShiftAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftAssignWith.impl.Op.328772.2: %Cpp.long.as.RightShiftAssignWith.impl.Op.type.f850d3.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %RightShiftAssignWith.impl_witness.df5: <witness> = impl_witness imports.%RightShiftAssignWith.impl_witness_table, @Cpp.long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
+// CHECK:STDOUT:   %RightShiftAssignWith.impl_witness.df5: <witness> = impl_witness imports.%RightShiftAssignWith.impl_witness_table.b55, @Cpp.long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftAssignWith.impl.Op.type.095737.1: type = fn_type @Cpp.long.as.RightShiftAssignWith.impl.Op.2, @Cpp.long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftAssignWith.impl.Op.860e6c.1: %Cpp.long.as.RightShiftAssignWith.impl.Op.type.095737.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.RightShiftAssignWith.impl.Op.type.095737.2: type = fn_type @Cpp.long.as.RightShiftAssignWith.impl.Op.1, @Cpp.long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.3fe) [concrete]
@@ -5341,36 +5342,36 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Core.import_ref.b8a: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.903 = impl_witness_table (%Core.import_ref.b8a), @Core.IntLiteral.as.ImplicitAs.impl.052 [concrete]
 // CHECK:STDOUT:   %Core.import_ref.d0e: @Cpp.long.as.AddAssignWith.impl.%Cpp.long.as.AddAssignWith.impl.Op.type.2 (%Cpp.long.as.AddAssignWith.impl.Op.type.9f3dfb.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.AddAssignWith.impl.%Cpp.long.as.AddAssignWith.impl.Op.2 (constants.%Cpp.long.as.AddAssignWith.impl.Op.78f138.1)]
-// CHECK:STDOUT:   %AddAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.d0e), @Cpp.long.as.AddAssignWith.impl [concrete]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness_table.07a = impl_witness_table (%Core.import_ref.d0e), @Cpp.long.as.AddAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.f81: @Cpp.long.as.AddAssignWith.impl.%Cpp.long.as.AddAssignWith.impl.Op.type.1 (%Cpp.long.as.AddAssignWith.impl.Op.type.9f3dfb.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.AddAssignWith.impl.%Cpp.long.as.AddAssignWith.impl.Op.1 (constants.%Cpp.long.as.AddAssignWith.impl.Op.78f138.2)]
 // CHECK:STDOUT:   %Core.import_ref.915: %Cpp.long.as.Copy.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long.as.Copy.impl.Op]
 // CHECK:STDOUT:   %Copy.impl_witness_table.572 = impl_witness_table (%Core.import_ref.915), @Cpp.long.as.Copy.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.bcb: @Cpp.long.as.SubAssignWith.impl.%Cpp.long.as.SubAssignWith.impl.Op.type.2 (%Cpp.long.as.SubAssignWith.impl.Op.type.1f2d1c.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.SubAssignWith.impl.%Cpp.long.as.SubAssignWith.impl.Op.2 (constants.%Cpp.long.as.SubAssignWith.impl.Op.c39240.1)]
-// CHECK:STDOUT:   %SubAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.bcb), @Cpp.long.as.SubAssignWith.impl [concrete]
+// CHECK:STDOUT:   %SubAssignWith.impl_witness_table.f4b = impl_witness_table (%Core.import_ref.bcb), @Cpp.long.as.SubAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.739: @Cpp.long.as.SubAssignWith.impl.%Cpp.long.as.SubAssignWith.impl.Op.type.1 (%Cpp.long.as.SubAssignWith.impl.Op.type.1f2d1c.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.SubAssignWith.impl.%Cpp.long.as.SubAssignWith.impl.Op.1 (constants.%Cpp.long.as.SubAssignWith.impl.Op.c39240.2)]
 // CHECK:STDOUT:   %Core.import_ref.c5b: @Cpp.long.as.MulAssignWith.impl.%Cpp.long.as.MulAssignWith.impl.Op.type.2 (%Cpp.long.as.MulAssignWith.impl.Op.type.afa7f7.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.MulAssignWith.impl.%Cpp.long.as.MulAssignWith.impl.Op.2 (constants.%Cpp.long.as.MulAssignWith.impl.Op.421374.1)]
-// CHECK:STDOUT:   %MulAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.c5b), @Cpp.long.as.MulAssignWith.impl [concrete]
+// CHECK:STDOUT:   %MulAssignWith.impl_witness_table.8cc = impl_witness_table (%Core.import_ref.c5b), @Cpp.long.as.MulAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.3b8: @Cpp.long.as.MulAssignWith.impl.%Cpp.long.as.MulAssignWith.impl.Op.type.1 (%Cpp.long.as.MulAssignWith.impl.Op.type.afa7f7.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.MulAssignWith.impl.%Cpp.long.as.MulAssignWith.impl.Op.1 (constants.%Cpp.long.as.MulAssignWith.impl.Op.421374.2)]
 // CHECK:STDOUT:   %Core.import_ref.84d: @Cpp.long.as.DivAssignWith.impl.%Cpp.long.as.DivAssignWith.impl.Op.type.2 (%Cpp.long.as.DivAssignWith.impl.Op.type.f3536d.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.DivAssignWith.impl.%Cpp.long.as.DivAssignWith.impl.Op.2 (constants.%Cpp.long.as.DivAssignWith.impl.Op.6227df.1)]
-// CHECK:STDOUT:   %DivAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.84d), @Cpp.long.as.DivAssignWith.impl [concrete]
+// CHECK:STDOUT:   %DivAssignWith.impl_witness_table.6f7 = impl_witness_table (%Core.import_ref.84d), @Cpp.long.as.DivAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.f47: @Cpp.long.as.DivAssignWith.impl.%Cpp.long.as.DivAssignWith.impl.Op.type.1 (%Cpp.long.as.DivAssignWith.impl.Op.type.f3536d.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.DivAssignWith.impl.%Cpp.long.as.DivAssignWith.impl.Op.1 (constants.%Cpp.long.as.DivAssignWith.impl.Op.6227df.2)]
 // CHECK:STDOUT:   %Core.import_ref.e98: @Cpp.long.as.ModAssignWith.impl.%Cpp.long.as.ModAssignWith.impl.Op.type.2 (%Cpp.long.as.ModAssignWith.impl.Op.type.2d6972.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.ModAssignWith.impl.%Cpp.long.as.ModAssignWith.impl.Op.2 (constants.%Cpp.long.as.ModAssignWith.impl.Op.666e79.1)]
-// CHECK:STDOUT:   %ModAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.e98), @Cpp.long.as.ModAssignWith.impl [concrete]
+// CHECK:STDOUT:   %ModAssignWith.impl_witness_table.a2a = impl_witness_table (%Core.import_ref.e98), @Cpp.long.as.ModAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.b37: @Cpp.long.as.ModAssignWith.impl.%Cpp.long.as.ModAssignWith.impl.Op.type.1 (%Cpp.long.as.ModAssignWith.impl.Op.type.2d6972.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.ModAssignWith.impl.%Cpp.long.as.ModAssignWith.impl.Op.1 (constants.%Cpp.long.as.ModAssignWith.impl.Op.666e79.2)]
 // CHECK:STDOUT:   %Core.import_ref.325: @Cpp.long.as.BitAndAssignWith.impl.%Cpp.long.as.BitAndAssignWith.impl.Op.type.2 (%Cpp.long.as.BitAndAssignWith.impl.Op.type.442dcf.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.BitAndAssignWith.impl.%Cpp.long.as.BitAndAssignWith.impl.Op.2 (constants.%Cpp.long.as.BitAndAssignWith.impl.Op.d99897.1)]
-// CHECK:STDOUT:   %BitAndAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.325), @Cpp.long.as.BitAndAssignWith.impl [concrete]
+// CHECK:STDOUT:   %BitAndAssignWith.impl_witness_table.cc9 = impl_witness_table (%Core.import_ref.325), @Cpp.long.as.BitAndAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.fe8: @Cpp.long.as.BitAndAssignWith.impl.%Cpp.long.as.BitAndAssignWith.impl.Op.type.1 (%Cpp.long.as.BitAndAssignWith.impl.Op.type.442dcf.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.BitAndAssignWith.impl.%Cpp.long.as.BitAndAssignWith.impl.Op.1 (constants.%Cpp.long.as.BitAndAssignWith.impl.Op.d99897.2)]
 // CHECK:STDOUT:   %Core.import_ref.01a: @Cpp.long.as.BitOrAssignWith.impl.%Cpp.long.as.BitOrAssignWith.impl.Op.type.2 (%Cpp.long.as.BitOrAssignWith.impl.Op.type.219f14.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.BitOrAssignWith.impl.%Cpp.long.as.BitOrAssignWith.impl.Op.2 (constants.%Cpp.long.as.BitOrAssignWith.impl.Op.e5afa1.1)]
-// CHECK:STDOUT:   %BitOrAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.01a), @Cpp.long.as.BitOrAssignWith.impl [concrete]
+// CHECK:STDOUT:   %BitOrAssignWith.impl_witness_table.54c = impl_witness_table (%Core.import_ref.01a), @Cpp.long.as.BitOrAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.5c2: @Cpp.long.as.BitOrAssignWith.impl.%Cpp.long.as.BitOrAssignWith.impl.Op.type.1 (%Cpp.long.as.BitOrAssignWith.impl.Op.type.219f14.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.BitOrAssignWith.impl.%Cpp.long.as.BitOrAssignWith.impl.Op.1 (constants.%Cpp.long.as.BitOrAssignWith.impl.Op.e5afa1.2)]
 // CHECK:STDOUT:   %Core.import_ref.c8f: @Cpp.long.as.BitXorAssignWith.impl.%Cpp.long.as.BitXorAssignWith.impl.Op.type.2 (%Cpp.long.as.BitXorAssignWith.impl.Op.type.8b07a5.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.BitXorAssignWith.impl.%Cpp.long.as.BitXorAssignWith.impl.Op.2 (constants.%Cpp.long.as.BitXorAssignWith.impl.Op.3c4d0d.1)]
-// CHECK:STDOUT:   %BitXorAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.c8f), @Cpp.long.as.BitXorAssignWith.impl [concrete]
+// CHECK:STDOUT:   %BitXorAssignWith.impl_witness_table.a39 = impl_witness_table (%Core.import_ref.c8f), @Cpp.long.as.BitXorAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.caf: @Cpp.long.as.BitXorAssignWith.impl.%Cpp.long.as.BitXorAssignWith.impl.Op.type.1 (%Cpp.long.as.BitXorAssignWith.impl.Op.type.8b07a5.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.BitXorAssignWith.impl.%Cpp.long.as.BitXorAssignWith.impl.Op.1 (constants.%Cpp.long.as.BitXorAssignWith.impl.Op.3c4d0d.2)]
 // CHECK:STDOUT:   %Core.import_ref.bcc: @Cpp.long.as.LeftShiftAssignWith.impl.%Cpp.long.as.LeftShiftAssignWith.impl.Op.type.2 (%Cpp.long.as.LeftShiftAssignWith.impl.Op.type.21420b.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.LeftShiftAssignWith.impl.%Cpp.long.as.LeftShiftAssignWith.impl.Op.2 (constants.%Cpp.long.as.LeftShiftAssignWith.impl.Op.e204a3.1)]
-// CHECK:STDOUT:   %LeftShiftAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.bcc), @Cpp.long.as.LeftShiftAssignWith.impl [concrete]
+// CHECK:STDOUT:   %LeftShiftAssignWith.impl_witness_table.74d = impl_witness_table (%Core.import_ref.bcc), @Cpp.long.as.LeftShiftAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.030: @Cpp.long.as.LeftShiftAssignWith.impl.%Cpp.long.as.LeftShiftAssignWith.impl.Op.type.1 (%Cpp.long.as.LeftShiftAssignWith.impl.Op.type.21420b.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.LeftShiftAssignWith.impl.%Cpp.long.as.LeftShiftAssignWith.impl.Op.1 (constants.%Cpp.long.as.LeftShiftAssignWith.impl.Op.e204a3.2)]
 // CHECK:STDOUT:   %Core.import_ref.5f5: @Cpp.long.as.RightShiftAssignWith.impl.%Cpp.long.as.RightShiftAssignWith.impl.Op.type.2 (%Cpp.long.as.RightShiftAssignWith.impl.Op.type.f850d3.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.RightShiftAssignWith.impl.%Cpp.long.as.RightShiftAssignWith.impl.Op.2 (constants.%Cpp.long.as.RightShiftAssignWith.impl.Op.328772.1)]
-// CHECK:STDOUT:   %RightShiftAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.5f5), @Cpp.long.as.RightShiftAssignWith.impl [concrete]
+// CHECK:STDOUT:   %RightShiftAssignWith.impl_witness_table.b55 = impl_witness_table (%Core.import_ref.5f5), @Cpp.long.as.RightShiftAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.3b5: @Cpp.long.as.RightShiftAssignWith.impl.%Cpp.long.as.RightShiftAssignWith.impl.Op.type.1 (%Cpp.long.as.RightShiftAssignWith.impl.Op.type.f850d3.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.RightShiftAssignWith.impl.%Cpp.long.as.RightShiftAssignWith.impl.Op.1 (constants.%Cpp.long.as.RightShiftAssignWith.impl.Op.328772.2)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -6221,7 +6222,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.78f138.1: %Cpp.long.as.AddAssignWith.impl.Op.type.9f3dfb.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.type.9f3dfb.2: type = fn_type @Cpp.long.as.AddAssignWith.impl.Op.2, @Cpp.long.as.AddAssignWith.impl(%U.57d) [symbolic]
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.78f138.2: %Cpp.long.as.AddAssignWith.impl.Op.type.9f3dfb.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %AddAssignWith.impl_witness.623: <witness> = impl_witness imports.%AddAssignWith.impl_witness_table, @Cpp.long.as.AddAssignWith.impl(%ImplicitAs.facet) [concrete]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness.623: <witness> = impl_witness imports.%AddAssignWith.impl_witness_table.07a, @Cpp.long.as.AddAssignWith.impl(%ImplicitAs.facet) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.type.a474b7.1: type = fn_type @Cpp.long.as.AddAssignWith.impl.Op.2, @Cpp.long.as.AddAssignWith.impl(%ImplicitAs.facet) [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.5fb128.1: %Cpp.long.as.AddAssignWith.impl.Op.type.a474b7.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %Cpp.long.as.AddAssignWith.impl.Op.type.a474b7.2: type = fn_type @Cpp.long.as.AddAssignWith.impl.Op.1, @Cpp.long.as.AddAssignWith.impl(%ImplicitAs.facet) [concrete]
@@ -6242,7 +6243,7 @@ fn CopyUnsignedLong() {
 // CHECK:STDOUT:   %Core.import_ref.b8a: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.903 = impl_witness_table (%Core.import_ref.b8a), @Core.IntLiteral.as.ImplicitAs.impl.052 [concrete]
 // CHECK:STDOUT:   %Core.import_ref.d0e: @Cpp.long.as.AddAssignWith.impl.%Cpp.long.as.AddAssignWith.impl.Op.type.2 (%Cpp.long.as.AddAssignWith.impl.Op.type.9f3dfb.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long.as.AddAssignWith.impl.%Cpp.long.as.AddAssignWith.impl.Op.2 (constants.%Cpp.long.as.AddAssignWith.impl.Op.78f138.1)]
-// CHECK:STDOUT:   %AddAssignWith.impl_witness_table = impl_witness_table (%Core.import_ref.d0e), @Cpp.long.as.AddAssignWith.impl [concrete]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness_table.07a = impl_witness_table (%Core.import_ref.d0e), @Cpp.long.as.AddAssignWith.impl [concrete]
 // CHECK:STDOUT:   %Core.Op.f81: @Cpp.long.as.AddAssignWith.impl.%Cpp.long.as.AddAssignWith.impl.Op.type.1 (%Cpp.long.as.AddAssignWith.impl.Op.type.9f3dfb.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long.as.AddAssignWith.impl.%Cpp.long.as.AddAssignWith.impl.Op.1 (constants.%Cpp.long.as.AddAssignWith.impl.Op.78f138.2)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/builtins.lp64.carbon
+++ b/toolchain/check/testdata/interop/cpp/builtins.lp64.carbon
@@ -62,11 +62,30 @@ fn F() {
   let cpp_compat_long_long: Core.CppCompat.LongLong64 = cpp_long_long;
   let cpp_compat_long_long_result: Cpp.LongLongResult = Cpp.PassLongLong(cpp_compat_long_long);
 
-  let carbon_i64: i64 = cpp_long_long;
+  let carbon_i64: i64 = cpp_long_long as i64;
   let carbon_i64_result: Cpp.LongResult = Cpp.PassLongLong(carbon_i64);
 
   var a: array(f32, 1 as Cpp.long_long) = (1.0,);
   //@dump-sem-ir-end
+}
+
+
+// --- fail_implicit_conversion_long_long_to_i64.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn F() {
+  let cpp_long_long: Cpp.long_long = 1;
+  // CHECK:STDERR: fail_implicit_conversion_long_long_to_i64.carbon:[[@LINE+7]]:25: error: cannot implicitly convert expression of type `Cpp.long_long` to `i64` [ConversionFailure]
+  // CHECK:STDERR:   let carbon_i64: i64 = cpp_long_long;
+  // CHECK:STDERR:                         ^~~~~~~~~~~~~
+  // CHECK:STDERR: fail_implicit_conversion_long_long_to_i64.carbon:[[@LINE+4]]:25: note: type `Cpp.long_long` does not implement interface `Core.ImplicitAs(i64)` [MissingImplInMemberAccessNote]
+  // CHECK:STDERR:   let carbon_i64: i64 = cpp_long_long;
+  // CHECK:STDERR:                         ^~~~~~~~~~~~~
+  // CHECK:STDERR:
+  let carbon_i64: i64 = cpp_long_long;
 }
 
 // --- copy_long_long.carbon
@@ -188,7 +207,7 @@ fn ComparisonsHeterogeneousLongLongAndI32() {
   b == a;
 }
 
-// --- fail_todo_comparisons_heterogeneous_long_long_and_i128.carbon
+// --- comparisons_heterogeneous_long_long_and_i128.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -197,16 +216,406 @@ import Cpp;
 fn ComparisonsHeterogeneousLongLongAndI128() {
   let a: Cpp.long_long = 1;
   let b: i128 = 1;
-  // CHECK:STDERR: fail_todo_comparisons_heterogeneous_long_long_and_i128.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.EqWith(i128)` in type `Cpp.long_long` that does not implement that interface [MissingImplInMemberAccess]
+  a == b;
+  b == a;
+}
+
+// --- fail_todo_comparisons_heterogeneous_long_long_and_i256.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn ComparisonsHeterogeneousLongLongAndI256() {
+  let a: Cpp.long_long = 1;
+  let b: i256 = 1;
+  // CHECK:STDERR: fail_todo_comparisons_heterogeneous_long_long_and_i256.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.EqWith(i256)` in type `Cpp.long_long` that does not implement that interface [MissingImplInMemberAccess]
   // CHECK:STDERR:   a == b;
   // CHECK:STDERR:   ^~~~~~
   // CHECK:STDERR:
   a == b;
-  // CHECK:STDERR: fail_todo_comparisons_heterogeneous_long_long_and_i128.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.EqWith(Cpp.long_long)` in type `i128` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR: fail_todo_comparisons_heterogeneous_long_long_and_i256.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.EqWith(Cpp.long_long)` in type `i256` that does not implement that interface [MissingImplInMemberAccess]
   // CHECK:STDERR:   b == a;
   // CHECK:STDERR:   ^~~~~~
   // CHECK:STDERR:
   b == a;
+}
+
+// --- arithmetic_homogeneous_long_long.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn ArithmeticHomogeneousLongLong() {
+  //@dump-sem-ir-begin
+  let x: Cpp.long_long = 1;
+  let y: Cpp.long_long = 1;
+
+  AssertSameType(-x, x);
+  AssertSameType(x + y, x);
+  AssertSameType(x - y, x);
+  AssertSameType(x * y, x);
+  AssertSameType(x / y, x);
+  AssertSameType(x % y, x);
+  //@dump-sem-ir-end
+}
+
+// --- arithmetic_heterogeneous_long_long_left_side.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn ArithmeticHeterogeneousLongLongLeftSide() {
+  //@dump-sem-ir-begin
+  let x: Cpp.long_long = 1;
+
+  AssertSameType(x + (1 as i64), x);
+  AssertSameType(x - (1 as i64), x);
+  AssertSameType(x * (1 as i64), x);
+  AssertSameType(x / (1 as i64), x);
+  AssertSameType(x % (1 as i64), x);
+
+  AssertSameType(x + 1, x);
+  AssertSameType(x - 1, x);
+  AssertSameType(x * 1, x);
+  AssertSameType(x / 1, x);
+  AssertSameType(x % 1, x);
+
+  let y: i64 = 1;
+  AssertSameType(x + y, x);
+  AssertSameType(x - y, x);
+  AssertSameType(x * y, x);
+  AssertSameType(x / y, x);
+  AssertSameType(x % y, x);
+  //@dump-sem-ir-end
+}
+
+// --- arithmetic_heterogeneous_long_long_right_side.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn ArithmeticHeterogeneousLongLongRightSide() {
+  //@dump-sem-ir-begin
+  let x: Cpp.long_long = 1;
+  AssertSameType((1 as i64) + x, x);
+  AssertSameType((1 as i64) - x, x);
+  AssertSameType((1 as i64) * x, x);
+  AssertSameType((1 as i64) / x, x);
+  AssertSameType((1 as i64) % x, x);
+
+  AssertSameType(1 + x, x);
+  AssertSameType(1 - x, x);
+  AssertSameType(1 * x, x);
+  AssertSameType(1 / x, x);
+  AssertSameType(1 % x, x);
+
+  let y: i64 = 1;
+  AssertSameType(y + x, x);
+  AssertSameType(y - x, x);
+  AssertSameType(y * x, x);
+  AssertSameType(y / x, x);
+  AssertSameType(y % x, x);
+  //@dump-sem-ir-end
+}
+
+// --- fail_todo_arithmetic_heterogeneous_long_long_and_i32.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn ArithmeticHeterogeneousLongLongAndI32() {
+  let x: Cpp.long_long = 1;
+  let y: i32 = 1;
+  // CHECK:STDERR: fail_todo_arithmetic_heterogeneous_long_long_and_i32.carbon:[[@LINE+4]]:18: error: cannot access member of interface `Core.AddWith(i32)` in type `Cpp.long_long` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   AssertSameType(x + y, x);
+  // CHECK:STDERR:                  ^~~~~
+  // CHECK:STDERR:
+  AssertSameType(x + y, x);
+
+  // CHECK:STDERR: fail_todo_arithmetic_heterogeneous_long_long_and_i32.carbon:[[@LINE+4]]:18: error: cannot access member of interface `Core.AddWith(Cpp.long_long)` in type `i32` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   AssertSameType(y + x, x);
+  // CHECK:STDERR:                  ^~~~~
+  // CHECK:STDERR:
+  AssertSameType(y + x, x);
+}
+
+// --- arithmetic_heterogeneous_long_long_and_i128.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn ArithmeticHeterogeneousLongLongAndI128() {
+  //@dump-sem-ir-begin
+  let x: Cpp.long_long = 1;
+  let y: i128 = 1;
+  AssertSameType(x + y, y);
+  AssertSameType(y + x, y);
+  //@dump-sem-ir-end
+}
+
+// --- bitwise_homogeneous_long_long.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn BitWiseHomogeneousLongLong() {
+  //@dump-sem-ir-begin
+  let a: Cpp.long_long = 1;
+  let b: Cpp.long_long = 1;
+
+  AssertSameType(^a, a);
+  AssertSameType(a & b, a);
+  AssertSameType(a | b, a);
+  AssertSameType(a ^ b, a);
+  AssertSameType(a << b, a);
+  AssertSameType(a >> b, a);
+  //@dump-sem-ir-end
+}
+
+// --- bitwise_heterogeneous_long_long_left_side.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn BitWiseHeterogeneousLongLongLeftSide() {
+  //@dump-sem-ir-begin
+  let a: Cpp.long_long = 1;
+
+  AssertSameType(a & (1 as i64), a);
+  AssertSameType(a | (1 as i64), a);
+  AssertSameType(a ^ (1 as i64), a);
+  AssertSameType(a << (1 as i64), a);
+  AssertSameType(a >> (1 as i64), a);
+
+  AssertSameType(a & 1, a);
+  AssertSameType(a | 1, a);
+  AssertSameType(a ^ 1, a);
+  AssertSameType(a << 1, a);
+  AssertSameType(a >> 1, a);
+
+  let b: i64 = 1;
+  AssertSameType(a & b, a);
+  AssertSameType(a | b, a);
+  AssertSameType(a ^ b, a);
+  AssertSameType(a << b, a);
+  AssertSameType(a >> b, a);
+  //@dump-sem-ir-end
+}
+
+// --- bitwise_heterogeneous_long_long_right_side.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn BitWiseHeterogeneousLongLongRightSide() {
+  //@dump-sem-ir-begin
+  let a: Cpp.long_long = 1;
+
+  AssertSameType((1 as i64) & a, a);
+  AssertSameType((1 as i64) | a, a);
+  AssertSameType((1 as i64) ^ a, a);
+  AssertSameType((1 as i64) << a, a);
+  AssertSameType((1 as i64) >> a, a);
+
+  AssertSameType(1 & a, a);
+  AssertSameType(1 | a, a);
+  AssertSameType(1 ^ a, a);
+  AssertSameType(1 << a, a);
+  AssertSameType(1 >> a, a);
+
+  let b: i64 = 1;
+  AssertSameType(b & a, a);
+  AssertSameType(b | a, a);
+  AssertSameType(b ^ a, a);
+  AssertSameType(b << a, a);
+  AssertSameType(b >> a, a);
+  //@dump-sem-ir-end
+}
+
+// --- fail_todo_bitwise_heterogeneous_long_long_and_i32.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn BitWiseHeterogeneousLongLongAndI32() {
+  let a: Cpp.long_long = 1;
+  let b: i32 = 1;
+
+  // CHECK:STDERR: fail_todo_bitwise_heterogeneous_long_long_and_i32.carbon:[[@LINE+4]]:18: error: cannot access member of interface `Core.BitAndWith(i32)` in type `Cpp.long_long` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   AssertSameType(a & b, a);
+  // CHECK:STDERR:                  ^~~~~
+  // CHECK:STDERR:
+  AssertSameType(a & b, a);
+  // CHECK:STDERR: fail_todo_bitwise_heterogeneous_long_long_and_i32.carbon:[[@LINE+4]]:18: error: cannot access member of interface `Core.BitAndWith(Cpp.long_long)` in type `i32` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   AssertSameType(b & a, a);
+  // CHECK:STDERR:                  ^~~~~
+  // CHECK:STDERR:
+  AssertSameType(b & a, a);
+}
+
+// --- bitwise_heterogeneous_long_long_and_i128.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn AssertSameType[T:! type](a: T, b: T) {}
+
+fn BitWiseHeterogeneousLongLongAndI128() {
+  //@dump-sem-ir-begin
+  let a: Cpp.long_long = 1;
+  let b: i128 = 1;
+
+  AssertSameType(a & b, b);
+  AssertSameType(b & a, b);
+  //@dump-sem-ir-end
+}
+
+// --- compound_assignment_homogeneous_long_long.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn CompoundAssignmentHomogeneousLongLong() {
+  //@dump-sem-ir-begin
+  var a: Cpp.long_long = 1;
+  var b: Cpp.long_long = 1;
+
+  a += b;
+  a -= b;
+  a *= b;
+  a /= b;
+  a %= b;
+
+  a &= b;
+  a |= b;
+  a ^= b;
+  a <<= b;
+  a >>= b;
+  //@dump-sem-ir-end
+}
+
+// --- compound_assignment_hereogeneous_long_long_and_i64.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn CompoundAssignmentLongLongAndI64() {
+  //@dump-sem-ir-begin
+  var a: Cpp.long_long = 1;
+  a += (1 as i64);
+  a -= (1 as i64);
+  a *= (1 as i64);
+  a /= (1 as i64);
+  a %= (1 as i64);
+
+  a &= (1 as i64);
+  a |= (1 as i64);
+  a ^= (1 as i64);
+  a <<= (1 as i64);
+  a >>= (1 as i64);
+  //@dump-sem-ir-end
+}
+
+// --- compound_assignment_heterogeneous_long_long_and_int_literal.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn CompoundAssignmentLongLongAndIntLiteral() {
+  //@dump-sem-ir-begin
+  var a: Cpp.long_long = 1;
+  a += 1;
+  //@dump-sem-ir-end
+}
+
+// --- compound_assignment_heterogeneous_long_long_and_runtime_i64.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn CompoundAssignmentLongLongAndRuntimeI64() {
+  //@dump-sem-ir-begin
+  var a: Cpp.long_long = 1;
+  let b: i64 = 1;
+  a += b;
+  //@dump-sem-ir-end
+}
+
+// --- fail_todo_compound_assignment_heterogeneous_long_long_and_i32.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn CompoundAssignmentHeterogeneousLongLongAndI32() {
+  var a: Cpp.long_long = 1;
+  // CHECK:STDERR: fail_todo_compound_assignment_heterogeneous_long_long_and_i32.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.AddAssignWith(i32)` in type `Cpp.long_long` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   a += (1 as i32);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  a += (1 as i32);
+}
+
+// --- fail_compound_assignment_heterogeneous_long_long_and_i128.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn CompoundAssignmentHeterogeneousLongLongAndI128() {
+  var a: Cpp.long_long = 1;
+  // CHECK:STDERR: fail_compound_assignment_heterogeneous_long_long_and_i128.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.AddAssignWith(i128)` in type `Cpp.long_long` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   a += (1 as i128);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  a += (1 as i128);
+}
+
+// --- increment_decrement_long_long.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn IncrementDecrementLongLong() {
+  //@dump-sem-ir-begin
+  var a: Cpp.long_long = 1;
+  ++a;
+  --a;
+  //@dump-sem-ir-end
 }
 
 // --- unsigned_long_long.carbon
@@ -601,14 +1010,12 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.139: type = facet_type <@ImplicitAs, @ImplicitAs(Core.IntLiteral)> [concrete]
 // CHECK:STDOUT:   %ImplicitAs.Convert.type.71e: type = fn_type @ImplicitAs.Convert, @ImplicitAs(Core.IntLiteral) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.type.2ad: type = facet_type <@ImplicitAs, @ImplicitAs(%i64)> [concrete]
-// CHECK:STDOUT:   %ImplicitAs.Convert.type.94e: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i64) [concrete]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
 // CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
 // CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
-// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
-// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
-// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
 // CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
 // CHECK:STDOUT:   %LongLongResult: type = class_type @LongLongResult [concrete]
 // CHECK:STDOUT:   %pattern_type.257: type = pattern_type %LongLongResult [concrete]
@@ -618,11 +1025,6 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %PassLongLong__carbon_thunk.type.aa8bde.1: type = fn_type @PassLongLong__carbon_thunk.1 [concrete]
 // CHECK:STDOUT:   %PassLongLong__carbon_thunk.9998b6.1: %PassLongLong__carbon_thunk.type.aa8bde.1 = struct_value () [concrete]
 // CHECK:STDOUT:   %pattern_type.95b: type = pattern_type %i64 [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.a63: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.563 [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.660: %ImplicitAs.type.2ad = facet_value %Cpp.long_long, (%ImplicitAs.impl_witness.a63) [concrete]
-// CHECK:STDOUT:   %.912: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.660 [concrete]
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.type.194: type = fn_type @Cpp.long_long.as.ImplicitAs.impl.Convert.1 [concrete]
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.c03: %Cpp.long_long.as.ImplicitAs.impl.Convert.type.194 = struct_value () [concrete]
 // CHECK:STDOUT:   %LongResult: type = class_type @LongResult [concrete]
 // CHECK:STDOUT:   %pattern_type.cd9: type = pattern_type %LongResult [concrete]
 // CHECK:STDOUT:   %ptr.305: type = ptr_type %LongResult [concrete]
@@ -644,9 +1046,9 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %ImplicitAs.impl_witness.737: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.64f [concrete]
 // CHECK:STDOUT:   %ImplicitAs.facet.084: %ImplicitAs.type.139 = facet_value %Cpp.long_long, (%ImplicitAs.impl_witness.737) [concrete]
 // CHECK:STDOUT:   %.7c8: type = fn_type_with_self_type %ImplicitAs.Convert.type.71e, %ImplicitAs.facet.084 [concrete]
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.type.506: type = fn_type @Cpp.long_long.as.ImplicitAs.impl.Convert.2 [concrete]
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.ad2: %Cpp.long_long.as.ImplicitAs.impl.Convert.type.506 = struct_value () [concrete]
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.092, %Cpp.long_long.as.ImplicitAs.impl.Convert.ad2 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.type: type = fn_type @Cpp.long_long.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert: %Cpp.long_long.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.092, %Cpp.long_long.as.ImplicitAs.impl.Convert [concrete]
 // CHECK:STDOUT:   %array_type: type = array_type %int_1.5b8, %f32.97e [concrete]
 // CHECK:STDOUT:   %pattern_type.b36: type = pattern_type %array_type [concrete]
 // CHECK:STDOUT:   %float.674: Core.FloatLiteral = float_literal_value 10e-1 [concrete]
@@ -702,7 +1104,7 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.LongLong64: type = import_ref Core//prelude/types/cpp/int, LongLong64, loaded [concrete = constants.%Cpp.long_long]
 // CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.cc7 = import_ref Core//prelude/operators/as, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
-// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
 // CHECK:STDOUT:   %LongLongResult.decl: type = class_decl @LongLongResult [concrete = constants.%LongLongResult] {} {}
 // CHECK:STDOUT:   %PassLongLong.cpp_overload_set.value: %PassLongLong.cpp_overload_set.type = cpp_overload_set_value @PassLongLong.cpp_overload_set [concrete = constants.%PassLongLong.cpp_overload_set.value]
@@ -712,8 +1114,6 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.Int: %Int.type = import_ref Core//prelude/types/int, Int, loaded [concrete = constants.%Int.generic]
-// CHECK:STDOUT:   %Core.import_ref.91c3: %Cpp.long_long.as.ImplicitAs.impl.Convert.type.194 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert.c03]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.563 = impl_witness_table (%Core.import_ref.91c3), @Cpp.long_long.as.ImplicitAs.impl.034 [concrete]
 // CHECK:STDOUT:   %LongResult.decl: type = class_decl @LongResult [concrete = constants.%LongResult] {} {}
 // CHECK:STDOUT:   %PassLongLong__carbon_thunk.decl.139b1c.2: %PassLongLong__carbon_thunk.type.aa8bde.2 = fn_decl @PassLongLong__carbon_thunk.2 [concrete = constants.%PassLongLong__carbon_thunk.9998b6.2] {
 // CHECK:STDOUT:     <elided>
@@ -724,7 +1124,7 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %Core.As: %As.type.90f = import_ref Core//prelude/operators/as, As, loaded [concrete = constants.%As.generic]
 // CHECK:STDOUT:   %Core.import_ref.cdc: %Core.IntLiteral.as.As.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.As.impl.Convert]
 // CHECK:STDOUT:   %As.impl_witness_table.eb3 = impl_witness_table (%Core.import_ref.cdc), @Core.IntLiteral.as.As.impl.823 [concrete]
-// CHECK:STDOUT:   %Core.import_ref.74a: %Cpp.long_long.as.ImplicitAs.impl.Convert.type.506 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert.ad2]
+// CHECK:STDOUT:   %Core.import_ref.74a: %Cpp.long_long.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.64f = impl_witness_table (%Core.import_ref.74a), @Cpp.long_long.as.ImplicitAs.impl.60b [concrete]
 // CHECK:STDOUT:   %Core.import_ref.38a: @Core.FloatLiteral.as.ImplicitAs.impl.%Core.FloatLiteral.as.ImplicitAs.impl.Convert.type (%Core.FloatLiteral.as.ImplicitAs.impl.Convert.type.02f) = import_ref Core//prelude/types/float, loc{{\d+_\d+}}, loaded [symbolic = @Core.FloatLiteral.as.ImplicitAs.impl.%Core.FloatLiteral.as.ImplicitAs.impl.Convert (constants.%Core.FloatLiteral.as.ImplicitAs.impl.Convert.1f0)]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.31a = impl_witness_table (%Core.import_ref.38a), @Core.FloatLiteral.as.ImplicitAs.impl [concrete]
@@ -741,7 +1141,7 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:     %Cpp.ref.loc15: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %long_long.ref.loc15: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc15: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %impl.elem0.loc15: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
 // CHECK:STDOUT:   %bound_method.loc15: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call: init %Cpp.long_long = call %bound_method.loc15(%int_1.loc15) [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc15_38.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call [concrete = constants.%int_1.092]
@@ -795,16 +1195,15 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:     %carbon_i64.patt: %pattern_type.95b = value_binding_pattern carbon_i64 [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %cpp_long_long.ref.loc21: %Cpp.long_long = name_ref cpp_long_long, %cpp_long_long
-// CHECK:STDOUT:   %.loc21_19: type = splice_block %i64 [concrete = constants.%i64] {
-// CHECK:STDOUT:     %int_64: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
-// CHECK:STDOUT:     %i64: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %int_64.loc21_42: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc21_42: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %.loc21_39.1: %i64 = as_compatible %cpp_long_long.ref.loc21
+// CHECK:STDOUT:   %.loc21_39.2: %i64 = converted %cpp_long_long.ref.loc21, %.loc21_39.1
+// CHECK:STDOUT:   %.loc21_19: type = splice_block %i64.loc21_19 [concrete = constants.%i64] {
+// CHECK:STDOUT:     %int_64.loc21_19: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:     %i64.loc21_19: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %impl.elem0.loc21: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert.c03]
-// CHECK:STDOUT:   %bound_method.loc21: <bound method> = bound_method %cpp_long_long.ref.loc21, %impl.elem0.loc21
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc21: init %i64 = call %bound_method.loc21(%cpp_long_long.ref.loc21)
-// CHECK:STDOUT:   %.loc21_25.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc21
-// CHECK:STDOUT:   %.loc21_25.2: %i64 = converted %cpp_long_long.ref.loc21, %.loc21_25.1
-// CHECK:STDOUT:   %carbon_i64: %i64 = value_binding carbon_i64, %.loc21_25.2
+// CHECK:STDOUT:   %carbon_i64: %i64 = value_binding carbon_i64, %.loc21_39.2
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %carbon_i64_result.patt: %pattern_type.cd9 = value_binding_pattern carbon_i64_result [concrete]
 // CHECK:STDOUT:   }
@@ -852,10 +1251,10 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:     %Core.IntLiteral.as.As.impl.Convert.call: init %Cpp.long_long = call %bound_method.loc24_23.1(%int_1.loc24) [concrete = constants.%int_1.092]
 // CHECK:STDOUT:     %.loc24_23.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call [concrete = constants.%int_1.092]
 // CHECK:STDOUT:     %.loc24_23.2: %Cpp.long_long = converted %int_1.loc24, %.loc24_23.1 [concrete = constants.%int_1.092]
-// CHECK:STDOUT:     %impl.elem0.loc24_23.2: %.7c8 = impl_witness_access constants.%ImplicitAs.impl_witness.737, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert.ad2]
+// CHECK:STDOUT:     %impl.elem0.loc24_23.2: %.7c8 = impl_witness_access constants.%ImplicitAs.impl_witness.737, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
 // CHECK:STDOUT:     %bound_method.loc24_23.2: <bound method> = bound_method %.loc24_23.2, %impl.elem0.loc24_23.2 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert.bound]
-// CHECK:STDOUT:     %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc24: init Core.IntLiteral = call %bound_method.loc24_23.2(%.loc24_23.2) [concrete = constants.%int_1.5b8]
-// CHECK:STDOUT:     %.loc24_23.3: Core.IntLiteral = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc24 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:     %Cpp.long_long.as.ImplicitAs.impl.Convert.call: init Core.IntLiteral = call %bound_method.loc24_23.2(%.loc24_23.2) [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:     %.loc24_23.3: Core.IntLiteral = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:     %.loc24_23.4: Core.IntLiteral = converted %.loc24_23.2, %.loc24_23.3 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:     %array_type: type = array_type %.loc24_23.4, %f32 [concrete = constants.%array_type]
 // CHECK:STDOUT:   }
@@ -1861,8 +2260,6 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
 // CHECK:STDOUT:   %int_64: Core.IntLiteral = int_value 64 [concrete]
-// CHECK:STDOUT:   %N: Core.IntLiteral = symbolic_binding N, 0 [symbolic]
-// CHECK:STDOUT:   %Int.fc6021.1: type = class_type @Int, @Int(%N) [symbolic]
 // CHECK:STDOUT:   %i64: type = class_type @Int, @Int(%int_64) [concrete]
 // CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
 // CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
@@ -1904,47 +2301,38 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.bbf235.1: %T.binding.as_type.as.EqWith.impl.Equal.type.066d1d.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.type.066d1d.2: type = fn_type @T.binding.as_type.as.EqWith.impl.Equal.4, @T.binding.as_type.as.EqWith.impl.b07(%T.ea5) [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.bbf235.2: %T.binding.as_type.as.EqWith.impl.Equal.type.066d1d.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %ImplicitAs.type.39a54f.1: type = facet_type <@ImplicitAs, @ImplicitAs(%Int.fc6021.1)> [symbolic]
-// CHECK:STDOUT:   %T.354: %ImplicitAs.type.39a54f.1 = symbolic_binding T, 1 [symbolic]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.type.db1e05.1: type = fn_type @Int.as.EqWith.impl.NotEqual.2, @Int.as.EqWith.impl.42c(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.088a98.1: %Int.as.EqWith.impl.NotEqual.type.db1e05.1 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.type.db1e05.2: type = fn_type @Int.as.EqWith.impl.NotEqual.3, @Int.as.EqWith.impl.42c(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.088a98.2: %Int.as.EqWith.impl.NotEqual.type.db1e05.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.type.a94820.1: type = fn_type @Int.as.EqWith.impl.Equal.2, @Int.as.EqWith.impl.42c(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.737ae8.1: %Int.as.EqWith.impl.Equal.type.a94820.1 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.type.a94820.2: type = fn_type @Int.as.EqWith.impl.Equal.3, @Int.as.EqWith.impl.42c(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.737ae8.2: %Int.as.EqWith.impl.Equal.type.a94820.2 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To.fe9) [symbolic]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.a63: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.563 [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.660: %ImplicitAs.type.2ad = facet_value %Cpp.long_long, (%ImplicitAs.impl_witness.a63) [concrete]
-// CHECK:STDOUT:   %EqWith.impl_witness.367: <witness> = impl_witness imports.%EqWith.impl_witness_table.600, @Int.as.EqWith.impl.42c(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.type.e5f20b.1: type = fn_type @Int.as.EqWith.impl.Equal.3, @Int.as.EqWith.impl.42c(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.e49d18.1: %Int.as.EqWith.impl.Equal.type.e5f20b.1 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.type.9ab064.1: type = fn_type @Int.as.EqWith.impl.NotEqual.3, @Int.as.EqWith.impl.42c(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.af2dce.1: %Int.as.EqWith.impl.NotEqual.type.9ab064.1 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.type.e5f20b.2: type = fn_type @Int.as.EqWith.impl.Equal.2, @Int.as.EqWith.impl.42c(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.e49d18.2: %Int.as.EqWith.impl.Equal.type.e5f20b.2 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.type.9ab064.2: type = fn_type @Int.as.EqWith.impl.NotEqual.2, @Int.as.EqWith.impl.42c(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.af2dce.2: %Int.as.EqWith.impl.NotEqual.type.9ab064.2 = struct_value () [concrete]
-// CHECK:STDOUT:   %EqWith.facet.5fc: %EqWith.type.4be = facet_value %i64, (%EqWith.impl_witness.367) [concrete]
-// CHECK:STDOUT:   %.144: type = fn_type_with_self_type %EqWith.Equal.type.6d5, %EqWith.facet.5fc [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.bound.e9a871.1: <bound method> = bound_method %int_1.41a, %Int.as.EqWith.impl.Equal.e49d18.2 [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.specific_fn.443739.1: <specific function> = specific_function %Int.as.EqWith.impl.Equal.e49d18.2, @Int.as.EqWith.impl.Equal.2(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.a45aed.1: <bound method> = bound_method %int_1.41a, %Int.as.EqWith.impl.Equal.specific_fn.443739.1 [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.bound.e9a871.2: <bound method> = bound_method %int_1.41a, %Int.as.EqWith.impl.Equal.e49d18.1 [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.specific_fn.443739.2: <specific function> = specific_function %Int.as.EqWith.impl.Equal.e49d18.1, @Int.as.EqWith.impl.Equal.3(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.a45aed.2: <bound method> = bound_method %int_1.41a, %Int.as.EqWith.impl.Equal.specific_fn.443739.2 [concrete]
-// CHECK:STDOUT:   %.912: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.660 [concrete]
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.type: type = fn_type @Cpp.long_long.as.ImplicitAs.impl.Convert [concrete]
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert: %Cpp.long_long.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
-// CHECK:STDOUT:   %.b78: type = fn_type_with_self_type %EqWith.NotEqual.type.c18, %EqWith.facet.5fc [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.bound.9611a1.1: <bound method> = bound_method %int_1.41a, %Int.as.EqWith.impl.NotEqual.af2dce.2 [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.specific_fn.044259.1: <specific function> = specific_function %Int.as.EqWith.impl.NotEqual.af2dce.2, @Int.as.EqWith.impl.NotEqual.2(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.356533.1: <bound method> = bound_method %int_1.41a, %Int.as.EqWith.impl.NotEqual.specific_fn.044259.1 [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.bound.9611a1.2: <bound method> = bound_method %int_1.41a, %Int.as.EqWith.impl.NotEqual.af2dce.1 [concrete]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.specific_fn.044259.2: <specific function> = specific_function %Int.as.EqWith.impl.NotEqual.af2dce.1, @Int.as.EqWith.impl.NotEqual.3(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.356533.2: <bound method> = bound_method %int_1.41a, %Int.as.EqWith.impl.NotEqual.specific_fn.044259.2 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.1b3: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.b19 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.c59: %ImplicitAs.type.a03 = facet_value %i64, (%ImplicitAs.impl_witness.1b3) [concrete]
+// CHECK:STDOUT:   %EqWith.impl_witness.52e: <witness> = impl_witness imports.%EqWith.impl_witness_table.7e5, @T.binding.as_type.as.EqWith.impl.b07(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.type.5ab1af.1: type = fn_type @T.binding.as_type.as.EqWith.impl.Equal.4, @T.binding.as_type.as.EqWith.impl.b07(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.971403.1: %T.binding.as_type.as.EqWith.impl.Equal.type.5ab1af.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.type.7cb54d.1: type = fn_type @T.binding.as_type.as.EqWith.impl.NotEqual.4, @T.binding.as_type.as.EqWith.impl.b07(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.1: %T.binding.as_type.as.EqWith.impl.NotEqual.type.7cb54d.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.type.5ab1af.2: type = fn_type @T.binding.as_type.as.EqWith.impl.Equal.3, @T.binding.as_type.as.EqWith.impl.b07(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.971403.2: %T.binding.as_type.as.EqWith.impl.Equal.type.5ab1af.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.type.7cb54d.2: type = fn_type @T.binding.as_type.as.EqWith.impl.NotEqual.3, @T.binding.as_type.as.EqWith.impl.b07(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.2: %T.binding.as_type.as.EqWith.impl.NotEqual.type.7cb54d.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %EqWith.facet.71f: %EqWith.type.4be = facet_value %i64, (%EqWith.impl_witness.52e) [concrete]
+// CHECK:STDOUT:   %.7df: type = fn_type_with_self_type %EqWith.Equal.type.6d5, %EqWith.facet.71f [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.bound.a06d0f.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.EqWith.impl.Equal.971403.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.14854f.1: <specific function> = specific_function %T.binding.as_type.as.EqWith.impl.Equal.971403.2, @T.binding.as_type.as.EqWith.impl.Equal.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.2aad7c.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.14854f.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.bound.a06d0f.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.EqWith.impl.Equal.971403.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.14854f.2: <specific function> = specific_function %T.binding.as_type.as.EqWith.impl.Equal.971403.1, @T.binding.as_type.as.EqWith.impl.Equal.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.2aad7c.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.14854f.2 [concrete]
+// CHECK:STDOUT:   %.b29: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.c59 [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.type: type = fn_type @i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert: %i64.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.41a, %i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %.232: type = fn_type_with_self_type %EqWith.NotEqual.type.c18, %EqWith.facet.71f [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.bound.f4efb4.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.b0f056.1: <specific function> = specific_function %T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.2, @T.binding.as_type.as.EqWith.impl.NotEqual.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.fbe68b.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.b0f056.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.bound.f4efb4.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.b0f056.2: <specific function> = specific_function %T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.1, @T.binding.as_type.as.EqWith.impl.NotEqual.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.fbe68b.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.b0f056.2 [concrete]
 // CHECK:STDOUT:   %OrderedWith.type.65e: type = facet_type <@OrderedWith, @OrderedWith(%Cpp.long_long)> [concrete]
 // CHECK:STDOUT:   %OrderedWith.Less.type.bc1: type = fn_type @OrderedWith.Less, @OrderedWith(%Cpp.long_long) [concrete]
 // CHECK:STDOUT:   %OrderedWith.LessOrEquivalent.type.1cc: type = fn_type @OrderedWith.LessOrEquivalent, @OrderedWith(%Cpp.long_long) [concrete]
@@ -1966,68 +2354,52 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.31696a.1: %T.binding.as_type.as.OrderedWith.impl.Less.type.4623e2.1 = struct_value () [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.type.4623e2.2: type = fn_type @T.binding.as_type.as.OrderedWith.impl.Less.4, @T.binding.as_type.as.OrderedWith.impl.895(%T.ea5) [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.31696a.2: %T.binding.as_type.as.OrderedWith.impl.Less.type.4623e2.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.40683b.1: type = fn_type @Int.as.OrderedWith.impl.GreaterOrEquivalent.2, @Int.as.OrderedWith.impl.aba(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.abd089.1: %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.40683b.1 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.40683b.2: type = fn_type @Int.as.OrderedWith.impl.GreaterOrEquivalent.3, @Int.as.OrderedWith.impl.aba(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.abd089.2: %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.40683b.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.type.8b8cf7.1: type = fn_type @Int.as.OrderedWith.impl.Greater.2, @Int.as.OrderedWith.impl.aba(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.4a2789.1: %Int.as.OrderedWith.impl.Greater.type.8b8cf7.1 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.type.8b8cf7.2: type = fn_type @Int.as.OrderedWith.impl.Greater.3, @Int.as.OrderedWith.impl.aba(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.4a2789.2: %Int.as.OrderedWith.impl.Greater.type.8b8cf7.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.type.2a47fa.1: type = fn_type @Int.as.OrderedWith.impl.LessOrEquivalent.2, @Int.as.OrderedWith.impl.aba(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.52f78e.1: %Int.as.OrderedWith.impl.LessOrEquivalent.type.2a47fa.1 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.type.2a47fa.2: type = fn_type @Int.as.OrderedWith.impl.LessOrEquivalent.3, @Int.as.OrderedWith.impl.aba(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.52f78e.2: %Int.as.OrderedWith.impl.LessOrEquivalent.type.2a47fa.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.type.797264.1: type = fn_type @Int.as.OrderedWith.impl.Less.2, @Int.as.OrderedWith.impl.aba(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.c4a430.1: %Int.as.OrderedWith.impl.Less.type.797264.1 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.type.797264.2: type = fn_type @Int.as.OrderedWith.impl.Less.3, @Int.as.OrderedWith.impl.aba(%N, %T.354) [symbolic]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.c4a430.2: %Int.as.OrderedWith.impl.Less.type.797264.2 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OrderedWith.impl_witness.27d: <witness> = impl_witness imports.%OrderedWith.impl_witness_table.03f, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.type.0fa05d.1: type = fn_type @Int.as.OrderedWith.impl.Less.3, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.f7d683.1: %Int.as.OrderedWith.impl.Less.type.0fa05d.1 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.type.f1c847.1: type = fn_type @Int.as.OrderedWith.impl.LessOrEquivalent.3, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.56c691.1: %Int.as.OrderedWith.impl.LessOrEquivalent.type.f1c847.1 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.type.e91ea2.1: type = fn_type @Int.as.OrderedWith.impl.Greater.3, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.2b7c26.1: %Int.as.OrderedWith.impl.Greater.type.e91ea2.1 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.0e0c4f.1: type = fn_type @Int.as.OrderedWith.impl.GreaterOrEquivalent.3, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.1: %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.0e0c4f.1 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.type.0fa05d.2: type = fn_type @Int.as.OrderedWith.impl.Less.2, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.f7d683.2: %Int.as.OrderedWith.impl.Less.type.0fa05d.2 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.type.f1c847.2: type = fn_type @Int.as.OrderedWith.impl.LessOrEquivalent.2, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.56c691.2: %Int.as.OrderedWith.impl.LessOrEquivalent.type.f1c847.2 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.type.e91ea2.2: type = fn_type @Int.as.OrderedWith.impl.Greater.2, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.2b7c26.2: %Int.as.OrderedWith.impl.Greater.type.e91ea2.2 = struct_value () [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.0e0c4f.2: type = fn_type @Int.as.OrderedWith.impl.GreaterOrEquivalent.2, @Int.as.OrderedWith.impl.aba(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.2: %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.0e0c4f.2 = struct_value () [concrete]
-// CHECK:STDOUT:   %OrderedWith.facet.642: %OrderedWith.type.65e = facet_value %i64, (%OrderedWith.impl_witness.27d) [concrete]
-// CHECK:STDOUT:   %.8f1: type = fn_type_with_self_type %OrderedWith.Greater.type.921, %OrderedWith.facet.642 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.bound.d9ebd2.1: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.Greater.2b7c26.2 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.specific_fn.c215f8.1: <specific function> = specific_function %Int.as.OrderedWith.impl.Greater.2b7c26.2, @Int.as.OrderedWith.impl.Greater.2(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.8ea317.1: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.Greater.specific_fn.c215f8.1 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.bound.d9ebd2.2: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.Greater.2b7c26.1 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.specific_fn.c215f8.2: <specific function> = specific_function %Int.as.OrderedWith.impl.Greater.2b7c26.1, @Int.as.OrderedWith.impl.Greater.3(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.8ea317.2: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.Greater.specific_fn.c215f8.2 [concrete]
-// CHECK:STDOUT:   %.6ba: type = fn_type_with_self_type %OrderedWith.Less.type.bc1, %OrderedWith.facet.642 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.bound.d163a5.1: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.Less.f7d683.2 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.specific_fn.e635f0.1: <specific function> = specific_function %Int.as.OrderedWith.impl.Less.f7d683.2, @Int.as.OrderedWith.impl.Less.2(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.af4a52.1: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.Less.specific_fn.e635f0.1 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.bound.d163a5.2: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.Less.f7d683.1 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.specific_fn.e635f0.2: <specific function> = specific_function %Int.as.OrderedWith.impl.Less.f7d683.1, @Int.as.OrderedWith.impl.Less.3(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.af4a52.2: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.Less.specific_fn.e635f0.2 [concrete]
-// CHECK:STDOUT:   %.cf1: type = fn_type_with_self_type %OrderedWith.GreaterOrEquivalent.type.fcf, %OrderedWith.facet.642 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.bound.e6a2af.1: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.2 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.751116.1: <specific function> = specific_function %Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.2, @Int.as.OrderedWith.impl.GreaterOrEquivalent.2(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.e2b9a3.1: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.751116.1 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.bound.e6a2af.2: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.1 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.751116.2: <specific function> = specific_function %Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.1, @Int.as.OrderedWith.impl.GreaterOrEquivalent.3(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.e2b9a3.2: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.751116.2 [concrete]
-// CHECK:STDOUT:   %.ec7: type = fn_type_with_self_type %OrderedWith.LessOrEquivalent.type.1cc, %OrderedWith.facet.642 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.bound.2ed161.1: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.LessOrEquivalent.56c691.2 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.100dc7.1: <specific function> = specific_function %Int.as.OrderedWith.impl.LessOrEquivalent.56c691.2, @Int.as.OrderedWith.impl.LessOrEquivalent.2(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.cb16a7.1: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.100dc7.1 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.bound.2ed161.2: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.LessOrEquivalent.56c691.1 [concrete]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.100dc7.2: <specific function> = specific_function %Int.as.OrderedWith.impl.LessOrEquivalent.56c691.1, @Int.as.OrderedWith.impl.LessOrEquivalent.3(%int_64, %ImplicitAs.facet.660) [concrete]
-// CHECK:STDOUT:   %bound_method.cb16a7.2: <bound method> = bound_method %int_1.41a, %Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.100dc7.2 [concrete]
+// CHECK:STDOUT:   %OrderedWith.impl_witness.5fb: <witness> = impl_witness imports.%OrderedWith.impl_witness_table.8cd, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.type.8c7c29.1: type = fn_type @T.binding.as_type.as.OrderedWith.impl.Less.4, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.4846a7.1: %T.binding.as_type.as.OrderedWith.impl.Less.type.8c7c29.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bba1e4.1: type = fn_type @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.4, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.1: %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bba1e4.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.type.125113.1: type = fn_type @T.binding.as_type.as.OrderedWith.impl.Greater.4, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.356766.1: %T.binding.as_type.as.OrderedWith.impl.Greater.type.125113.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.6d7684.1: type = fn_type @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.4, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.1: %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.6d7684.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.type.8c7c29.2: type = fn_type @T.binding.as_type.as.OrderedWith.impl.Less.3, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.4846a7.2: %T.binding.as_type.as.OrderedWith.impl.Less.type.8c7c29.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bba1e4.2: type = fn_type @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.3, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.2: %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bba1e4.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.type.125113.2: type = fn_type @T.binding.as_type.as.OrderedWith.impl.Greater.3, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.356766.2: %T.binding.as_type.as.OrderedWith.impl.Greater.type.125113.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.6d7684.2: type = fn_type @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.3, @T.binding.as_type.as.OrderedWith.impl.895(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.2: %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.6d7684.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %OrderedWith.facet.2d0: %OrderedWith.type.65e = facet_value %i64, (%OrderedWith.impl_witness.5fb) [concrete]
+// CHECK:STDOUT:   %.ed1: type = fn_type_with_self_type %OrderedWith.Greater.type.921, %OrderedWith.facet.2d0 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.bound.f119ae.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.Greater.356766.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.fc67f6.1: <specific function> = specific_function %T.binding.as_type.as.OrderedWith.impl.Greater.356766.2, @T.binding.as_type.as.OrderedWith.impl.Greater.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.cbabde.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.fc67f6.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.bound.f119ae.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.Greater.356766.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.fc67f6.2: <specific function> = specific_function %T.binding.as_type.as.OrderedWith.impl.Greater.356766.1, @T.binding.as_type.as.OrderedWith.impl.Greater.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.cbabde.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.fc67f6.2 [concrete]
+// CHECK:STDOUT:   %.c89: type = fn_type_with_self_type %OrderedWith.Less.type.bc1, %OrderedWith.facet.2d0 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.bound.2ac964.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.Less.4846a7.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.ab0306.1: <specific function> = specific_function %T.binding.as_type.as.OrderedWith.impl.Less.4846a7.2, @T.binding.as_type.as.OrderedWith.impl.Less.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.72fc63.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.ab0306.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.bound.2ac964.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.Less.4846a7.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.ab0306.2: <specific function> = specific_function %T.binding.as_type.as.OrderedWith.impl.Less.4846a7.1, @T.binding.as_type.as.OrderedWith.impl.Less.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.72fc63.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.ab0306.2 [concrete]
+// CHECK:STDOUT:   %.00e: type = fn_type_with_self_type %OrderedWith.GreaterOrEquivalent.type.fcf, %OrderedWith.facet.2d0 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.eaeae7.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.b93d5d.1: <specific function> = specific_function %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.2, @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.eaf797.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.b93d5d.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.eaeae7.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.b93d5d.2: <specific function> = specific_function %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.1, @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.eaf797.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.b93d5d.2 [concrete]
+// CHECK:STDOUT:   %.3fe: type = fn_type_with_self_type %OrderedWith.LessOrEquivalent.type.1cc, %OrderedWith.facet.2d0 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.e5c103.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.67339b.1: <specific function> = specific_function %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.2, @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.e08cee.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.67339b.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.e5c103.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.67339b.2: <specific function> = specific_function %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.1, @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.e08cee.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.67339b.2 [concrete]
 // CHECK:STDOUT:   %EqWith.impl_witness.a59: <witness> = impl_witness imports.%EqWith.impl_witness_table.7e5, @T.binding.as_type.as.EqWith.impl.b07(%ImplicitAs.facet.d52) [concrete]
 // CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.type.e71550.1: type = fn_type @T.binding.as_type.as.EqWith.impl.Equal.4, @T.binding.as_type.as.EqWith.impl.b07(%ImplicitAs.facet.d52) [concrete]
 // CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.3cf73d.1: %T.binding.as_type.as.EqWith.impl.Equal.type.e71550.1 = struct_value () [concrete]
@@ -2122,15 +2494,10 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %EqWith.impl_witness_table.7e5 = impl_witness_table (%Core.import_ref.eb5, %Core.import_ref.597), @T.binding.as_type.as.EqWith.impl.b07 [concrete]
 // CHECK:STDOUT:   %Core.NotEqual.421: @T.binding.as_type.as.EqWith.impl.b07.%T.binding.as_type.as.EqWith.impl.NotEqual.type.1 (%T.binding.as_type.as.EqWith.impl.NotEqual.type.d96a78.2) = import_ref Core//prelude/types/cpp/int, NotEqual, loaded [symbolic = @T.binding.as_type.as.EqWith.impl.b07.%T.binding.as_type.as.EqWith.impl.NotEqual.1 (constants.%T.binding.as_type.as.EqWith.impl.NotEqual.83a9a5.2)]
 // CHECK:STDOUT:   %Core.Equal.d94: @T.binding.as_type.as.EqWith.impl.b07.%T.binding.as_type.as.EqWith.impl.Equal.type.1 (%T.binding.as_type.as.EqWith.impl.Equal.type.066d1d.2) = import_ref Core//prelude/types/cpp/int, Equal, loaded [symbolic = @T.binding.as_type.as.EqWith.impl.b07.%T.binding.as_type.as.EqWith.impl.Equal.1 (constants.%T.binding.as_type.as.EqWith.impl.Equal.bbf235.2)]
-// CHECK:STDOUT:   %Core.import_ref.613: @Int.as.EqWith.impl.42c.%Int.as.EqWith.impl.Equal.type.2 (%Int.as.EqWith.impl.Equal.type.a94820.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.EqWith.impl.42c.%Int.as.EqWith.impl.Equal.2 (constants.%Int.as.EqWith.impl.Equal.737ae8.1)]
-// CHECK:STDOUT:   %Core.import_ref.23d: @Int.as.EqWith.impl.42c.%Int.as.EqWith.impl.NotEqual.type.2 (%Int.as.EqWith.impl.NotEqual.type.db1e05.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.EqWith.impl.42c.%Int.as.EqWith.impl.NotEqual.2 (constants.%Int.as.EqWith.impl.NotEqual.088a98.1)]
-// CHECK:STDOUT:   %EqWith.impl_witness_table.600 = impl_witness_table (%Core.import_ref.613, %Core.import_ref.23d), @Int.as.EqWith.impl.42c [concrete]
-// CHECK:STDOUT:   %Core.NotEqual.334: @Int.as.EqWith.impl.42c.%Int.as.EqWith.impl.NotEqual.type.1 (%Int.as.EqWith.impl.NotEqual.type.db1e05.2) = import_ref Core//prelude/types/int, NotEqual, loaded [symbolic = @Int.as.EqWith.impl.42c.%Int.as.EqWith.impl.NotEqual.1 (constants.%Int.as.EqWith.impl.NotEqual.088a98.2)]
-// CHECK:STDOUT:   %Core.Equal.ca9: @Int.as.EqWith.impl.42c.%Int.as.EqWith.impl.Equal.type.1 (%Int.as.EqWith.impl.Equal.type.a94820.2) = import_ref Core//prelude/types/int, Equal, loaded [symbolic = @Int.as.EqWith.impl.42c.%Int.as.EqWith.impl.Equal.1 (constants.%Int.as.EqWith.impl.Equal.737ae8.2)]
 // CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
-// CHECK:STDOUT:   %Core.import_ref.91c: %Cpp.long_long.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.563 = impl_witness_table (%Core.import_ref.91c), @Cpp.long_long.as.ImplicitAs.impl.034 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.4f4b: %i64.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.b19 = impl_witness_table (%Core.import_ref.4f4b), @i64.as.ImplicitAs.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.d4b: @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.Less.type.2 (%T.binding.as_type.as.OrderedWith.impl.Less.type.4623e2.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.Less.2 (constants.%T.binding.as_type.as.OrderedWith.impl.Less.31696a.1)]
 // CHECK:STDOUT:   %Core.import_ref.54d: @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.2 (%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bfda3a.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.2 (constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.d63604.1)]
 // CHECK:STDOUT:   %Core.import_ref.aa8: @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.Greater.type.2 (%T.binding.as_type.as.OrderedWith.impl.Greater.type.1733df.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.Greater.2 (constants.%T.binding.as_type.as.OrderedWith.impl.Greater.07eebf.1)]
@@ -2140,15 +2507,6 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %Core.Greater.cff: @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.Greater.type.1 (%T.binding.as_type.as.OrderedWith.impl.Greater.type.1733df.2) = import_ref Core//prelude/types/cpp/int, Greater, loaded [symbolic = @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.Greater.1 (constants.%T.binding.as_type.as.OrderedWith.impl.Greater.07eebf.2)]
 // CHECK:STDOUT:   %Core.LessOrEquivalent.792: @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.1 (%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bfda3a.2) = import_ref Core//prelude/types/cpp/int, LessOrEquivalent, loaded [symbolic = @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.1 (constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.d63604.2)]
 // CHECK:STDOUT:   %Core.Less.aac: @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.Less.type.1 (%T.binding.as_type.as.OrderedWith.impl.Less.type.4623e2.2) = import_ref Core//prelude/types/cpp/int, Less, loaded [symbolic = @T.binding.as_type.as.OrderedWith.impl.895.%T.binding.as_type.as.OrderedWith.impl.Less.1 (constants.%T.binding.as_type.as.OrderedWith.impl.Less.31696a.2)]
-// CHECK:STDOUT:   %Core.import_ref.711: @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.Less.type.2 (%Int.as.OrderedWith.impl.Less.type.797264.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.Less.2 (constants.%Int.as.OrderedWith.impl.Less.c4a430.1)]
-// CHECK:STDOUT:   %Core.import_ref.0b3: @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.LessOrEquivalent.type.2 (%Int.as.OrderedWith.impl.LessOrEquivalent.type.2a47fa.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.LessOrEquivalent.2 (constants.%Int.as.OrderedWith.impl.LessOrEquivalent.52f78e.1)]
-// CHECK:STDOUT:   %Core.import_ref.d5e: @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.Greater.type.2 (%Int.as.OrderedWith.impl.Greater.type.8b8cf7.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.Greater.2 (constants.%Int.as.OrderedWith.impl.Greater.4a2789.1)]
-// CHECK:STDOUT:   %Core.import_ref.a06: @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.GreaterOrEquivalent.type.2 (%Int.as.OrderedWith.impl.GreaterOrEquivalent.type.40683b.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.GreaterOrEquivalent.2 (constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.abd089.1)]
-// CHECK:STDOUT:   %OrderedWith.impl_witness_table.03f = impl_witness_table (%Core.import_ref.711, %Core.import_ref.0b3, %Core.import_ref.d5e, %Core.import_ref.a06), @Int.as.OrderedWith.impl.aba [concrete]
-// CHECK:STDOUT:   %Core.GreaterOrEquivalent.757: @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.GreaterOrEquivalent.type.1 (%Int.as.OrderedWith.impl.GreaterOrEquivalent.type.40683b.2) = import_ref Core//prelude/types/int, GreaterOrEquivalent, loaded [symbolic = @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.GreaterOrEquivalent.1 (constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.abd089.2)]
-// CHECK:STDOUT:   %Core.Greater.cd9: @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.Greater.type.1 (%Int.as.OrderedWith.impl.Greater.type.8b8cf7.2) = import_ref Core//prelude/types/int, Greater, loaded [symbolic = @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.Greater.1 (constants.%Int.as.OrderedWith.impl.Greater.4a2789.2)]
-// CHECK:STDOUT:   %Core.LessOrEquivalent.c5f: @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.LessOrEquivalent.type.1 (%Int.as.OrderedWith.impl.LessOrEquivalent.type.2a47fa.2) = import_ref Core//prelude/types/int, LessOrEquivalent, loaded [symbolic = @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.LessOrEquivalent.1 (constants.%Int.as.OrderedWith.impl.LessOrEquivalent.52f78e.2)]
-// CHECK:STDOUT:   %Core.Less.df4: @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.Less.type.1 (%Int.as.OrderedWith.impl.Less.type.797264.2) = import_ref Core//prelude/types/int, Less, loaded [symbolic = @Int.as.OrderedWith.impl.aba.%Int.as.OrderedWith.impl.Less.1 (constants.%Int.as.OrderedWith.impl.Less.c4a430.2)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @ComparisonsHeterogeneousLongLongRightSide() {
@@ -2170,159 +2528,159 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %int_1.loc9: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_64.loc9: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
 // CHECK:STDOUT:   %i64.loc9: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
-// CHECK:STDOUT:   %impl.elem0.loc9_6: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
-// CHECK:STDOUT:   %bound_method.loc9_6.1: <bound method> = bound_method %int_1.loc9, %impl.elem0.loc9_6 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc9_6: <specific function> = specific_function %impl.elem0.loc9_6, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %impl.elem0.loc9_6.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc9_6.1: <bound method> = bound_method %int_1.loc9, %impl.elem0.loc9_6.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc9_6: <specific function> = specific_function %impl.elem0.loc9_6.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc9_6.2: <bound method> = bound_method %int_1.loc9, %specific_fn.loc9_6 [concrete = constants.%bound_method.41b]
 // CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc9: init %i64 = call %bound_method.loc9_6.2(%int_1.loc9) [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc9_6.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc9 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc9_6.2: %i64 = converted %int_1.loc9, %.loc9_6.1 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %a.ref.loc9: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem0.loc9_14: %.144 = impl_witness_access constants.%EqWith.impl_witness.367, element0 [concrete = constants.%Int.as.EqWith.impl.Equal.e49d18.2]
-// CHECK:STDOUT:   %bound_method.loc9_14.1: <bound method> = bound_method %.loc9_6.2, %impl.elem0.loc9_14 [concrete = constants.%Int.as.EqWith.impl.Equal.bound.e9a871.1]
-// CHECK:STDOUT:   %specific_fn.loc9_14: <specific function> = specific_function %impl.elem0.loc9_14, @Int.as.EqWith.impl.Equal.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.Equal.specific_fn.443739.1]
-// CHECK:STDOUT:   %bound_method.loc9_14.2: <bound method> = bound_method %.loc9_6.2, %specific_fn.loc9_14 [concrete = constants.%bound_method.a45aed.1]
-// CHECK:STDOUT:   %.loc9_14: %Int.as.EqWith.impl.Equal.type.e5f20b.1 = specific_constant imports.%Core.Equal.ca9, @Int.as.EqWith.impl.42c(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.Equal.e49d18.1]
-// CHECK:STDOUT:   %Equal.ref.loc9: %Int.as.EqWith.impl.Equal.type.e5f20b.1 = name_ref Equal, %.loc9_14 [concrete = constants.%Int.as.EqWith.impl.Equal.e49d18.1]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.bound.loc9: <bound method> = bound_method %.loc9_6.2, %Equal.ref.loc9 [concrete = constants.%Int.as.EqWith.impl.Equal.bound.e9a871.2]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.specific_fn.loc9: <specific function> = specific_function %Equal.ref.loc9, @Int.as.EqWith.impl.Equal.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.Equal.specific_fn.443739.2]
-// CHECK:STDOUT:   %bound_method.loc9_14.3: <bound method> = bound_method %.loc9_6.2, %Int.as.EqWith.impl.Equal.specific_fn.loc9 [concrete = constants.%bound_method.a45aed.2]
-// CHECK:STDOUT:   %impl.elem0.loc9_17: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc9_17: <bound method> = bound_method %a.ref.loc9, %impl.elem0.loc9_17
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc9: init %i64 = call %bound_method.loc9_17(%a.ref.loc9)
-// CHECK:STDOUT:   %.loc9_17.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc9
-// CHECK:STDOUT:   %.loc9_17.2: %i64 = converted %a.ref.loc9, %.loc9_17.1
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.call.loc9: init bool = call %bound_method.loc9_14.3(%.loc9_6.2, %.loc9_17.2)
+// CHECK:STDOUT:   %impl.elem0.loc9_14: %.7df = impl_witness_access constants.%EqWith.impl_witness.52e, element0 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.971403.2]
+// CHECK:STDOUT:   %bound_method.loc9_14.1: <bound method> = bound_method %.loc9_6.2, %impl.elem0.loc9_14 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.bound.a06d0f.1]
+// CHECK:STDOUT:   %specific_fn.loc9_14: <specific function> = specific_function %impl.elem0.loc9_14, @T.binding.as_type.as.EqWith.impl.Equal.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.specific_fn.14854f.1]
+// CHECK:STDOUT:   %bound_method.loc9_14.2: <bound method> = bound_method %.loc9_6.2, %specific_fn.loc9_14 [concrete = constants.%bound_method.2aad7c.1]
+// CHECK:STDOUT:   %.loc9_14: %T.binding.as_type.as.EqWith.impl.Equal.type.5ab1af.1 = specific_constant imports.%Core.Equal.d94, @T.binding.as_type.as.EqWith.impl.b07(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.971403.1]
+// CHECK:STDOUT:   %Equal.ref.loc9: %T.binding.as_type.as.EqWith.impl.Equal.type.5ab1af.1 = name_ref Equal, %.loc9_14 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.971403.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.bound.loc9: <bound method> = bound_method %.loc9_6.2, %Equal.ref.loc9 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.bound.a06d0f.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.loc9: <specific function> = specific_function %Equal.ref.loc9, @T.binding.as_type.as.EqWith.impl.Equal.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.specific_fn.14854f.2]
+// CHECK:STDOUT:   %bound_method.loc9_14.3: <bound method> = bound_method %.loc9_6.2, %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.loc9 [concrete = constants.%bound_method.2aad7c.2]
+// CHECK:STDOUT:   %impl.elem0.loc9_6.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc9_6.3: <bound method> = bound_method %.loc9_6.2, %impl.elem0.loc9_6.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc9: init %Cpp.long_long = call %bound_method.loc9_6.3(%.loc9_6.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_6.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc9 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_6.4: %Cpp.long_long = converted %.loc9_6.2, %.loc9_6.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.call.loc9: init bool = call %bound_method.loc9_14.3(%.loc9_6.4, %a.ref.loc9)
 // CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_64.loc10: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
 // CHECK:STDOUT:   %i64.loc10: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
-// CHECK:STDOUT:   %impl.elem0.loc10_6: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
-// CHECK:STDOUT:   %bound_method.loc10_6.1: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10_6 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc10_6: <specific function> = specific_function %impl.elem0.loc10_6, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %impl.elem0.loc10_6.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc10_6.1: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10_6.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc10_6: <specific function> = specific_function %impl.elem0.loc10_6.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc10_6.2: <bound method> = bound_method %int_1.loc10, %specific_fn.loc10_6 [concrete = constants.%bound_method.41b]
 // CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc10: init %i64 = call %bound_method.loc10_6.2(%int_1.loc10) [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc10_6.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc10 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc10_6.2: %i64 = converted %int_1.loc10, %.loc10_6.1 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %a.ref.loc10: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem1.loc10: %.b78 = impl_witness_access constants.%EqWith.impl_witness.367, element1 [concrete = constants.%Int.as.EqWith.impl.NotEqual.af2dce.2]
-// CHECK:STDOUT:   %bound_method.loc10_14.1: <bound method> = bound_method %.loc10_6.2, %impl.elem1.loc10 [concrete = constants.%Int.as.EqWith.impl.NotEqual.bound.9611a1.1]
-// CHECK:STDOUT:   %specific_fn.loc10_14: <specific function> = specific_function %impl.elem1.loc10, @Int.as.EqWith.impl.NotEqual.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.NotEqual.specific_fn.044259.1]
-// CHECK:STDOUT:   %bound_method.loc10_14.2: <bound method> = bound_method %.loc10_6.2, %specific_fn.loc10_14 [concrete = constants.%bound_method.356533.1]
-// CHECK:STDOUT:   %.loc10_14: %Int.as.EqWith.impl.NotEqual.type.9ab064.1 = specific_constant imports.%Core.NotEqual.334, @Int.as.EqWith.impl.42c(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.NotEqual.af2dce.1]
-// CHECK:STDOUT:   %NotEqual.ref.loc10: %Int.as.EqWith.impl.NotEqual.type.9ab064.1 = name_ref NotEqual, %.loc10_14 [concrete = constants.%Int.as.EqWith.impl.NotEqual.af2dce.1]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.bound.loc10: <bound method> = bound_method %.loc10_6.2, %NotEqual.ref.loc10 [concrete = constants.%Int.as.EqWith.impl.NotEqual.bound.9611a1.2]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.specific_fn.loc10: <specific function> = specific_function %NotEqual.ref.loc10, @Int.as.EqWith.impl.NotEqual.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.NotEqual.specific_fn.044259.2]
-// CHECK:STDOUT:   %bound_method.loc10_14.3: <bound method> = bound_method %.loc10_6.2, %Int.as.EqWith.impl.NotEqual.specific_fn.loc10 [concrete = constants.%bound_method.356533.2]
-// CHECK:STDOUT:   %impl.elem0.loc10_17: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc10_17: <bound method> = bound_method %a.ref.loc10, %impl.elem0.loc10_17
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc10: init %i64 = call %bound_method.loc10_17(%a.ref.loc10)
-// CHECK:STDOUT:   %.loc10_17.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc10
-// CHECK:STDOUT:   %.loc10_17.2: %i64 = converted %a.ref.loc10, %.loc10_17.1
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.call.loc10: init bool = call %bound_method.loc10_14.3(%.loc10_6.2, %.loc10_17.2)
+// CHECK:STDOUT:   %impl.elem1.loc10: %.232 = impl_witness_access constants.%EqWith.impl_witness.52e, element1 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.2]
+// CHECK:STDOUT:   %bound_method.loc10_14.1: <bound method> = bound_method %.loc10_6.2, %impl.elem1.loc10 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bound.f4efb4.1]
+// CHECK:STDOUT:   %specific_fn.loc10_14: <specific function> = specific_function %impl.elem1.loc10, @T.binding.as_type.as.EqWith.impl.NotEqual.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.b0f056.1]
+// CHECK:STDOUT:   %bound_method.loc10_14.2: <bound method> = bound_method %.loc10_6.2, %specific_fn.loc10_14 [concrete = constants.%bound_method.fbe68b.1]
+// CHECK:STDOUT:   %.loc10_14: %T.binding.as_type.as.EqWith.impl.NotEqual.type.7cb54d.1 = specific_constant imports.%Core.NotEqual.421, @T.binding.as_type.as.EqWith.impl.b07(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.1]
+// CHECK:STDOUT:   %NotEqual.ref.loc10: %T.binding.as_type.as.EqWith.impl.NotEqual.type.7cb54d.1 = name_ref NotEqual, %.loc10_14 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.bound.loc10: <bound method> = bound_method %.loc10_6.2, %NotEqual.ref.loc10 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bound.f4efb4.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.loc10: <specific function> = specific_function %NotEqual.ref.loc10, @T.binding.as_type.as.EqWith.impl.NotEqual.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.b0f056.2]
+// CHECK:STDOUT:   %bound_method.loc10_14.3: <bound method> = bound_method %.loc10_6.2, %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.loc10 [concrete = constants.%bound_method.fbe68b.2]
+// CHECK:STDOUT:   %impl.elem0.loc10_6.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc10_6.3: <bound method> = bound_method %.loc10_6.2, %impl.elem0.loc10_6.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10_6.3(%.loc10_6.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_6.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_6.4: %Cpp.long_long = converted %.loc10_6.2, %.loc10_6.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.call.loc10: init bool = call %bound_method.loc10_14.3(%.loc10_6.4, %a.ref.loc10)
 // CHECK:STDOUT:   %int_1.loc11: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_64.loc11: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
 // CHECK:STDOUT:   %i64.loc11: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
-// CHECK:STDOUT:   %impl.elem0.loc11_6: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
-// CHECK:STDOUT:   %bound_method.loc11_6.1: <bound method> = bound_method %int_1.loc11, %impl.elem0.loc11_6 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc11_6: <specific function> = specific_function %impl.elem0.loc11_6, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %impl.elem0.loc11_6.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc11_6.1: <bound method> = bound_method %int_1.loc11, %impl.elem0.loc11_6.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc11_6: <specific function> = specific_function %impl.elem0.loc11_6.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc11_6.2: <bound method> = bound_method %int_1.loc11, %specific_fn.loc11_6 [concrete = constants.%bound_method.41b]
 // CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc11: init %i64 = call %bound_method.loc11_6.2(%int_1.loc11) [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc11_6.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc11 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc11_6.2: %i64 = converted %int_1.loc11, %.loc11_6.1 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %a.ref.loc11: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem2.loc11: %.8f1 = impl_witness_access constants.%OrderedWith.impl_witness.27d, element2 [concrete = constants.%Int.as.OrderedWith.impl.Greater.2b7c26.2]
-// CHECK:STDOUT:   %bound_method.loc11_14.1: <bound method> = bound_method %.loc11_6.2, %impl.elem2.loc11 [concrete = constants.%Int.as.OrderedWith.impl.Greater.bound.d9ebd2.1]
-// CHECK:STDOUT:   %specific_fn.loc11_14: <specific function> = specific_function %impl.elem2.loc11, @Int.as.OrderedWith.impl.Greater.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Greater.specific_fn.c215f8.1]
-// CHECK:STDOUT:   %bound_method.loc11_14.2: <bound method> = bound_method %.loc11_6.2, %specific_fn.loc11_14 [concrete = constants.%bound_method.8ea317.1]
-// CHECK:STDOUT:   %.loc11_14: %Int.as.OrderedWith.impl.Greater.type.e91ea2.1 = specific_constant imports.%Core.Greater.cd9, @Int.as.OrderedWith.impl.aba(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Greater.2b7c26.1]
-// CHECK:STDOUT:   %Greater.ref.loc11: %Int.as.OrderedWith.impl.Greater.type.e91ea2.1 = name_ref Greater, %.loc11_14 [concrete = constants.%Int.as.OrderedWith.impl.Greater.2b7c26.1]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.bound.loc11: <bound method> = bound_method %.loc11_6.2, %Greater.ref.loc11 [concrete = constants.%Int.as.OrderedWith.impl.Greater.bound.d9ebd2.2]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.specific_fn.loc11: <specific function> = specific_function %Greater.ref.loc11, @Int.as.OrderedWith.impl.Greater.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Greater.specific_fn.c215f8.2]
-// CHECK:STDOUT:   %bound_method.loc11_14.3: <bound method> = bound_method %.loc11_6.2, %Int.as.OrderedWith.impl.Greater.specific_fn.loc11 [concrete = constants.%bound_method.8ea317.2]
-// CHECK:STDOUT:   %impl.elem0.loc11_16: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc11_16: <bound method> = bound_method %a.ref.loc11, %impl.elem0.loc11_16
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc11: init %i64 = call %bound_method.loc11_16(%a.ref.loc11)
-// CHECK:STDOUT:   %.loc11_16.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc11
-// CHECK:STDOUT:   %.loc11_16.2: %i64 = converted %a.ref.loc11, %.loc11_16.1
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.call.loc11: init bool = call %bound_method.loc11_14.3(%.loc11_6.2, %.loc11_16.2)
+// CHECK:STDOUT:   %impl.elem2.loc11: %.ed1 = impl_witness_access constants.%OrderedWith.impl_witness.5fb, element2 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.356766.2]
+// CHECK:STDOUT:   %bound_method.loc11_14.1: <bound method> = bound_method %.loc11_6.2, %impl.elem2.loc11 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.bound.f119ae.1]
+// CHECK:STDOUT:   %specific_fn.loc11_14: <specific function> = specific_function %impl.elem2.loc11, @T.binding.as_type.as.OrderedWith.impl.Greater.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.fc67f6.1]
+// CHECK:STDOUT:   %bound_method.loc11_14.2: <bound method> = bound_method %.loc11_6.2, %specific_fn.loc11_14 [concrete = constants.%bound_method.cbabde.1]
+// CHECK:STDOUT:   %.loc11_14: %T.binding.as_type.as.OrderedWith.impl.Greater.type.125113.1 = specific_constant imports.%Core.Greater.cff, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.356766.1]
+// CHECK:STDOUT:   %Greater.ref.loc11: %T.binding.as_type.as.OrderedWith.impl.Greater.type.125113.1 = name_ref Greater, %.loc11_14 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.356766.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.bound.loc11: <bound method> = bound_method %.loc11_6.2, %Greater.ref.loc11 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.bound.f119ae.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.loc11: <specific function> = specific_function %Greater.ref.loc11, @T.binding.as_type.as.OrderedWith.impl.Greater.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.fc67f6.2]
+// CHECK:STDOUT:   %bound_method.loc11_14.3: <bound method> = bound_method %.loc11_6.2, %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.loc11 [concrete = constants.%bound_method.cbabde.2]
+// CHECK:STDOUT:   %impl.elem0.loc11_6.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc11_6.3: <bound method> = bound_method %.loc11_6.2, %impl.elem0.loc11_6.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc11: init %Cpp.long_long = call %bound_method.loc11_6.3(%.loc11_6.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_6.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_6.4: %Cpp.long_long = converted %.loc11_6.2, %.loc11_6.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.call.loc11: init bool = call %bound_method.loc11_14.3(%.loc11_6.4, %a.ref.loc11)
 // CHECK:STDOUT:   %int_1.loc12: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_64.loc12: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
 // CHECK:STDOUT:   %i64.loc12: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
-// CHECK:STDOUT:   %impl.elem0.loc12_6: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
-// CHECK:STDOUT:   %bound_method.loc12_6.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_6 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc12_6: <specific function> = specific_function %impl.elem0.loc12_6, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %impl.elem0.loc12_6.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc12_6.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_6.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc12_6: <specific function> = specific_function %impl.elem0.loc12_6.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc12_6.2: <bound method> = bound_method %int_1.loc12, %specific_fn.loc12_6 [concrete = constants.%bound_method.41b]
 // CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc12: init %i64 = call %bound_method.loc12_6.2(%int_1.loc12) [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc12_6.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc12 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc12_6.2: %i64 = converted %int_1.loc12, %.loc12_6.1 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %a.ref.loc12: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem0.loc12_14: %.6ba = impl_witness_access constants.%OrderedWith.impl_witness.27d, element0 [concrete = constants.%Int.as.OrderedWith.impl.Less.f7d683.2]
-// CHECK:STDOUT:   %bound_method.loc12_14.1: <bound method> = bound_method %.loc12_6.2, %impl.elem0.loc12_14 [concrete = constants.%Int.as.OrderedWith.impl.Less.bound.d163a5.1]
-// CHECK:STDOUT:   %specific_fn.loc12_14: <specific function> = specific_function %impl.elem0.loc12_14, @Int.as.OrderedWith.impl.Less.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Less.specific_fn.e635f0.1]
-// CHECK:STDOUT:   %bound_method.loc12_14.2: <bound method> = bound_method %.loc12_6.2, %specific_fn.loc12_14 [concrete = constants.%bound_method.af4a52.1]
-// CHECK:STDOUT:   %.loc12_14: %Int.as.OrderedWith.impl.Less.type.0fa05d.1 = specific_constant imports.%Core.Less.df4, @Int.as.OrderedWith.impl.aba(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Less.f7d683.1]
-// CHECK:STDOUT:   %Less.ref.loc12: %Int.as.OrderedWith.impl.Less.type.0fa05d.1 = name_ref Less, %.loc12_14 [concrete = constants.%Int.as.OrderedWith.impl.Less.f7d683.1]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.bound.loc12: <bound method> = bound_method %.loc12_6.2, %Less.ref.loc12 [concrete = constants.%Int.as.OrderedWith.impl.Less.bound.d163a5.2]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.specific_fn.loc12: <specific function> = specific_function %Less.ref.loc12, @Int.as.OrderedWith.impl.Less.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Less.specific_fn.e635f0.2]
-// CHECK:STDOUT:   %bound_method.loc12_14.3: <bound method> = bound_method %.loc12_6.2, %Int.as.OrderedWith.impl.Less.specific_fn.loc12 [concrete = constants.%bound_method.af4a52.2]
-// CHECK:STDOUT:   %impl.elem0.loc12_16: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc12_16: <bound method> = bound_method %a.ref.loc12, %impl.elem0.loc12_16
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc12: init %i64 = call %bound_method.loc12_16(%a.ref.loc12)
-// CHECK:STDOUT:   %.loc12_16.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc12
-// CHECK:STDOUT:   %.loc12_16.2: %i64 = converted %a.ref.loc12, %.loc12_16.1
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.call.loc12: init bool = call %bound_method.loc12_14.3(%.loc12_6.2, %.loc12_16.2)
+// CHECK:STDOUT:   %impl.elem0.loc12_14: %.c89 = impl_witness_access constants.%OrderedWith.impl_witness.5fb, element0 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.4846a7.2]
+// CHECK:STDOUT:   %bound_method.loc12_14.1: <bound method> = bound_method %.loc12_6.2, %impl.elem0.loc12_14 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.bound.2ac964.1]
+// CHECK:STDOUT:   %specific_fn.loc12_14: <specific function> = specific_function %impl.elem0.loc12_14, @T.binding.as_type.as.OrderedWith.impl.Less.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.ab0306.1]
+// CHECK:STDOUT:   %bound_method.loc12_14.2: <bound method> = bound_method %.loc12_6.2, %specific_fn.loc12_14 [concrete = constants.%bound_method.72fc63.1]
+// CHECK:STDOUT:   %.loc12_14: %T.binding.as_type.as.OrderedWith.impl.Less.type.8c7c29.1 = specific_constant imports.%Core.Less.aac, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.4846a7.1]
+// CHECK:STDOUT:   %Less.ref.loc12: %T.binding.as_type.as.OrderedWith.impl.Less.type.8c7c29.1 = name_ref Less, %.loc12_14 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.4846a7.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.bound.loc12: <bound method> = bound_method %.loc12_6.2, %Less.ref.loc12 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.bound.2ac964.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.loc12: <specific function> = specific_function %Less.ref.loc12, @T.binding.as_type.as.OrderedWith.impl.Less.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.ab0306.2]
+// CHECK:STDOUT:   %bound_method.loc12_14.3: <bound method> = bound_method %.loc12_6.2, %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.loc12 [concrete = constants.%bound_method.72fc63.2]
+// CHECK:STDOUT:   %impl.elem0.loc12_6.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_6.3: <bound method> = bound_method %.loc12_6.2, %impl.elem0.loc12_6.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12: init %Cpp.long_long = call %bound_method.loc12_6.3(%.loc12_6.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_6.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_6.4: %Cpp.long_long = converted %.loc12_6.2, %.loc12_6.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.call.loc12: init bool = call %bound_method.loc12_14.3(%.loc12_6.4, %a.ref.loc12)
 // CHECK:STDOUT:   %int_1.loc13: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_64.loc13: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
 // CHECK:STDOUT:   %i64.loc13: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
-// CHECK:STDOUT:   %impl.elem0.loc13_6: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
-// CHECK:STDOUT:   %bound_method.loc13_6.1: <bound method> = bound_method %int_1.loc13, %impl.elem0.loc13_6 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc13_6: <specific function> = specific_function %impl.elem0.loc13_6, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %impl.elem0.loc13_6.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc13_6.1: <bound method> = bound_method %int_1.loc13, %impl.elem0.loc13_6.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc13_6: <specific function> = specific_function %impl.elem0.loc13_6.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc13_6.2: <bound method> = bound_method %int_1.loc13, %specific_fn.loc13_6 [concrete = constants.%bound_method.41b]
 // CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc13: init %i64 = call %bound_method.loc13_6.2(%int_1.loc13) [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc13_6.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc13 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc13_6.2: %i64 = converted %int_1.loc13, %.loc13_6.1 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %a.ref.loc13: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem3.loc13: %.cf1 = impl_witness_access constants.%OrderedWith.impl_witness.27d, element3 [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.2]
-// CHECK:STDOUT:   %bound_method.loc13_14.1: <bound method> = bound_method %.loc13_6.2, %impl.elem3.loc13 [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.bound.e6a2af.1]
-// CHECK:STDOUT:   %specific_fn.loc13_14: <specific function> = specific_function %impl.elem3.loc13, @Int.as.OrderedWith.impl.GreaterOrEquivalent.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.751116.1]
-// CHECK:STDOUT:   %bound_method.loc13_14.2: <bound method> = bound_method %.loc13_6.2, %specific_fn.loc13_14 [concrete = constants.%bound_method.e2b9a3.1]
-// CHECK:STDOUT:   %.loc13_14: %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.0e0c4f.1 = specific_constant imports.%Core.GreaterOrEquivalent.757, @Int.as.OrderedWith.impl.aba(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.1]
-// CHECK:STDOUT:   %GreaterOrEquivalent.ref.loc13: %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.0e0c4f.1 = name_ref GreaterOrEquivalent, %.loc13_14 [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.1]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.bound.loc13: <bound method> = bound_method %.loc13_6.2, %GreaterOrEquivalent.ref.loc13 [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.bound.e6a2af.2]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc13: <specific function> = specific_function %GreaterOrEquivalent.ref.loc13, @Int.as.OrderedWith.impl.GreaterOrEquivalent.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.751116.2]
-// CHECK:STDOUT:   %bound_method.loc13_14.3: <bound method> = bound_method %.loc13_6.2, %Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc13 [concrete = constants.%bound_method.e2b9a3.2]
-// CHECK:STDOUT:   %impl.elem0.loc13_17: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc13_17: <bound method> = bound_method %a.ref.loc13, %impl.elem0.loc13_17
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc13: init %i64 = call %bound_method.loc13_17(%a.ref.loc13)
-// CHECK:STDOUT:   %.loc13_17.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc13
-// CHECK:STDOUT:   %.loc13_17.2: %i64 = converted %a.ref.loc13, %.loc13_17.1
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.call.loc13: init bool = call %bound_method.loc13_14.3(%.loc13_6.2, %.loc13_17.2)
+// CHECK:STDOUT:   %impl.elem3.loc13: %.00e = impl_witness_access constants.%OrderedWith.impl_witness.5fb, element3 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.2]
+// CHECK:STDOUT:   %bound_method.loc13_14.1: <bound method> = bound_method %.loc13_6.2, %impl.elem3.loc13 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.eaeae7.1]
+// CHECK:STDOUT:   %specific_fn.loc13_14: <specific function> = specific_function %impl.elem3.loc13, @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.b93d5d.1]
+// CHECK:STDOUT:   %bound_method.loc13_14.2: <bound method> = bound_method %.loc13_6.2, %specific_fn.loc13_14 [concrete = constants.%bound_method.eaf797.1]
+// CHECK:STDOUT:   %.loc13_14: %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.6d7684.1 = specific_constant imports.%Core.GreaterOrEquivalent.b91, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.1]
+// CHECK:STDOUT:   %GreaterOrEquivalent.ref.loc13: %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.6d7684.1 = name_ref GreaterOrEquivalent, %.loc13_14 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.loc13: <bound method> = bound_method %.loc13_6.2, %GreaterOrEquivalent.ref.loc13 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.eaeae7.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc13: <specific function> = specific_function %GreaterOrEquivalent.ref.loc13, @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.b93d5d.2]
+// CHECK:STDOUT:   %bound_method.loc13_14.3: <bound method> = bound_method %.loc13_6.2, %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc13 [concrete = constants.%bound_method.eaf797.2]
+// CHECK:STDOUT:   %impl.elem0.loc13_6.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_6.3: <bound method> = bound_method %.loc13_6.2, %impl.elem0.loc13_6.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13: init %Cpp.long_long = call %bound_method.loc13_6.3(%.loc13_6.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_6.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_6.4: %Cpp.long_long = converted %.loc13_6.2, %.loc13_6.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.call.loc13: init bool = call %bound_method.loc13_14.3(%.loc13_6.4, %a.ref.loc13)
 // CHECK:STDOUT:   %int_1.loc14: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %int_64.loc14: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
 // CHECK:STDOUT:   %i64.loc14: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
-// CHECK:STDOUT:   %impl.elem0.loc14_6: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
-// CHECK:STDOUT:   %bound_method.loc14_6.1: <bound method> = bound_method %int_1.loc14, %impl.elem0.loc14_6 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
-// CHECK:STDOUT:   %specific_fn.loc14_6: <specific function> = specific_function %impl.elem0.loc14_6, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %impl.elem0.loc14_6.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc14_6.1: <bound method> = bound_method %int_1.loc14, %impl.elem0.loc14_6.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc14_6: <specific function> = specific_function %impl.elem0.loc14_6.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc14_6.2: <bound method> = bound_method %int_1.loc14, %specific_fn.loc14_6 [concrete = constants.%bound_method.41b]
 // CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc14: init %i64 = call %bound_method.loc14_6.2(%int_1.loc14) [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc14_6.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc14 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %.loc14_6.2: %i64 = converted %int_1.loc14, %.loc14_6.1 [concrete = constants.%int_1.41a]
 // CHECK:STDOUT:   %a.ref.loc14: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem1.loc14: %.ec7 = impl_witness_access constants.%OrderedWith.impl_witness.27d, element1 [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.56c691.2]
-// CHECK:STDOUT:   %bound_method.loc14_14.1: <bound method> = bound_method %.loc14_6.2, %impl.elem1.loc14 [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.bound.2ed161.1]
-// CHECK:STDOUT:   %specific_fn.loc14_14: <specific function> = specific_function %impl.elem1.loc14, @Int.as.OrderedWith.impl.LessOrEquivalent.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.100dc7.1]
-// CHECK:STDOUT:   %bound_method.loc14_14.2: <bound method> = bound_method %.loc14_6.2, %specific_fn.loc14_14 [concrete = constants.%bound_method.cb16a7.1]
-// CHECK:STDOUT:   %.loc14_14: %Int.as.OrderedWith.impl.LessOrEquivalent.type.f1c847.1 = specific_constant imports.%Core.LessOrEquivalent.c5f, @Int.as.OrderedWith.impl.aba(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.56c691.1]
-// CHECK:STDOUT:   %LessOrEquivalent.ref.loc14: %Int.as.OrderedWith.impl.LessOrEquivalent.type.f1c847.1 = name_ref LessOrEquivalent, %.loc14_14 [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.56c691.1]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.bound.loc14: <bound method> = bound_method %.loc14_6.2, %LessOrEquivalent.ref.loc14 [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.bound.2ed161.2]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc14: <specific function> = specific_function %LessOrEquivalent.ref.loc14, @Int.as.OrderedWith.impl.LessOrEquivalent.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.100dc7.2]
-// CHECK:STDOUT:   %bound_method.loc14_14.3: <bound method> = bound_method %.loc14_6.2, %Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc14 [concrete = constants.%bound_method.cb16a7.2]
-// CHECK:STDOUT:   %impl.elem0.loc14_17: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc14_17: <bound method> = bound_method %a.ref.loc14, %impl.elem0.loc14_17
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc14: init %i64 = call %bound_method.loc14_17(%a.ref.loc14)
-// CHECK:STDOUT:   %.loc14_17.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc14
-// CHECK:STDOUT:   %.loc14_17.2: %i64 = converted %a.ref.loc14, %.loc14_17.1
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.call.loc14: init bool = call %bound_method.loc14_14.3(%.loc14_6.2, %.loc14_17.2)
+// CHECK:STDOUT:   %impl.elem1.loc14: %.3fe = impl_witness_access constants.%OrderedWith.impl_witness.5fb, element1 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.2]
+// CHECK:STDOUT:   %bound_method.loc14_14.1: <bound method> = bound_method %.loc14_6.2, %impl.elem1.loc14 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.e5c103.1]
+// CHECK:STDOUT:   %specific_fn.loc14_14: <specific function> = specific_function %impl.elem1.loc14, @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.67339b.1]
+// CHECK:STDOUT:   %bound_method.loc14_14.2: <bound method> = bound_method %.loc14_6.2, %specific_fn.loc14_14 [concrete = constants.%bound_method.e08cee.1]
+// CHECK:STDOUT:   %.loc14_14: %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bba1e4.1 = specific_constant imports.%Core.LessOrEquivalent.792, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.1]
+// CHECK:STDOUT:   %LessOrEquivalent.ref.loc14: %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bba1e4.1 = name_ref LessOrEquivalent, %.loc14_14 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.loc14: <bound method> = bound_method %.loc14_6.2, %LessOrEquivalent.ref.loc14 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.e5c103.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc14: <specific function> = specific_function %LessOrEquivalent.ref.loc14, @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.67339b.2]
+// CHECK:STDOUT:   %bound_method.loc14_14.3: <bound method> = bound_method %.loc14_6.2, %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc14 [concrete = constants.%bound_method.e08cee.2]
+// CHECK:STDOUT:   %impl.elem0.loc14_6.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc14_6.3: <bound method> = bound_method %.loc14_6.2, %impl.elem0.loc14_6.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc14: init %Cpp.long_long = call %bound_method.loc14_6.3(%.loc14_6.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_6.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc14 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_6.4: %Cpp.long_long = converted %.loc14_6.2, %.loc14_6.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.call.loc14: init bool = call %bound_method.loc14_14.3(%.loc14_6.4, %a.ref.loc14)
 // CHECK:STDOUT:   %int_1.loc16: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %a.ref.loc16: %Cpp.long_long = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem0.loc16_5: %.90a = impl_witness_access constants.%EqWith.impl_witness.a59, element0 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.3cf73d.2]
@@ -2331,15 +2689,15 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %bound_method.loc16_5.2: <bound method> = bound_method %int_1.loc16, %specific_fn.loc16 [concrete = constants.%bound_method.1699f5.1]
 // CHECK:STDOUT:   %.loc16_5: %T.binding.as_type.as.EqWith.impl.Equal.type.e71550.1 = specific_constant imports.%Core.Equal.d94, @T.binding.as_type.as.EqWith.impl.b07(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.3cf73d.1]
 // CHECK:STDOUT:   %Equal.ref.loc16: %T.binding.as_type.as.EqWith.impl.Equal.type.e71550.1 = name_ref Equal, %.loc16_5 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.3cf73d.1]
-// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.bound: <bound method> = bound_method %int_1.loc16, %Equal.ref.loc16 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.bound.e0853e.2]
-// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.specific_fn: <specific function> = specific_function %Equal.ref.loc16, @T.binding.as_type.as.EqWith.impl.Equal.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.specific_fn.54d028.2]
-// CHECK:STDOUT:   %bound_method.loc16_5.3: <bound method> = bound_method %int_1.loc16, %T.binding.as_type.as.EqWith.impl.Equal.specific_fn [concrete = constants.%bound_method.1699f5.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.bound.loc16: <bound method> = bound_method %int_1.loc16, %Equal.ref.loc16 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.bound.e0853e.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.loc16: <specific function> = specific_function %Equal.ref.loc16, @T.binding.as_type.as.EqWith.impl.Equal.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.specific_fn.54d028.2]
+// CHECK:STDOUT:   %bound_method.loc16_5.3: <bound method> = bound_method %int_1.loc16, %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.loc16 [concrete = constants.%bound_method.1699f5.2]
 // CHECK:STDOUT:   %impl.elem0.loc16_3: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
 // CHECK:STDOUT:   %bound_method.loc16_3: <bound method> = bound_method %int_1.loc16, %impl.elem0.loc16_3 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc16: init %Cpp.long_long = call %bound_method.loc16_3(%int_1.loc16) [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc16_3.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc16 [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc16_3.2: %Cpp.long_long = converted %int_1.loc16, %.loc16_3.1 [concrete = constants.%int_1.092]
-// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.call: init bool = call %bound_method.loc16_5.3(%.loc16_3.2, %a.ref.loc16)
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.call.loc16: init bool = call %bound_method.loc16_5.3(%.loc16_3.2, %a.ref.loc16)
 // CHECK:STDOUT:   %int_1.loc17: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %a.ref.loc17: %Cpp.long_long = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem1.loc17: %.d05 = impl_witness_access constants.%EqWith.impl_witness.a59, element1 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.55dccd.2]
@@ -2348,15 +2706,15 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %bound_method.loc17_5.2: <bound method> = bound_method %int_1.loc17, %specific_fn.loc17 [concrete = constants.%bound_method.7aede5.1]
 // CHECK:STDOUT:   %.loc17_5: %T.binding.as_type.as.EqWith.impl.NotEqual.type.635206.1 = specific_constant imports.%Core.NotEqual.421, @T.binding.as_type.as.EqWith.impl.b07(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.55dccd.1]
 // CHECK:STDOUT:   %NotEqual.ref.loc17: %T.binding.as_type.as.EqWith.impl.NotEqual.type.635206.1 = name_ref NotEqual, %.loc17_5 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.55dccd.1]
-// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.bound: <bound method> = bound_method %int_1.loc17, %NotEqual.ref.loc17 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bound.0bb6c5.2]
-// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn: <specific function> = specific_function %NotEqual.ref.loc17, @T.binding.as_type.as.EqWith.impl.NotEqual.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.d399fc.2]
-// CHECK:STDOUT:   %bound_method.loc17_5.3: <bound method> = bound_method %int_1.loc17, %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn [concrete = constants.%bound_method.7aede5.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.bound.loc17: <bound method> = bound_method %int_1.loc17, %NotEqual.ref.loc17 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bound.0bb6c5.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.loc17: <specific function> = specific_function %NotEqual.ref.loc17, @T.binding.as_type.as.EqWith.impl.NotEqual.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.d399fc.2]
+// CHECK:STDOUT:   %bound_method.loc17_5.3: <bound method> = bound_method %int_1.loc17, %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.loc17 [concrete = constants.%bound_method.7aede5.2]
 // CHECK:STDOUT:   %impl.elem0.loc17: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
 // CHECK:STDOUT:   %bound_method.loc17_3: <bound method> = bound_method %int_1.loc17, %impl.elem0.loc17 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc17: init %Cpp.long_long = call %bound_method.loc17_3(%int_1.loc17) [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc17_3.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc17 [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc17_3.2: %Cpp.long_long = converted %int_1.loc17, %.loc17_3.1 [concrete = constants.%int_1.092]
-// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.call: init bool = call %bound_method.loc17_5.3(%.loc17_3.2, %a.ref.loc17)
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.call.loc17: init bool = call %bound_method.loc17_5.3(%.loc17_3.2, %a.ref.loc17)
 // CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %a.ref.loc18: %Cpp.long_long = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem2.loc18: %.5c6 = impl_witness_access constants.%OrderedWith.impl_witness.aae, element2 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.9aafa8.2]
@@ -2365,15 +2723,15 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %bound_method.loc18_5.2: <bound method> = bound_method %int_1.loc18, %specific_fn.loc18 [concrete = constants.%bound_method.a32da1.1]
 // CHECK:STDOUT:   %.loc18_5: %T.binding.as_type.as.OrderedWith.impl.Greater.type.e76509.1 = specific_constant imports.%Core.Greater.cff, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.9aafa8.1]
 // CHECK:STDOUT:   %Greater.ref.loc18: %T.binding.as_type.as.OrderedWith.impl.Greater.type.e76509.1 = name_ref Greater, %.loc18_5 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.9aafa8.1]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.bound: <bound method> = bound_method %int_1.loc18, %Greater.ref.loc18 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.bound.483e05.2]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn: <specific function> = specific_function %Greater.ref.loc18, @T.binding.as_type.as.OrderedWith.impl.Greater.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.d2b07b.2]
-// CHECK:STDOUT:   %bound_method.loc18_5.3: <bound method> = bound_method %int_1.loc18, %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn [concrete = constants.%bound_method.a32da1.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.bound.loc18: <bound method> = bound_method %int_1.loc18, %Greater.ref.loc18 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.bound.483e05.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.loc18: <specific function> = specific_function %Greater.ref.loc18, @T.binding.as_type.as.OrderedWith.impl.Greater.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.d2b07b.2]
+// CHECK:STDOUT:   %bound_method.loc18_5.3: <bound method> = bound_method %int_1.loc18, %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.loc18 [concrete = constants.%bound_method.a32da1.2]
 // CHECK:STDOUT:   %impl.elem0.loc18: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
 // CHECK:STDOUT:   %bound_method.loc18_3: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18: init %Cpp.long_long = call %bound_method.loc18_3(%int_1.loc18) [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc18_3.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18 [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc18_3.2: %Cpp.long_long = converted %int_1.loc18, %.loc18_3.1 [concrete = constants.%int_1.092]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.call: init bool = call %bound_method.loc18_5.3(%.loc18_3.2, %a.ref.loc18)
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.call.loc18: init bool = call %bound_method.loc18_5.3(%.loc18_3.2, %a.ref.loc18)
 // CHECK:STDOUT:   %int_1.loc19: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %a.ref.loc19: %Cpp.long_long = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem0.loc19_5: %.f13 = impl_witness_access constants.%OrderedWith.impl_witness.aae, element0 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.e8fdd7.2]
@@ -2382,15 +2740,15 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %bound_method.loc19_5.2: <bound method> = bound_method %int_1.loc19, %specific_fn.loc19 [concrete = constants.%bound_method.8f808d.1]
 // CHECK:STDOUT:   %.loc19_5: %T.binding.as_type.as.OrderedWith.impl.Less.type.987d0b.1 = specific_constant imports.%Core.Less.aac, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.e8fdd7.1]
 // CHECK:STDOUT:   %Less.ref.loc19: %T.binding.as_type.as.OrderedWith.impl.Less.type.987d0b.1 = name_ref Less, %.loc19_5 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.e8fdd7.1]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.bound: <bound method> = bound_method %int_1.loc19, %Less.ref.loc19 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.bound.66e1cb.2]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn: <specific function> = specific_function %Less.ref.loc19, @T.binding.as_type.as.OrderedWith.impl.Less.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.06ee45.2]
-// CHECK:STDOUT:   %bound_method.loc19_5.3: <bound method> = bound_method %int_1.loc19, %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn [concrete = constants.%bound_method.8f808d.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.bound.loc19: <bound method> = bound_method %int_1.loc19, %Less.ref.loc19 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.bound.66e1cb.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.loc19: <specific function> = specific_function %Less.ref.loc19, @T.binding.as_type.as.OrderedWith.impl.Less.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.06ee45.2]
+// CHECK:STDOUT:   %bound_method.loc19_5.3: <bound method> = bound_method %int_1.loc19, %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.loc19 [concrete = constants.%bound_method.8f808d.2]
 // CHECK:STDOUT:   %impl.elem0.loc19_3: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
 // CHECK:STDOUT:   %bound_method.loc19_3: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19_3 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19: init %Cpp.long_long = call %bound_method.loc19_3(%int_1.loc19) [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc19_3.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19 [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc19_3.2: %Cpp.long_long = converted %int_1.loc19, %.loc19_3.1 [concrete = constants.%int_1.092]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.call: init bool = call %bound_method.loc19_5.3(%.loc19_3.2, %a.ref.loc19)
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.call.loc19: init bool = call %bound_method.loc19_5.3(%.loc19_3.2, %a.ref.loc19)
 // CHECK:STDOUT:   %int_1.loc20: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %a.ref.loc20: %Cpp.long_long = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem3.loc20: %.184 = impl_witness_access constants.%OrderedWith.impl_witness.aae, element3 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.755c9d.2]
@@ -2399,15 +2757,15 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %bound_method.loc20_5.2: <bound method> = bound_method %int_1.loc20, %specific_fn.loc20 [concrete = constants.%bound_method.2c548f.1]
 // CHECK:STDOUT:   %.loc20_5: %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.fc9354.1 = specific_constant imports.%Core.GreaterOrEquivalent.b91, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.755c9d.1]
 // CHECK:STDOUT:   %GreaterOrEquivalent.ref.loc20: %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.fc9354.1 = name_ref GreaterOrEquivalent, %.loc20_5 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.755c9d.1]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound: <bound method> = bound_method %int_1.loc20, %GreaterOrEquivalent.ref.loc20 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.b10f47.2]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn: <specific function> = specific_function %GreaterOrEquivalent.ref.loc20, @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.ca5627.2]
-// CHECK:STDOUT:   %bound_method.loc20_5.3: <bound method> = bound_method %int_1.loc20, %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn [concrete = constants.%bound_method.2c548f.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.loc20: <bound method> = bound_method %int_1.loc20, %GreaterOrEquivalent.ref.loc20 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.b10f47.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc20: <specific function> = specific_function %GreaterOrEquivalent.ref.loc20, @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.ca5627.2]
+// CHECK:STDOUT:   %bound_method.loc20_5.3: <bound method> = bound_method %int_1.loc20, %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc20 [concrete = constants.%bound_method.2c548f.2]
 // CHECK:STDOUT:   %impl.elem0.loc20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
 // CHECK:STDOUT:   %bound_method.loc20_3: <bound method> = bound_method %int_1.loc20, %impl.elem0.loc20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20: init %Cpp.long_long = call %bound_method.loc20_3(%int_1.loc20) [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc20_3.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20 [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc20_3.2: %Cpp.long_long = converted %int_1.loc20, %.loc20_3.1 [concrete = constants.%int_1.092]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.call: init bool = call %bound_method.loc20_5.3(%.loc20_3.2, %a.ref.loc20)
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.call.loc20: init bool = call %bound_method.loc20_5.3(%.loc20_3.2, %a.ref.loc20)
 // CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
 // CHECK:STDOUT:   %a.ref.loc21: %Cpp.long_long = name_ref a, %a
 // CHECK:STDOUT:   %impl.elem1.loc21: %.5f9 = impl_witness_access constants.%OrderedWith.impl_witness.aae, element1 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.9bb133.2]
@@ -2416,15 +2774,15 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %bound_method.loc21_5.2: <bound method> = bound_method %int_1.loc21, %specific_fn.loc21 [concrete = constants.%bound_method.caef99.1]
 // CHECK:STDOUT:   %.loc21_5: %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.39171f.1 = specific_constant imports.%Core.LessOrEquivalent.792, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.9bb133.1]
 // CHECK:STDOUT:   %LessOrEquivalent.ref.loc21: %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.39171f.1 = name_ref LessOrEquivalent, %.loc21_5 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.9bb133.1]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound: <bound method> = bound_method %int_1.loc21, %LessOrEquivalent.ref.loc21 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.0b467c.2]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn: <specific function> = specific_function %LessOrEquivalent.ref.loc21, @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.2d74e0.2]
-// CHECK:STDOUT:   %bound_method.loc21_5.3: <bound method> = bound_method %int_1.loc21, %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn [concrete = constants.%bound_method.caef99.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.loc21: <bound method> = bound_method %int_1.loc21, %LessOrEquivalent.ref.loc21 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.0b467c.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc21: <specific function> = specific_function %LessOrEquivalent.ref.loc21, @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.2d74e0.2]
+// CHECK:STDOUT:   %bound_method.loc21_5.3: <bound method> = bound_method %int_1.loc21, %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc21 [concrete = constants.%bound_method.caef99.2]
 // CHECK:STDOUT:   %impl.elem0.loc21: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
 // CHECK:STDOUT:   %bound_method.loc21_3: <bound method> = bound_method %int_1.loc21, %impl.elem0.loc21 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
 // CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21: init %Cpp.long_long = call %bound_method.loc21_3(%int_1.loc21) [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc21_3.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21 [concrete = constants.%int_1.092]
 // CHECK:STDOUT:   %.loc21_3.2: %Cpp.long_long = converted %int_1.loc21, %.loc21_3.1 [concrete = constants.%int_1.092]
-// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.call: init bool = call %bound_method.loc21_5.3(%.loc21_3.2, %a.ref.loc21)
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.call.loc21: init bool = call %bound_method.loc21_5.3(%.loc21_3.2, %a.ref.loc21)
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %pattern_type.95b = value_binding_pattern b [concrete]
 // CHECK:STDOUT:   }
@@ -2443,108 +2801,5130 @@ fn CopyUnsignedLongLong() {
 // CHECK:STDOUT:   %b: %i64 = value_binding b, %.loc23_16.2
 // CHECK:STDOUT:   %b.ref.loc24: %i64 = name_ref b, %b
 // CHECK:STDOUT:   %a.ref.loc24: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem0.loc24_5: %.144 = impl_witness_access constants.%EqWith.impl_witness.367, element0 [concrete = constants.%Int.as.EqWith.impl.Equal.e49d18.2]
+// CHECK:STDOUT:   %impl.elem0.loc24_5: %.7df = impl_witness_access constants.%EqWith.impl_witness.52e, element0 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.971403.2]
 // CHECK:STDOUT:   %bound_method.loc24_5.1: <bound method> = bound_method %b.ref.loc24, %impl.elem0.loc24_5
-// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem0.loc24_5, @Int.as.EqWith.impl.Equal.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.Equal.specific_fn.443739.1]
+// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem0.loc24_5, @T.binding.as_type.as.EqWith.impl.Equal.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.specific_fn.14854f.1]
 // CHECK:STDOUT:   %bound_method.loc24_5.2: <bound method> = bound_method %b.ref.loc24, %specific_fn.loc24
-// CHECK:STDOUT:   %.loc24_5: %Int.as.EqWith.impl.Equal.type.e5f20b.1 = specific_constant imports.%Core.Equal.ca9, @Int.as.EqWith.impl.42c(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.Equal.e49d18.1]
-// CHECK:STDOUT:   %Equal.ref.loc24: %Int.as.EqWith.impl.Equal.type.e5f20b.1 = name_ref Equal, %.loc24_5 [concrete = constants.%Int.as.EqWith.impl.Equal.e49d18.1]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.bound.loc24: <bound method> = bound_method %b.ref.loc24, %Equal.ref.loc24
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.specific_fn.loc24: <specific function> = specific_function %Equal.ref.loc24, @Int.as.EqWith.impl.Equal.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.Equal.specific_fn.443739.2]
-// CHECK:STDOUT:   %bound_method.loc24_5.3: <bound method> = bound_method %b.ref.loc24, %Int.as.EqWith.impl.Equal.specific_fn.loc24
-// CHECK:STDOUT:   %impl.elem0.loc24_8: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc24_8: <bound method> = bound_method %a.ref.loc24, %impl.elem0.loc24_8
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc24: init %i64 = call %bound_method.loc24_8(%a.ref.loc24)
-// CHECK:STDOUT:   %.loc24_8.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc24
-// CHECK:STDOUT:   %.loc24_8.2: %i64 = converted %a.ref.loc24, %.loc24_8.1
-// CHECK:STDOUT:   %Int.as.EqWith.impl.Equal.call.loc24: init bool = call %bound_method.loc24_5.3(%b.ref.loc24, %.loc24_8.2)
+// CHECK:STDOUT:   %.loc24_5: %T.binding.as_type.as.EqWith.impl.Equal.type.5ab1af.1 = specific_constant imports.%Core.Equal.d94, @T.binding.as_type.as.EqWith.impl.b07(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.971403.1]
+// CHECK:STDOUT:   %Equal.ref.loc24: %T.binding.as_type.as.EqWith.impl.Equal.type.5ab1af.1 = name_ref Equal, %.loc24_5 [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.971403.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.bound.loc24: <bound method> = bound_method %b.ref.loc24, %Equal.ref.loc24
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.loc24: <specific function> = specific_function %Equal.ref.loc24, @T.binding.as_type.as.EqWith.impl.Equal.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.Equal.specific_fn.14854f.2]
+// CHECK:STDOUT:   %bound_method.loc24_5.3: <bound method> = bound_method %b.ref.loc24, %T.binding.as_type.as.EqWith.impl.Equal.specific_fn.loc24
+// CHECK:STDOUT:   %impl.elem0.loc24_3: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc24_3: <bound method> = bound_method %b.ref.loc24, %impl.elem0.loc24_3
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc24: init %Cpp.long_long = call %bound_method.loc24_3(%b.ref.loc24)
+// CHECK:STDOUT:   %.loc24_3.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc24
+// CHECK:STDOUT:   %.loc24_3.2: %Cpp.long_long = converted %b.ref.loc24, %.loc24_3.1
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.Equal.call.loc24: init bool = call %bound_method.loc24_5.3(%.loc24_3.2, %a.ref.loc24)
 // CHECK:STDOUT:   %b.ref.loc25: %i64 = name_ref b, %b
 // CHECK:STDOUT:   %a.ref.loc25: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem1.loc25: %.b78 = impl_witness_access constants.%EqWith.impl_witness.367, element1 [concrete = constants.%Int.as.EqWith.impl.NotEqual.af2dce.2]
+// CHECK:STDOUT:   %impl.elem1.loc25: %.232 = impl_witness_access constants.%EqWith.impl_witness.52e, element1 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.2]
 // CHECK:STDOUT:   %bound_method.loc25_5.1: <bound method> = bound_method %b.ref.loc25, %impl.elem1.loc25
-// CHECK:STDOUT:   %specific_fn.loc25: <specific function> = specific_function %impl.elem1.loc25, @Int.as.EqWith.impl.NotEqual.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.NotEqual.specific_fn.044259.1]
+// CHECK:STDOUT:   %specific_fn.loc25: <specific function> = specific_function %impl.elem1.loc25, @T.binding.as_type.as.EqWith.impl.NotEqual.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.b0f056.1]
 // CHECK:STDOUT:   %bound_method.loc25_5.2: <bound method> = bound_method %b.ref.loc25, %specific_fn.loc25
-// CHECK:STDOUT:   %.loc25_5: %Int.as.EqWith.impl.NotEqual.type.9ab064.1 = specific_constant imports.%Core.NotEqual.334, @Int.as.EqWith.impl.42c(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.NotEqual.af2dce.1]
-// CHECK:STDOUT:   %NotEqual.ref.loc25: %Int.as.EqWith.impl.NotEqual.type.9ab064.1 = name_ref NotEqual, %.loc25_5 [concrete = constants.%Int.as.EqWith.impl.NotEqual.af2dce.1]
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.bound.loc25: <bound method> = bound_method %b.ref.loc25, %NotEqual.ref.loc25
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.specific_fn.loc25: <specific function> = specific_function %NotEqual.ref.loc25, @Int.as.EqWith.impl.NotEqual.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.EqWith.impl.NotEqual.specific_fn.044259.2]
-// CHECK:STDOUT:   %bound_method.loc25_5.3: <bound method> = bound_method %b.ref.loc25, %Int.as.EqWith.impl.NotEqual.specific_fn.loc25
-// CHECK:STDOUT:   %impl.elem0.loc25: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc25_8: <bound method> = bound_method %a.ref.loc25, %impl.elem0.loc25
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc25: init %i64 = call %bound_method.loc25_8(%a.ref.loc25)
-// CHECK:STDOUT:   %.loc25_8.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc25
-// CHECK:STDOUT:   %.loc25_8.2: %i64 = converted %a.ref.loc25, %.loc25_8.1
-// CHECK:STDOUT:   %Int.as.EqWith.impl.NotEqual.call.loc25: init bool = call %bound_method.loc25_5.3(%b.ref.loc25, %.loc25_8.2)
+// CHECK:STDOUT:   %.loc25_5: %T.binding.as_type.as.EqWith.impl.NotEqual.type.7cb54d.1 = specific_constant imports.%Core.NotEqual.421, @T.binding.as_type.as.EqWith.impl.b07(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.1]
+// CHECK:STDOUT:   %NotEqual.ref.loc25: %T.binding.as_type.as.EqWith.impl.NotEqual.type.7cb54d.1 = name_ref NotEqual, %.loc25_5 [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.bd87a0.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.bound.loc25: <bound method> = bound_method %b.ref.loc25, %NotEqual.ref.loc25
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.loc25: <specific function> = specific_function %NotEqual.ref.loc25, @T.binding.as_type.as.EqWith.impl.NotEqual.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.b0f056.2]
+// CHECK:STDOUT:   %bound_method.loc25_5.3: <bound method> = bound_method %b.ref.loc25, %T.binding.as_type.as.EqWith.impl.NotEqual.specific_fn.loc25
+// CHECK:STDOUT:   %impl.elem0.loc25: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc25_3: <bound method> = bound_method %b.ref.loc25, %impl.elem0.loc25
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc25: init %Cpp.long_long = call %bound_method.loc25_3(%b.ref.loc25)
+// CHECK:STDOUT:   %.loc25_3.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc25
+// CHECK:STDOUT:   %.loc25_3.2: %Cpp.long_long = converted %b.ref.loc25, %.loc25_3.1
+// CHECK:STDOUT:   %T.binding.as_type.as.EqWith.impl.NotEqual.call.loc25: init bool = call %bound_method.loc25_5.3(%.loc25_3.2, %a.ref.loc25)
 // CHECK:STDOUT:   %b.ref.loc26: %i64 = name_ref b, %b
 // CHECK:STDOUT:   %a.ref.loc26: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem2.loc26: %.8f1 = impl_witness_access constants.%OrderedWith.impl_witness.27d, element2 [concrete = constants.%Int.as.OrderedWith.impl.Greater.2b7c26.2]
+// CHECK:STDOUT:   %impl.elem2.loc26: %.ed1 = impl_witness_access constants.%OrderedWith.impl_witness.5fb, element2 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.356766.2]
 // CHECK:STDOUT:   %bound_method.loc26_5.1: <bound method> = bound_method %b.ref.loc26, %impl.elem2.loc26
-// CHECK:STDOUT:   %specific_fn.loc26: <specific function> = specific_function %impl.elem2.loc26, @Int.as.OrderedWith.impl.Greater.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Greater.specific_fn.c215f8.1]
+// CHECK:STDOUT:   %specific_fn.loc26: <specific function> = specific_function %impl.elem2.loc26, @T.binding.as_type.as.OrderedWith.impl.Greater.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.fc67f6.1]
 // CHECK:STDOUT:   %bound_method.loc26_5.2: <bound method> = bound_method %b.ref.loc26, %specific_fn.loc26
-// CHECK:STDOUT:   %.loc26_5: %Int.as.OrderedWith.impl.Greater.type.e91ea2.1 = specific_constant imports.%Core.Greater.cd9, @Int.as.OrderedWith.impl.aba(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Greater.2b7c26.1]
-// CHECK:STDOUT:   %Greater.ref.loc26: %Int.as.OrderedWith.impl.Greater.type.e91ea2.1 = name_ref Greater, %.loc26_5 [concrete = constants.%Int.as.OrderedWith.impl.Greater.2b7c26.1]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.bound.loc26: <bound method> = bound_method %b.ref.loc26, %Greater.ref.loc26
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.specific_fn.loc26: <specific function> = specific_function %Greater.ref.loc26, @Int.as.OrderedWith.impl.Greater.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Greater.specific_fn.c215f8.2]
-// CHECK:STDOUT:   %bound_method.loc26_5.3: <bound method> = bound_method %b.ref.loc26, %Int.as.OrderedWith.impl.Greater.specific_fn.loc26
-// CHECK:STDOUT:   %impl.elem0.loc26: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc26_7: <bound method> = bound_method %a.ref.loc26, %impl.elem0.loc26
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc26: init %i64 = call %bound_method.loc26_7(%a.ref.loc26)
-// CHECK:STDOUT:   %.loc26_7.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc26
-// CHECK:STDOUT:   %.loc26_7.2: %i64 = converted %a.ref.loc26, %.loc26_7.1
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.call.loc26: init bool = call %bound_method.loc26_5.3(%b.ref.loc26, %.loc26_7.2)
+// CHECK:STDOUT:   %.loc26_5: %T.binding.as_type.as.OrderedWith.impl.Greater.type.125113.1 = specific_constant imports.%Core.Greater.cff, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.356766.1]
+// CHECK:STDOUT:   %Greater.ref.loc26: %T.binding.as_type.as.OrderedWith.impl.Greater.type.125113.1 = name_ref Greater, %.loc26_5 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.356766.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.bound.loc26: <bound method> = bound_method %b.ref.loc26, %Greater.ref.loc26
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.loc26: <specific function> = specific_function %Greater.ref.loc26, @T.binding.as_type.as.OrderedWith.impl.Greater.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.fc67f6.2]
+// CHECK:STDOUT:   %bound_method.loc26_5.3: <bound method> = bound_method %b.ref.loc26, %T.binding.as_type.as.OrderedWith.impl.Greater.specific_fn.loc26
+// CHECK:STDOUT:   %impl.elem0.loc26: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc26_3: <bound method> = bound_method %b.ref.loc26, %impl.elem0.loc26
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc26: init %Cpp.long_long = call %bound_method.loc26_3(%b.ref.loc26)
+// CHECK:STDOUT:   %.loc26_3.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc26
+// CHECK:STDOUT:   %.loc26_3.2: %Cpp.long_long = converted %b.ref.loc26, %.loc26_3.1
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Greater.call.loc26: init bool = call %bound_method.loc26_5.3(%.loc26_3.2, %a.ref.loc26)
 // CHECK:STDOUT:   %b.ref.loc27: %i64 = name_ref b, %b
 // CHECK:STDOUT:   %a.ref.loc27: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem0.loc27_5: %.6ba = impl_witness_access constants.%OrderedWith.impl_witness.27d, element0 [concrete = constants.%Int.as.OrderedWith.impl.Less.f7d683.2]
+// CHECK:STDOUT:   %impl.elem0.loc27_5: %.c89 = impl_witness_access constants.%OrderedWith.impl_witness.5fb, element0 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.4846a7.2]
 // CHECK:STDOUT:   %bound_method.loc27_5.1: <bound method> = bound_method %b.ref.loc27, %impl.elem0.loc27_5
-// CHECK:STDOUT:   %specific_fn.loc27: <specific function> = specific_function %impl.elem0.loc27_5, @Int.as.OrderedWith.impl.Less.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Less.specific_fn.e635f0.1]
+// CHECK:STDOUT:   %specific_fn.loc27: <specific function> = specific_function %impl.elem0.loc27_5, @T.binding.as_type.as.OrderedWith.impl.Less.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.ab0306.1]
 // CHECK:STDOUT:   %bound_method.loc27_5.2: <bound method> = bound_method %b.ref.loc27, %specific_fn.loc27
-// CHECK:STDOUT:   %.loc27_5: %Int.as.OrderedWith.impl.Less.type.0fa05d.1 = specific_constant imports.%Core.Less.df4, @Int.as.OrderedWith.impl.aba(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Less.f7d683.1]
-// CHECK:STDOUT:   %Less.ref.loc27: %Int.as.OrderedWith.impl.Less.type.0fa05d.1 = name_ref Less, %.loc27_5 [concrete = constants.%Int.as.OrderedWith.impl.Less.f7d683.1]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.bound.loc27: <bound method> = bound_method %b.ref.loc27, %Less.ref.loc27
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.specific_fn.loc27: <specific function> = specific_function %Less.ref.loc27, @Int.as.OrderedWith.impl.Less.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.Less.specific_fn.e635f0.2]
-// CHECK:STDOUT:   %bound_method.loc27_5.3: <bound method> = bound_method %b.ref.loc27, %Int.as.OrderedWith.impl.Less.specific_fn.loc27
-// CHECK:STDOUT:   %impl.elem0.loc27_7: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc27_7: <bound method> = bound_method %a.ref.loc27, %impl.elem0.loc27_7
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc27: init %i64 = call %bound_method.loc27_7(%a.ref.loc27)
-// CHECK:STDOUT:   %.loc27_7.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc27
-// CHECK:STDOUT:   %.loc27_7.2: %i64 = converted %a.ref.loc27, %.loc27_7.1
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.call.loc27: init bool = call %bound_method.loc27_5.3(%b.ref.loc27, %.loc27_7.2)
+// CHECK:STDOUT:   %.loc27_5: %T.binding.as_type.as.OrderedWith.impl.Less.type.8c7c29.1 = specific_constant imports.%Core.Less.aac, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.4846a7.1]
+// CHECK:STDOUT:   %Less.ref.loc27: %T.binding.as_type.as.OrderedWith.impl.Less.type.8c7c29.1 = name_ref Less, %.loc27_5 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.4846a7.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.bound.loc27: <bound method> = bound_method %b.ref.loc27, %Less.ref.loc27
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.loc27: <specific function> = specific_function %Less.ref.loc27, @T.binding.as_type.as.OrderedWith.impl.Less.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.ab0306.2]
+// CHECK:STDOUT:   %bound_method.loc27_5.3: <bound method> = bound_method %b.ref.loc27, %T.binding.as_type.as.OrderedWith.impl.Less.specific_fn.loc27
+// CHECK:STDOUT:   %impl.elem0.loc27_3: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc27_3: <bound method> = bound_method %b.ref.loc27, %impl.elem0.loc27_3
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc27: init %Cpp.long_long = call %bound_method.loc27_3(%b.ref.loc27)
+// CHECK:STDOUT:   %.loc27_3.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc27
+// CHECK:STDOUT:   %.loc27_3.2: %Cpp.long_long = converted %b.ref.loc27, %.loc27_3.1
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.Less.call.loc27: init bool = call %bound_method.loc27_5.3(%.loc27_3.2, %a.ref.loc27)
 // CHECK:STDOUT:   %b.ref.loc28: %i64 = name_ref b, %b
 // CHECK:STDOUT:   %a.ref.loc28: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem3.loc28: %.cf1 = impl_witness_access constants.%OrderedWith.impl_witness.27d, element3 [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.2]
+// CHECK:STDOUT:   %impl.elem3.loc28: %.00e = impl_witness_access constants.%OrderedWith.impl_witness.5fb, element3 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.2]
 // CHECK:STDOUT:   %bound_method.loc28_5.1: <bound method> = bound_method %b.ref.loc28, %impl.elem3.loc28
-// CHECK:STDOUT:   %specific_fn.loc28: <specific function> = specific_function %impl.elem3.loc28, @Int.as.OrderedWith.impl.GreaterOrEquivalent.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.751116.1]
+// CHECK:STDOUT:   %specific_fn.loc28: <specific function> = specific_function %impl.elem3.loc28, @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.b93d5d.1]
 // CHECK:STDOUT:   %bound_method.loc28_5.2: <bound method> = bound_method %b.ref.loc28, %specific_fn.loc28
-// CHECK:STDOUT:   %.loc28_5: %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.0e0c4f.1 = specific_constant imports.%Core.GreaterOrEquivalent.757, @Int.as.OrderedWith.impl.aba(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.1]
-// CHECK:STDOUT:   %GreaterOrEquivalent.ref.loc28: %Int.as.OrderedWith.impl.GreaterOrEquivalent.type.0e0c4f.1 = name_ref GreaterOrEquivalent, %.loc28_5 [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.520fbe.1]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.bound.loc28: <bound method> = bound_method %b.ref.loc28, %GreaterOrEquivalent.ref.loc28
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc28: <specific function> = specific_function %GreaterOrEquivalent.ref.loc28, @Int.as.OrderedWith.impl.GreaterOrEquivalent.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.751116.2]
-// CHECK:STDOUT:   %bound_method.loc28_5.3: <bound method> = bound_method %b.ref.loc28, %Int.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc28
-// CHECK:STDOUT:   %impl.elem0.loc28: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc28_8: <bound method> = bound_method %a.ref.loc28, %impl.elem0.loc28
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc28: init %i64 = call %bound_method.loc28_8(%a.ref.loc28)
-// CHECK:STDOUT:   %.loc28_8.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc28
-// CHECK:STDOUT:   %.loc28_8.2: %i64 = converted %a.ref.loc28, %.loc28_8.1
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.GreaterOrEquivalent.call.loc28: init bool = call %bound_method.loc28_5.3(%b.ref.loc28, %.loc28_8.2)
+// CHECK:STDOUT:   %.loc28_5: %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.6d7684.1 = specific_constant imports.%Core.GreaterOrEquivalent.b91, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.1]
+// CHECK:STDOUT:   %GreaterOrEquivalent.ref.loc28: %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.type.6d7684.1 = name_ref GreaterOrEquivalent, %.loc28_5 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.7a66f5.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.bound.loc28: <bound method> = bound_method %b.ref.loc28, %GreaterOrEquivalent.ref.loc28
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc28: <specific function> = specific_function %GreaterOrEquivalent.ref.loc28, @T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.b93d5d.2]
+// CHECK:STDOUT:   %bound_method.loc28_5.3: <bound method> = bound_method %b.ref.loc28, %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.specific_fn.loc28
+// CHECK:STDOUT:   %impl.elem0.loc28: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc28_3: <bound method> = bound_method %b.ref.loc28, %impl.elem0.loc28
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc28: init %Cpp.long_long = call %bound_method.loc28_3(%b.ref.loc28)
+// CHECK:STDOUT:   %.loc28_3.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc28
+// CHECK:STDOUT:   %.loc28_3.2: %Cpp.long_long = converted %b.ref.loc28, %.loc28_3.1
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.GreaterOrEquivalent.call.loc28: init bool = call %bound_method.loc28_5.3(%.loc28_3.2, %a.ref.loc28)
 // CHECK:STDOUT:   %b.ref.loc29: %i64 = name_ref b, %b
 // CHECK:STDOUT:   %a.ref.loc29: %Cpp.long_long = name_ref a, %a
-// CHECK:STDOUT:   %impl.elem1.loc29: %.ec7 = impl_witness_access constants.%OrderedWith.impl_witness.27d, element1 [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.56c691.2]
+// CHECK:STDOUT:   %impl.elem1.loc29: %.3fe = impl_witness_access constants.%OrderedWith.impl_witness.5fb, element1 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.2]
 // CHECK:STDOUT:   %bound_method.loc29_5.1: <bound method> = bound_method %b.ref.loc29, %impl.elem1.loc29
-// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem1.loc29, @Int.as.OrderedWith.impl.LessOrEquivalent.2(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.100dc7.1]
+// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem1.loc29, @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.67339b.1]
 // CHECK:STDOUT:   %bound_method.loc29_5.2: <bound method> = bound_method %b.ref.loc29, %specific_fn.loc29
-// CHECK:STDOUT:   %.loc29_5: %Int.as.OrderedWith.impl.LessOrEquivalent.type.f1c847.1 = specific_constant imports.%Core.LessOrEquivalent.c5f, @Int.as.OrderedWith.impl.aba(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.56c691.1]
-// CHECK:STDOUT:   %LessOrEquivalent.ref.loc29: %Int.as.OrderedWith.impl.LessOrEquivalent.type.f1c847.1 = name_ref LessOrEquivalent, %.loc29_5 [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.56c691.1]
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.bound.loc29: <bound method> = bound_method %b.ref.loc29, %LessOrEquivalent.ref.loc29
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc29: <specific function> = specific_function %LessOrEquivalent.ref.loc29, @Int.as.OrderedWith.impl.LessOrEquivalent.3(constants.%int_64, constants.%ImplicitAs.facet.660) [concrete = constants.%Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.100dc7.2]
-// CHECK:STDOUT:   %bound_method.loc29_5.3: <bound method> = bound_method %b.ref.loc29, %Int.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc29
-// CHECK:STDOUT:   %impl.elem0.loc29: %.912 = impl_witness_access constants.%ImplicitAs.impl_witness.a63, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
-// CHECK:STDOUT:   %bound_method.loc29_8: <bound method> = bound_method %a.ref.loc29, %impl.elem0.loc29
-// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc29: init %i64 = call %bound_method.loc29_8(%a.ref.loc29)
-// CHECK:STDOUT:   %.loc29_8.1: %i64 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc29
-// CHECK:STDOUT:   %.loc29_8.2: %i64 = converted %a.ref.loc29, %.loc29_8.1
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.LessOrEquivalent.call.loc29: init bool = call %bound_method.loc29_5.3(%b.ref.loc29, %.loc29_8.2)
+// CHECK:STDOUT:   %.loc29_5: %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bba1e4.1 = specific_constant imports.%Core.LessOrEquivalent.792, @T.binding.as_type.as.OrderedWith.impl.895(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.1]
+// CHECK:STDOUT:   %LessOrEquivalent.ref.loc29: %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.type.bba1e4.1 = name_ref LessOrEquivalent, %.loc29_5 [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.ebfce3.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.bound.loc29: <bound method> = bound_method %b.ref.loc29, %LessOrEquivalent.ref.loc29
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc29: <specific function> = specific_function %LessOrEquivalent.ref.loc29, @T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.67339b.2]
+// CHECK:STDOUT:   %bound_method.loc29_5.3: <bound method> = bound_method %b.ref.loc29, %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.specific_fn.loc29
+// CHECK:STDOUT:   %impl.elem0.loc29: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc29_3: <bound method> = bound_method %b.ref.loc29, %impl.elem0.loc29
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc29: init %Cpp.long_long = call %bound_method.loc29_3(%b.ref.loc29)
+// CHECK:STDOUT:   %.loc29_3.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc29
+// CHECK:STDOUT:   %.loc29_3.2: %Cpp.long_long = converted %b.ref.loc29, %.loc29_3.1
+// CHECK:STDOUT:   %T.binding.as_type.as.OrderedWith.impl.LessOrEquivalent.call.loc29: init bool = call %bound_method.loc29_5.3(%.loc29_3.2, %a.ref.loc29)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- arithmetic_homogeneous_long_long.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %AssertSameType.type: type = fn_type @AssertSameType [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %AssertSameType: %AssertSameType.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %Negate.type: type = facet_type <@Negate> [concrete]
+// CHECK:STDOUT:   %Negate.Op.type: type = fn_type @Negate.Op [concrete]
+// CHECK:STDOUT:   %Negate.impl_witness: <witness> = impl_witness imports.%Negate.impl_witness_table [concrete]
+// CHECK:STDOUT:   %Negate.facet: %Negate.type = facet_value %Cpp.long_long, (%Negate.impl_witness) [concrete]
+// CHECK:STDOUT:   %.b75: type = fn_type_with_self_type %Negate.Op.type, %Negate.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.Negate.impl.Op.type: type = fn_type @Cpp.long_long.as.Negate.impl.Op [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.Negate.impl.Op: %Cpp.long_long.as.Negate.impl.Op.type = struct_value () [concrete]
+// CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %AddWith.type.e97: type = facet_type <@AddWith, @AddWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %AddWith.Op.type.4a8: type = fn_type @AddWith.Op, @AddWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %AddWith.impl_witness.006: <witness> = impl_witness imports.%AddWith.impl_witness_table.820 [concrete]
+// CHECK:STDOUT:   %AddWith.facet: %AddWith.type.e97 = facet_value %Cpp.long_long, (%AddWith.impl_witness.006) [concrete]
+// CHECK:STDOUT:   %.ea0: type = fn_type_with_self_type %AddWith.Op.type.4a8, %AddWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.type.4c8: type = fn_type @Cpp.long_long.as.AddWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.bab: %Cpp.long_long.as.AddWith.impl.Op.type.4c8 = struct_value () [concrete]
+// CHECK:STDOUT:   %SubWith.type.172: type = facet_type <@SubWith, @SubWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %SubWith.Op.type.929: type = fn_type @SubWith.Op, @SubWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %SubWith.impl_witness.653: <witness> = impl_witness imports.%SubWith.impl_witness_table.ea2 [concrete]
+// CHECK:STDOUT:   %SubWith.facet: %SubWith.type.172 = facet_value %Cpp.long_long, (%SubWith.impl_witness.653) [concrete]
+// CHECK:STDOUT:   %.134: type = fn_type_with_self_type %SubWith.Op.type.929, %SubWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.type.d1e: type = fn_type @Cpp.long_long.as.SubWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.d4c: %Cpp.long_long.as.SubWith.impl.Op.type.d1e = struct_value () [concrete]
+// CHECK:STDOUT:   %MulWith.type.693: type = facet_type <@MulWith, @MulWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %MulWith.Op.type.1a1: type = fn_type @MulWith.Op, @MulWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %MulWith.impl_witness.655: <witness> = impl_witness imports.%MulWith.impl_witness_table.4c5 [concrete]
+// CHECK:STDOUT:   %MulWith.facet: %MulWith.type.693 = facet_value %Cpp.long_long, (%MulWith.impl_witness.655) [concrete]
+// CHECK:STDOUT:   %.1c5: type = fn_type_with_self_type %MulWith.Op.type.1a1, %MulWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.type.bae: type = fn_type @Cpp.long_long.as.MulWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.48e: %Cpp.long_long.as.MulWith.impl.Op.type.bae = struct_value () [concrete]
+// CHECK:STDOUT:   %DivWith.type.f07: type = facet_type <@DivWith, @DivWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %DivWith.Op.type.ccd: type = fn_type @DivWith.Op, @DivWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %DivWith.impl_witness.d45: <witness> = impl_witness imports.%DivWith.impl_witness_table.552 [concrete]
+// CHECK:STDOUT:   %DivWith.facet: %DivWith.type.f07 = facet_value %Cpp.long_long, (%DivWith.impl_witness.d45) [concrete]
+// CHECK:STDOUT:   %.3ea: type = fn_type_with_self_type %DivWith.Op.type.ccd, %DivWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.type.29d: type = fn_type @Cpp.long_long.as.DivWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.8e4: %Cpp.long_long.as.DivWith.impl.Op.type.29d = struct_value () [concrete]
+// CHECK:STDOUT:   %ModWith.type.b3d: type = facet_type <@ModWith, @ModWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ModWith.Op.type.9b8: type = fn_type @ModWith.Op, @ModWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ModWith.impl_witness.32d: <witness> = impl_witness imports.%ModWith.impl_witness_table.568 [concrete]
+// CHECK:STDOUT:   %ModWith.facet: %ModWith.type.b3d = facet_value %Cpp.long_long, (%ModWith.impl_witness.32d) [concrete]
+// CHECK:STDOUT:   %.161: type = fn_type_with_self_type %ModWith.Op.type.9b8, %ModWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.type.176: type = fn_type @Cpp.long_long.as.ModWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.d4a: %Cpp.long_long.as.ModWith.impl.Op.type.176 = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.1 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.db2: %Cpp.long_long.as.Negate.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.Negate.impl.Op]
+// CHECK:STDOUT:   %Negate.impl_witness_table = impl_witness_table (%Core.import_ref.ce3a05.1, %Core.import_ref.db2), @Cpp.long_long.as.Negate.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.4 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.c5f: %Cpp.long_long.as.AddWith.impl.Op.type.4c8 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.bab]
+// CHECK:STDOUT:   %AddWith.impl_witness_table.820 = impl_witness_table (%Core.import_ref.ce3a05.4, %Core.import_ref.c5f), @Cpp.long_long.as.AddWith.impl.085 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.7 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.4c0: %Cpp.long_long.as.SubWith.impl.Op.type.d1e = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.d4c]
+// CHECK:STDOUT:   %SubWith.impl_witness_table.ea2 = impl_witness_table (%Core.import_ref.ce3a05.7, %Core.import_ref.4c0), @Cpp.long_long.as.SubWith.impl.996 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.10 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.243: %Cpp.long_long.as.MulWith.impl.Op.type.bae = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.48e]
+// CHECK:STDOUT:   %MulWith.impl_witness_table.4c5 = impl_witness_table (%Core.import_ref.ce3a05.10, %Core.import_ref.243), @Cpp.long_long.as.MulWith.impl.03b [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.13 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.44c: %Cpp.long_long.as.DivWith.impl.Op.type.29d = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.8e4]
+// CHECK:STDOUT:   %DivWith.impl_witness_table.552 = impl_witness_table (%Core.import_ref.ce3a05.13, %Core.import_ref.44c), @Cpp.long_long.as.DivWith.impl.0e8 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.16 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.302: %Cpp.long_long.as.ModWith.impl.Op.type.176 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.d4a]
+// CHECK:STDOUT:   %ModWith.impl_witness_table.568 = impl_witness_table (%Core.import_ref.ce3a05.16, %Core.import_ref.302), @Cpp.long_long.as.ModWith.impl.0e9 [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @ArithmeticHomogeneousLongLong() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %x.patt: %pattern_type.76e = value_binding_pattern x [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc10_13: type = splice_block %long_long.ref.loc10 [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref.loc10: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc10: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10(%int_1.loc10) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.2: %Cpp.long_long = converted %int_1.loc10, %.loc10_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %x: %Cpp.long_long = value_binding x, %.loc10_26.2
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %y.patt: %pattern_type.76e = value_binding_pattern y [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc11: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc11_13: type = splice_block %long_long.ref.loc11 [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref.loc11: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc11: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc11: <bound method> = bound_method %int_1.loc11, %impl.elem0.loc11 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc11: init %Cpp.long_long = call %bound_method.loc11(%int_1.loc11) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_26.2: %Cpp.long_long = converted %int_1.loc11, %.loc11_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %y: %Cpp.long_long = value_binding y, %.loc11_26.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc13: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc13_19: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc13: %.b75 = impl_witness_access constants.%Negate.impl_witness, element1 [concrete = constants.%Cpp.long_long.as.Negate.impl.Op]
+// CHECK:STDOUT:   %bound_method.loc13: <bound method> = bound_method %x.ref.loc13_19, %impl.elem1.loc13
+// CHECK:STDOUT:   %Cpp.long_long.as.Negate.impl.Op.call: init %Cpp.long_long = call %bound_method.loc13(%x.ref.loc13_19)
+// CHECK:STDOUT:   %x.ref.loc13_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc13: <specific function> = specific_function %AssertSameType.ref.loc13, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc13_18.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.Negate.impl.Op.call
+// CHECK:STDOUT:   %.loc13_18.2: %Cpp.long_long = converted %Cpp.long_long.as.Negate.impl.Op.call, %.loc13_18.1
+// CHECK:STDOUT:   %AssertSameType.call.loc13: init %empty_tuple.type = call %AssertSameType.specific_fn.loc13(%.loc13_18.2, %x.ref.loc13_22)
+// CHECK:STDOUT:   %AssertSameType.ref.loc14: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc14_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc14: %Cpp.long_long = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc14: %.ea0 = impl_witness_access constants.%AddWith.impl_witness.006, element1 [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.bab]
+// CHECK:STDOUT:   %bound_method.loc14: <bound method> = bound_method %x.ref.loc14_18, %impl.elem1.loc14
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc14(%x.ref.loc14_18, %y.ref.loc14)
+// CHECK:STDOUT:   %x.ref.loc14_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc14: <specific function> = specific_function %AssertSameType.ref.loc14, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc14_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.AddWith.impl.Op.call
+// CHECK:STDOUT:   %.loc14_20.2: %Cpp.long_long = converted %Cpp.long_long.as.AddWith.impl.Op.call, %.loc14_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc14: init %empty_tuple.type = call %AssertSameType.specific_fn.loc14(%.loc14_20.2, %x.ref.loc14_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc15: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc15_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc15: %Cpp.long_long = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc15: %.134 = impl_witness_access constants.%SubWith.impl_witness.653, element1 [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.d4c]
+// CHECK:STDOUT:   %bound_method.loc15: <bound method> = bound_method %x.ref.loc15_18, %impl.elem1.loc15
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc15(%x.ref.loc15_18, %y.ref.loc15)
+// CHECK:STDOUT:   %x.ref.loc15_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc15: <specific function> = specific_function %AssertSameType.ref.loc15, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc15_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.SubWith.impl.Op.call
+// CHECK:STDOUT:   %.loc15_20.2: %Cpp.long_long = converted %Cpp.long_long.as.SubWith.impl.Op.call, %.loc15_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc15: init %empty_tuple.type = call %AssertSameType.specific_fn.loc15(%.loc15_20.2, %x.ref.loc15_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc16: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc16_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc16: %Cpp.long_long = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc16: %.1c5 = impl_witness_access constants.%MulWith.impl_witness.655, element1 [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.48e]
+// CHECK:STDOUT:   %bound_method.loc16: <bound method> = bound_method %x.ref.loc16_18, %impl.elem1.loc16
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc16(%x.ref.loc16_18, %y.ref.loc16)
+// CHECK:STDOUT:   %x.ref.loc16_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc16: <specific function> = specific_function %AssertSameType.ref.loc16, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc16_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.MulWith.impl.Op.call
+// CHECK:STDOUT:   %.loc16_20.2: %Cpp.long_long = converted %Cpp.long_long.as.MulWith.impl.Op.call, %.loc16_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc16: init %empty_tuple.type = call %AssertSameType.specific_fn.loc16(%.loc16_20.2, %x.ref.loc16_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc17: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc17_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc17: %Cpp.long_long = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc17: %.3ea = impl_witness_access constants.%DivWith.impl_witness.d45, element1 [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.8e4]
+// CHECK:STDOUT:   %bound_method.loc17: <bound method> = bound_method %x.ref.loc17_18, %impl.elem1.loc17
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc17(%x.ref.loc17_18, %y.ref.loc17)
+// CHECK:STDOUT:   %x.ref.loc17_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc17: <specific function> = specific_function %AssertSameType.ref.loc17, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc17_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.DivWith.impl.Op.call
+// CHECK:STDOUT:   %.loc17_20.2: %Cpp.long_long = converted %Cpp.long_long.as.DivWith.impl.Op.call, %.loc17_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc17: init %empty_tuple.type = call %AssertSameType.specific_fn.loc17(%.loc17_20.2, %x.ref.loc17_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc18: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc18_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc18: %Cpp.long_long = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc18: %.161 = impl_witness_access constants.%ModWith.impl_witness.32d, element1 [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.d4a]
+// CHECK:STDOUT:   %bound_method.loc18: <bound method> = bound_method %x.ref.loc18_18, %impl.elem1.loc18
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc18(%x.ref.loc18_18, %y.ref.loc18)
+// CHECK:STDOUT:   %x.ref.loc18_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc18: <specific function> = specific_function %AssertSameType.ref.loc18, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc18_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.ModWith.impl.Op.call
+// CHECK:STDOUT:   %.loc18_20.2: %Cpp.long_long = converted %Cpp.long_long.as.ModWith.impl.Op.call, %.loc18_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc18: init %empty_tuple.type = call %AssertSameType.specific_fn.loc18(%.loc18_20.2, %x.ref.loc18_25)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- arithmetic_heterogeneous_long_long_left_side.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %AssertSameType.type: type = fn_type @AssertSameType [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %AssertSameType: %AssertSameType.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %int_64: Core.IntLiteral = int_value 64 [concrete]
+// CHECK:STDOUT:   %i64: type = class_type @Int, @Int(%int_64) [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.2ad: type = facet_type <@ImplicitAs, @ImplicitAs(%i64)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.94e: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i64) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %As.type.229: type = facet_type <@As, @As(%i64)> [concrete]
+// CHECK:STDOUT:   %As.Convert.type.d57: type = fn_type @As.Convert, @As(%i64) [concrete]
+// CHECK:STDOUT:   %To.fe9: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.09e: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.dbe: %Core.IntLiteral.as.As.impl.Convert.type.09e = struct_value () [symbolic]
+// CHECK:STDOUT:   %As.impl_witness.c71: <witness> = impl_witness imports.%As.impl_witness_table.9fc, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.cee: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.a54: %Core.IntLiteral.as.As.impl.Convert.type.cee = struct_value () [concrete]
+// CHECK:STDOUT:   %As.facet: %As.type.229 = facet_value Core.IntLiteral, (%As.impl_witness.c71) [concrete]
+// CHECK:STDOUT:   %.aba: type = fn_type_with_self_type %As.Convert.type.d57, %As.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.a54 [concrete]
+// CHECK:STDOUT:   %pattern_type.95b: type = pattern_type %i64 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.As.impl.Convert.a54, @Core.IntLiteral.as.As.impl.Convert(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method.41b: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_1.41a: %i64 = int_value 1 [concrete]
+// CHECK:STDOUT:   %AddWith.type.f83: type = facet_type <@AddWith, @AddWith(%i64)> [concrete]
+// CHECK:STDOUT:   %AddWith.Op.type.c7f: type = fn_type @AddWith.Op, @AddWith(%i64) [concrete]
+// CHECK:STDOUT:   %T.ea5: %ImplicitAs.type.a03 = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.type.b32b60.1: type = fn_type @Cpp.long_long.as.AddWith.impl.Op.1, @Cpp.long_long.as.AddWith.impl.2ad(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.8cdaa8.1: %Cpp.long_long.as.AddWith.impl.Op.type.b32b60.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.type.b32b60.2: type = fn_type @Cpp.long_long.as.AddWith.impl.Op.2, @Cpp.long_long.as.AddWith.impl.2ad(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.8cdaa8.2: %Cpp.long_long.as.AddWith.impl.Op.type.b32b60.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %AddWith.type.4c0: type = facet_type <@AddWith, @AddWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %AddWith.Op.type.0ee: type = fn_type @AddWith.Op, @AddWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.1b3: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.b19 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.c59: %ImplicitAs.type.a03 = facet_value %i64, (%ImplicitAs.impl_witness.1b3) [concrete]
+// CHECK:STDOUT:   %AddWith.impl_witness.24c: <witness> = impl_witness imports.%AddWith.impl_witness_table.a7c, @Cpp.long_long.as.AddWith.impl.2ad(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.type.f5b88b.1: type = fn_type @Cpp.long_long.as.AddWith.impl.Op.2, @Cpp.long_long.as.AddWith.impl.2ad(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.f65668.1: %Cpp.long_long.as.AddWith.impl.Op.type.f5b88b.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.type.f5b88b.2: type = fn_type @Cpp.long_long.as.AddWith.impl.Op.1, @Cpp.long_long.as.AddWith.impl.2ad(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.f65668.2: %Cpp.long_long.as.AddWith.impl.Op.type.f5b88b.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddWith.facet.275: %AddWith.type.f83 = facet_value %Cpp.long_long, (%AddWith.impl_witness.24c) [concrete]
+// CHECK:STDOUT:   %.1e9: type = fn_type_with_self_type %AddWith.Op.type.c7f, %AddWith.facet.275 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.specific_fn.be49b1.1: <specific function> = specific_function %Cpp.long_long.as.AddWith.impl.Op.f65668.2, @Cpp.long_long.as.AddWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %.b29: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.c59 [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.type: type = fn_type @i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert: %i64.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.41a, %i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.specific_fn.be49b1.2: <specific function> = specific_function %Cpp.long_long.as.AddWith.impl.Op.f65668.1, @Cpp.long_long.as.AddWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %SubWith.type.089: type = facet_type <@SubWith, @SubWith(%i64)> [concrete]
+// CHECK:STDOUT:   %SubWith.Op.type.344: type = fn_type @SubWith.Op, @SubWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.type.8c27c7.1: type = fn_type @Cpp.long_long.as.SubWith.impl.Op.1, @Cpp.long_long.as.SubWith.impl.182(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.58d0ca.1: %Cpp.long_long.as.SubWith.impl.Op.type.8c27c7.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.type.8c27c7.2: type = fn_type @Cpp.long_long.as.SubWith.impl.Op.2, @Cpp.long_long.as.SubWith.impl.182(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.58d0ca.2: %Cpp.long_long.as.SubWith.impl.Op.type.8c27c7.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %SubWith.type.a89: type = facet_type <@SubWith, @SubWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %SubWith.Op.type.95d: type = fn_type @SubWith.Op, @SubWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %SubWith.impl_witness.07a: <witness> = impl_witness imports.%SubWith.impl_witness_table.741, @Cpp.long_long.as.SubWith.impl.182(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.type.e1aaf1.1: type = fn_type @Cpp.long_long.as.SubWith.impl.Op.2, @Cpp.long_long.as.SubWith.impl.182(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.85827a.1: %Cpp.long_long.as.SubWith.impl.Op.type.e1aaf1.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.type.e1aaf1.2: type = fn_type @Cpp.long_long.as.SubWith.impl.Op.1, @Cpp.long_long.as.SubWith.impl.182(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.85827a.2: %Cpp.long_long.as.SubWith.impl.Op.type.e1aaf1.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %SubWith.facet.8b1: %SubWith.type.089 = facet_value %Cpp.long_long, (%SubWith.impl_witness.07a) [concrete]
+// CHECK:STDOUT:   %.036: type = fn_type_with_self_type %SubWith.Op.type.344, %SubWith.facet.8b1 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.specific_fn.8f1b07.1: <specific function> = specific_function %Cpp.long_long.as.SubWith.impl.Op.85827a.2, @Cpp.long_long.as.SubWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.specific_fn.8f1b07.2: <specific function> = specific_function %Cpp.long_long.as.SubWith.impl.Op.85827a.1, @Cpp.long_long.as.SubWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %MulWith.type.884: type = facet_type <@MulWith, @MulWith(%i64)> [concrete]
+// CHECK:STDOUT:   %MulWith.Op.type.fcc: type = fn_type @MulWith.Op, @MulWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.type.68c2bf.1: type = fn_type @Cpp.long_long.as.MulWith.impl.Op.1, @Cpp.long_long.as.MulWith.impl.eea(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.4cb78c.1: %Cpp.long_long.as.MulWith.impl.Op.type.68c2bf.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.type.68c2bf.2: type = fn_type @Cpp.long_long.as.MulWith.impl.Op.2, @Cpp.long_long.as.MulWith.impl.eea(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.4cb78c.2: %Cpp.long_long.as.MulWith.impl.Op.type.68c2bf.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %MulWith.type.4ce: type = facet_type <@MulWith, @MulWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %MulWith.Op.type.ff6: type = fn_type @MulWith.Op, @MulWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %MulWith.impl_witness.0f5: <witness> = impl_witness imports.%MulWith.impl_witness_table.75e, @Cpp.long_long.as.MulWith.impl.eea(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.type.0f8803.1: type = fn_type @Cpp.long_long.as.MulWith.impl.Op.2, @Cpp.long_long.as.MulWith.impl.eea(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.dd0f62.1: %Cpp.long_long.as.MulWith.impl.Op.type.0f8803.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.type.0f8803.2: type = fn_type @Cpp.long_long.as.MulWith.impl.Op.1, @Cpp.long_long.as.MulWith.impl.eea(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.dd0f62.2: %Cpp.long_long.as.MulWith.impl.Op.type.0f8803.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %MulWith.facet.73a: %MulWith.type.884 = facet_value %Cpp.long_long, (%MulWith.impl_witness.0f5) [concrete]
+// CHECK:STDOUT:   %.830: type = fn_type_with_self_type %MulWith.Op.type.fcc, %MulWith.facet.73a [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.specific_fn.f1361f.1: <specific function> = specific_function %Cpp.long_long.as.MulWith.impl.Op.dd0f62.2, @Cpp.long_long.as.MulWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.specific_fn.f1361f.2: <specific function> = specific_function %Cpp.long_long.as.MulWith.impl.Op.dd0f62.1, @Cpp.long_long.as.MulWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %DivWith.type.4ca: type = facet_type <@DivWith, @DivWith(%i64)> [concrete]
+// CHECK:STDOUT:   %DivWith.Op.type.246: type = fn_type @DivWith.Op, @DivWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.type.3de041.1: type = fn_type @Cpp.long_long.as.DivWith.impl.Op.1, @Cpp.long_long.as.DivWith.impl.543(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.bff666.1: %Cpp.long_long.as.DivWith.impl.Op.type.3de041.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.type.3de041.2: type = fn_type @Cpp.long_long.as.DivWith.impl.Op.2, @Cpp.long_long.as.DivWith.impl.543(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.bff666.2: %Cpp.long_long.as.DivWith.impl.Op.type.3de041.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %DivWith.type.234: type = facet_type <@DivWith, @DivWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %DivWith.Op.type.c64: type = fn_type @DivWith.Op, @DivWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %DivWith.impl_witness.4d9: <witness> = impl_witness imports.%DivWith.impl_witness_table.e78, @Cpp.long_long.as.DivWith.impl.543(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.type.c562f2.1: type = fn_type @Cpp.long_long.as.DivWith.impl.Op.2, @Cpp.long_long.as.DivWith.impl.543(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.306cec.1: %Cpp.long_long.as.DivWith.impl.Op.type.c562f2.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.type.c562f2.2: type = fn_type @Cpp.long_long.as.DivWith.impl.Op.1, @Cpp.long_long.as.DivWith.impl.543(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.306cec.2: %Cpp.long_long.as.DivWith.impl.Op.type.c562f2.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %DivWith.facet.5ad: %DivWith.type.4ca = facet_value %Cpp.long_long, (%DivWith.impl_witness.4d9) [concrete]
+// CHECK:STDOUT:   %.310: type = fn_type_with_self_type %DivWith.Op.type.246, %DivWith.facet.5ad [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.specific_fn.eb685a.1: <specific function> = specific_function %Cpp.long_long.as.DivWith.impl.Op.306cec.2, @Cpp.long_long.as.DivWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.specific_fn.eb685a.2: <specific function> = specific_function %Cpp.long_long.as.DivWith.impl.Op.306cec.1, @Cpp.long_long.as.DivWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %ModWith.type.e0d: type = facet_type <@ModWith, @ModWith(%i64)> [concrete]
+// CHECK:STDOUT:   %ModWith.Op.type.227: type = fn_type @ModWith.Op, @ModWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.type.95fc8a.1: type = fn_type @Cpp.long_long.as.ModWith.impl.Op.1, @Cpp.long_long.as.ModWith.impl.18e(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.3ec9be.1: %Cpp.long_long.as.ModWith.impl.Op.type.95fc8a.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.type.95fc8a.2: type = fn_type @Cpp.long_long.as.ModWith.impl.Op.2, @Cpp.long_long.as.ModWith.impl.18e(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.3ec9be.2: %Cpp.long_long.as.ModWith.impl.Op.type.95fc8a.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ModWith.type.920: type = facet_type <@ModWith, @ModWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %ModWith.Op.type.295: type = fn_type @ModWith.Op, @ModWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %ModWith.impl_witness.87d: <witness> = impl_witness imports.%ModWith.impl_witness_table.b3a, @Cpp.long_long.as.ModWith.impl.18e(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.type.d806b7.1: type = fn_type @Cpp.long_long.as.ModWith.impl.Op.2, @Cpp.long_long.as.ModWith.impl.18e(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.2a70b6.1: %Cpp.long_long.as.ModWith.impl.Op.type.d806b7.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.type.d806b7.2: type = fn_type @Cpp.long_long.as.ModWith.impl.Op.1, @Cpp.long_long.as.ModWith.impl.18e(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.2a70b6.2: %Cpp.long_long.as.ModWith.impl.Op.type.d806b7.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %ModWith.facet.31b: %ModWith.type.e0d = facet_value %Cpp.long_long, (%ModWith.impl_witness.87d) [concrete]
+// CHECK:STDOUT:   %.7be: type = fn_type_with_self_type %ModWith.Op.type.227, %ModWith.facet.31b [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.specific_fn.0712c6.1: <specific function> = specific_function %Cpp.long_long.as.ModWith.impl.Op.2a70b6.2, @Cpp.long_long.as.ModWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.specific_fn.0712c6.2: <specific function> = specific_function %Cpp.long_long.as.ModWith.impl.Op.2a70b6.1, @Cpp.long_long.as.ModWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %AddWith.impl_witness.3da: <witness> = impl_witness imports.%AddWith.impl_witness_table.a7c, @Cpp.long_long.as.AddWith.impl.2ad(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.type.993564.1: type = fn_type @Cpp.long_long.as.AddWith.impl.Op.2, @Cpp.long_long.as.AddWith.impl.2ad(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.ca408b.1: %Cpp.long_long.as.AddWith.impl.Op.type.993564.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.type.993564.2: type = fn_type @Cpp.long_long.as.AddWith.impl.Op.1, @Cpp.long_long.as.AddWith.impl.2ad(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.ca408b.2: %Cpp.long_long.as.AddWith.impl.Op.type.993564.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddWith.facet.df3: %AddWith.type.4c0 = facet_value %Cpp.long_long, (%AddWith.impl_witness.3da) [concrete]
+// CHECK:STDOUT:   %.83b: type = fn_type_with_self_type %AddWith.Op.type.0ee, %AddWith.facet.df3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.specific_fn.843525.1: <specific function> = specific_function %Cpp.long_long.as.AddWith.impl.Op.ca408b.2, @Cpp.long_long.as.AddWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.specific_fn.843525.2: <specific function> = specific_function %Cpp.long_long.as.AddWith.impl.Op.ca408b.1, @Cpp.long_long.as.AddWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %SubWith.impl_witness.e45: <witness> = impl_witness imports.%SubWith.impl_witness_table.741, @Cpp.long_long.as.SubWith.impl.182(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.type.d8fc6c.1: type = fn_type @Cpp.long_long.as.SubWith.impl.Op.2, @Cpp.long_long.as.SubWith.impl.182(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.a0f7a7.1: %Cpp.long_long.as.SubWith.impl.Op.type.d8fc6c.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.type.d8fc6c.2: type = fn_type @Cpp.long_long.as.SubWith.impl.Op.1, @Cpp.long_long.as.SubWith.impl.182(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.a0f7a7.2: %Cpp.long_long.as.SubWith.impl.Op.type.d8fc6c.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %SubWith.facet.326: %SubWith.type.a89 = facet_value %Cpp.long_long, (%SubWith.impl_witness.e45) [concrete]
+// CHECK:STDOUT:   %.70c: type = fn_type_with_self_type %SubWith.Op.type.95d, %SubWith.facet.326 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.specific_fn.b28cbd.1: <specific function> = specific_function %Cpp.long_long.as.SubWith.impl.Op.a0f7a7.2, @Cpp.long_long.as.SubWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.specific_fn.b28cbd.2: <specific function> = specific_function %Cpp.long_long.as.SubWith.impl.Op.a0f7a7.1, @Cpp.long_long.as.SubWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %MulWith.impl_witness.e35: <witness> = impl_witness imports.%MulWith.impl_witness_table.75e, @Cpp.long_long.as.MulWith.impl.eea(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.type.1463e0.1: type = fn_type @Cpp.long_long.as.MulWith.impl.Op.2, @Cpp.long_long.as.MulWith.impl.eea(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.d9ae5b.1: %Cpp.long_long.as.MulWith.impl.Op.type.1463e0.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.type.1463e0.2: type = fn_type @Cpp.long_long.as.MulWith.impl.Op.1, @Cpp.long_long.as.MulWith.impl.eea(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.d9ae5b.2: %Cpp.long_long.as.MulWith.impl.Op.type.1463e0.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %MulWith.facet.004: %MulWith.type.4ce = facet_value %Cpp.long_long, (%MulWith.impl_witness.e35) [concrete]
+// CHECK:STDOUT:   %.10e: type = fn_type_with_self_type %MulWith.Op.type.ff6, %MulWith.facet.004 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.specific_fn.e6b65e.1: <specific function> = specific_function %Cpp.long_long.as.MulWith.impl.Op.d9ae5b.2, @Cpp.long_long.as.MulWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.specific_fn.e6b65e.2: <specific function> = specific_function %Cpp.long_long.as.MulWith.impl.Op.d9ae5b.1, @Cpp.long_long.as.MulWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %DivWith.impl_witness.591: <witness> = impl_witness imports.%DivWith.impl_witness_table.e78, @Cpp.long_long.as.DivWith.impl.543(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.type.0e5a2e.1: type = fn_type @Cpp.long_long.as.DivWith.impl.Op.2, @Cpp.long_long.as.DivWith.impl.543(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.16569a.1: %Cpp.long_long.as.DivWith.impl.Op.type.0e5a2e.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.type.0e5a2e.2: type = fn_type @Cpp.long_long.as.DivWith.impl.Op.1, @Cpp.long_long.as.DivWith.impl.543(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.16569a.2: %Cpp.long_long.as.DivWith.impl.Op.type.0e5a2e.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %DivWith.facet.e43: %DivWith.type.234 = facet_value %Cpp.long_long, (%DivWith.impl_witness.591) [concrete]
+// CHECK:STDOUT:   %.e74: type = fn_type_with_self_type %DivWith.Op.type.c64, %DivWith.facet.e43 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.specific_fn.9f24e4.1: <specific function> = specific_function %Cpp.long_long.as.DivWith.impl.Op.16569a.2, @Cpp.long_long.as.DivWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.specific_fn.9f24e4.2: <specific function> = specific_function %Cpp.long_long.as.DivWith.impl.Op.16569a.1, @Cpp.long_long.as.DivWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %ModWith.impl_witness.f74: <witness> = impl_witness imports.%ModWith.impl_witness_table.b3a, @Cpp.long_long.as.ModWith.impl.18e(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.type.3b4b62.1: type = fn_type @Cpp.long_long.as.ModWith.impl.Op.2, @Cpp.long_long.as.ModWith.impl.18e(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.7eaa96.1: %Cpp.long_long.as.ModWith.impl.Op.type.3b4b62.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.type.3b4b62.2: type = fn_type @Cpp.long_long.as.ModWith.impl.Op.1, @Cpp.long_long.as.ModWith.impl.18e(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.7eaa96.2: %Cpp.long_long.as.ModWith.impl.Op.type.3b4b62.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %ModWith.facet.b9f: %ModWith.type.920 = facet_value %Cpp.long_long, (%ModWith.impl_witness.f74) [concrete]
+// CHECK:STDOUT:   %.c35: type = fn_type_with_self_type %ModWith.Op.type.295, %ModWith.facet.b9f [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.specific_fn.b95c4a.1: <specific function> = specific_function %Cpp.long_long.as.ModWith.impl.Op.7eaa96.2, @Cpp.long_long.as.ModWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.specific_fn.b95c4a.2: <specific function> = specific_function %Cpp.long_long.as.ModWith.impl.Op.7eaa96.1, @Cpp.long_long.as.ModWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.556: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.74f, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d48: %ImplicitAs.type.2ad = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.556) [concrete]
+// CHECK:STDOUT:   %.567: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.d48 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method.288: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ca0: @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert.type (%Core.IntLiteral.as.As.impl.Convert.type.09e) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert (constants.%Core.IntLiteral.as.As.impl.Convert.dbe)]
+// CHECK:STDOUT:   %As.impl_witness_table.9fc = impl_witness_table (%Core.import_ref.ca0), @Core.IntLiteral.as.As.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.1 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.809: @Cpp.long_long.as.AddWith.impl.2ad.%Cpp.long_long.as.AddWith.impl.Op.type.2 (%Cpp.long_long.as.AddWith.impl.Op.type.b32b60.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.AddWith.impl.2ad.%Cpp.long_long.as.AddWith.impl.Op.2 (constants.%Cpp.long_long.as.AddWith.impl.Op.8cdaa8.1)]
+// CHECK:STDOUT:   %AddWith.impl_witness_table.a7c = impl_witness_table (%Core.import_ref.ce3a05.1, %Core.import_ref.809), @Cpp.long_long.as.AddWith.impl.2ad [concrete]
+// CHECK:STDOUT:   %Core.Op.b7d: @Cpp.long_long.as.AddWith.impl.2ad.%Cpp.long_long.as.AddWith.impl.Op.type.1 (%Cpp.long_long.as.AddWith.impl.Op.type.b32b60.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.AddWith.impl.2ad.%Cpp.long_long.as.AddWith.impl.Op.1 (constants.%Cpp.long_long.as.AddWith.impl.Op.8cdaa8.2)]
+// CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
+// CHECK:STDOUT:   %Core.import_ref.4f4b: %i64.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.b19 = impl_witness_table (%Core.import_ref.4f4b), @i64.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.3 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.a31: @Cpp.long_long.as.SubWith.impl.182.%Cpp.long_long.as.SubWith.impl.Op.type.2 (%Cpp.long_long.as.SubWith.impl.Op.type.8c27c7.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.SubWith.impl.182.%Cpp.long_long.as.SubWith.impl.Op.2 (constants.%Cpp.long_long.as.SubWith.impl.Op.58d0ca.1)]
+// CHECK:STDOUT:   %SubWith.impl_witness_table.741 = impl_witness_table (%Core.import_ref.ce3a05.3, %Core.import_ref.a31), @Cpp.long_long.as.SubWith.impl.182 [concrete]
+// CHECK:STDOUT:   %Core.Op.15a: @Cpp.long_long.as.SubWith.impl.182.%Cpp.long_long.as.SubWith.impl.Op.type.1 (%Cpp.long_long.as.SubWith.impl.Op.type.8c27c7.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.SubWith.impl.182.%Cpp.long_long.as.SubWith.impl.Op.1 (constants.%Cpp.long_long.as.SubWith.impl.Op.58d0ca.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.5 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.02d: @Cpp.long_long.as.MulWith.impl.eea.%Cpp.long_long.as.MulWith.impl.Op.type.2 (%Cpp.long_long.as.MulWith.impl.Op.type.68c2bf.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.MulWith.impl.eea.%Cpp.long_long.as.MulWith.impl.Op.2 (constants.%Cpp.long_long.as.MulWith.impl.Op.4cb78c.1)]
+// CHECK:STDOUT:   %MulWith.impl_witness_table.75e = impl_witness_table (%Core.import_ref.ce3a05.5, %Core.import_ref.02d), @Cpp.long_long.as.MulWith.impl.eea [concrete]
+// CHECK:STDOUT:   %Core.Op.bb0: @Cpp.long_long.as.MulWith.impl.eea.%Cpp.long_long.as.MulWith.impl.Op.type.1 (%Cpp.long_long.as.MulWith.impl.Op.type.68c2bf.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.MulWith.impl.eea.%Cpp.long_long.as.MulWith.impl.Op.1 (constants.%Cpp.long_long.as.MulWith.impl.Op.4cb78c.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.7 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.bd4: @Cpp.long_long.as.DivWith.impl.543.%Cpp.long_long.as.DivWith.impl.Op.type.2 (%Cpp.long_long.as.DivWith.impl.Op.type.3de041.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.DivWith.impl.543.%Cpp.long_long.as.DivWith.impl.Op.2 (constants.%Cpp.long_long.as.DivWith.impl.Op.bff666.1)]
+// CHECK:STDOUT:   %DivWith.impl_witness_table.e78 = impl_witness_table (%Core.import_ref.ce3a05.7, %Core.import_ref.bd4), @Cpp.long_long.as.DivWith.impl.543 [concrete]
+// CHECK:STDOUT:   %Core.Op.ac1: @Cpp.long_long.as.DivWith.impl.543.%Cpp.long_long.as.DivWith.impl.Op.type.1 (%Cpp.long_long.as.DivWith.impl.Op.type.3de041.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.DivWith.impl.543.%Cpp.long_long.as.DivWith.impl.Op.1 (constants.%Cpp.long_long.as.DivWith.impl.Op.bff666.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.9 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.a84: @Cpp.long_long.as.ModWith.impl.18e.%Cpp.long_long.as.ModWith.impl.Op.type.2 (%Cpp.long_long.as.ModWith.impl.Op.type.95fc8a.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.ModWith.impl.18e.%Cpp.long_long.as.ModWith.impl.Op.2 (constants.%Cpp.long_long.as.ModWith.impl.Op.3ec9be.1)]
+// CHECK:STDOUT:   %ModWith.impl_witness_table.b3a = impl_witness_table (%Core.import_ref.ce3a05.9, %Core.import_ref.a84), @Cpp.long_long.as.ModWith.impl.18e [concrete]
+// CHECK:STDOUT:   %Core.Op.a7a: @Cpp.long_long.as.ModWith.impl.18e.%Cpp.long_long.as.ModWith.impl.Op.type.1 (%Cpp.long_long.as.ModWith.impl.Op.type.95fc8a.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.ModWith.impl.18e.%Cpp.long_long.as.ModWith.impl.Op.1 (constants.%Cpp.long_long.as.ModWith.impl.Op.3ec9be.2)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @ArithmeticHeterogeneousLongLongLeftSide() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %x.patt: %pattern_type.76e = value_binding_pattern x [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc10_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc10: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10(%int_1.loc10) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.2: %Cpp.long_long = converted %int_1.loc10, %.loc10_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %x: %Cpp.long_long = value_binding x, %.loc10_26.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc12: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc12_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc12: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc12: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc12: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc12_25.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc12_25.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_25.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc12_25: <specific function> = specific_function %impl.elem0.loc12_25.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc12_25.2: <bound method> = bound_method %int_1.loc12, %specific_fn.loc12_25 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc12: init %i64 = call %bound_method.loc12_25.2(%int_1.loc12) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_25.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc12 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_25.2: %i64 = converted %int_1.loc12, %.loc12_25.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc12: %.1e9 = impl_witness_access constants.%AddWith.impl_witness.24c, element1 [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.f65668.2]
+// CHECK:STDOUT:   %bound_method.loc12_20.1: <bound method> = bound_method %x.ref.loc12_18, %impl.elem1.loc12
+// CHECK:STDOUT:   %ImplicitAs.facet.loc12_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc12_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc12_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc12_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc12_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc12_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc12_20: <specific function> = specific_function %impl.elem1.loc12, @Cpp.long_long.as.AddWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.specific_fn.be49b1.1]
+// CHECK:STDOUT:   %bound_method.loc12_20.2: <bound method> = bound_method %x.ref.loc12_18, %specific_fn.loc12_20
+// CHECK:STDOUT:   %.loc12_20.3: %Cpp.long_long.as.AddWith.impl.Op.type.f5b88b.1 = specific_constant imports.%Core.Op.b7d, @Cpp.long_long.as.AddWith.impl.2ad(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.f65668.1]
+// CHECK:STDOUT:   %Op.ref.loc12: %Cpp.long_long.as.AddWith.impl.Op.type.f5b88b.1 = name_ref Op, %.loc12_20.3 [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.f65668.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.bound.loc12: <bound method> = bound_method %x.ref.loc12_18, %Op.ref.loc12
+// CHECK:STDOUT:   %impl.elem0.loc12_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_20.3: <bound method> = bound_method %.loc12_25.2, %impl.elem0.loc12_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12_20: init %Cpp.long_long = call %bound_method.loc12_20.3(%.loc12_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_20.5: %Cpp.long_long = converted %.loc12_25.2, %.loc12_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.specific_fn.loc12: <specific function> = specific_function %Op.ref.loc12, @Cpp.long_long.as.AddWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.specific_fn.be49b1.2]
+// CHECK:STDOUT:   %bound_method.loc12_20.4: <bound method> = bound_method %x.ref.loc12_18, %Cpp.long_long.as.AddWith.impl.Op.specific_fn.loc12
+// CHECK:STDOUT:   %impl.elem0.loc12_25.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_25.3: <bound method> = bound_method %.loc12_25.2, %impl.elem0.loc12_25.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12_25: init %Cpp.long_long = call %bound_method.loc12_25.3(%.loc12_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_25.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12_25 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_25.4: %Cpp.long_long = converted %.loc12_25.2, %.loc12_25.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.call.loc12: init %Cpp.long_long = call %bound_method.loc12_20.4(%x.ref.loc12_18, %.loc12_25.4)
+// CHECK:STDOUT:   %x.ref.loc12_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc12: <specific function> = specific_function %AssertSameType.ref.loc12, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc12_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.AddWith.impl.Op.call.loc12
+// CHECK:STDOUT:   %.loc12_20.7: %Cpp.long_long = converted %Cpp.long_long.as.AddWith.impl.Op.call.loc12, %.loc12_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc12: init %empty_tuple.type = call %AssertSameType.specific_fn.loc12(%.loc12_20.7, %x.ref.loc12_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc13: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc13_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc13: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc13: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc13: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc13_25.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc13_25.1: <bound method> = bound_method %int_1.loc13, %impl.elem0.loc13_25.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc13_25: <specific function> = specific_function %impl.elem0.loc13_25.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc13_25.2: <bound method> = bound_method %int_1.loc13, %specific_fn.loc13_25 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc13: init %i64 = call %bound_method.loc13_25.2(%int_1.loc13) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_25.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc13 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_25.2: %i64 = converted %int_1.loc13, %.loc13_25.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc13: %.036 = impl_witness_access constants.%SubWith.impl_witness.07a, element1 [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.85827a.2]
+// CHECK:STDOUT:   %bound_method.loc13_20.1: <bound method> = bound_method %x.ref.loc13_18, %impl.elem1.loc13
+// CHECK:STDOUT:   %ImplicitAs.facet.loc13_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc13_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc13_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc13_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc13_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc13_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc13_20: <specific function> = specific_function %impl.elem1.loc13, @Cpp.long_long.as.SubWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.specific_fn.8f1b07.1]
+// CHECK:STDOUT:   %bound_method.loc13_20.2: <bound method> = bound_method %x.ref.loc13_18, %specific_fn.loc13_20
+// CHECK:STDOUT:   %.loc13_20.3: %Cpp.long_long.as.SubWith.impl.Op.type.e1aaf1.1 = specific_constant imports.%Core.Op.15a, @Cpp.long_long.as.SubWith.impl.182(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.85827a.1]
+// CHECK:STDOUT:   %Op.ref.loc13: %Cpp.long_long.as.SubWith.impl.Op.type.e1aaf1.1 = name_ref Op, %.loc13_20.3 [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.85827a.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.bound.loc13: <bound method> = bound_method %x.ref.loc13_18, %Op.ref.loc13
+// CHECK:STDOUT:   %impl.elem0.loc13_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_20.3: <bound method> = bound_method %.loc13_25.2, %impl.elem0.loc13_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13_20: init %Cpp.long_long = call %bound_method.loc13_20.3(%.loc13_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_20.5: %Cpp.long_long = converted %.loc13_25.2, %.loc13_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.specific_fn.loc13: <specific function> = specific_function %Op.ref.loc13, @Cpp.long_long.as.SubWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.specific_fn.8f1b07.2]
+// CHECK:STDOUT:   %bound_method.loc13_20.4: <bound method> = bound_method %x.ref.loc13_18, %Cpp.long_long.as.SubWith.impl.Op.specific_fn.loc13
+// CHECK:STDOUT:   %impl.elem0.loc13_25.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_25.3: <bound method> = bound_method %.loc13_25.2, %impl.elem0.loc13_25.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13_25: init %Cpp.long_long = call %bound_method.loc13_25.3(%.loc13_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_25.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13_25 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_25.4: %Cpp.long_long = converted %.loc13_25.2, %.loc13_25.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.call.loc13: init %Cpp.long_long = call %bound_method.loc13_20.4(%x.ref.loc13_18, %.loc13_25.4)
+// CHECK:STDOUT:   %x.ref.loc13_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc13: <specific function> = specific_function %AssertSameType.ref.loc13, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc13_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.SubWith.impl.Op.call.loc13
+// CHECK:STDOUT:   %.loc13_20.7: %Cpp.long_long = converted %Cpp.long_long.as.SubWith.impl.Op.call.loc13, %.loc13_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc13: init %empty_tuple.type = call %AssertSameType.specific_fn.loc13(%.loc13_20.7, %x.ref.loc13_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc14: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc14_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc14: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc14: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc14: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc14_25.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc14_25.1: <bound method> = bound_method %int_1.loc14, %impl.elem0.loc14_25.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc14_25: <specific function> = specific_function %impl.elem0.loc14_25.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc14_25.2: <bound method> = bound_method %int_1.loc14, %specific_fn.loc14_25 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc14: init %i64 = call %bound_method.loc14_25.2(%int_1.loc14) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc14_25.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc14 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc14_25.2: %i64 = converted %int_1.loc14, %.loc14_25.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc14: %.830 = impl_witness_access constants.%MulWith.impl_witness.0f5, element1 [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.dd0f62.2]
+// CHECK:STDOUT:   %bound_method.loc14_20.1: <bound method> = bound_method %x.ref.loc14_18, %impl.elem1.loc14
+// CHECK:STDOUT:   %ImplicitAs.facet.loc14_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc14_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc14_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc14_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc14_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc14_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc14_20: <specific function> = specific_function %impl.elem1.loc14, @Cpp.long_long.as.MulWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.specific_fn.f1361f.1]
+// CHECK:STDOUT:   %bound_method.loc14_20.2: <bound method> = bound_method %x.ref.loc14_18, %specific_fn.loc14_20
+// CHECK:STDOUT:   %.loc14_20.3: %Cpp.long_long.as.MulWith.impl.Op.type.0f8803.1 = specific_constant imports.%Core.Op.bb0, @Cpp.long_long.as.MulWith.impl.eea(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.dd0f62.1]
+// CHECK:STDOUT:   %Op.ref.loc14: %Cpp.long_long.as.MulWith.impl.Op.type.0f8803.1 = name_ref Op, %.loc14_20.3 [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.dd0f62.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.bound.loc14: <bound method> = bound_method %x.ref.loc14_18, %Op.ref.loc14
+// CHECK:STDOUT:   %impl.elem0.loc14_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc14_20.3: <bound method> = bound_method %.loc14_25.2, %impl.elem0.loc14_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc14_20: init %Cpp.long_long = call %bound_method.loc14_20.3(%.loc14_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc14_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_20.5: %Cpp.long_long = converted %.loc14_25.2, %.loc14_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.specific_fn.loc14: <specific function> = specific_function %Op.ref.loc14, @Cpp.long_long.as.MulWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.specific_fn.f1361f.2]
+// CHECK:STDOUT:   %bound_method.loc14_20.4: <bound method> = bound_method %x.ref.loc14_18, %Cpp.long_long.as.MulWith.impl.Op.specific_fn.loc14
+// CHECK:STDOUT:   %impl.elem0.loc14_25.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc14_25.3: <bound method> = bound_method %.loc14_25.2, %impl.elem0.loc14_25.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc14_25: init %Cpp.long_long = call %bound_method.loc14_25.3(%.loc14_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_25.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc14_25 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_25.4: %Cpp.long_long = converted %.loc14_25.2, %.loc14_25.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.call.loc14: init %Cpp.long_long = call %bound_method.loc14_20.4(%x.ref.loc14_18, %.loc14_25.4)
+// CHECK:STDOUT:   %x.ref.loc14_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc14: <specific function> = specific_function %AssertSameType.ref.loc14, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc14_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.MulWith.impl.Op.call.loc14
+// CHECK:STDOUT:   %.loc14_20.7: %Cpp.long_long = converted %Cpp.long_long.as.MulWith.impl.Op.call.loc14, %.loc14_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc14: init %empty_tuple.type = call %AssertSameType.specific_fn.loc14(%.loc14_20.7, %x.ref.loc14_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc15: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc15_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc15: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc15: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc15_25.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc15_25.1: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15_25.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc15_25: <specific function> = specific_function %impl.elem0.loc15_25.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_25.2: <bound method> = bound_method %int_1.loc15, %specific_fn.loc15_25 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc15: init %i64 = call %bound_method.loc15_25.2(%int_1.loc15) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_25.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc15 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_25.2: %i64 = converted %int_1.loc15, %.loc15_25.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc15: %.310 = impl_witness_access constants.%DivWith.impl_witness.4d9, element1 [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.306cec.2]
+// CHECK:STDOUT:   %bound_method.loc15_20.1: <bound method> = bound_method %x.ref.loc15_18, %impl.elem1.loc15
+// CHECK:STDOUT:   %ImplicitAs.facet.loc15_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc15_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc15_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc15_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc15_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc15_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc15_20: <specific function> = specific_function %impl.elem1.loc15, @Cpp.long_long.as.DivWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.specific_fn.eb685a.1]
+// CHECK:STDOUT:   %bound_method.loc15_20.2: <bound method> = bound_method %x.ref.loc15_18, %specific_fn.loc15_20
+// CHECK:STDOUT:   %.loc15_20.3: %Cpp.long_long.as.DivWith.impl.Op.type.c562f2.1 = specific_constant imports.%Core.Op.ac1, @Cpp.long_long.as.DivWith.impl.543(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.306cec.1]
+// CHECK:STDOUT:   %Op.ref.loc15: %Cpp.long_long.as.DivWith.impl.Op.type.c562f2.1 = name_ref Op, %.loc15_20.3 [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.306cec.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.bound.loc15: <bound method> = bound_method %x.ref.loc15_18, %Op.ref.loc15
+// CHECK:STDOUT:   %impl.elem0.loc15_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc15_20.3: <bound method> = bound_method %.loc15_25.2, %impl.elem0.loc15_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc15_20: init %Cpp.long_long = call %bound_method.loc15_20.3(%.loc15_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc15_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_20.5: %Cpp.long_long = converted %.loc15_25.2, %.loc15_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.specific_fn.loc15: <specific function> = specific_function %Op.ref.loc15, @Cpp.long_long.as.DivWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.specific_fn.eb685a.2]
+// CHECK:STDOUT:   %bound_method.loc15_20.4: <bound method> = bound_method %x.ref.loc15_18, %Cpp.long_long.as.DivWith.impl.Op.specific_fn.loc15
+// CHECK:STDOUT:   %impl.elem0.loc15_25.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc15_25.3: <bound method> = bound_method %.loc15_25.2, %impl.elem0.loc15_25.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc15_25: init %Cpp.long_long = call %bound_method.loc15_25.3(%.loc15_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_25.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc15_25 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_25.4: %Cpp.long_long = converted %.loc15_25.2, %.loc15_25.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.call.loc15: init %Cpp.long_long = call %bound_method.loc15_20.4(%x.ref.loc15_18, %.loc15_25.4)
+// CHECK:STDOUT:   %x.ref.loc15_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc15: <specific function> = specific_function %AssertSameType.ref.loc15, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc15_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.DivWith.impl.Op.call.loc15
+// CHECK:STDOUT:   %.loc15_20.7: %Cpp.long_long = converted %Cpp.long_long.as.DivWith.impl.Op.call.loc15, %.loc15_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc15: init %empty_tuple.type = call %AssertSameType.specific_fn.loc15(%.loc15_20.7, %x.ref.loc15_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc16: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc16_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc16: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc16: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc16: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc16_25.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc16_25.1: <bound method> = bound_method %int_1.loc16, %impl.elem0.loc16_25.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc16_25: <specific function> = specific_function %impl.elem0.loc16_25.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc16_25.2: <bound method> = bound_method %int_1.loc16, %specific_fn.loc16_25 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc16: init %i64 = call %bound_method.loc16_25.2(%int_1.loc16) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc16_25.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc16 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc16_25.2: %i64 = converted %int_1.loc16, %.loc16_25.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc16: %.7be = impl_witness_access constants.%ModWith.impl_witness.87d, element1 [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.2a70b6.2]
+// CHECK:STDOUT:   %bound_method.loc16_20.1: <bound method> = bound_method %x.ref.loc16_18, %impl.elem1.loc16
+// CHECK:STDOUT:   %ImplicitAs.facet.loc16_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc16_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc16_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc16_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc16_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc16_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc16_20: <specific function> = specific_function %impl.elem1.loc16, @Cpp.long_long.as.ModWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.specific_fn.0712c6.1]
+// CHECK:STDOUT:   %bound_method.loc16_20.2: <bound method> = bound_method %x.ref.loc16_18, %specific_fn.loc16_20
+// CHECK:STDOUT:   %.loc16_20.3: %Cpp.long_long.as.ModWith.impl.Op.type.d806b7.1 = specific_constant imports.%Core.Op.a7a, @Cpp.long_long.as.ModWith.impl.18e(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.2a70b6.1]
+// CHECK:STDOUT:   %Op.ref.loc16: %Cpp.long_long.as.ModWith.impl.Op.type.d806b7.1 = name_ref Op, %.loc16_20.3 [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.2a70b6.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.bound.loc16: <bound method> = bound_method %x.ref.loc16_18, %Op.ref.loc16
+// CHECK:STDOUT:   %impl.elem0.loc16_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc16_20.3: <bound method> = bound_method %.loc16_25.2, %impl.elem0.loc16_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc16_20: init %Cpp.long_long = call %bound_method.loc16_20.3(%.loc16_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc16_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_20.5: %Cpp.long_long = converted %.loc16_25.2, %.loc16_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.specific_fn.loc16: <specific function> = specific_function %Op.ref.loc16, @Cpp.long_long.as.ModWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.specific_fn.0712c6.2]
+// CHECK:STDOUT:   %bound_method.loc16_20.4: <bound method> = bound_method %x.ref.loc16_18, %Cpp.long_long.as.ModWith.impl.Op.specific_fn.loc16
+// CHECK:STDOUT:   %impl.elem0.loc16_25.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc16_25.3: <bound method> = bound_method %.loc16_25.2, %impl.elem0.loc16_25.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc16_25: init %Cpp.long_long = call %bound_method.loc16_25.3(%.loc16_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_25.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc16_25 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_25.4: %Cpp.long_long = converted %.loc16_25.2, %.loc16_25.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.call.loc16: init %Cpp.long_long = call %bound_method.loc16_20.4(%x.ref.loc16_18, %.loc16_25.4)
+// CHECK:STDOUT:   %x.ref.loc16_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc16: <specific function> = specific_function %AssertSameType.ref.loc16, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc16_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.ModWith.impl.Op.call.loc16
+// CHECK:STDOUT:   %.loc16_20.7: %Cpp.long_long = converted %Cpp.long_long.as.ModWith.impl.Op.call.loc16, %.loc16_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc16: init %empty_tuple.type = call %AssertSameType.specific_fn.loc16(%.loc16_20.7, %x.ref.loc16_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc18: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc18_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc18: %.83b = impl_witness_access constants.%AddWith.impl_witness.3da, element1 [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.ca408b.2]
+// CHECK:STDOUT:   %bound_method.loc18_20.1: <bound method> = bound_method %x.ref.loc18_18, %impl.elem1.loc18
+// CHECK:STDOUT:   %ImplicitAs.facet.loc18_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc18_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc18_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc18_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc18_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc18_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc18: <specific function> = specific_function %impl.elem1.loc18, @Cpp.long_long.as.AddWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.specific_fn.843525.1]
+// CHECK:STDOUT:   %bound_method.loc18_20.2: <bound method> = bound_method %x.ref.loc18_18, %specific_fn.loc18
+// CHECK:STDOUT:   %.loc18_20.3: %Cpp.long_long.as.AddWith.impl.Op.type.993564.1 = specific_constant imports.%Core.Op.b7d, @Cpp.long_long.as.AddWith.impl.2ad(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.ca408b.1]
+// CHECK:STDOUT:   %Op.ref.loc18: %Cpp.long_long.as.AddWith.impl.Op.type.993564.1 = name_ref Op, %.loc18_20.3 [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.ca408b.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.bound.loc18: <bound method> = bound_method %x.ref.loc18_18, %Op.ref.loc18
+// CHECK:STDOUT:   %impl.elem0.loc18_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc18_20.3: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18_20: init %Cpp.long_long = call %bound_method.loc18_20.3(%int_1.loc18) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_20.5: %Cpp.long_long = converted %int_1.loc18, %.loc18_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.specific_fn.loc18: <specific function> = specific_function %Op.ref.loc18, @Cpp.long_long.as.AddWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.specific_fn.843525.2]
+// CHECK:STDOUT:   %bound_method.loc18_20.4: <bound method> = bound_method %x.ref.loc18_18, %Cpp.long_long.as.AddWith.impl.Op.specific_fn.loc18
+// CHECK:STDOUT:   %impl.elem0.loc18_22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc18_22: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18_22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18_22: init %Cpp.long_long = call %bound_method.loc18_22(%int_1.loc18) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_22.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18_22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_22.2: %Cpp.long_long = converted %int_1.loc18, %.loc18_22.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.call.loc18: init %Cpp.long_long = call %bound_method.loc18_20.4(%x.ref.loc18_18, %.loc18_22.2)
+// CHECK:STDOUT:   %x.ref.loc18_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc18: <specific function> = specific_function %AssertSameType.ref.loc18, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc18_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.AddWith.impl.Op.call.loc18
+// CHECK:STDOUT:   %.loc18_20.7: %Cpp.long_long = converted %Cpp.long_long.as.AddWith.impl.Op.call.loc18, %.loc18_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc18: init %empty_tuple.type = call %AssertSameType.specific_fn.loc18(%.loc18_20.7, %x.ref.loc18_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc19: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc19_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc19: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc19: %.70c = impl_witness_access constants.%SubWith.impl_witness.e45, element1 [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.a0f7a7.2]
+// CHECK:STDOUT:   %bound_method.loc19_20.1: <bound method> = bound_method %x.ref.loc19_18, %impl.elem1.loc19
+// CHECK:STDOUT:   %ImplicitAs.facet.loc19_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc19_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc19_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc19_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc19_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc19_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc19: <specific function> = specific_function %impl.elem1.loc19, @Cpp.long_long.as.SubWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.specific_fn.b28cbd.1]
+// CHECK:STDOUT:   %bound_method.loc19_20.2: <bound method> = bound_method %x.ref.loc19_18, %specific_fn.loc19
+// CHECK:STDOUT:   %.loc19_20.3: %Cpp.long_long.as.SubWith.impl.Op.type.d8fc6c.1 = specific_constant imports.%Core.Op.15a, @Cpp.long_long.as.SubWith.impl.182(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.a0f7a7.1]
+// CHECK:STDOUT:   %Op.ref.loc19: %Cpp.long_long.as.SubWith.impl.Op.type.d8fc6c.1 = name_ref Op, %.loc19_20.3 [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.a0f7a7.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.bound.loc19: <bound method> = bound_method %x.ref.loc19_18, %Op.ref.loc19
+// CHECK:STDOUT:   %impl.elem0.loc19_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc19_20.3: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19_20: init %Cpp.long_long = call %bound_method.loc19_20.3(%int_1.loc19) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_20.5: %Cpp.long_long = converted %int_1.loc19, %.loc19_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.specific_fn.loc19: <specific function> = specific_function %Op.ref.loc19, @Cpp.long_long.as.SubWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.specific_fn.b28cbd.2]
+// CHECK:STDOUT:   %bound_method.loc19_20.4: <bound method> = bound_method %x.ref.loc19_18, %Cpp.long_long.as.SubWith.impl.Op.specific_fn.loc19
+// CHECK:STDOUT:   %impl.elem0.loc19_22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc19_22: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19_22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19_22: init %Cpp.long_long = call %bound_method.loc19_22(%int_1.loc19) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_22.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19_22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_22.2: %Cpp.long_long = converted %int_1.loc19, %.loc19_22.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.call.loc19: init %Cpp.long_long = call %bound_method.loc19_20.4(%x.ref.loc19_18, %.loc19_22.2)
+// CHECK:STDOUT:   %x.ref.loc19_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc19: <specific function> = specific_function %AssertSameType.ref.loc19, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc19_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.SubWith.impl.Op.call.loc19
+// CHECK:STDOUT:   %.loc19_20.7: %Cpp.long_long = converted %Cpp.long_long.as.SubWith.impl.Op.call.loc19, %.loc19_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc19: init %empty_tuple.type = call %AssertSameType.specific_fn.loc19(%.loc19_20.7, %x.ref.loc19_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc20: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc20_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc20: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc20: %.10e = impl_witness_access constants.%MulWith.impl_witness.e35, element1 [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.d9ae5b.2]
+// CHECK:STDOUT:   %bound_method.loc20_20.1: <bound method> = bound_method %x.ref.loc20_18, %impl.elem1.loc20
+// CHECK:STDOUT:   %ImplicitAs.facet.loc20_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc20_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc20_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc20_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc20_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc20_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc20: <specific function> = specific_function %impl.elem1.loc20, @Cpp.long_long.as.MulWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.specific_fn.e6b65e.1]
+// CHECK:STDOUT:   %bound_method.loc20_20.2: <bound method> = bound_method %x.ref.loc20_18, %specific_fn.loc20
+// CHECK:STDOUT:   %.loc20_20.3: %Cpp.long_long.as.MulWith.impl.Op.type.1463e0.1 = specific_constant imports.%Core.Op.bb0, @Cpp.long_long.as.MulWith.impl.eea(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.d9ae5b.1]
+// CHECK:STDOUT:   %Op.ref.loc20: %Cpp.long_long.as.MulWith.impl.Op.type.1463e0.1 = name_ref Op, %.loc20_20.3 [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.d9ae5b.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.bound.loc20: <bound method> = bound_method %x.ref.loc20_18, %Op.ref.loc20
+// CHECK:STDOUT:   %impl.elem0.loc20_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc20_20.3: <bound method> = bound_method %int_1.loc20, %impl.elem0.loc20_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20_20: init %Cpp.long_long = call %bound_method.loc20_20.3(%int_1.loc20) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_20.5: %Cpp.long_long = converted %int_1.loc20, %.loc20_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.specific_fn.loc20: <specific function> = specific_function %Op.ref.loc20, @Cpp.long_long.as.MulWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.specific_fn.e6b65e.2]
+// CHECK:STDOUT:   %bound_method.loc20_20.4: <bound method> = bound_method %x.ref.loc20_18, %Cpp.long_long.as.MulWith.impl.Op.specific_fn.loc20
+// CHECK:STDOUT:   %impl.elem0.loc20_22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc20_22: <bound method> = bound_method %int_1.loc20, %impl.elem0.loc20_22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20_22: init %Cpp.long_long = call %bound_method.loc20_22(%int_1.loc20) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_22.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20_22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_22.2: %Cpp.long_long = converted %int_1.loc20, %.loc20_22.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.call.loc20: init %Cpp.long_long = call %bound_method.loc20_20.4(%x.ref.loc20_18, %.loc20_22.2)
+// CHECK:STDOUT:   %x.ref.loc20_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc20: <specific function> = specific_function %AssertSameType.ref.loc20, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc20_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.MulWith.impl.Op.call.loc20
+// CHECK:STDOUT:   %.loc20_20.7: %Cpp.long_long = converted %Cpp.long_long.as.MulWith.impl.Op.call.loc20, %.loc20_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc20: init %empty_tuple.type = call %AssertSameType.specific_fn.loc20(%.loc20_20.7, %x.ref.loc20_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc21: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc21_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc21: %.e74 = impl_witness_access constants.%DivWith.impl_witness.591, element1 [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.16569a.2]
+// CHECK:STDOUT:   %bound_method.loc21_20.1: <bound method> = bound_method %x.ref.loc21_18, %impl.elem1.loc21
+// CHECK:STDOUT:   %ImplicitAs.facet.loc21_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc21_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc21_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc21_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc21_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc21_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem1.loc21, @Cpp.long_long.as.DivWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.specific_fn.9f24e4.1]
+// CHECK:STDOUT:   %bound_method.loc21_20.2: <bound method> = bound_method %x.ref.loc21_18, %specific_fn.loc21
+// CHECK:STDOUT:   %.loc21_20.3: %Cpp.long_long.as.DivWith.impl.Op.type.0e5a2e.1 = specific_constant imports.%Core.Op.ac1, @Cpp.long_long.as.DivWith.impl.543(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.16569a.1]
+// CHECK:STDOUT:   %Op.ref.loc21: %Cpp.long_long.as.DivWith.impl.Op.type.0e5a2e.1 = name_ref Op, %.loc21_20.3 [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.16569a.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.bound.loc21: <bound method> = bound_method %x.ref.loc21_18, %Op.ref.loc21
+// CHECK:STDOUT:   %impl.elem0.loc21_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc21_20.3: <bound method> = bound_method %int_1.loc21, %impl.elem0.loc21_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21_20: init %Cpp.long_long = call %bound_method.loc21_20.3(%int_1.loc21) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_20.5: %Cpp.long_long = converted %int_1.loc21, %.loc21_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.specific_fn.loc21: <specific function> = specific_function %Op.ref.loc21, @Cpp.long_long.as.DivWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.specific_fn.9f24e4.2]
+// CHECK:STDOUT:   %bound_method.loc21_20.4: <bound method> = bound_method %x.ref.loc21_18, %Cpp.long_long.as.DivWith.impl.Op.specific_fn.loc21
+// CHECK:STDOUT:   %impl.elem0.loc21_22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc21_22: <bound method> = bound_method %int_1.loc21, %impl.elem0.loc21_22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21_22: init %Cpp.long_long = call %bound_method.loc21_22(%int_1.loc21) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_22.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21_22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_22.2: %Cpp.long_long = converted %int_1.loc21, %.loc21_22.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.call.loc21: init %Cpp.long_long = call %bound_method.loc21_20.4(%x.ref.loc21_18, %.loc21_22.2)
+// CHECK:STDOUT:   %x.ref.loc21_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc21: <specific function> = specific_function %AssertSameType.ref.loc21, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc21_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.DivWith.impl.Op.call.loc21
+// CHECK:STDOUT:   %.loc21_20.7: %Cpp.long_long = converted %Cpp.long_long.as.DivWith.impl.Op.call.loc21, %.loc21_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc21: init %empty_tuple.type = call %AssertSameType.specific_fn.loc21(%.loc21_20.7, %x.ref.loc21_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc22: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc22_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %int_1.loc22: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc22: %.c35 = impl_witness_access constants.%ModWith.impl_witness.f74, element1 [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.7eaa96.2]
+// CHECK:STDOUT:   %bound_method.loc22_20.1: <bound method> = bound_method %x.ref.loc22_18, %impl.elem1.loc22
+// CHECK:STDOUT:   %ImplicitAs.facet.loc22_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc22_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc22_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc22_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc22_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc22_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc22: <specific function> = specific_function %impl.elem1.loc22, @Cpp.long_long.as.ModWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.specific_fn.b95c4a.1]
+// CHECK:STDOUT:   %bound_method.loc22_20.2: <bound method> = bound_method %x.ref.loc22_18, %specific_fn.loc22
+// CHECK:STDOUT:   %.loc22_20.3: %Cpp.long_long.as.ModWith.impl.Op.type.3b4b62.1 = specific_constant imports.%Core.Op.a7a, @Cpp.long_long.as.ModWith.impl.18e(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.7eaa96.1]
+// CHECK:STDOUT:   %Op.ref.loc22: %Cpp.long_long.as.ModWith.impl.Op.type.3b4b62.1 = name_ref Op, %.loc22_20.3 [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.7eaa96.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.bound.loc22: <bound method> = bound_method %x.ref.loc22_18, %Op.ref.loc22
+// CHECK:STDOUT:   %impl.elem0.loc22_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc22_20.3: <bound method> = bound_method %int_1.loc22, %impl.elem0.loc22_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22_20: init %Cpp.long_long = call %bound_method.loc22_20.3(%int_1.loc22) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_20.5: %Cpp.long_long = converted %int_1.loc22, %.loc22_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.specific_fn.loc22: <specific function> = specific_function %Op.ref.loc22, @Cpp.long_long.as.ModWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.specific_fn.b95c4a.2]
+// CHECK:STDOUT:   %bound_method.loc22_20.4: <bound method> = bound_method %x.ref.loc22_18, %Cpp.long_long.as.ModWith.impl.Op.specific_fn.loc22
+// CHECK:STDOUT:   %impl.elem0.loc22_22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc22_22: <bound method> = bound_method %int_1.loc22, %impl.elem0.loc22_22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22_22: init %Cpp.long_long = call %bound_method.loc22_22(%int_1.loc22) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_22.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22_22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_22.2: %Cpp.long_long = converted %int_1.loc22, %.loc22_22.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.call.loc22: init %Cpp.long_long = call %bound_method.loc22_20.4(%x.ref.loc22_18, %.loc22_22.2)
+// CHECK:STDOUT:   %x.ref.loc22_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc22: <specific function> = specific_function %AssertSameType.ref.loc22, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc22_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.ModWith.impl.Op.call.loc22
+// CHECK:STDOUT:   %.loc22_20.7: %Cpp.long_long = converted %Cpp.long_long.as.ModWith.impl.Op.call.loc22, %.loc22_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc22: init %empty_tuple.type = call %AssertSameType.specific_fn.loc22(%.loc22_20.7, %x.ref.loc22_25)
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %y.patt: %pattern_type.95b = value_binding_pattern y [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc24: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc24_10: type = splice_block %i64.loc24 [concrete = constants.%i64] {
+// CHECK:STDOUT:     %int_64.loc24: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:     %i64.loc24: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc24: %.567 = impl_witness_access constants.%ImplicitAs.impl_witness.556, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.57d]
+// CHECK:STDOUT:   %bound_method.loc24_16.1: <bound method> = bound_method %int_1.loc24, %impl.elem0.loc24 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102]
+// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem0.loc24, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc24_16.2: <bound method> = bound_method %int_1.loc24, %specific_fn.loc24 [concrete = constants.%bound_method.288]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc24: init %i64 = call %bound_method.loc24_16.2(%int_1.loc24) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc24_16.1: %i64 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc24 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc24_16.2: %i64 = converted %int_1.loc24, %.loc24_16.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %y: %i64 = value_binding y, %.loc24_16.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc25: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc25_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc25: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc25: %.1e9 = impl_witness_access constants.%AddWith.impl_witness.24c, element1 [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.f65668.2]
+// CHECK:STDOUT:   %bound_method.loc25_20.1: <bound method> = bound_method %x.ref.loc25_18, %impl.elem1.loc25
+// CHECK:STDOUT:   %ImplicitAs.facet.loc25_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc25_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc25_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc25_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc25_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc25_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc25: <specific function> = specific_function %impl.elem1.loc25, @Cpp.long_long.as.AddWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.specific_fn.be49b1.1]
+// CHECK:STDOUT:   %bound_method.loc25_20.2: <bound method> = bound_method %x.ref.loc25_18, %specific_fn.loc25
+// CHECK:STDOUT:   %.loc25_20.3: %Cpp.long_long.as.AddWith.impl.Op.type.f5b88b.1 = specific_constant imports.%Core.Op.b7d, @Cpp.long_long.as.AddWith.impl.2ad(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.f65668.1]
+// CHECK:STDOUT:   %Op.ref.loc25: %Cpp.long_long.as.AddWith.impl.Op.type.f5b88b.1 = name_ref Op, %.loc25_20.3 [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.f65668.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.bound.loc25: <bound method> = bound_method %x.ref.loc25_18, %Op.ref.loc25
+// CHECK:STDOUT:   %impl.elem0.loc25_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc25_20.3: <bound method> = bound_method %y.ref.loc25, %impl.elem0.loc25_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc25_20: init %Cpp.long_long = call %bound_method.loc25_20.3(%y.ref.loc25)
+// CHECK:STDOUT:   %.loc25_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc25_20
+// CHECK:STDOUT:   %.loc25_20.5: %Cpp.long_long = converted %y.ref.loc25, %.loc25_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.specific_fn.loc25: <specific function> = specific_function %Op.ref.loc25, @Cpp.long_long.as.AddWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddWith.impl.Op.specific_fn.be49b1.2]
+// CHECK:STDOUT:   %bound_method.loc25_20.4: <bound method> = bound_method %x.ref.loc25_18, %Cpp.long_long.as.AddWith.impl.Op.specific_fn.loc25
+// CHECK:STDOUT:   %impl.elem0.loc25_22: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc25_22: <bound method> = bound_method %y.ref.loc25, %impl.elem0.loc25_22
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc25_22: init %Cpp.long_long = call %bound_method.loc25_22(%y.ref.loc25)
+// CHECK:STDOUT:   %.loc25_22.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc25_22
+// CHECK:STDOUT:   %.loc25_22.2: %Cpp.long_long = converted %y.ref.loc25, %.loc25_22.1
+// CHECK:STDOUT:   %Cpp.long_long.as.AddWith.impl.Op.call.loc25: init %Cpp.long_long = call %bound_method.loc25_20.4(%x.ref.loc25_18, %.loc25_22.2)
+// CHECK:STDOUT:   %x.ref.loc25_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc25: <specific function> = specific_function %AssertSameType.ref.loc25, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc25_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.AddWith.impl.Op.call.loc25
+// CHECK:STDOUT:   %.loc25_20.7: %Cpp.long_long = converted %Cpp.long_long.as.AddWith.impl.Op.call.loc25, %.loc25_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc25: init %empty_tuple.type = call %AssertSameType.specific_fn.loc25(%.loc25_20.7, %x.ref.loc25_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc26: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc26_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc26: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc26: %.036 = impl_witness_access constants.%SubWith.impl_witness.07a, element1 [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.85827a.2]
+// CHECK:STDOUT:   %bound_method.loc26_20.1: <bound method> = bound_method %x.ref.loc26_18, %impl.elem1.loc26
+// CHECK:STDOUT:   %ImplicitAs.facet.loc26_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc26_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc26_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc26_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc26_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc26_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc26: <specific function> = specific_function %impl.elem1.loc26, @Cpp.long_long.as.SubWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.specific_fn.8f1b07.1]
+// CHECK:STDOUT:   %bound_method.loc26_20.2: <bound method> = bound_method %x.ref.loc26_18, %specific_fn.loc26
+// CHECK:STDOUT:   %.loc26_20.3: %Cpp.long_long.as.SubWith.impl.Op.type.e1aaf1.1 = specific_constant imports.%Core.Op.15a, @Cpp.long_long.as.SubWith.impl.182(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.85827a.1]
+// CHECK:STDOUT:   %Op.ref.loc26: %Cpp.long_long.as.SubWith.impl.Op.type.e1aaf1.1 = name_ref Op, %.loc26_20.3 [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.85827a.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.bound.loc26: <bound method> = bound_method %x.ref.loc26_18, %Op.ref.loc26
+// CHECK:STDOUT:   %impl.elem0.loc26_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc26_20.3: <bound method> = bound_method %y.ref.loc26, %impl.elem0.loc26_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc26_20: init %Cpp.long_long = call %bound_method.loc26_20.3(%y.ref.loc26)
+// CHECK:STDOUT:   %.loc26_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc26_20
+// CHECK:STDOUT:   %.loc26_20.5: %Cpp.long_long = converted %y.ref.loc26, %.loc26_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.specific_fn.loc26: <specific function> = specific_function %Op.ref.loc26, @Cpp.long_long.as.SubWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubWith.impl.Op.specific_fn.8f1b07.2]
+// CHECK:STDOUT:   %bound_method.loc26_20.4: <bound method> = bound_method %x.ref.loc26_18, %Cpp.long_long.as.SubWith.impl.Op.specific_fn.loc26
+// CHECK:STDOUT:   %impl.elem0.loc26_22: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc26_22: <bound method> = bound_method %y.ref.loc26, %impl.elem0.loc26_22
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc26_22: init %Cpp.long_long = call %bound_method.loc26_22(%y.ref.loc26)
+// CHECK:STDOUT:   %.loc26_22.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc26_22
+// CHECK:STDOUT:   %.loc26_22.2: %Cpp.long_long = converted %y.ref.loc26, %.loc26_22.1
+// CHECK:STDOUT:   %Cpp.long_long.as.SubWith.impl.Op.call.loc26: init %Cpp.long_long = call %bound_method.loc26_20.4(%x.ref.loc26_18, %.loc26_22.2)
+// CHECK:STDOUT:   %x.ref.loc26_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc26: <specific function> = specific_function %AssertSameType.ref.loc26, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc26_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.SubWith.impl.Op.call.loc26
+// CHECK:STDOUT:   %.loc26_20.7: %Cpp.long_long = converted %Cpp.long_long.as.SubWith.impl.Op.call.loc26, %.loc26_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc26: init %empty_tuple.type = call %AssertSameType.specific_fn.loc26(%.loc26_20.7, %x.ref.loc26_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc27: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc27_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc27: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc27: %.830 = impl_witness_access constants.%MulWith.impl_witness.0f5, element1 [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.dd0f62.2]
+// CHECK:STDOUT:   %bound_method.loc27_20.1: <bound method> = bound_method %x.ref.loc27_18, %impl.elem1.loc27
+// CHECK:STDOUT:   %ImplicitAs.facet.loc27_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc27_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc27_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc27_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc27_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc27_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc27: <specific function> = specific_function %impl.elem1.loc27, @Cpp.long_long.as.MulWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.specific_fn.f1361f.1]
+// CHECK:STDOUT:   %bound_method.loc27_20.2: <bound method> = bound_method %x.ref.loc27_18, %specific_fn.loc27
+// CHECK:STDOUT:   %.loc27_20.3: %Cpp.long_long.as.MulWith.impl.Op.type.0f8803.1 = specific_constant imports.%Core.Op.bb0, @Cpp.long_long.as.MulWith.impl.eea(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.dd0f62.1]
+// CHECK:STDOUT:   %Op.ref.loc27: %Cpp.long_long.as.MulWith.impl.Op.type.0f8803.1 = name_ref Op, %.loc27_20.3 [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.dd0f62.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.bound.loc27: <bound method> = bound_method %x.ref.loc27_18, %Op.ref.loc27
+// CHECK:STDOUT:   %impl.elem0.loc27_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc27_20.3: <bound method> = bound_method %y.ref.loc27, %impl.elem0.loc27_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc27_20: init %Cpp.long_long = call %bound_method.loc27_20.3(%y.ref.loc27)
+// CHECK:STDOUT:   %.loc27_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc27_20
+// CHECK:STDOUT:   %.loc27_20.5: %Cpp.long_long = converted %y.ref.loc27, %.loc27_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.specific_fn.loc27: <specific function> = specific_function %Op.ref.loc27, @Cpp.long_long.as.MulWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulWith.impl.Op.specific_fn.f1361f.2]
+// CHECK:STDOUT:   %bound_method.loc27_20.4: <bound method> = bound_method %x.ref.loc27_18, %Cpp.long_long.as.MulWith.impl.Op.specific_fn.loc27
+// CHECK:STDOUT:   %impl.elem0.loc27_22: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc27_22: <bound method> = bound_method %y.ref.loc27, %impl.elem0.loc27_22
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc27_22: init %Cpp.long_long = call %bound_method.loc27_22(%y.ref.loc27)
+// CHECK:STDOUT:   %.loc27_22.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc27_22
+// CHECK:STDOUT:   %.loc27_22.2: %Cpp.long_long = converted %y.ref.loc27, %.loc27_22.1
+// CHECK:STDOUT:   %Cpp.long_long.as.MulWith.impl.Op.call.loc27: init %Cpp.long_long = call %bound_method.loc27_20.4(%x.ref.loc27_18, %.loc27_22.2)
+// CHECK:STDOUT:   %x.ref.loc27_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc27: <specific function> = specific_function %AssertSameType.ref.loc27, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc27_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.MulWith.impl.Op.call.loc27
+// CHECK:STDOUT:   %.loc27_20.7: %Cpp.long_long = converted %Cpp.long_long.as.MulWith.impl.Op.call.loc27, %.loc27_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc27: init %empty_tuple.type = call %AssertSameType.specific_fn.loc27(%.loc27_20.7, %x.ref.loc27_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc28: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc28_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc28: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc28: %.310 = impl_witness_access constants.%DivWith.impl_witness.4d9, element1 [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.306cec.2]
+// CHECK:STDOUT:   %bound_method.loc28_20.1: <bound method> = bound_method %x.ref.loc28_18, %impl.elem1.loc28
+// CHECK:STDOUT:   %ImplicitAs.facet.loc28_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc28_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc28_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc28_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc28_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc28_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc28: <specific function> = specific_function %impl.elem1.loc28, @Cpp.long_long.as.DivWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.specific_fn.eb685a.1]
+// CHECK:STDOUT:   %bound_method.loc28_20.2: <bound method> = bound_method %x.ref.loc28_18, %specific_fn.loc28
+// CHECK:STDOUT:   %.loc28_20.3: %Cpp.long_long.as.DivWith.impl.Op.type.c562f2.1 = specific_constant imports.%Core.Op.ac1, @Cpp.long_long.as.DivWith.impl.543(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.306cec.1]
+// CHECK:STDOUT:   %Op.ref.loc28: %Cpp.long_long.as.DivWith.impl.Op.type.c562f2.1 = name_ref Op, %.loc28_20.3 [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.306cec.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.bound.loc28: <bound method> = bound_method %x.ref.loc28_18, %Op.ref.loc28
+// CHECK:STDOUT:   %impl.elem0.loc28_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc28_20.3: <bound method> = bound_method %y.ref.loc28, %impl.elem0.loc28_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc28_20: init %Cpp.long_long = call %bound_method.loc28_20.3(%y.ref.loc28)
+// CHECK:STDOUT:   %.loc28_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc28_20
+// CHECK:STDOUT:   %.loc28_20.5: %Cpp.long_long = converted %y.ref.loc28, %.loc28_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.specific_fn.loc28: <specific function> = specific_function %Op.ref.loc28, @Cpp.long_long.as.DivWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivWith.impl.Op.specific_fn.eb685a.2]
+// CHECK:STDOUT:   %bound_method.loc28_20.4: <bound method> = bound_method %x.ref.loc28_18, %Cpp.long_long.as.DivWith.impl.Op.specific_fn.loc28
+// CHECK:STDOUT:   %impl.elem0.loc28_22: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc28_22: <bound method> = bound_method %y.ref.loc28, %impl.elem0.loc28_22
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc28_22: init %Cpp.long_long = call %bound_method.loc28_22(%y.ref.loc28)
+// CHECK:STDOUT:   %.loc28_22.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc28_22
+// CHECK:STDOUT:   %.loc28_22.2: %Cpp.long_long = converted %y.ref.loc28, %.loc28_22.1
+// CHECK:STDOUT:   %Cpp.long_long.as.DivWith.impl.Op.call.loc28: init %Cpp.long_long = call %bound_method.loc28_20.4(%x.ref.loc28_18, %.loc28_22.2)
+// CHECK:STDOUT:   %x.ref.loc28_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc28: <specific function> = specific_function %AssertSameType.ref.loc28, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc28_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.DivWith.impl.Op.call.loc28
+// CHECK:STDOUT:   %.loc28_20.7: %Cpp.long_long = converted %Cpp.long_long.as.DivWith.impl.Op.call.loc28, %.loc28_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc28: init %empty_tuple.type = call %AssertSameType.specific_fn.loc28(%.loc28_20.7, %x.ref.loc28_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc29: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc29_18: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc29: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc29: %.7be = impl_witness_access constants.%ModWith.impl_witness.87d, element1 [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.2a70b6.2]
+// CHECK:STDOUT:   %bound_method.loc29_20.1: <bound method> = bound_method %x.ref.loc29_18, %impl.elem1.loc29
+// CHECK:STDOUT:   %ImplicitAs.facet.loc29_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc29_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc29_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc29_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc29_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc29_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem1.loc29, @Cpp.long_long.as.ModWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.specific_fn.0712c6.1]
+// CHECK:STDOUT:   %bound_method.loc29_20.2: <bound method> = bound_method %x.ref.loc29_18, %specific_fn.loc29
+// CHECK:STDOUT:   %.loc29_20.3: %Cpp.long_long.as.ModWith.impl.Op.type.d806b7.1 = specific_constant imports.%Core.Op.a7a, @Cpp.long_long.as.ModWith.impl.18e(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.2a70b6.1]
+// CHECK:STDOUT:   %Op.ref.loc29: %Cpp.long_long.as.ModWith.impl.Op.type.d806b7.1 = name_ref Op, %.loc29_20.3 [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.2a70b6.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.bound.loc29: <bound method> = bound_method %x.ref.loc29_18, %Op.ref.loc29
+// CHECK:STDOUT:   %impl.elem0.loc29_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc29_20.3: <bound method> = bound_method %y.ref.loc29, %impl.elem0.loc29_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc29_20: init %Cpp.long_long = call %bound_method.loc29_20.3(%y.ref.loc29)
+// CHECK:STDOUT:   %.loc29_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc29_20
+// CHECK:STDOUT:   %.loc29_20.5: %Cpp.long_long = converted %y.ref.loc29, %.loc29_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.specific_fn.loc29: <specific function> = specific_function %Op.ref.loc29, @Cpp.long_long.as.ModWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModWith.impl.Op.specific_fn.0712c6.2]
+// CHECK:STDOUT:   %bound_method.loc29_20.4: <bound method> = bound_method %x.ref.loc29_18, %Cpp.long_long.as.ModWith.impl.Op.specific_fn.loc29
+// CHECK:STDOUT:   %impl.elem0.loc29_22: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc29_22: <bound method> = bound_method %y.ref.loc29, %impl.elem0.loc29_22
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc29_22: init %Cpp.long_long = call %bound_method.loc29_22(%y.ref.loc29)
+// CHECK:STDOUT:   %.loc29_22.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc29_22
+// CHECK:STDOUT:   %.loc29_22.2: %Cpp.long_long = converted %y.ref.loc29, %.loc29_22.1
+// CHECK:STDOUT:   %Cpp.long_long.as.ModWith.impl.Op.call.loc29: init %Cpp.long_long = call %bound_method.loc29_20.4(%x.ref.loc29_18, %.loc29_22.2)
+// CHECK:STDOUT:   %x.ref.loc29_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc29: <specific function> = specific_function %AssertSameType.ref.loc29, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc29_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.ModWith.impl.Op.call.loc29
+// CHECK:STDOUT:   %.loc29_20.7: %Cpp.long_long = converted %Cpp.long_long.as.ModWith.impl.Op.call.loc29, %.loc29_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc29: init %empty_tuple.type = call %AssertSameType.specific_fn.loc29(%.loc29_20.7, %x.ref.loc29_25)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- arithmetic_heterogeneous_long_long_right_side.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %AssertSameType.type: type = fn_type @AssertSameType [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %AssertSameType: %AssertSameType.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %int_64: Core.IntLiteral = int_value 64 [concrete]
+// CHECK:STDOUT:   %i64: type = class_type @Int, @Int(%int_64) [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.2ad: type = facet_type <@ImplicitAs, @ImplicitAs(%i64)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.94e: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i64) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %As.type.229: type = facet_type <@As, @As(%i64)> [concrete]
+// CHECK:STDOUT:   %As.Convert.type.d57: type = fn_type @As.Convert, @As(%i64) [concrete]
+// CHECK:STDOUT:   %To.fe9: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.09e: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.dbe: %Core.IntLiteral.as.As.impl.Convert.type.09e = struct_value () [symbolic]
+// CHECK:STDOUT:   %As.impl_witness.c71: <witness> = impl_witness imports.%As.impl_witness_table.9fc, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.cee: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.a54: %Core.IntLiteral.as.As.impl.Convert.type.cee = struct_value () [concrete]
+// CHECK:STDOUT:   %As.facet: %As.type.229 = facet_value Core.IntLiteral, (%As.impl_witness.c71) [concrete]
+// CHECK:STDOUT:   %.aba: type = fn_type_with_self_type %As.Convert.type.d57, %As.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.a54 [concrete]
+// CHECK:STDOUT:   %pattern_type.95b: type = pattern_type %i64 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.As.impl.Convert.a54, @Core.IntLiteral.as.As.impl.Convert(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method.41b: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_1.41a: %i64 = int_value 1 [concrete]
+// CHECK:STDOUT:   %AddWith.type.e97: type = facet_type <@AddWith, @AddWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %AddWith.Op.type.4a8: type = fn_type @AddWith.Op, @AddWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.ea5: %ImplicitAs.type.a03 = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.34704d.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.3, @T.binding.as_type.as.AddWith.impl.3cb(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.897736.1: %T.binding.as_type.as.AddWith.impl.Op.type.34704d.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.34704d.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.4, @T.binding.as_type.as.AddWith.impl.3cb(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.897736.2: %T.binding.as_type.as.AddWith.impl.Op.type.34704d.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.1b3: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.b19 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.c59: %ImplicitAs.type.a03 = facet_value %i64, (%ImplicitAs.impl_witness.1b3) [concrete]
+// CHECK:STDOUT:   %AddWith.impl_witness.870: <witness> = impl_witness imports.%AddWith.impl_witness_table.36e, @T.binding.as_type.as.AddWith.impl.3cb(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.5353e6.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.4, @T.binding.as_type.as.AddWith.impl.3cb(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.1269d8.1: %T.binding.as_type.as.AddWith.impl.Op.type.5353e6.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.5353e6.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.3, @T.binding.as_type.as.AddWith.impl.3cb(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.1269d8.2: %T.binding.as_type.as.AddWith.impl.Op.type.5353e6.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddWith.facet.4c4: %AddWith.type.e97 = facet_value %i64, (%AddWith.impl_witness.870) [concrete]
+// CHECK:STDOUT:   %.3bd: type = fn_type_with_self_type %AddWith.Op.type.4a8, %AddWith.facet.4c4 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound.58766a.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.AddWith.impl.Op.1269d8.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.468a32.1: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.1269d8.2, @T.binding.as_type.as.AddWith.impl.Op.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.7e7cfb.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.AddWith.impl.Op.specific_fn.468a32.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound.58766a.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.AddWith.impl.Op.1269d8.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.468a32.2: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.1269d8.1, @T.binding.as_type.as.AddWith.impl.Op.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.7e7cfb.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.AddWith.impl.Op.specific_fn.468a32.2 [concrete]
+// CHECK:STDOUT:   %.b29: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.c59 [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.type: type = fn_type @i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert: %i64.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.41a, %i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %SubWith.type.172: type = facet_type <@SubWith, @SubWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %SubWith.Op.type.929: type = fn_type @SubWith.Op, @SubWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.type.6d5eac.1: type = fn_type @T.binding.as_type.as.SubWith.impl.Op.3, @T.binding.as_type.as.SubWith.impl.366(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.7bffad.1: %T.binding.as_type.as.SubWith.impl.Op.type.6d5eac.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.type.6d5eac.2: type = fn_type @T.binding.as_type.as.SubWith.impl.Op.4, @T.binding.as_type.as.SubWith.impl.366(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.7bffad.2: %T.binding.as_type.as.SubWith.impl.Op.type.6d5eac.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %SubWith.impl_witness.297: <witness> = impl_witness imports.%SubWith.impl_witness_table.3ce, @T.binding.as_type.as.SubWith.impl.366(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.type.b3c095.1: type = fn_type @T.binding.as_type.as.SubWith.impl.Op.4, @T.binding.as_type.as.SubWith.impl.366(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.83c119.1: %T.binding.as_type.as.SubWith.impl.Op.type.b3c095.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.type.b3c095.2: type = fn_type @T.binding.as_type.as.SubWith.impl.Op.3, @T.binding.as_type.as.SubWith.impl.366(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.83c119.2: %T.binding.as_type.as.SubWith.impl.Op.type.b3c095.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %SubWith.facet.685: %SubWith.type.172 = facet_value %i64, (%SubWith.impl_witness.297) [concrete]
+// CHECK:STDOUT:   %.4af: type = fn_type_with_self_type %SubWith.Op.type.929, %SubWith.facet.685 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.bound.208360.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.SubWith.impl.Op.83c119.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.specific_fn.7a43f4.1: <specific function> = specific_function %T.binding.as_type.as.SubWith.impl.Op.83c119.2, @T.binding.as_type.as.SubWith.impl.Op.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.3d4b69.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.SubWith.impl.Op.specific_fn.7a43f4.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.bound.208360.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.SubWith.impl.Op.83c119.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.specific_fn.7a43f4.2: <specific function> = specific_function %T.binding.as_type.as.SubWith.impl.Op.83c119.1, @T.binding.as_type.as.SubWith.impl.Op.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.3d4b69.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.SubWith.impl.Op.specific_fn.7a43f4.2 [concrete]
+// CHECK:STDOUT:   %MulWith.type.693: type = facet_type <@MulWith, @MulWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %MulWith.Op.type.1a1: type = fn_type @MulWith.Op, @MulWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.type.c346b9.1: type = fn_type @T.binding.as_type.as.MulWith.impl.Op.3, @T.binding.as_type.as.MulWith.impl.9c8(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.9f3dbd.1: %T.binding.as_type.as.MulWith.impl.Op.type.c346b9.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.type.c346b9.2: type = fn_type @T.binding.as_type.as.MulWith.impl.Op.4, @T.binding.as_type.as.MulWith.impl.9c8(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.9f3dbd.2: %T.binding.as_type.as.MulWith.impl.Op.type.c346b9.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %MulWith.impl_witness.47a: <witness> = impl_witness imports.%MulWith.impl_witness_table.4a2, @T.binding.as_type.as.MulWith.impl.9c8(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.type.e434da.1: type = fn_type @T.binding.as_type.as.MulWith.impl.Op.4, @T.binding.as_type.as.MulWith.impl.9c8(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.40fc91.1: %T.binding.as_type.as.MulWith.impl.Op.type.e434da.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.type.e434da.2: type = fn_type @T.binding.as_type.as.MulWith.impl.Op.3, @T.binding.as_type.as.MulWith.impl.9c8(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.40fc91.2: %T.binding.as_type.as.MulWith.impl.Op.type.e434da.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %MulWith.facet.cb5: %MulWith.type.693 = facet_value %i64, (%MulWith.impl_witness.47a) [concrete]
+// CHECK:STDOUT:   %.326: type = fn_type_with_self_type %MulWith.Op.type.1a1, %MulWith.facet.cb5 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.bound.97a870.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.MulWith.impl.Op.40fc91.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.specific_fn.7c50b1.1: <specific function> = specific_function %T.binding.as_type.as.MulWith.impl.Op.40fc91.2, @T.binding.as_type.as.MulWith.impl.Op.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.065427.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.MulWith.impl.Op.specific_fn.7c50b1.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.bound.97a870.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.MulWith.impl.Op.40fc91.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.specific_fn.7c50b1.2: <specific function> = specific_function %T.binding.as_type.as.MulWith.impl.Op.40fc91.1, @T.binding.as_type.as.MulWith.impl.Op.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.065427.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.MulWith.impl.Op.specific_fn.7c50b1.2 [concrete]
+// CHECK:STDOUT:   %DivWith.type.f07: type = facet_type <@DivWith, @DivWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %DivWith.Op.type.ccd: type = fn_type @DivWith.Op, @DivWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.type.c1995a.1: type = fn_type @T.binding.as_type.as.DivWith.impl.Op.3, @T.binding.as_type.as.DivWith.impl.b8b(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.844df9.1: %T.binding.as_type.as.DivWith.impl.Op.type.c1995a.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.type.c1995a.2: type = fn_type @T.binding.as_type.as.DivWith.impl.Op.4, @T.binding.as_type.as.DivWith.impl.b8b(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.844df9.2: %T.binding.as_type.as.DivWith.impl.Op.type.c1995a.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %DivWith.impl_witness.922: <witness> = impl_witness imports.%DivWith.impl_witness_table.f50, @T.binding.as_type.as.DivWith.impl.b8b(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.type.59d47d.1: type = fn_type @T.binding.as_type.as.DivWith.impl.Op.4, @T.binding.as_type.as.DivWith.impl.b8b(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.12e7c2.1: %T.binding.as_type.as.DivWith.impl.Op.type.59d47d.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.type.59d47d.2: type = fn_type @T.binding.as_type.as.DivWith.impl.Op.3, @T.binding.as_type.as.DivWith.impl.b8b(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.12e7c2.2: %T.binding.as_type.as.DivWith.impl.Op.type.59d47d.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %DivWith.facet.6fc: %DivWith.type.f07 = facet_value %i64, (%DivWith.impl_witness.922) [concrete]
+// CHECK:STDOUT:   %.6ef: type = fn_type_with_self_type %DivWith.Op.type.ccd, %DivWith.facet.6fc [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bound.76edc8.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.DivWith.impl.Op.12e7c2.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.specific_fn.4203a1.1: <specific function> = specific_function %T.binding.as_type.as.DivWith.impl.Op.12e7c2.2, @T.binding.as_type.as.DivWith.impl.Op.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.f43c33.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.DivWith.impl.Op.specific_fn.4203a1.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bound.76edc8.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.DivWith.impl.Op.12e7c2.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.specific_fn.4203a1.2: <specific function> = specific_function %T.binding.as_type.as.DivWith.impl.Op.12e7c2.1, @T.binding.as_type.as.DivWith.impl.Op.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.f43c33.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.DivWith.impl.Op.specific_fn.4203a1.2 [concrete]
+// CHECK:STDOUT:   %ModWith.type.b3d: type = facet_type <@ModWith, @ModWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ModWith.Op.type.9b8: type = fn_type @ModWith.Op, @ModWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.type.a310d9.1: type = fn_type @T.binding.as_type.as.ModWith.impl.Op.3, @T.binding.as_type.as.ModWith.impl.236(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.8be663.1: %T.binding.as_type.as.ModWith.impl.Op.type.a310d9.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.type.a310d9.2: type = fn_type @T.binding.as_type.as.ModWith.impl.Op.4, @T.binding.as_type.as.ModWith.impl.236(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.8be663.2: %T.binding.as_type.as.ModWith.impl.Op.type.a310d9.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ModWith.impl_witness.8f4: <witness> = impl_witness imports.%ModWith.impl_witness_table.e42, @T.binding.as_type.as.ModWith.impl.236(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.type.e2b11f.1: type = fn_type @T.binding.as_type.as.ModWith.impl.Op.4, @T.binding.as_type.as.ModWith.impl.236(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.5e6d70.1: %T.binding.as_type.as.ModWith.impl.Op.type.e2b11f.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.type.e2b11f.2: type = fn_type @T.binding.as_type.as.ModWith.impl.Op.3, @T.binding.as_type.as.ModWith.impl.236(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.5e6d70.2: %T.binding.as_type.as.ModWith.impl.Op.type.e2b11f.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %ModWith.facet.8c7: %ModWith.type.b3d = facet_value %i64, (%ModWith.impl_witness.8f4) [concrete]
+// CHECK:STDOUT:   %.f0a: type = fn_type_with_self_type %ModWith.Op.type.9b8, %ModWith.facet.8c7 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.bound.63f19a.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.ModWith.impl.Op.5e6d70.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.specific_fn.e520cf.1: <specific function> = specific_function %T.binding.as_type.as.ModWith.impl.Op.5e6d70.2, @T.binding.as_type.as.ModWith.impl.Op.3(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.eca518.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.ModWith.impl.Op.specific_fn.e520cf.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.bound.63f19a.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.ModWith.impl.Op.5e6d70.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.specific_fn.e520cf.2: <specific function> = specific_function %T.binding.as_type.as.ModWith.impl.Op.5e6d70.1, @T.binding.as_type.as.ModWith.impl.Op.4(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.eca518.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.ModWith.impl.Op.specific_fn.e520cf.2 [concrete]
+// CHECK:STDOUT:   %AddWith.impl_witness.9d4: <witness> = impl_witness imports.%AddWith.impl_witness_table.36e, @T.binding.as_type.as.AddWith.impl.3cb(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.066411.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.4, @T.binding.as_type.as.AddWith.impl.3cb(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bf8142.1: %T.binding.as_type.as.AddWith.impl.Op.type.066411.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.066411.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.3, @T.binding.as_type.as.AddWith.impl.3cb(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bf8142.2: %T.binding.as_type.as.AddWith.impl.Op.type.066411.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddWith.facet.95c: %AddWith.type.e97 = facet_value Core.IntLiteral, (%AddWith.impl_witness.9d4) [concrete]
+// CHECK:STDOUT:   %.179: type = fn_type_with_self_type %AddWith.Op.type.4a8, %AddWith.facet.95c [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound.605e02.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.AddWith.impl.Op.bf8142.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.9c4571.1: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.bf8142.2, @T.binding.as_type.as.AddWith.impl.Op.3(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.e3fb08.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.AddWith.impl.Op.specific_fn.9c4571.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound.605e02.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.AddWith.impl.Op.bf8142.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.9c4571.2: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.bf8142.1, @T.binding.as_type.as.AddWith.impl.Op.4(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.e3fb08.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.AddWith.impl.Op.specific_fn.9c4571.2 [concrete]
+// CHECK:STDOUT:   %SubWith.impl_witness.b03: <witness> = impl_witness imports.%SubWith.impl_witness_table.3ce, @T.binding.as_type.as.SubWith.impl.366(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.type.a9ed32.1: type = fn_type @T.binding.as_type.as.SubWith.impl.Op.4, @T.binding.as_type.as.SubWith.impl.366(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.fe5aec.1: %T.binding.as_type.as.SubWith.impl.Op.type.a9ed32.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.type.a9ed32.2: type = fn_type @T.binding.as_type.as.SubWith.impl.Op.3, @T.binding.as_type.as.SubWith.impl.366(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.fe5aec.2: %T.binding.as_type.as.SubWith.impl.Op.type.a9ed32.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %SubWith.facet.13e: %SubWith.type.172 = facet_value Core.IntLiteral, (%SubWith.impl_witness.b03) [concrete]
+// CHECK:STDOUT:   %.83a: type = fn_type_with_self_type %SubWith.Op.type.929, %SubWith.facet.13e [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.bound.bb7ef2.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.SubWith.impl.Op.fe5aec.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.specific_fn.a8a25c.1: <specific function> = specific_function %T.binding.as_type.as.SubWith.impl.Op.fe5aec.2, @T.binding.as_type.as.SubWith.impl.Op.3(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.703d6e.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.SubWith.impl.Op.specific_fn.a8a25c.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.bound.bb7ef2.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.SubWith.impl.Op.fe5aec.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.specific_fn.a8a25c.2: <specific function> = specific_function %T.binding.as_type.as.SubWith.impl.Op.fe5aec.1, @T.binding.as_type.as.SubWith.impl.Op.4(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.703d6e.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.SubWith.impl.Op.specific_fn.a8a25c.2 [concrete]
+// CHECK:STDOUT:   %MulWith.impl_witness.452: <witness> = impl_witness imports.%MulWith.impl_witness_table.4a2, @T.binding.as_type.as.MulWith.impl.9c8(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.type.4ddc19.1: type = fn_type @T.binding.as_type.as.MulWith.impl.Op.4, @T.binding.as_type.as.MulWith.impl.9c8(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.b572bf.1: %T.binding.as_type.as.MulWith.impl.Op.type.4ddc19.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.type.4ddc19.2: type = fn_type @T.binding.as_type.as.MulWith.impl.Op.3, @T.binding.as_type.as.MulWith.impl.9c8(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.b572bf.2: %T.binding.as_type.as.MulWith.impl.Op.type.4ddc19.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %MulWith.facet.a47: %MulWith.type.693 = facet_value Core.IntLiteral, (%MulWith.impl_witness.452) [concrete]
+// CHECK:STDOUT:   %.083: type = fn_type_with_self_type %MulWith.Op.type.1a1, %MulWith.facet.a47 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.bound.cc8bc8.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.MulWith.impl.Op.b572bf.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.specific_fn.c40ccc.1: <specific function> = specific_function %T.binding.as_type.as.MulWith.impl.Op.b572bf.2, @T.binding.as_type.as.MulWith.impl.Op.3(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.5e5b06.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.MulWith.impl.Op.specific_fn.c40ccc.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.bound.cc8bc8.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.MulWith.impl.Op.b572bf.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.specific_fn.c40ccc.2: <specific function> = specific_function %T.binding.as_type.as.MulWith.impl.Op.b572bf.1, @T.binding.as_type.as.MulWith.impl.Op.4(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.5e5b06.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.MulWith.impl.Op.specific_fn.c40ccc.2 [concrete]
+// CHECK:STDOUT:   %DivWith.impl_witness.8ae: <witness> = impl_witness imports.%DivWith.impl_witness_table.f50, @T.binding.as_type.as.DivWith.impl.b8b(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.type.a76bb3.1: type = fn_type @T.binding.as_type.as.DivWith.impl.Op.4, @T.binding.as_type.as.DivWith.impl.b8b(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bb0620.1: %T.binding.as_type.as.DivWith.impl.Op.type.a76bb3.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.type.a76bb3.2: type = fn_type @T.binding.as_type.as.DivWith.impl.Op.3, @T.binding.as_type.as.DivWith.impl.b8b(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bb0620.2: %T.binding.as_type.as.DivWith.impl.Op.type.a76bb3.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %DivWith.facet.286: %DivWith.type.f07 = facet_value Core.IntLiteral, (%DivWith.impl_witness.8ae) [concrete]
+// CHECK:STDOUT:   %.c95: type = fn_type_with_self_type %DivWith.Op.type.ccd, %DivWith.facet.286 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bound.e9391e.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.DivWith.impl.Op.bb0620.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.specific_fn.c11faf.1: <specific function> = specific_function %T.binding.as_type.as.DivWith.impl.Op.bb0620.2, @T.binding.as_type.as.DivWith.impl.Op.3(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.91b5ad.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.DivWith.impl.Op.specific_fn.c11faf.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bound.e9391e.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.DivWith.impl.Op.bb0620.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.specific_fn.c11faf.2: <specific function> = specific_function %T.binding.as_type.as.DivWith.impl.Op.bb0620.1, @T.binding.as_type.as.DivWith.impl.Op.4(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.91b5ad.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.DivWith.impl.Op.specific_fn.c11faf.2 [concrete]
+// CHECK:STDOUT:   %ModWith.impl_witness.17a: <witness> = impl_witness imports.%ModWith.impl_witness_table.e42, @T.binding.as_type.as.ModWith.impl.236(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.type.8239b7.1: type = fn_type @T.binding.as_type.as.ModWith.impl.Op.4, @T.binding.as_type.as.ModWith.impl.236(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.97c315.1: %T.binding.as_type.as.ModWith.impl.Op.type.8239b7.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.type.8239b7.2: type = fn_type @T.binding.as_type.as.ModWith.impl.Op.3, @T.binding.as_type.as.ModWith.impl.236(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.97c315.2: %T.binding.as_type.as.ModWith.impl.Op.type.8239b7.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %ModWith.facet.254: %ModWith.type.b3d = facet_value Core.IntLiteral, (%ModWith.impl_witness.17a) [concrete]
+// CHECK:STDOUT:   %.738: type = fn_type_with_self_type %ModWith.Op.type.9b8, %ModWith.facet.254 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.bound.9f87a0.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.ModWith.impl.Op.97c315.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.specific_fn.c19386.1: <specific function> = specific_function %T.binding.as_type.as.ModWith.impl.Op.97c315.2, @T.binding.as_type.as.ModWith.impl.Op.3(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.1e0cef.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.ModWith.impl.Op.specific_fn.c19386.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.bound.9f87a0.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.ModWith.impl.Op.97c315.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.specific_fn.c19386.2: <specific function> = specific_function %T.binding.as_type.as.ModWith.impl.Op.97c315.1, @T.binding.as_type.as.ModWith.impl.Op.4(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.1e0cef.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.ModWith.impl.Op.specific_fn.c19386.2 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.556: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.74f, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d48: %ImplicitAs.type.2ad = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.556) [concrete]
+// CHECK:STDOUT:   %.567: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.d48 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method.288: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ca0: @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert.type (%Core.IntLiteral.as.As.impl.Convert.type.09e) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert (constants.%Core.IntLiteral.as.As.impl.Convert.dbe)]
+// CHECK:STDOUT:   %As.impl_witness_table.9fc = impl_witness_table (%Core.import_ref.ca0), @Core.IntLiteral.as.As.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.2 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.675: @T.binding.as_type.as.AddWith.impl.3cb.%T.binding.as_type.as.AddWith.impl.Op.type.2 (%T.binding.as_type.as.AddWith.impl.Op.type.34704d.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.AddWith.impl.3cb.%T.binding.as_type.as.AddWith.impl.Op.2 (constants.%T.binding.as_type.as.AddWith.impl.Op.897736.1)]
+// CHECK:STDOUT:   %AddWith.impl_witness_table.36e = impl_witness_table (%Core.import_ref.ce3a05.2, %Core.import_ref.675), @T.binding.as_type.as.AddWith.impl.3cb [concrete]
+// CHECK:STDOUT:   %Core.Op.70b: @T.binding.as_type.as.AddWith.impl.3cb.%T.binding.as_type.as.AddWith.impl.Op.type.1 (%T.binding.as_type.as.AddWith.impl.Op.type.34704d.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.AddWith.impl.3cb.%T.binding.as_type.as.AddWith.impl.Op.1 (constants.%T.binding.as_type.as.AddWith.impl.Op.897736.2)]
+// CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
+// CHECK:STDOUT:   %Core.import_ref.4f4b: %i64.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.b19 = impl_witness_table (%Core.import_ref.4f4b), @i64.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.4 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.721: @T.binding.as_type.as.SubWith.impl.366.%T.binding.as_type.as.SubWith.impl.Op.type.2 (%T.binding.as_type.as.SubWith.impl.Op.type.6d5eac.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.SubWith.impl.366.%T.binding.as_type.as.SubWith.impl.Op.2 (constants.%T.binding.as_type.as.SubWith.impl.Op.7bffad.1)]
+// CHECK:STDOUT:   %SubWith.impl_witness_table.3ce = impl_witness_table (%Core.import_ref.ce3a05.4, %Core.import_ref.721), @T.binding.as_type.as.SubWith.impl.366 [concrete]
+// CHECK:STDOUT:   %Core.Op.deb: @T.binding.as_type.as.SubWith.impl.366.%T.binding.as_type.as.SubWith.impl.Op.type.1 (%T.binding.as_type.as.SubWith.impl.Op.type.6d5eac.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.SubWith.impl.366.%T.binding.as_type.as.SubWith.impl.Op.1 (constants.%T.binding.as_type.as.SubWith.impl.Op.7bffad.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.6 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.f6e: @T.binding.as_type.as.MulWith.impl.9c8.%T.binding.as_type.as.MulWith.impl.Op.type.2 (%T.binding.as_type.as.MulWith.impl.Op.type.c346b9.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.MulWith.impl.9c8.%T.binding.as_type.as.MulWith.impl.Op.2 (constants.%T.binding.as_type.as.MulWith.impl.Op.9f3dbd.1)]
+// CHECK:STDOUT:   %MulWith.impl_witness_table.4a2 = impl_witness_table (%Core.import_ref.ce3a05.6, %Core.import_ref.f6e), @T.binding.as_type.as.MulWith.impl.9c8 [concrete]
+// CHECK:STDOUT:   %Core.Op.16e: @T.binding.as_type.as.MulWith.impl.9c8.%T.binding.as_type.as.MulWith.impl.Op.type.1 (%T.binding.as_type.as.MulWith.impl.Op.type.c346b9.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.MulWith.impl.9c8.%T.binding.as_type.as.MulWith.impl.Op.1 (constants.%T.binding.as_type.as.MulWith.impl.Op.9f3dbd.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.8 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.f50: @T.binding.as_type.as.DivWith.impl.b8b.%T.binding.as_type.as.DivWith.impl.Op.type.2 (%T.binding.as_type.as.DivWith.impl.Op.type.c1995a.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.DivWith.impl.b8b.%T.binding.as_type.as.DivWith.impl.Op.2 (constants.%T.binding.as_type.as.DivWith.impl.Op.844df9.1)]
+// CHECK:STDOUT:   %DivWith.impl_witness_table.f50 = impl_witness_table (%Core.import_ref.ce3a05.8, %Core.import_ref.f50), @T.binding.as_type.as.DivWith.impl.b8b [concrete]
+// CHECK:STDOUT:   %Core.Op.6d6: @T.binding.as_type.as.DivWith.impl.b8b.%T.binding.as_type.as.DivWith.impl.Op.type.1 (%T.binding.as_type.as.DivWith.impl.Op.type.c1995a.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.DivWith.impl.b8b.%T.binding.as_type.as.DivWith.impl.Op.1 (constants.%T.binding.as_type.as.DivWith.impl.Op.844df9.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.10 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.4d5: @T.binding.as_type.as.ModWith.impl.236.%T.binding.as_type.as.ModWith.impl.Op.type.2 (%T.binding.as_type.as.ModWith.impl.Op.type.a310d9.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.ModWith.impl.236.%T.binding.as_type.as.ModWith.impl.Op.2 (constants.%T.binding.as_type.as.ModWith.impl.Op.8be663.1)]
+// CHECK:STDOUT:   %ModWith.impl_witness_table.e42 = impl_witness_table (%Core.import_ref.ce3a05.10, %Core.import_ref.4d5), @T.binding.as_type.as.ModWith.impl.236 [concrete]
+// CHECK:STDOUT:   %Core.Op.498: @T.binding.as_type.as.ModWith.impl.236.%T.binding.as_type.as.ModWith.impl.Op.type.1 (%T.binding.as_type.as.ModWith.impl.Op.type.a310d9.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.ModWith.impl.236.%T.binding.as_type.as.ModWith.impl.Op.1 (constants.%T.binding.as_type.as.ModWith.impl.Op.8be663.2)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @ArithmeticHeterogeneousLongLongRightSide() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %x.patt: %pattern_type.76e = value_binding_pattern x [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc10_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc10: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10(%int_1.loc10) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.2: %Cpp.long_long = converted %int_1.loc10, %.loc10_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %x: %Cpp.long_long = value_binding x, %.loc10_26.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc11: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc11: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc11: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc11: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc11_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc11_21.1: <bound method> = bound_method %int_1.loc11, %impl.elem0.loc11_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc11_21: <specific function> = specific_function %impl.elem0.loc11_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc11_21.2: <bound method> = bound_method %int_1.loc11, %specific_fn.loc11_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc11: init %i64 = call %bound_method.loc11_21.2(%int_1.loc11) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc11_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc11 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc11_21.2: %i64 = converted %int_1.loc11, %.loc11_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %x.ref.loc11_31: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc11: %.3bd = impl_witness_access constants.%AddWith.impl_witness.870, element1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.1269d8.2]
+// CHECK:STDOUT:   %bound_method.loc11_29.1: <bound method> = bound_method %.loc11_21.2, %impl.elem1.loc11 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.bound.58766a.1]
+// CHECK:STDOUT:   %specific_fn.loc11_29: <specific function> = specific_function %impl.elem1.loc11, @T.binding.as_type.as.AddWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.468a32.1]
+// CHECK:STDOUT:   %bound_method.loc11_29.2: <bound method> = bound_method %.loc11_21.2, %specific_fn.loc11_29 [concrete = constants.%bound_method.7e7cfb.1]
+// CHECK:STDOUT:   %.loc11_29.1: %T.binding.as_type.as.AddWith.impl.Op.type.5353e6.1 = specific_constant imports.%Core.Op.70b, @T.binding.as_type.as.AddWith.impl.3cb(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.1269d8.1]
+// CHECK:STDOUT:   %Op.ref.loc11: %T.binding.as_type.as.AddWith.impl.Op.type.5353e6.1 = name_ref Op, %.loc11_29.1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.1269d8.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound.loc11: <bound method> = bound_method %.loc11_21.2, %Op.ref.loc11 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.bound.58766a.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.loc11: <specific function> = specific_function %Op.ref.loc11, @T.binding.as_type.as.AddWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.468a32.2]
+// CHECK:STDOUT:   %bound_method.loc11_29.3: <bound method> = bound_method %.loc11_21.2, %T.binding.as_type.as.AddWith.impl.Op.specific_fn.loc11 [concrete = constants.%bound_method.7e7cfb.2]
+// CHECK:STDOUT:   %impl.elem0.loc11_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc11_21.3: <bound method> = bound_method %.loc11_21.2, %impl.elem0.loc11_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc11: init %Cpp.long_long = call %bound_method.loc11_21.3(%.loc11_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_21.4: %Cpp.long_long = converted %.loc11_21.2, %.loc11_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.call.loc11: init %Cpp.long_long = call %bound_method.loc11_29.3(%.loc11_21.4, %x.ref.loc11_31)
+// CHECK:STDOUT:   %x.ref.loc11_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc11: <specific function> = specific_function %AssertSameType.ref.loc11, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc11_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.AddWith.impl.Op.call.loc11
+// CHECK:STDOUT:   %.loc11_29.3: %Cpp.long_long = converted %T.binding.as_type.as.AddWith.impl.Op.call.loc11, %.loc11_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc11: init %empty_tuple.type = call %AssertSameType.specific_fn.loc11(%.loc11_29.3, %x.ref.loc11_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc12: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc12: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc12: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc12: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc12_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc12_21.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc12_21: <specific function> = specific_function %impl.elem0.loc12_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc12_21.2: <bound method> = bound_method %int_1.loc12, %specific_fn.loc12_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc12: init %i64 = call %bound_method.loc12_21.2(%int_1.loc12) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc12 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_21.2: %i64 = converted %int_1.loc12, %.loc12_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %x.ref.loc12_31: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc12: %.4af = impl_witness_access constants.%SubWith.impl_witness.297, element1 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.83c119.2]
+// CHECK:STDOUT:   %bound_method.loc12_29.1: <bound method> = bound_method %.loc12_21.2, %impl.elem1.loc12 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.bound.208360.1]
+// CHECK:STDOUT:   %specific_fn.loc12_29: <specific function> = specific_function %impl.elem1.loc12, @T.binding.as_type.as.SubWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.specific_fn.7a43f4.1]
+// CHECK:STDOUT:   %bound_method.loc12_29.2: <bound method> = bound_method %.loc12_21.2, %specific_fn.loc12_29 [concrete = constants.%bound_method.3d4b69.1]
+// CHECK:STDOUT:   %.loc12_29.1: %T.binding.as_type.as.SubWith.impl.Op.type.b3c095.1 = specific_constant imports.%Core.Op.deb, @T.binding.as_type.as.SubWith.impl.366(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.83c119.1]
+// CHECK:STDOUT:   %Op.ref.loc12: %T.binding.as_type.as.SubWith.impl.Op.type.b3c095.1 = name_ref Op, %.loc12_29.1 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.83c119.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.bound.loc12: <bound method> = bound_method %.loc12_21.2, %Op.ref.loc12 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.bound.208360.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.specific_fn.loc12: <specific function> = specific_function %Op.ref.loc12, @T.binding.as_type.as.SubWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.specific_fn.7a43f4.2]
+// CHECK:STDOUT:   %bound_method.loc12_29.3: <bound method> = bound_method %.loc12_21.2, %T.binding.as_type.as.SubWith.impl.Op.specific_fn.loc12 [concrete = constants.%bound_method.3d4b69.2]
+// CHECK:STDOUT:   %impl.elem0.loc12_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_21.3: <bound method> = bound_method %.loc12_21.2, %impl.elem0.loc12_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12: init %Cpp.long_long = call %bound_method.loc12_21.3(%.loc12_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_21.4: %Cpp.long_long = converted %.loc12_21.2, %.loc12_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.call.loc12: init %Cpp.long_long = call %bound_method.loc12_29.3(%.loc12_21.4, %x.ref.loc12_31)
+// CHECK:STDOUT:   %x.ref.loc12_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc12: <specific function> = specific_function %AssertSameType.ref.loc12, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc12_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.SubWith.impl.Op.call.loc12
+// CHECK:STDOUT:   %.loc12_29.3: %Cpp.long_long = converted %T.binding.as_type.as.SubWith.impl.Op.call.loc12, %.loc12_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc12: init %empty_tuple.type = call %AssertSameType.specific_fn.loc12(%.loc12_29.3, %x.ref.loc12_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc13: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc13: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc13: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc13: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc13_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc13_21.1: <bound method> = bound_method %int_1.loc13, %impl.elem0.loc13_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc13_21: <specific function> = specific_function %impl.elem0.loc13_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc13_21.2: <bound method> = bound_method %int_1.loc13, %specific_fn.loc13_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc13: init %i64 = call %bound_method.loc13_21.2(%int_1.loc13) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc13 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_21.2: %i64 = converted %int_1.loc13, %.loc13_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %x.ref.loc13_31: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc13: %.326 = impl_witness_access constants.%MulWith.impl_witness.47a, element1 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.40fc91.2]
+// CHECK:STDOUT:   %bound_method.loc13_29.1: <bound method> = bound_method %.loc13_21.2, %impl.elem1.loc13 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.bound.97a870.1]
+// CHECK:STDOUT:   %specific_fn.loc13_29: <specific function> = specific_function %impl.elem1.loc13, @T.binding.as_type.as.MulWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.specific_fn.7c50b1.1]
+// CHECK:STDOUT:   %bound_method.loc13_29.2: <bound method> = bound_method %.loc13_21.2, %specific_fn.loc13_29 [concrete = constants.%bound_method.065427.1]
+// CHECK:STDOUT:   %.loc13_29.1: %T.binding.as_type.as.MulWith.impl.Op.type.e434da.1 = specific_constant imports.%Core.Op.16e, @T.binding.as_type.as.MulWith.impl.9c8(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.40fc91.1]
+// CHECK:STDOUT:   %Op.ref.loc13: %T.binding.as_type.as.MulWith.impl.Op.type.e434da.1 = name_ref Op, %.loc13_29.1 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.40fc91.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.bound.loc13: <bound method> = bound_method %.loc13_21.2, %Op.ref.loc13 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.bound.97a870.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.specific_fn.loc13: <specific function> = specific_function %Op.ref.loc13, @T.binding.as_type.as.MulWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.specific_fn.7c50b1.2]
+// CHECK:STDOUT:   %bound_method.loc13_29.3: <bound method> = bound_method %.loc13_21.2, %T.binding.as_type.as.MulWith.impl.Op.specific_fn.loc13 [concrete = constants.%bound_method.065427.2]
+// CHECK:STDOUT:   %impl.elem0.loc13_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_21.3: <bound method> = bound_method %.loc13_21.2, %impl.elem0.loc13_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13: init %Cpp.long_long = call %bound_method.loc13_21.3(%.loc13_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_21.4: %Cpp.long_long = converted %.loc13_21.2, %.loc13_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.call.loc13: init %Cpp.long_long = call %bound_method.loc13_29.3(%.loc13_21.4, %x.ref.loc13_31)
+// CHECK:STDOUT:   %x.ref.loc13_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc13: <specific function> = specific_function %AssertSameType.ref.loc13, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc13_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.MulWith.impl.Op.call.loc13
+// CHECK:STDOUT:   %.loc13_29.3: %Cpp.long_long = converted %T.binding.as_type.as.MulWith.impl.Op.call.loc13, %.loc13_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc13: init %empty_tuple.type = call %AssertSameType.specific_fn.loc13(%.loc13_29.3, %x.ref.loc13_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc14: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc14: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc14: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc14: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc14_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc14_21.1: <bound method> = bound_method %int_1.loc14, %impl.elem0.loc14_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc14_21: <specific function> = specific_function %impl.elem0.loc14_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc14_21.2: <bound method> = bound_method %int_1.loc14, %specific_fn.loc14_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc14: init %i64 = call %bound_method.loc14_21.2(%int_1.loc14) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc14_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc14 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc14_21.2: %i64 = converted %int_1.loc14, %.loc14_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %x.ref.loc14_31: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc14: %.6ef = impl_witness_access constants.%DivWith.impl_witness.922, element1 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.12e7c2.2]
+// CHECK:STDOUT:   %bound_method.loc14_29.1: <bound method> = bound_method %.loc14_21.2, %impl.elem1.loc14 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.bound.76edc8.1]
+// CHECK:STDOUT:   %specific_fn.loc14_29: <specific function> = specific_function %impl.elem1.loc14, @T.binding.as_type.as.DivWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.specific_fn.4203a1.1]
+// CHECK:STDOUT:   %bound_method.loc14_29.2: <bound method> = bound_method %.loc14_21.2, %specific_fn.loc14_29 [concrete = constants.%bound_method.f43c33.1]
+// CHECK:STDOUT:   %.loc14_29.1: %T.binding.as_type.as.DivWith.impl.Op.type.59d47d.1 = specific_constant imports.%Core.Op.6d6, @T.binding.as_type.as.DivWith.impl.b8b(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.12e7c2.1]
+// CHECK:STDOUT:   %Op.ref.loc14: %T.binding.as_type.as.DivWith.impl.Op.type.59d47d.1 = name_ref Op, %.loc14_29.1 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.12e7c2.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bound.loc14: <bound method> = bound_method %.loc14_21.2, %Op.ref.loc14 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.bound.76edc8.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.specific_fn.loc14: <specific function> = specific_function %Op.ref.loc14, @T.binding.as_type.as.DivWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.specific_fn.4203a1.2]
+// CHECK:STDOUT:   %bound_method.loc14_29.3: <bound method> = bound_method %.loc14_21.2, %T.binding.as_type.as.DivWith.impl.Op.specific_fn.loc14 [concrete = constants.%bound_method.f43c33.2]
+// CHECK:STDOUT:   %impl.elem0.loc14_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc14_21.3: <bound method> = bound_method %.loc14_21.2, %impl.elem0.loc14_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc14: init %Cpp.long_long = call %bound_method.loc14_21.3(%.loc14_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc14 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_21.4: %Cpp.long_long = converted %.loc14_21.2, %.loc14_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.call.loc14: init %Cpp.long_long = call %bound_method.loc14_29.3(%.loc14_21.4, %x.ref.loc14_31)
+// CHECK:STDOUT:   %x.ref.loc14_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc14: <specific function> = specific_function %AssertSameType.ref.loc14, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc14_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.DivWith.impl.Op.call.loc14
+// CHECK:STDOUT:   %.loc14_29.3: %Cpp.long_long = converted %T.binding.as_type.as.DivWith.impl.Op.call.loc14, %.loc14_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc14: init %empty_tuple.type = call %AssertSameType.specific_fn.loc14(%.loc14_29.3, %x.ref.loc14_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc15: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc15: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc15: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc15_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc15_21.1: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc15_21: <specific function> = specific_function %impl.elem0.loc15_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_21.2: <bound method> = bound_method %int_1.loc15, %specific_fn.loc15_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc15: init %i64 = call %bound_method.loc15_21.2(%int_1.loc15) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc15 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_21.2: %i64 = converted %int_1.loc15, %.loc15_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %x.ref.loc15_31: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc15: %.f0a = impl_witness_access constants.%ModWith.impl_witness.8f4, element1 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.5e6d70.2]
+// CHECK:STDOUT:   %bound_method.loc15_29.1: <bound method> = bound_method %.loc15_21.2, %impl.elem1.loc15 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.bound.63f19a.1]
+// CHECK:STDOUT:   %specific_fn.loc15_29: <specific function> = specific_function %impl.elem1.loc15, @T.binding.as_type.as.ModWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.specific_fn.e520cf.1]
+// CHECK:STDOUT:   %bound_method.loc15_29.2: <bound method> = bound_method %.loc15_21.2, %specific_fn.loc15_29 [concrete = constants.%bound_method.eca518.1]
+// CHECK:STDOUT:   %.loc15_29.1: %T.binding.as_type.as.ModWith.impl.Op.type.e2b11f.1 = specific_constant imports.%Core.Op.498, @T.binding.as_type.as.ModWith.impl.236(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.5e6d70.1]
+// CHECK:STDOUT:   %Op.ref.loc15: %T.binding.as_type.as.ModWith.impl.Op.type.e2b11f.1 = name_ref Op, %.loc15_29.1 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.5e6d70.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.bound.loc15: <bound method> = bound_method %.loc15_21.2, %Op.ref.loc15 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.bound.63f19a.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.specific_fn.loc15: <specific function> = specific_function %Op.ref.loc15, @T.binding.as_type.as.ModWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.specific_fn.e520cf.2]
+// CHECK:STDOUT:   %bound_method.loc15_29.3: <bound method> = bound_method %.loc15_21.2, %T.binding.as_type.as.ModWith.impl.Op.specific_fn.loc15 [concrete = constants.%bound_method.eca518.2]
+// CHECK:STDOUT:   %impl.elem0.loc15_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc15_21.3: <bound method> = bound_method %.loc15_21.2, %impl.elem0.loc15_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc15: init %Cpp.long_long = call %bound_method.loc15_21.3(%.loc15_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc15 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_21.4: %Cpp.long_long = converted %.loc15_21.2, %.loc15_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.call.loc15: init %Cpp.long_long = call %bound_method.loc15_29.3(%.loc15_21.4, %x.ref.loc15_31)
+// CHECK:STDOUT:   %x.ref.loc15_34: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc15: <specific function> = specific_function %AssertSameType.ref.loc15, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc15_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.ModWith.impl.Op.call.loc15
+// CHECK:STDOUT:   %.loc15_29.3: %Cpp.long_long = converted %T.binding.as_type.as.ModWith.impl.Op.call.loc15, %.loc15_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc15: init %empty_tuple.type = call %AssertSameType.specific_fn.loc15(%.loc15_29.3, %x.ref.loc15_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc17: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc17: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %x.ref.loc17_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc17: %.179 = impl_witness_access constants.%AddWith.impl_witness.9d4, element1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.bf8142.2]
+// CHECK:STDOUT:   %bound_method.loc17_20.1: <bound method> = bound_method %int_1.loc17, %impl.elem1.loc17 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.bound.605e02.1]
+// CHECK:STDOUT:   %specific_fn.loc17: <specific function> = specific_function %impl.elem1.loc17, @T.binding.as_type.as.AddWith.impl.Op.3(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.9c4571.1]
+// CHECK:STDOUT:   %bound_method.loc17_20.2: <bound method> = bound_method %int_1.loc17, %specific_fn.loc17 [concrete = constants.%bound_method.e3fb08.1]
+// CHECK:STDOUT:   %.loc17_20.1: %T.binding.as_type.as.AddWith.impl.Op.type.066411.1 = specific_constant imports.%Core.Op.70b, @T.binding.as_type.as.AddWith.impl.3cb(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.bf8142.1]
+// CHECK:STDOUT:   %Op.ref.loc17: %T.binding.as_type.as.AddWith.impl.Op.type.066411.1 = name_ref Op, %.loc17_20.1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.bf8142.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound.loc17: <bound method> = bound_method %int_1.loc17, %Op.ref.loc17 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.bound.605e02.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.loc17: <specific function> = specific_function %Op.ref.loc17, @T.binding.as_type.as.AddWith.impl.Op.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.9c4571.2]
+// CHECK:STDOUT:   %bound_method.loc17_20.3: <bound method> = bound_method %int_1.loc17, %T.binding.as_type.as.AddWith.impl.Op.specific_fn.loc17 [concrete = constants.%bound_method.e3fb08.2]
+// CHECK:STDOUT:   %impl.elem0.loc17: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc17_18: <bound method> = bound_method %int_1.loc17, %impl.elem0.loc17 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc17: init %Cpp.long_long = call %bound_method.loc17_18(%int_1.loc17) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc17_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc17 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc17_18.2: %Cpp.long_long = converted %int_1.loc17, %.loc17_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.call.loc17: init %Cpp.long_long = call %bound_method.loc17_20.3(%.loc17_18.2, %x.ref.loc17_22)
+// CHECK:STDOUT:   %x.ref.loc17_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc17: <specific function> = specific_function %AssertSameType.ref.loc17, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc17_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.AddWith.impl.Op.call.loc17
+// CHECK:STDOUT:   %.loc17_20.3: %Cpp.long_long = converted %T.binding.as_type.as.AddWith.impl.Op.call.loc17, %.loc17_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc17: init %empty_tuple.type = call %AssertSameType.specific_fn.loc17(%.loc17_20.3, %x.ref.loc17_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc18: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %x.ref.loc18_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc18: %.83a = impl_witness_access constants.%SubWith.impl_witness.b03, element1 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.fe5aec.2]
+// CHECK:STDOUT:   %bound_method.loc18_20.1: <bound method> = bound_method %int_1.loc18, %impl.elem1.loc18 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.bound.bb7ef2.1]
+// CHECK:STDOUT:   %specific_fn.loc18: <specific function> = specific_function %impl.elem1.loc18, @T.binding.as_type.as.SubWith.impl.Op.3(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.specific_fn.a8a25c.1]
+// CHECK:STDOUT:   %bound_method.loc18_20.2: <bound method> = bound_method %int_1.loc18, %specific_fn.loc18 [concrete = constants.%bound_method.703d6e.1]
+// CHECK:STDOUT:   %.loc18_20.1: %T.binding.as_type.as.SubWith.impl.Op.type.a9ed32.1 = specific_constant imports.%Core.Op.deb, @T.binding.as_type.as.SubWith.impl.366(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.fe5aec.1]
+// CHECK:STDOUT:   %Op.ref.loc18: %T.binding.as_type.as.SubWith.impl.Op.type.a9ed32.1 = name_ref Op, %.loc18_20.1 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.fe5aec.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.bound.loc18: <bound method> = bound_method %int_1.loc18, %Op.ref.loc18 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.bound.bb7ef2.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.specific_fn.loc18: <specific function> = specific_function %Op.ref.loc18, @T.binding.as_type.as.SubWith.impl.Op.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.specific_fn.a8a25c.2]
+// CHECK:STDOUT:   %bound_method.loc18_20.3: <bound method> = bound_method %int_1.loc18, %T.binding.as_type.as.SubWith.impl.Op.specific_fn.loc18 [concrete = constants.%bound_method.703d6e.2]
+// CHECK:STDOUT:   %impl.elem0.loc18: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc18_18: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18: init %Cpp.long_long = call %bound_method.loc18_18(%int_1.loc18) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_18.2: %Cpp.long_long = converted %int_1.loc18, %.loc18_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.call.loc18: init %Cpp.long_long = call %bound_method.loc18_20.3(%.loc18_18.2, %x.ref.loc18_22)
+// CHECK:STDOUT:   %x.ref.loc18_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc18: <specific function> = specific_function %AssertSameType.ref.loc18, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc18_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.SubWith.impl.Op.call.loc18
+// CHECK:STDOUT:   %.loc18_20.3: %Cpp.long_long = converted %T.binding.as_type.as.SubWith.impl.Op.call.loc18, %.loc18_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc18: init %empty_tuple.type = call %AssertSameType.specific_fn.loc18(%.loc18_20.3, %x.ref.loc18_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc19: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc19: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %x.ref.loc19_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc19: %.083 = impl_witness_access constants.%MulWith.impl_witness.452, element1 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.b572bf.2]
+// CHECK:STDOUT:   %bound_method.loc19_20.1: <bound method> = bound_method %int_1.loc19, %impl.elem1.loc19 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.bound.cc8bc8.1]
+// CHECK:STDOUT:   %specific_fn.loc19: <specific function> = specific_function %impl.elem1.loc19, @T.binding.as_type.as.MulWith.impl.Op.3(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.specific_fn.c40ccc.1]
+// CHECK:STDOUT:   %bound_method.loc19_20.2: <bound method> = bound_method %int_1.loc19, %specific_fn.loc19 [concrete = constants.%bound_method.5e5b06.1]
+// CHECK:STDOUT:   %.loc19_20.1: %T.binding.as_type.as.MulWith.impl.Op.type.4ddc19.1 = specific_constant imports.%Core.Op.16e, @T.binding.as_type.as.MulWith.impl.9c8(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.b572bf.1]
+// CHECK:STDOUT:   %Op.ref.loc19: %T.binding.as_type.as.MulWith.impl.Op.type.4ddc19.1 = name_ref Op, %.loc19_20.1 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.b572bf.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.bound.loc19: <bound method> = bound_method %int_1.loc19, %Op.ref.loc19 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.bound.cc8bc8.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.specific_fn.loc19: <specific function> = specific_function %Op.ref.loc19, @T.binding.as_type.as.MulWith.impl.Op.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.specific_fn.c40ccc.2]
+// CHECK:STDOUT:   %bound_method.loc19_20.3: <bound method> = bound_method %int_1.loc19, %T.binding.as_type.as.MulWith.impl.Op.specific_fn.loc19 [concrete = constants.%bound_method.5e5b06.2]
+// CHECK:STDOUT:   %impl.elem0.loc19: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc19_18: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19: init %Cpp.long_long = call %bound_method.loc19_18(%int_1.loc19) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_18.2: %Cpp.long_long = converted %int_1.loc19, %.loc19_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.call.loc19: init %Cpp.long_long = call %bound_method.loc19_20.3(%.loc19_18.2, %x.ref.loc19_22)
+// CHECK:STDOUT:   %x.ref.loc19_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc19: <specific function> = specific_function %AssertSameType.ref.loc19, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc19_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.MulWith.impl.Op.call.loc19
+// CHECK:STDOUT:   %.loc19_20.3: %Cpp.long_long = converted %T.binding.as_type.as.MulWith.impl.Op.call.loc19, %.loc19_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc19: init %empty_tuple.type = call %AssertSameType.specific_fn.loc19(%.loc19_20.3, %x.ref.loc19_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc20: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc20: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %x.ref.loc20_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc20: %.c95 = impl_witness_access constants.%DivWith.impl_witness.8ae, element1 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.bb0620.2]
+// CHECK:STDOUT:   %bound_method.loc20_20.1: <bound method> = bound_method %int_1.loc20, %impl.elem1.loc20 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.bound.e9391e.1]
+// CHECK:STDOUT:   %specific_fn.loc20: <specific function> = specific_function %impl.elem1.loc20, @T.binding.as_type.as.DivWith.impl.Op.3(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.specific_fn.c11faf.1]
+// CHECK:STDOUT:   %bound_method.loc20_20.2: <bound method> = bound_method %int_1.loc20, %specific_fn.loc20 [concrete = constants.%bound_method.91b5ad.1]
+// CHECK:STDOUT:   %.loc20_20.1: %T.binding.as_type.as.DivWith.impl.Op.type.a76bb3.1 = specific_constant imports.%Core.Op.6d6, @T.binding.as_type.as.DivWith.impl.b8b(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.bb0620.1]
+// CHECK:STDOUT:   %Op.ref.loc20: %T.binding.as_type.as.DivWith.impl.Op.type.a76bb3.1 = name_ref Op, %.loc20_20.1 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.bb0620.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bound.loc20: <bound method> = bound_method %int_1.loc20, %Op.ref.loc20 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.bound.e9391e.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.specific_fn.loc20: <specific function> = specific_function %Op.ref.loc20, @T.binding.as_type.as.DivWith.impl.Op.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.specific_fn.c11faf.2]
+// CHECK:STDOUT:   %bound_method.loc20_20.3: <bound method> = bound_method %int_1.loc20, %T.binding.as_type.as.DivWith.impl.Op.specific_fn.loc20 [concrete = constants.%bound_method.91b5ad.2]
+// CHECK:STDOUT:   %impl.elem0.loc20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc20_18: <bound method> = bound_method %int_1.loc20, %impl.elem0.loc20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20: init %Cpp.long_long = call %bound_method.loc20_18(%int_1.loc20) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_18.2: %Cpp.long_long = converted %int_1.loc20, %.loc20_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.call.loc20: init %Cpp.long_long = call %bound_method.loc20_20.3(%.loc20_18.2, %x.ref.loc20_22)
+// CHECK:STDOUT:   %x.ref.loc20_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc20: <specific function> = specific_function %AssertSameType.ref.loc20, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc20_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.DivWith.impl.Op.call.loc20
+// CHECK:STDOUT:   %.loc20_20.3: %Cpp.long_long = converted %T.binding.as_type.as.DivWith.impl.Op.call.loc20, %.loc20_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc20: init %empty_tuple.type = call %AssertSameType.specific_fn.loc20(%.loc20_20.3, %x.ref.loc20_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc21: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %x.ref.loc21_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc21: %.738 = impl_witness_access constants.%ModWith.impl_witness.17a, element1 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.97c315.2]
+// CHECK:STDOUT:   %bound_method.loc21_20.1: <bound method> = bound_method %int_1.loc21, %impl.elem1.loc21 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.bound.9f87a0.1]
+// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem1.loc21, @T.binding.as_type.as.ModWith.impl.Op.3(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.specific_fn.c19386.1]
+// CHECK:STDOUT:   %bound_method.loc21_20.2: <bound method> = bound_method %int_1.loc21, %specific_fn.loc21 [concrete = constants.%bound_method.1e0cef.1]
+// CHECK:STDOUT:   %.loc21_20.1: %T.binding.as_type.as.ModWith.impl.Op.type.8239b7.1 = specific_constant imports.%Core.Op.498, @T.binding.as_type.as.ModWith.impl.236(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.97c315.1]
+// CHECK:STDOUT:   %Op.ref.loc21: %T.binding.as_type.as.ModWith.impl.Op.type.8239b7.1 = name_ref Op, %.loc21_20.1 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.97c315.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.bound.loc21: <bound method> = bound_method %int_1.loc21, %Op.ref.loc21 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.bound.9f87a0.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.specific_fn.loc21: <specific function> = specific_function %Op.ref.loc21, @T.binding.as_type.as.ModWith.impl.Op.4(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.specific_fn.c19386.2]
+// CHECK:STDOUT:   %bound_method.loc21_20.3: <bound method> = bound_method %int_1.loc21, %T.binding.as_type.as.ModWith.impl.Op.specific_fn.loc21 [concrete = constants.%bound_method.1e0cef.2]
+// CHECK:STDOUT:   %impl.elem0.loc21: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc21_18: <bound method> = bound_method %int_1.loc21, %impl.elem0.loc21 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21: init %Cpp.long_long = call %bound_method.loc21_18(%int_1.loc21) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_18.2: %Cpp.long_long = converted %int_1.loc21, %.loc21_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.call.loc21: init %Cpp.long_long = call %bound_method.loc21_20.3(%.loc21_18.2, %x.ref.loc21_22)
+// CHECK:STDOUT:   %x.ref.loc21_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc21: <specific function> = specific_function %AssertSameType.ref.loc21, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc21_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.ModWith.impl.Op.call.loc21
+// CHECK:STDOUT:   %.loc21_20.3: %Cpp.long_long = converted %T.binding.as_type.as.ModWith.impl.Op.call.loc21, %.loc21_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc21: init %empty_tuple.type = call %AssertSameType.specific_fn.loc21(%.loc21_20.3, %x.ref.loc21_25)
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %y.patt: %pattern_type.95b = value_binding_pattern y [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc23: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc23_10: type = splice_block %i64.loc23 [concrete = constants.%i64] {
+// CHECK:STDOUT:     %int_64.loc23: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:     %i64.loc23: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc23: %.567 = impl_witness_access constants.%ImplicitAs.impl_witness.556, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.57d]
+// CHECK:STDOUT:   %bound_method.loc23_16.1: <bound method> = bound_method %int_1.loc23, %impl.elem0.loc23 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102]
+// CHECK:STDOUT:   %specific_fn.loc23: <specific function> = specific_function %impl.elem0.loc23, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc23_16.2: <bound method> = bound_method %int_1.loc23, %specific_fn.loc23 [concrete = constants.%bound_method.288]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc23: init %i64 = call %bound_method.loc23_16.2(%int_1.loc23) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc23_16.1: %i64 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc23 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc23_16.2: %i64 = converted %int_1.loc23, %.loc23_16.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %y: %i64 = value_binding y, %.loc23_16.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc24: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %y.ref.loc24: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %x.ref.loc24_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc24: %.3bd = impl_witness_access constants.%AddWith.impl_witness.870, element1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.1269d8.2]
+// CHECK:STDOUT:   %bound_method.loc24_20.1: <bound method> = bound_method %y.ref.loc24, %impl.elem1.loc24
+// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem1.loc24, @T.binding.as_type.as.AddWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.468a32.1]
+// CHECK:STDOUT:   %bound_method.loc24_20.2: <bound method> = bound_method %y.ref.loc24, %specific_fn.loc24
+// CHECK:STDOUT:   %.loc24_20.1: %T.binding.as_type.as.AddWith.impl.Op.type.5353e6.1 = specific_constant imports.%Core.Op.70b, @T.binding.as_type.as.AddWith.impl.3cb(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.1269d8.1]
+// CHECK:STDOUT:   %Op.ref.loc24: %T.binding.as_type.as.AddWith.impl.Op.type.5353e6.1 = name_ref Op, %.loc24_20.1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.1269d8.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound.loc24: <bound method> = bound_method %y.ref.loc24, %Op.ref.loc24
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.loc24: <specific function> = specific_function %Op.ref.loc24, @T.binding.as_type.as.AddWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.468a32.2]
+// CHECK:STDOUT:   %bound_method.loc24_20.3: <bound method> = bound_method %y.ref.loc24, %T.binding.as_type.as.AddWith.impl.Op.specific_fn.loc24
+// CHECK:STDOUT:   %impl.elem0.loc24: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc24_18: <bound method> = bound_method %y.ref.loc24, %impl.elem0.loc24
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc24: init %Cpp.long_long = call %bound_method.loc24_18(%y.ref.loc24)
+// CHECK:STDOUT:   %.loc24_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc24
+// CHECK:STDOUT:   %.loc24_18.2: %Cpp.long_long = converted %y.ref.loc24, %.loc24_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.call.loc24: init %Cpp.long_long = call %bound_method.loc24_20.3(%.loc24_18.2, %x.ref.loc24_22)
+// CHECK:STDOUT:   %x.ref.loc24_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc24: <specific function> = specific_function %AssertSameType.ref.loc24, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc24_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.AddWith.impl.Op.call.loc24
+// CHECK:STDOUT:   %.loc24_20.3: %Cpp.long_long = converted %T.binding.as_type.as.AddWith.impl.Op.call.loc24, %.loc24_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc24: init %empty_tuple.type = call %AssertSameType.specific_fn.loc24(%.loc24_20.3, %x.ref.loc24_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc25: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %y.ref.loc25: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %x.ref.loc25_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc25: %.4af = impl_witness_access constants.%SubWith.impl_witness.297, element1 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.83c119.2]
+// CHECK:STDOUT:   %bound_method.loc25_20.1: <bound method> = bound_method %y.ref.loc25, %impl.elem1.loc25
+// CHECK:STDOUT:   %specific_fn.loc25: <specific function> = specific_function %impl.elem1.loc25, @T.binding.as_type.as.SubWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.specific_fn.7a43f4.1]
+// CHECK:STDOUT:   %bound_method.loc25_20.2: <bound method> = bound_method %y.ref.loc25, %specific_fn.loc25
+// CHECK:STDOUT:   %.loc25_20.1: %T.binding.as_type.as.SubWith.impl.Op.type.b3c095.1 = specific_constant imports.%Core.Op.deb, @T.binding.as_type.as.SubWith.impl.366(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.83c119.1]
+// CHECK:STDOUT:   %Op.ref.loc25: %T.binding.as_type.as.SubWith.impl.Op.type.b3c095.1 = name_ref Op, %.loc25_20.1 [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.83c119.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.bound.loc25: <bound method> = bound_method %y.ref.loc25, %Op.ref.loc25
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.specific_fn.loc25: <specific function> = specific_function %Op.ref.loc25, @T.binding.as_type.as.SubWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.SubWith.impl.Op.specific_fn.7a43f4.2]
+// CHECK:STDOUT:   %bound_method.loc25_20.3: <bound method> = bound_method %y.ref.loc25, %T.binding.as_type.as.SubWith.impl.Op.specific_fn.loc25
+// CHECK:STDOUT:   %impl.elem0.loc25: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc25_18: <bound method> = bound_method %y.ref.loc25, %impl.elem0.loc25
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc25: init %Cpp.long_long = call %bound_method.loc25_18(%y.ref.loc25)
+// CHECK:STDOUT:   %.loc25_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc25
+// CHECK:STDOUT:   %.loc25_18.2: %Cpp.long_long = converted %y.ref.loc25, %.loc25_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.SubWith.impl.Op.call.loc25: init %Cpp.long_long = call %bound_method.loc25_20.3(%.loc25_18.2, %x.ref.loc25_22)
+// CHECK:STDOUT:   %x.ref.loc25_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc25: <specific function> = specific_function %AssertSameType.ref.loc25, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc25_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.SubWith.impl.Op.call.loc25
+// CHECK:STDOUT:   %.loc25_20.3: %Cpp.long_long = converted %T.binding.as_type.as.SubWith.impl.Op.call.loc25, %.loc25_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc25: init %empty_tuple.type = call %AssertSameType.specific_fn.loc25(%.loc25_20.3, %x.ref.loc25_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc26: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %y.ref.loc26: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %x.ref.loc26_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc26: %.326 = impl_witness_access constants.%MulWith.impl_witness.47a, element1 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.40fc91.2]
+// CHECK:STDOUT:   %bound_method.loc26_20.1: <bound method> = bound_method %y.ref.loc26, %impl.elem1.loc26
+// CHECK:STDOUT:   %specific_fn.loc26: <specific function> = specific_function %impl.elem1.loc26, @T.binding.as_type.as.MulWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.specific_fn.7c50b1.1]
+// CHECK:STDOUT:   %bound_method.loc26_20.2: <bound method> = bound_method %y.ref.loc26, %specific_fn.loc26
+// CHECK:STDOUT:   %.loc26_20.1: %T.binding.as_type.as.MulWith.impl.Op.type.e434da.1 = specific_constant imports.%Core.Op.16e, @T.binding.as_type.as.MulWith.impl.9c8(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.40fc91.1]
+// CHECK:STDOUT:   %Op.ref.loc26: %T.binding.as_type.as.MulWith.impl.Op.type.e434da.1 = name_ref Op, %.loc26_20.1 [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.40fc91.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.bound.loc26: <bound method> = bound_method %y.ref.loc26, %Op.ref.loc26
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.specific_fn.loc26: <specific function> = specific_function %Op.ref.loc26, @T.binding.as_type.as.MulWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.MulWith.impl.Op.specific_fn.7c50b1.2]
+// CHECK:STDOUT:   %bound_method.loc26_20.3: <bound method> = bound_method %y.ref.loc26, %T.binding.as_type.as.MulWith.impl.Op.specific_fn.loc26
+// CHECK:STDOUT:   %impl.elem0.loc26: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc26_18: <bound method> = bound_method %y.ref.loc26, %impl.elem0.loc26
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc26: init %Cpp.long_long = call %bound_method.loc26_18(%y.ref.loc26)
+// CHECK:STDOUT:   %.loc26_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc26
+// CHECK:STDOUT:   %.loc26_18.2: %Cpp.long_long = converted %y.ref.loc26, %.loc26_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.MulWith.impl.Op.call.loc26: init %Cpp.long_long = call %bound_method.loc26_20.3(%.loc26_18.2, %x.ref.loc26_22)
+// CHECK:STDOUT:   %x.ref.loc26_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc26: <specific function> = specific_function %AssertSameType.ref.loc26, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc26_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.MulWith.impl.Op.call.loc26
+// CHECK:STDOUT:   %.loc26_20.3: %Cpp.long_long = converted %T.binding.as_type.as.MulWith.impl.Op.call.loc26, %.loc26_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc26: init %empty_tuple.type = call %AssertSameType.specific_fn.loc26(%.loc26_20.3, %x.ref.loc26_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc27: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %y.ref.loc27: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %x.ref.loc27_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc27: %.6ef = impl_witness_access constants.%DivWith.impl_witness.922, element1 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.12e7c2.2]
+// CHECK:STDOUT:   %bound_method.loc27_20.1: <bound method> = bound_method %y.ref.loc27, %impl.elem1.loc27
+// CHECK:STDOUT:   %specific_fn.loc27: <specific function> = specific_function %impl.elem1.loc27, @T.binding.as_type.as.DivWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.specific_fn.4203a1.1]
+// CHECK:STDOUT:   %bound_method.loc27_20.2: <bound method> = bound_method %y.ref.loc27, %specific_fn.loc27
+// CHECK:STDOUT:   %.loc27_20.1: %T.binding.as_type.as.DivWith.impl.Op.type.59d47d.1 = specific_constant imports.%Core.Op.6d6, @T.binding.as_type.as.DivWith.impl.b8b(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.12e7c2.1]
+// CHECK:STDOUT:   %Op.ref.loc27: %T.binding.as_type.as.DivWith.impl.Op.type.59d47d.1 = name_ref Op, %.loc27_20.1 [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.12e7c2.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.bound.loc27: <bound method> = bound_method %y.ref.loc27, %Op.ref.loc27
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.specific_fn.loc27: <specific function> = specific_function %Op.ref.loc27, @T.binding.as_type.as.DivWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.DivWith.impl.Op.specific_fn.4203a1.2]
+// CHECK:STDOUT:   %bound_method.loc27_20.3: <bound method> = bound_method %y.ref.loc27, %T.binding.as_type.as.DivWith.impl.Op.specific_fn.loc27
+// CHECK:STDOUT:   %impl.elem0.loc27: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc27_18: <bound method> = bound_method %y.ref.loc27, %impl.elem0.loc27
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc27: init %Cpp.long_long = call %bound_method.loc27_18(%y.ref.loc27)
+// CHECK:STDOUT:   %.loc27_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc27
+// CHECK:STDOUT:   %.loc27_18.2: %Cpp.long_long = converted %y.ref.loc27, %.loc27_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.DivWith.impl.Op.call.loc27: init %Cpp.long_long = call %bound_method.loc27_20.3(%.loc27_18.2, %x.ref.loc27_22)
+// CHECK:STDOUT:   %x.ref.loc27_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc27: <specific function> = specific_function %AssertSameType.ref.loc27, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc27_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.DivWith.impl.Op.call.loc27
+// CHECK:STDOUT:   %.loc27_20.3: %Cpp.long_long = converted %T.binding.as_type.as.DivWith.impl.Op.call.loc27, %.loc27_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc27: init %empty_tuple.type = call %AssertSameType.specific_fn.loc27(%.loc27_20.3, %x.ref.loc27_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc28: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %y.ref.loc28: %i64 = name_ref y, %y
+// CHECK:STDOUT:   %x.ref.loc28_22: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc28: %.f0a = impl_witness_access constants.%ModWith.impl_witness.8f4, element1 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.5e6d70.2]
+// CHECK:STDOUT:   %bound_method.loc28_20.1: <bound method> = bound_method %y.ref.loc28, %impl.elem1.loc28
+// CHECK:STDOUT:   %specific_fn.loc28: <specific function> = specific_function %impl.elem1.loc28, @T.binding.as_type.as.ModWith.impl.Op.3(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.specific_fn.e520cf.1]
+// CHECK:STDOUT:   %bound_method.loc28_20.2: <bound method> = bound_method %y.ref.loc28, %specific_fn.loc28
+// CHECK:STDOUT:   %.loc28_20.1: %T.binding.as_type.as.ModWith.impl.Op.type.e2b11f.1 = specific_constant imports.%Core.Op.498, @T.binding.as_type.as.ModWith.impl.236(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.5e6d70.1]
+// CHECK:STDOUT:   %Op.ref.loc28: %T.binding.as_type.as.ModWith.impl.Op.type.e2b11f.1 = name_ref Op, %.loc28_20.1 [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.5e6d70.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.bound.loc28: <bound method> = bound_method %y.ref.loc28, %Op.ref.loc28
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.specific_fn.loc28: <specific function> = specific_function %Op.ref.loc28, @T.binding.as_type.as.ModWith.impl.Op.4(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.ModWith.impl.Op.specific_fn.e520cf.2]
+// CHECK:STDOUT:   %bound_method.loc28_20.3: <bound method> = bound_method %y.ref.loc28, %T.binding.as_type.as.ModWith.impl.Op.specific_fn.loc28
+// CHECK:STDOUT:   %impl.elem0.loc28: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc28_18: <bound method> = bound_method %y.ref.loc28, %impl.elem0.loc28
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc28: init %Cpp.long_long = call %bound_method.loc28_18(%y.ref.loc28)
+// CHECK:STDOUT:   %.loc28_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc28
+// CHECK:STDOUT:   %.loc28_18.2: %Cpp.long_long = converted %y.ref.loc28, %.loc28_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.ModWith.impl.Op.call.loc28: init %Cpp.long_long = call %bound_method.loc28_20.3(%.loc28_18.2, %x.ref.loc28_22)
+// CHECK:STDOUT:   %x.ref.loc28_25: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc28: <specific function> = specific_function %AssertSameType.ref.loc28, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc28_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.ModWith.impl.Op.call.loc28
+// CHECK:STDOUT:   %.loc28_20.3: %Cpp.long_long = converted %T.binding.as_type.as.ModWith.impl.Op.call.loc28, %.loc28_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc28: init %empty_tuple.type = call %AssertSameType.specific_fn.loc28(%.loc28_20.3, %x.ref.loc28_25)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- arithmetic_heterogeneous_long_long_and_i128.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %AssertSameType.type: type = fn_type @AssertSameType [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %AssertSameType: %AssertSameType.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %N: Core.IntLiteral = symbolic_binding N, 0 [symbolic]
+// CHECK:STDOUT:   %Int.fc6021.1: type = class_type @Int, @Int(%N) [symbolic]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %int_128: Core.IntLiteral = int_value 128 [concrete]
+// CHECK:STDOUT:   %i128: type = class_type @Int, @Int(%int_128) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.e19: type = facet_type <@ImplicitAs, @ImplicitAs(%i128)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.812: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i128) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %pattern_type.57d: type = pattern_type %i128 [concrete]
+// CHECK:STDOUT:   %To: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.47a: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.74f, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_128) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.74a: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_128) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.75a: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.74a = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.daa: %ImplicitAs.type.e19 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.47a) [concrete]
+// CHECK:STDOUT:   %.700: type = fn_type_with_self_type %ImplicitAs.Convert.type.812, %ImplicitAs.facet.daa [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.e09: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.75a [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.ImplicitAs.impl.Convert.75a, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(%int_128) [concrete]
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_1.611: %i128 = int_value 1 [concrete]
+// CHECK:STDOUT:   %AddWith.type.d6e: type = facet_type <@AddWith, @AddWith(%i128)> [concrete]
+// CHECK:STDOUT:   %AddWith.Op.type.2a0: type = fn_type @AddWith.Op, @AddWith(%i128) [concrete]
+// CHECK:STDOUT:   %AddWith.type.e97: type = facet_type <@AddWith, @AddWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %AddWith.Op.type.4a8: type = fn_type @AddWith.Op, @AddWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.39a54f.2: type = facet_type <@ImplicitAs, @ImplicitAs(%Int.fc6021.1)> [symbolic]
+// CHECK:STDOUT:   %U.354: %ImplicitAs.type.39a54f.2 = symbolic_binding U, 1 [symbolic]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.type.188570.1: type = fn_type @Int.as.AddWith.impl.Op.2, @Int.as.AddWith.impl.b14(%N, %U.354) [symbolic]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.fecf95.1: %Int.as.AddWith.impl.Op.type.188570.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.type.188570.2: type = fn_type @Int.as.AddWith.impl.Op.3, @Int.as.AddWith.impl.b14(%N, %U.354) [symbolic]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.fecf95.2: %Int.as.AddWith.impl.Op.type.188570.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.354: %ImplicitAs.type.39a54f.2 = symbolic_binding T, 1 [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.5, @T.binding.as_type.as.AddWith.impl.83e(%N, %T.354) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.363ab3.1: %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.6, @T.binding.as_type.as.AddWith.impl.83e(%N, %T.354) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.363ab3.2: %T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.0f2: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.eb2 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.211: %ImplicitAs.type.e19 = facet_value %Cpp.long_long, (%ImplicitAs.impl_witness.0f2) [concrete]
+// CHECK:STDOUT:   %AddWith.impl_witness.97c: <witness> = impl_witness imports.%AddWith.impl_witness_table.787, @T.binding.as_type.as.AddWith.impl.83e(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.68d647.1: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.6, @T.binding.as_type.as.AddWith.impl.83e(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.ac85cc.1: %T.binding.as_type.as.AddWith.impl.Op.type.68d647.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.type.68d647.2: type = fn_type @T.binding.as_type.as.AddWith.impl.Op.5, @T.binding.as_type.as.AddWith.impl.83e(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.ac85cc.2: %T.binding.as_type.as.AddWith.impl.Op.type.68d647.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddWith.facet.634: %AddWith.type.d6e = facet_value %Cpp.long_long, (%AddWith.impl_witness.97c) [concrete]
+// CHECK:STDOUT:   %.d2a: type = fn_type_with_self_type %AddWith.Op.type.2a0, %AddWith.facet.634 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.5cf465.1: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.ac85cc.2, @T.binding.as_type.as.AddWith.impl.Op.5(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn.5cf465.2: <specific function> = specific_function %T.binding.as_type.as.AddWith.impl.Op.ac85cc.1, @T.binding.as_type.as.AddWith.impl.Op.6(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %.6e1: type = fn_type_with_self_type %ImplicitAs.Convert.type.812, %ImplicitAs.facet.211 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.type: type = fn_type @Cpp.long_long.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert: %Cpp.long_long.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%i128) [concrete]
+// CHECK:STDOUT:   %AddWith.impl_witness.f00: <witness> = impl_witness imports.%AddWith.impl_witness_table.c46, @Int.as.AddWith.impl.b14(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.type.8dafc6.1: type = fn_type @Int.as.AddWith.impl.Op.3, @Int.as.AddWith.impl.b14(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.dd7d43.1: %Int.as.AddWith.impl.Op.type.8dafc6.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.type.8dafc6.2: type = fn_type @Int.as.AddWith.impl.Op.2, @Int.as.AddWith.impl.b14(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.dd7d43.2: %Int.as.AddWith.impl.Op.type.8dafc6.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddWith.facet.882: %AddWith.type.e97 = facet_value %i128, (%AddWith.impl_witness.f00) [concrete]
+// CHECK:STDOUT:   %.f35: type = fn_type_with_self_type %AddWith.Op.type.4a8, %AddWith.facet.882 [concrete]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.specific_fn.898bfc.1: <specific function> = specific_function %Int.as.AddWith.impl.Op.dd7d43.2, @Int.as.AddWith.impl.Op.2(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.specific_fn.898bfc.2: <specific function> = specific_function %Int.as.AddWith.impl.Op.dd7d43.1, @Int.as.AddWith.impl.Op.3(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
+// CHECK:STDOUT:   %Core.import_ref.475cb3.2 = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.266: @Int.as.AddWith.impl.b14.%Int.as.AddWith.impl.Op.type.2 (%Int.as.AddWith.impl.Op.type.188570.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.AddWith.impl.b14.%Int.as.AddWith.impl.Op.2 (constants.%Int.as.AddWith.impl.Op.fecf95.1)]
+// CHECK:STDOUT:   %AddWith.impl_witness_table.c46 = impl_witness_table (%Core.import_ref.475cb3.2, %Core.import_ref.266), @Int.as.AddWith.impl.b14 [concrete]
+// CHECK:STDOUT:   %Core.Op.a76: @Int.as.AddWith.impl.b14.%Int.as.AddWith.impl.Op.type.1 (%Int.as.AddWith.impl.Op.type.188570.2) = import_ref Core//prelude/types/int, Op, loaded [symbolic = @Int.as.AddWith.impl.b14.%Int.as.AddWith.impl.Op.1 (constants.%Int.as.AddWith.impl.Op.fecf95.2)]
+// CHECK:STDOUT:   %Core.import_ref.475cb3.3 = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.bba: @T.binding.as_type.as.AddWith.impl.83e.%T.binding.as_type.as.AddWith.impl.Op.type.2 (%T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.AddWith.impl.83e.%T.binding.as_type.as.AddWith.impl.Op.2 (constants.%T.binding.as_type.as.AddWith.impl.Op.363ab3.1)]
+// CHECK:STDOUT:   %AddWith.impl_witness_table.787 = impl_witness_table (%Core.import_ref.475cb3.3, %Core.import_ref.bba), @T.binding.as_type.as.AddWith.impl.83e [concrete]
+// CHECK:STDOUT:   %Core.Op.fcd: @T.binding.as_type.as.AddWith.impl.83e.%T.binding.as_type.as.AddWith.impl.Op.type.1 (%T.binding.as_type.as.AddWith.impl.Op.type.4c3f59.2) = import_ref Core//prelude/types/int, Op, loaded [symbolic = @T.binding.as_type.as.AddWith.impl.83e.%T.binding.as_type.as.AddWith.impl.Op.1 (constants.%T.binding.as_type.as.AddWith.impl.Op.363ab3.2)]
+// CHECK:STDOUT:   %Core.import_ref.eca: %Cpp.long_long.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.eb2 = impl_witness_table (%Core.import_ref.eca), @Cpp.long_long.as.ImplicitAs.impl.0cb [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @ArithmeticHeterogeneousLongLongAndI128() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %x.patt: %pattern_type.76e = value_binding_pattern x [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc10_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc10: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10(%int_1.loc10) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.2: %Cpp.long_long = converted %int_1.loc10, %.loc10_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %x: %Cpp.long_long = value_binding x, %.loc10_26.2
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %y.patt: %pattern_type.57d = value_binding_pattern y [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc11: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc11_10: type = splice_block %i128 [concrete = constants.%i128] {
+// CHECK:STDOUT:     %int_128: Core.IntLiteral = int_value 128 [concrete = constants.%int_128]
+// CHECK:STDOUT:     %i128: type = class_type @Int, @Int(constants.%int_128) [concrete = constants.%i128]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc11: %.700 = impl_witness_access constants.%ImplicitAs.impl_witness.47a, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.75a]
+// CHECK:STDOUT:   %bound_method.loc11_17.1: <bound method> = bound_method %int_1.loc11, %impl.elem0.loc11 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.e09]
+// CHECK:STDOUT:   %specific_fn.loc11: <specific function> = specific_function %impl.elem0.loc11, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(constants.%int_128) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc11_17.2: <bound method> = bound_method %int_1.loc11, %specific_fn.loc11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc11: init %i128 = call %bound_method.loc11_17.2(%int_1.loc11) [concrete = constants.%int_1.611]
+// CHECK:STDOUT:   %.loc11_17.1: %i128 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc11 [concrete = constants.%int_1.611]
+// CHECK:STDOUT:   %.loc11_17.2: %i128 = converted %int_1.loc11, %.loc11_17.1 [concrete = constants.%int_1.611]
+// CHECK:STDOUT:   %y: %i128 = value_binding y, %.loc11_17.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc12: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %x.ref.loc12: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %y.ref.loc12_22: %i128 = name_ref y, %y
+// CHECK:STDOUT:   %impl.elem1.loc12: %.d2a = impl_witness_access constants.%AddWith.impl_witness.97c, element1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.ac85cc.2]
+// CHECK:STDOUT:   %bound_method.loc12_20.1: <bound method> = bound_method %x.ref.loc12, %impl.elem1.loc12
+// CHECK:STDOUT:   %specific_fn.loc12: <specific function> = specific_function %impl.elem1.loc12, @T.binding.as_type.as.AddWith.impl.Op.5(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.5cf465.1]
+// CHECK:STDOUT:   %bound_method.loc12_20.2: <bound method> = bound_method %x.ref.loc12, %specific_fn.loc12
+// CHECK:STDOUT:   %.loc12_20.1: %T.binding.as_type.as.AddWith.impl.Op.type.68d647.1 = specific_constant imports.%Core.Op.fcd, @T.binding.as_type.as.AddWith.impl.83e(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.ac85cc.1]
+// CHECK:STDOUT:   %Op.ref.loc12: %T.binding.as_type.as.AddWith.impl.Op.type.68d647.1 = name_ref Op, %.loc12_20.1 [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.ac85cc.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.bound: <bound method> = bound_method %x.ref.loc12, %Op.ref.loc12
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc12, @T.binding.as_type.as.AddWith.impl.Op.6(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%T.binding.as_type.as.AddWith.impl.Op.specific_fn.5cf465.2]
+// CHECK:STDOUT:   %bound_method.loc12_20.3: <bound method> = bound_method %x.ref.loc12, %T.binding.as_type.as.AddWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc12: %.6e1 = impl_witness_access constants.%ImplicitAs.impl_witness.0f2, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_18: <bound method> = bound_method %x.ref.loc12, %impl.elem0.loc12
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc12: init %i128 = call %bound_method.loc12_18(%x.ref.loc12)
+// CHECK:STDOUT:   %.loc12_18.1: %i128 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc12
+// CHECK:STDOUT:   %.loc12_18.2: %i128 = converted %x.ref.loc12, %.loc12_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.AddWith.impl.Op.call: init %i128 = call %bound_method.loc12_20.3(%.loc12_18.2, %y.ref.loc12_22)
+// CHECK:STDOUT:   %y.ref.loc12_25: %i128 = name_ref y, %y
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc12: <specific function> = specific_function %AssertSameType.ref.loc12, @AssertSameType(constants.%i128) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc12_20.2: %i128 = value_of_initializer %T.binding.as_type.as.AddWith.impl.Op.call
+// CHECK:STDOUT:   %.loc12_20.3: %i128 = converted %T.binding.as_type.as.AddWith.impl.Op.call, %.loc12_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc12: init %empty_tuple.type = call %AssertSameType.specific_fn.loc12(%.loc12_20.3, %y.ref.loc12_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc13: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %y.ref.loc13_18: %i128 = name_ref y, %y
+// CHECK:STDOUT:   %x.ref.loc13: %Cpp.long_long = name_ref x, %x
+// CHECK:STDOUT:   %impl.elem1.loc13: %.f35 = impl_witness_access constants.%AddWith.impl_witness.f00, element1 [concrete = constants.%Int.as.AddWith.impl.Op.dd7d43.2]
+// CHECK:STDOUT:   %bound_method.loc13_20.1: <bound method> = bound_method %y.ref.loc13_18, %impl.elem1.loc13
+// CHECK:STDOUT:   %specific_fn.loc13: <specific function> = specific_function %impl.elem1.loc13, @Int.as.AddWith.impl.Op.2(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%Int.as.AddWith.impl.Op.specific_fn.898bfc.1]
+// CHECK:STDOUT:   %bound_method.loc13_20.2: <bound method> = bound_method %y.ref.loc13_18, %specific_fn.loc13
+// CHECK:STDOUT:   %.loc13_20.1: %Int.as.AddWith.impl.Op.type.8dafc6.1 = specific_constant imports.%Core.Op.a76, @Int.as.AddWith.impl.b14(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%Int.as.AddWith.impl.Op.dd7d43.1]
+// CHECK:STDOUT:   %Op.ref.loc13: %Int.as.AddWith.impl.Op.type.8dafc6.1 = name_ref Op, %.loc13_20.1 [concrete = constants.%Int.as.AddWith.impl.Op.dd7d43.1]
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.bound: <bound method> = bound_method %y.ref.loc13_18, %Op.ref.loc13
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc13, @Int.as.AddWith.impl.Op.3(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%Int.as.AddWith.impl.Op.specific_fn.898bfc.2]
+// CHECK:STDOUT:   %bound_method.loc13_20.3: <bound method> = bound_method %y.ref.loc13_18, %Int.as.AddWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc13: %.6e1 = impl_witness_access constants.%ImplicitAs.impl_witness.0f2, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_22: <bound method> = bound_method %x.ref.loc13, %impl.elem0.loc13
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc13: init %i128 = call %bound_method.loc13_22(%x.ref.loc13)
+// CHECK:STDOUT:   %.loc13_22.1: %i128 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc13
+// CHECK:STDOUT:   %.loc13_22.2: %i128 = converted %x.ref.loc13, %.loc13_22.1
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call: init %i128 = call %bound_method.loc13_20.3(%y.ref.loc13_18, %.loc13_22.2)
+// CHECK:STDOUT:   %y.ref.loc13_25: %i128 = name_ref y, %y
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc13: <specific function> = specific_function %AssertSameType.ref.loc13, @AssertSameType(constants.%i128) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc13_20.2: %i128 = value_of_initializer %Int.as.AddWith.impl.Op.call
+// CHECK:STDOUT:   %.loc13_20.3: %i128 = converted %Int.as.AddWith.impl.Op.call, %.loc13_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc13: init %empty_tuple.type = call %AssertSameType.specific_fn.loc13(%.loc13_20.3, %y.ref.loc13_25)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- bitwise_homogeneous_long_long.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %AssertSameType.type: type = fn_type @AssertSameType [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %AssertSameType: %AssertSameType.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %BitComplement.type: type = facet_type <@BitComplement> [concrete]
+// CHECK:STDOUT:   %BitComplement.Op.type: type = fn_type @BitComplement.Op [concrete]
+// CHECK:STDOUT:   %BitComplement.impl_witness: <witness> = impl_witness imports.%BitComplement.impl_witness_table [concrete]
+// CHECK:STDOUT:   %BitComplement.facet: %BitComplement.type = facet_value %Cpp.long_long, (%BitComplement.impl_witness) [concrete]
+// CHECK:STDOUT:   %.f4b: type = fn_type_with_self_type %BitComplement.Op.type, %BitComplement.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitComplement.impl.Op.type: type = fn_type @Cpp.long_long.as.BitComplement.impl.Op [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitComplement.impl.Op: %Cpp.long_long.as.BitComplement.impl.Op.type = struct_value () [concrete]
+// CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %BitAndWith.type.97f: type = facet_type <@BitAndWith, @BitAndWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitAndWith.Op.type.c6c: type = fn_type @BitAndWith.Op, @BitAndWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.52f: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.940 [concrete]
+// CHECK:STDOUT:   %BitAndWith.facet: %BitAndWith.type.97f = facet_value %Cpp.long_long, (%BitAndWith.impl_witness.52f) [concrete]
+// CHECK:STDOUT:   %.568: type = fn_type_with_self_type %BitAndWith.Op.type.c6c, %BitAndWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.type.062: type = fn_type @Cpp.long_long.as.BitAndWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.f85: %Cpp.long_long.as.BitAndWith.impl.Op.type.062 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitOrWith.type.d59: type = facet_type <@BitOrWith, @BitOrWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitOrWith.Op.type.c9c: type = fn_type @BitOrWith.Op, @BitOrWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %BitOrWith.impl_witness.cce: <witness> = impl_witness imports.%BitOrWith.impl_witness_table.ccf [concrete]
+// CHECK:STDOUT:   %BitOrWith.facet: %BitOrWith.type.d59 = facet_value %Cpp.long_long, (%BitOrWith.impl_witness.cce) [concrete]
+// CHECK:STDOUT:   %.369: type = fn_type_with_self_type %BitOrWith.Op.type.c9c, %BitOrWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.type.644: type = fn_type @Cpp.long_long.as.BitOrWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.d90: %Cpp.long_long.as.BitOrWith.impl.Op.type.644 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitXorWith.type.b7e: type = facet_type <@BitXorWith, @BitXorWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitXorWith.Op.type.1d5: type = fn_type @BitXorWith.Op, @BitXorWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %BitXorWith.impl_witness.1e8: <witness> = impl_witness imports.%BitXorWith.impl_witness_table.aee [concrete]
+// CHECK:STDOUT:   %BitXorWith.facet: %BitXorWith.type.b7e = facet_value %Cpp.long_long, (%BitXorWith.impl_witness.1e8) [concrete]
+// CHECK:STDOUT:   %.a3f: type = fn_type_with_self_type %BitXorWith.Op.type.1d5, %BitXorWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.type.de1: type = fn_type @Cpp.long_long.as.BitXorWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.7b9: %Cpp.long_long.as.BitXorWith.impl.Op.type.de1 = struct_value () [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.type.091: type = facet_type <@LeftShiftWith, @LeftShiftWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.Op.type.5df: type = fn_type @LeftShiftWith.Op, @LeftShiftWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness.c23: <witness> = impl_witness imports.%LeftShiftWith.impl_witness_table.ffe [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.facet: %LeftShiftWith.type.091 = facet_value %Cpp.long_long, (%LeftShiftWith.impl_witness.c23) [concrete]
+// CHECK:STDOUT:   %.d48: type = fn_type_with_self_type %LeftShiftWith.Op.type.5df, %LeftShiftWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.type.85f: type = fn_type @Cpp.long_long.as.LeftShiftWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.c52: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.85f = struct_value () [concrete]
+// CHECK:STDOUT:   %RightShiftWith.type.382: type = facet_type <@RightShiftWith, @RightShiftWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %RightShiftWith.Op.type.202: type = fn_type @RightShiftWith.Op, @RightShiftWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness.64f: <witness> = impl_witness imports.%RightShiftWith.impl_witness_table.2dc [concrete]
+// CHECK:STDOUT:   %RightShiftWith.facet: %RightShiftWith.type.382 = facet_value %Cpp.long_long, (%RightShiftWith.impl_witness.64f) [concrete]
+// CHECK:STDOUT:   %.110: type = fn_type_with_self_type %RightShiftWith.Op.type.202, %RightShiftWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.type.c8d: type = fn_type @Cpp.long_long.as.RightShiftWith.impl.Op.3 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.843: %Cpp.long_long.as.RightShiftWith.impl.Op.type.c8d = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.1 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.d53d: %Cpp.long_long.as.BitComplement.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.BitComplement.impl.Op]
+// CHECK:STDOUT:   %BitComplement.impl_witness_table = impl_witness_table (%Core.import_ref.ce3a05.1, %Core.import_ref.d53d), @Cpp.long_long.as.BitComplement.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.4 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.592: %Cpp.long_long.as.BitAndWith.impl.Op.type.062 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.f85]
+// CHECK:STDOUT:   %BitAndWith.impl_witness_table.940 = impl_witness_table (%Core.import_ref.ce3a05.4, %Core.import_ref.592), @Cpp.long_long.as.BitAndWith.impl.1d9 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.7 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.940: %Cpp.long_long.as.BitOrWith.impl.Op.type.644 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.d90]
+// CHECK:STDOUT:   %BitOrWith.impl_witness_table.ccf = impl_witness_table (%Core.import_ref.ce3a05.7, %Core.import_ref.940), @Cpp.long_long.as.BitOrWith.impl.25c [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.10 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.e93: %Cpp.long_long.as.BitXorWith.impl.Op.type.de1 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.7b9]
+// CHECK:STDOUT:   %BitXorWith.impl_witness_table.aee = impl_witness_table (%Core.import_ref.ce3a05.10, %Core.import_ref.e93), @Cpp.long_long.as.BitXorWith.impl.af7 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.13 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.235: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.85f = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.c52]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness_table.ffe = impl_witness_table (%Core.import_ref.ce3a05.13, %Core.import_ref.235), @Cpp.long_long.as.LeftShiftWith.impl.563 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.16 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.2ca: %Cpp.long_long.as.RightShiftWith.impl.Op.type.c8d = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.843]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness_table.2dc = impl_witness_table (%Core.import_ref.ce3a05.16, %Core.import_ref.2ca), @Cpp.long_long.as.RightShiftWith.impl.54c [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @BitWiseHomogeneousLongLong() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = value_binding_pattern a [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc10_13: type = splice_block %long_long.ref.loc10 [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref.loc10: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc10: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10(%int_1.loc10) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.2: %Cpp.long_long = converted %int_1.loc10, %.loc10_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %a: %Cpp.long_long = value_binding a, %.loc10_26.2
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %b.patt: %pattern_type.76e = value_binding_pattern b [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc11: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc11_13: type = splice_block %long_long.ref.loc11 [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref.loc11: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc11: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc11: <bound method> = bound_method %int_1.loc11, %impl.elem0.loc11 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc11: init %Cpp.long_long = call %bound_method.loc11(%int_1.loc11) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_26.2: %Cpp.long_long = converted %int_1.loc11, %.loc11_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %b: %Cpp.long_long = value_binding b, %.loc11_26.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc13: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc13_19: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc13: %.f4b = impl_witness_access constants.%BitComplement.impl_witness, element1 [concrete = constants.%Cpp.long_long.as.BitComplement.impl.Op]
+// CHECK:STDOUT:   %bound_method.loc13: <bound method> = bound_method %a.ref.loc13_19, %impl.elem1.loc13
+// CHECK:STDOUT:   %Cpp.long_long.as.BitComplement.impl.Op.call: init %Cpp.long_long = call %bound_method.loc13(%a.ref.loc13_19)
+// CHECK:STDOUT:   %a.ref.loc13_22: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc13: <specific function> = specific_function %AssertSameType.ref.loc13, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc13_18.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitComplement.impl.Op.call
+// CHECK:STDOUT:   %.loc13_18.2: %Cpp.long_long = converted %Cpp.long_long.as.BitComplement.impl.Op.call, %.loc13_18.1
+// CHECK:STDOUT:   %AssertSameType.call.loc13: init %empty_tuple.type = call %AssertSameType.specific_fn.loc13(%.loc13_18.2, %a.ref.loc13_22)
+// CHECK:STDOUT:   %AssertSameType.ref.loc14: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc14_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc14: %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc14: %.568 = impl_witness_access constants.%BitAndWith.impl_witness.52f, element1 [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.f85]
+// CHECK:STDOUT:   %bound_method.loc14: <bound method> = bound_method %a.ref.loc14_18, %impl.elem1.loc14
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc14(%a.ref.loc14_18, %b.ref.loc14)
+// CHECK:STDOUT:   %a.ref.loc14_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc14: <specific function> = specific_function %AssertSameType.ref.loc14, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc14_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitAndWith.impl.Op.call
+// CHECK:STDOUT:   %.loc14_20.2: %Cpp.long_long = converted %Cpp.long_long.as.BitAndWith.impl.Op.call, %.loc14_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc14: init %empty_tuple.type = call %AssertSameType.specific_fn.loc14(%.loc14_20.2, %a.ref.loc14_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc15: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc15_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc15: %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc15: %.369 = impl_witness_access constants.%BitOrWith.impl_witness.cce, element1 [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.d90]
+// CHECK:STDOUT:   %bound_method.loc15: <bound method> = bound_method %a.ref.loc15_18, %impl.elem1.loc15
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc15(%a.ref.loc15_18, %b.ref.loc15)
+// CHECK:STDOUT:   %a.ref.loc15_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc15: <specific function> = specific_function %AssertSameType.ref.loc15, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc15_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitOrWith.impl.Op.call
+// CHECK:STDOUT:   %.loc15_20.2: %Cpp.long_long = converted %Cpp.long_long.as.BitOrWith.impl.Op.call, %.loc15_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc15: init %empty_tuple.type = call %AssertSameType.specific_fn.loc15(%.loc15_20.2, %a.ref.loc15_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc16: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc16_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc16: %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc16: %.a3f = impl_witness_access constants.%BitXorWith.impl_witness.1e8, element1 [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.7b9]
+// CHECK:STDOUT:   %bound_method.loc16: <bound method> = bound_method %a.ref.loc16_18, %impl.elem1.loc16
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc16(%a.ref.loc16_18, %b.ref.loc16)
+// CHECK:STDOUT:   %a.ref.loc16_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc16: <specific function> = specific_function %AssertSameType.ref.loc16, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc16_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitXorWith.impl.Op.call
+// CHECK:STDOUT:   %.loc16_20.2: %Cpp.long_long = converted %Cpp.long_long.as.BitXorWith.impl.Op.call, %.loc16_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc16: init %empty_tuple.type = call %AssertSameType.specific_fn.loc16(%.loc16_20.2, %a.ref.loc16_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc17: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc17_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc17: %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc17: %.d48 = impl_witness_access constants.%LeftShiftWith.impl_witness.c23, element1 [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.c52]
+// CHECK:STDOUT:   %bound_method.loc17: <bound method> = bound_method %a.ref.loc17_18, %impl.elem1.loc17
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc17(%a.ref.loc17_18, %b.ref.loc17)
+// CHECK:STDOUT:   %a.ref.loc17_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc17: <specific function> = specific_function %AssertSameType.ref.loc17, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc17_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.LeftShiftWith.impl.Op.call
+// CHECK:STDOUT:   %.loc17_20.2: %Cpp.long_long = converted %Cpp.long_long.as.LeftShiftWith.impl.Op.call, %.loc17_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc17: init %empty_tuple.type = call %AssertSameType.specific_fn.loc17(%.loc17_20.2, %a.ref.loc17_26)
+// CHECK:STDOUT:   %AssertSameType.ref.loc18: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc18_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc18: %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc18: %.110 = impl_witness_access constants.%RightShiftWith.impl_witness.64f, element1 [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.843]
+// CHECK:STDOUT:   %bound_method.loc18: <bound method> = bound_method %a.ref.loc18_18, %impl.elem1.loc18
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.call: init %Cpp.long_long = call %bound_method.loc18(%a.ref.loc18_18, %b.ref.loc18)
+// CHECK:STDOUT:   %a.ref.loc18_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc18: <specific function> = specific_function %AssertSameType.ref.loc18, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc18_20.1: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.RightShiftWith.impl.Op.call
+// CHECK:STDOUT:   %.loc18_20.2: %Cpp.long_long = converted %Cpp.long_long.as.RightShiftWith.impl.Op.call, %.loc18_20.1
+// CHECK:STDOUT:   %AssertSameType.call.loc18: init %empty_tuple.type = call %AssertSameType.specific_fn.loc18(%.loc18_20.2, %a.ref.loc18_26)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- bitwise_heterogeneous_long_long_left_side.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %AssertSameType.type: type = fn_type @AssertSameType [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %AssertSameType: %AssertSameType.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %int_64: Core.IntLiteral = int_value 64 [concrete]
+// CHECK:STDOUT:   %i64: type = class_type @Int, @Int(%int_64) [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.2ad: type = facet_type <@ImplicitAs, @ImplicitAs(%i64)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.94e: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i64) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %As.type.229: type = facet_type <@As, @As(%i64)> [concrete]
+// CHECK:STDOUT:   %As.Convert.type.d57: type = fn_type @As.Convert, @As(%i64) [concrete]
+// CHECK:STDOUT:   %To.fe9: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.09e: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.dbe: %Core.IntLiteral.as.As.impl.Convert.type.09e = struct_value () [symbolic]
+// CHECK:STDOUT:   %As.impl_witness.c71: <witness> = impl_witness imports.%As.impl_witness_table.9fc, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.cee: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.a54: %Core.IntLiteral.as.As.impl.Convert.type.cee = struct_value () [concrete]
+// CHECK:STDOUT:   %As.facet: %As.type.229 = facet_value Core.IntLiteral, (%As.impl_witness.c71) [concrete]
+// CHECK:STDOUT:   %.aba: type = fn_type_with_self_type %As.Convert.type.d57, %As.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.a54 [concrete]
+// CHECK:STDOUT:   %pattern_type.95b: type = pattern_type %i64 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.As.impl.Convert.a54, @Core.IntLiteral.as.As.impl.Convert(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method.41b: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_1.41a: %i64 = int_value 1 [concrete]
+// CHECK:STDOUT:   %BitAndWith.type.46b: type = facet_type <@BitAndWith, @BitAndWith(%i64)> [concrete]
+// CHECK:STDOUT:   %BitAndWith.Op.type.2e7: type = fn_type @BitAndWith.Op, @BitAndWith(%i64) [concrete]
+// CHECK:STDOUT:   %T.ea5: %ImplicitAs.type.a03 = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.type.fc814e.1: type = fn_type @Cpp.long_long.as.BitAndWith.impl.Op.1, @Cpp.long_long.as.BitAndWith.impl.f59(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.691e38.1: %Cpp.long_long.as.BitAndWith.impl.Op.type.fc814e.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.type.fc814e.2: type = fn_type @Cpp.long_long.as.BitAndWith.impl.Op.2, @Cpp.long_long.as.BitAndWith.impl.f59(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.691e38.2: %Cpp.long_long.as.BitAndWith.impl.Op.type.fc814e.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitAndWith.type.011: type = facet_type <@BitAndWith, @BitAndWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %BitAndWith.Op.type.4bf: type = fn_type @BitAndWith.Op, @BitAndWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.1b3: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.b19 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.c59: %ImplicitAs.type.a03 = facet_value %i64, (%ImplicitAs.impl_witness.1b3) [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.85b: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.300, @Cpp.long_long.as.BitAndWith.impl.f59(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.type.46a434.1: type = fn_type @Cpp.long_long.as.BitAndWith.impl.Op.2, @Cpp.long_long.as.BitAndWith.impl.f59(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.8819bd.1: %Cpp.long_long.as.BitAndWith.impl.Op.type.46a434.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.type.46a434.2: type = fn_type @Cpp.long_long.as.BitAndWith.impl.Op.1, @Cpp.long_long.as.BitAndWith.impl.f59(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.8819bd.2: %Cpp.long_long.as.BitAndWith.impl.Op.type.46a434.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitAndWith.facet.81a: %BitAndWith.type.46b = facet_value %Cpp.long_long, (%BitAndWith.impl_witness.85b) [concrete]
+// CHECK:STDOUT:   %.69f: type = fn_type_with_self_type %BitAndWith.Op.type.2e7, %BitAndWith.facet.81a [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.944ed2.1: <specific function> = specific_function %Cpp.long_long.as.BitAndWith.impl.Op.8819bd.2, @Cpp.long_long.as.BitAndWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %.b29: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.c59 [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.type: type = fn_type @i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert: %i64.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.41a, %i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.944ed2.2: <specific function> = specific_function %Cpp.long_long.as.BitAndWith.impl.Op.8819bd.1, @Cpp.long_long.as.BitAndWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %BitOrWith.type.5ff: type = facet_type <@BitOrWith, @BitOrWith(%i64)> [concrete]
+// CHECK:STDOUT:   %BitOrWith.Op.type.2ba: type = fn_type @BitOrWith.Op, @BitOrWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.type.19efa0.1: type = fn_type @Cpp.long_long.as.BitOrWith.impl.Op.1, @Cpp.long_long.as.BitOrWith.impl.c9b(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.a5c104.1: %Cpp.long_long.as.BitOrWith.impl.Op.type.19efa0.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.type.19efa0.2: type = fn_type @Cpp.long_long.as.BitOrWith.impl.Op.2, @Cpp.long_long.as.BitOrWith.impl.c9b(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.a5c104.2: %Cpp.long_long.as.BitOrWith.impl.Op.type.19efa0.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitOrWith.type.cba: type = facet_type <@BitOrWith, @BitOrWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %BitOrWith.Op.type.0e5: type = fn_type @BitOrWith.Op, @BitOrWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %BitOrWith.impl_witness.da7: <witness> = impl_witness imports.%BitOrWith.impl_witness_table.4ae, @Cpp.long_long.as.BitOrWith.impl.c9b(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.type.d3ab21.1: type = fn_type @Cpp.long_long.as.BitOrWith.impl.Op.2, @Cpp.long_long.as.BitOrWith.impl.c9b(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.1: %Cpp.long_long.as.BitOrWith.impl.Op.type.d3ab21.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.type.d3ab21.2: type = fn_type @Cpp.long_long.as.BitOrWith.impl.Op.1, @Cpp.long_long.as.BitOrWith.impl.c9b(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.2: %Cpp.long_long.as.BitOrWith.impl.Op.type.d3ab21.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitOrWith.facet.6fc: %BitOrWith.type.5ff = facet_value %Cpp.long_long, (%BitOrWith.impl_witness.da7) [concrete]
+// CHECK:STDOUT:   %.6dd: type = fn_type_with_self_type %BitOrWith.Op.type.2ba, %BitOrWith.facet.6fc [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.381f46.1: <specific function> = specific_function %Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.2, @Cpp.long_long.as.BitOrWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.381f46.2: <specific function> = specific_function %Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.1, @Cpp.long_long.as.BitOrWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %BitXorWith.type.f8c: type = facet_type <@BitXorWith, @BitXorWith(%i64)> [concrete]
+// CHECK:STDOUT:   %BitXorWith.Op.type.edf: type = fn_type @BitXorWith.Op, @BitXorWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.type.bece73.1: type = fn_type @Cpp.long_long.as.BitXorWith.impl.Op.1, @Cpp.long_long.as.BitXorWith.impl.3a7(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.4a09b2.1: %Cpp.long_long.as.BitXorWith.impl.Op.type.bece73.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.type.bece73.2: type = fn_type @Cpp.long_long.as.BitXorWith.impl.Op.2, @Cpp.long_long.as.BitXorWith.impl.3a7(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.4a09b2.2: %Cpp.long_long.as.BitXorWith.impl.Op.type.bece73.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitXorWith.type.fd0: type = facet_type <@BitXorWith, @BitXorWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %BitXorWith.Op.type.1f1: type = fn_type @BitXorWith.Op, @BitXorWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %BitXorWith.impl_witness.d73: <witness> = impl_witness imports.%BitXorWith.impl_witness_table.766, @Cpp.long_long.as.BitXorWith.impl.3a7(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.type.5edc0b.1: type = fn_type @Cpp.long_long.as.BitXorWith.impl.Op.2, @Cpp.long_long.as.BitXorWith.impl.3a7(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.8e4513.1: %Cpp.long_long.as.BitXorWith.impl.Op.type.5edc0b.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.type.5edc0b.2: type = fn_type @Cpp.long_long.as.BitXorWith.impl.Op.1, @Cpp.long_long.as.BitXorWith.impl.3a7(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.8e4513.2: %Cpp.long_long.as.BitXorWith.impl.Op.type.5edc0b.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitXorWith.facet.46d: %BitXorWith.type.f8c = facet_value %Cpp.long_long, (%BitXorWith.impl_witness.d73) [concrete]
+// CHECK:STDOUT:   %.a1e: type = fn_type_with_self_type %BitXorWith.Op.type.edf, %BitXorWith.facet.46d [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.741c0a.1: <specific function> = specific_function %Cpp.long_long.as.BitXorWith.impl.Op.8e4513.2, @Cpp.long_long.as.BitXorWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.741c0a.2: <specific function> = specific_function %Cpp.long_long.as.BitXorWith.impl.Op.8e4513.1, @Cpp.long_long.as.BitXorWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.type.214: type = facet_type <@LeftShiftWith, @LeftShiftWith(%i64)> [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.Op.type.399: type = fn_type @LeftShiftWith.Op, @LeftShiftWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.type.1e8c9e.1: type = fn_type @Cpp.long_long.as.LeftShiftWith.impl.Op.1, @Cpp.long_long.as.LeftShiftWith.impl.93e(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.436dd3.1: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.1e8c9e.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.type.1e8c9e.2: type = fn_type @Cpp.long_long.as.LeftShiftWith.impl.Op.2, @Cpp.long_long.as.LeftShiftWith.impl.93e(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.436dd3.2: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.1e8c9e.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %LeftShiftWith.type.a1f: type = facet_type <@LeftShiftWith, @LeftShiftWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.Op.type.55b: type = fn_type @LeftShiftWith.Op, @LeftShiftWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness.78f: <witness> = impl_witness imports.%LeftShiftWith.impl_witness_table.17a, @Cpp.long_long.as.LeftShiftWith.impl.93e(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.type.392305.1: type = fn_type @Cpp.long_long.as.LeftShiftWith.impl.Op.2, @Cpp.long_long.as.LeftShiftWith.impl.93e(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.1: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.392305.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.type.392305.2: type = fn_type @Cpp.long_long.as.LeftShiftWith.impl.Op.1, @Cpp.long_long.as.LeftShiftWith.impl.93e(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.2: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.392305.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.facet.391: %LeftShiftWith.type.214 = facet_value %Cpp.long_long, (%LeftShiftWith.impl_witness.78f) [concrete]
+// CHECK:STDOUT:   %.730: type = fn_type_with_self_type %LeftShiftWith.Op.type.399, %LeftShiftWith.facet.391 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.db6da6.1: <specific function> = specific_function %Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.2, @Cpp.long_long.as.LeftShiftWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.db6da6.2: <specific function> = specific_function %Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.1, @Cpp.long_long.as.LeftShiftWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %RightShiftWith.type.0a7: type = facet_type <@RightShiftWith, @RightShiftWith(%i64)> [concrete]
+// CHECK:STDOUT:   %RightShiftWith.Op.type.686: type = fn_type @RightShiftWith.Op, @RightShiftWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.type.65f3e2.1: type = fn_type @Cpp.long_long.as.RightShiftWith.impl.Op.1, @Cpp.long_long.as.RightShiftWith.impl.8e7(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.bf4ea4.1: %Cpp.long_long.as.RightShiftWith.impl.Op.type.65f3e2.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.type.65f3e2.2: type = fn_type @Cpp.long_long.as.RightShiftWith.impl.Op.2, @Cpp.long_long.as.RightShiftWith.impl.8e7(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.bf4ea4.2: %Cpp.long_long.as.RightShiftWith.impl.Op.type.65f3e2.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %RightShiftWith.type.18a: type = facet_type <@RightShiftWith, @RightShiftWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %RightShiftWith.Op.type.c0c: type = fn_type @RightShiftWith.Op, @RightShiftWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness.707: <witness> = impl_witness imports.%RightShiftWith.impl_witness_table.00a, @Cpp.long_long.as.RightShiftWith.impl.8e7(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.type.947ba1.1: type = fn_type @Cpp.long_long.as.RightShiftWith.impl.Op.2, @Cpp.long_long.as.RightShiftWith.impl.8e7(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.b17816.1: %Cpp.long_long.as.RightShiftWith.impl.Op.type.947ba1.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.type.947ba1.2: type = fn_type @Cpp.long_long.as.RightShiftWith.impl.Op.1, @Cpp.long_long.as.RightShiftWith.impl.8e7(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.b17816.2: %Cpp.long_long.as.RightShiftWith.impl.Op.type.947ba1.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %RightShiftWith.facet.dcf: %RightShiftWith.type.0a7 = facet_value %Cpp.long_long, (%RightShiftWith.impl_witness.707) [concrete]
+// CHECK:STDOUT:   %.6ec: type = fn_type_with_self_type %RightShiftWith.Op.type.686, %RightShiftWith.facet.dcf [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.bee934.1: <specific function> = specific_function %Cpp.long_long.as.RightShiftWith.impl.Op.b17816.2, @Cpp.long_long.as.RightShiftWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.bee934.2: <specific function> = specific_function %Cpp.long_long.as.RightShiftWith.impl.Op.b17816.1, @Cpp.long_long.as.RightShiftWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.83a: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.300, @Cpp.long_long.as.BitAndWith.impl.f59(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.type.454427.1: type = fn_type @Cpp.long_long.as.BitAndWith.impl.Op.2, @Cpp.long_long.as.BitAndWith.impl.f59(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.b2e429.1: %Cpp.long_long.as.BitAndWith.impl.Op.type.454427.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.type.454427.2: type = fn_type @Cpp.long_long.as.BitAndWith.impl.Op.1, @Cpp.long_long.as.BitAndWith.impl.f59(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.b2e429.2: %Cpp.long_long.as.BitAndWith.impl.Op.type.454427.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitAndWith.facet.126: %BitAndWith.type.011 = facet_value %Cpp.long_long, (%BitAndWith.impl_witness.83a) [concrete]
+// CHECK:STDOUT:   %.be5: type = fn_type_with_self_type %BitAndWith.Op.type.4bf, %BitAndWith.facet.126 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.87f720.1: <specific function> = specific_function %Cpp.long_long.as.BitAndWith.impl.Op.b2e429.2, @Cpp.long_long.as.BitAndWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.87f720.2: <specific function> = specific_function %Cpp.long_long.as.BitAndWith.impl.Op.b2e429.1, @Cpp.long_long.as.BitAndWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %BitOrWith.impl_witness.dc3: <witness> = impl_witness imports.%BitOrWith.impl_witness_table.4ae, @Cpp.long_long.as.BitOrWith.impl.c9b(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.type.2b2898.1: type = fn_type @Cpp.long_long.as.BitOrWith.impl.Op.2, @Cpp.long_long.as.BitOrWith.impl.c9b(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.58469f.1: %Cpp.long_long.as.BitOrWith.impl.Op.type.2b2898.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.type.2b2898.2: type = fn_type @Cpp.long_long.as.BitOrWith.impl.Op.1, @Cpp.long_long.as.BitOrWith.impl.c9b(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.58469f.2: %Cpp.long_long.as.BitOrWith.impl.Op.type.2b2898.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitOrWith.facet.9c9: %BitOrWith.type.cba = facet_value %Cpp.long_long, (%BitOrWith.impl_witness.dc3) [concrete]
+// CHECK:STDOUT:   %.35b: type = fn_type_with_self_type %BitOrWith.Op.type.0e5, %BitOrWith.facet.9c9 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.c253d2.1: <specific function> = specific_function %Cpp.long_long.as.BitOrWith.impl.Op.58469f.2, @Cpp.long_long.as.BitOrWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.c253d2.2: <specific function> = specific_function %Cpp.long_long.as.BitOrWith.impl.Op.58469f.1, @Cpp.long_long.as.BitOrWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %BitXorWith.impl_witness.943: <witness> = impl_witness imports.%BitXorWith.impl_witness_table.766, @Cpp.long_long.as.BitXorWith.impl.3a7(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.type.23f010.1: type = fn_type @Cpp.long_long.as.BitXorWith.impl.Op.2, @Cpp.long_long.as.BitXorWith.impl.3a7(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.b0b042.1: %Cpp.long_long.as.BitXorWith.impl.Op.type.23f010.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.type.23f010.2: type = fn_type @Cpp.long_long.as.BitXorWith.impl.Op.1, @Cpp.long_long.as.BitXorWith.impl.3a7(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.b0b042.2: %Cpp.long_long.as.BitXorWith.impl.Op.type.23f010.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitXorWith.facet.4ab: %BitXorWith.type.fd0 = facet_value %Cpp.long_long, (%BitXorWith.impl_witness.943) [concrete]
+// CHECK:STDOUT:   %.ce8: type = fn_type_with_self_type %BitXorWith.Op.type.1f1, %BitXorWith.facet.4ab [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.3d8d22.1: <specific function> = specific_function %Cpp.long_long.as.BitXorWith.impl.Op.b0b042.2, @Cpp.long_long.as.BitXorWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.3d8d22.2: <specific function> = specific_function %Cpp.long_long.as.BitXorWith.impl.Op.b0b042.1, @Cpp.long_long.as.BitXorWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness.0f1: <witness> = impl_witness imports.%LeftShiftWith.impl_witness_table.17a, @Cpp.long_long.as.LeftShiftWith.impl.93e(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.type.7ec0de.1: type = fn_type @Cpp.long_long.as.LeftShiftWith.impl.Op.2, @Cpp.long_long.as.LeftShiftWith.impl.93e(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.5502e8.1: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.7ec0de.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.type.7ec0de.2: type = fn_type @Cpp.long_long.as.LeftShiftWith.impl.Op.1, @Cpp.long_long.as.LeftShiftWith.impl.93e(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.5502e8.2: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.7ec0de.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.facet.ecc: %LeftShiftWith.type.a1f = facet_value %Cpp.long_long, (%LeftShiftWith.impl_witness.0f1) [concrete]
+// CHECK:STDOUT:   %.b37: type = fn_type_with_self_type %LeftShiftWith.Op.type.55b, %LeftShiftWith.facet.ecc [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.b9b4ae.1: <specific function> = specific_function %Cpp.long_long.as.LeftShiftWith.impl.Op.5502e8.2, @Cpp.long_long.as.LeftShiftWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.b9b4ae.2: <specific function> = specific_function %Cpp.long_long.as.LeftShiftWith.impl.Op.5502e8.1, @Cpp.long_long.as.LeftShiftWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness.1a5: <witness> = impl_witness imports.%RightShiftWith.impl_witness_table.00a, @Cpp.long_long.as.RightShiftWith.impl.8e7(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.type.94f032.1: type = fn_type @Cpp.long_long.as.RightShiftWith.impl.Op.2, @Cpp.long_long.as.RightShiftWith.impl.8e7(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.0261ea.1: %Cpp.long_long.as.RightShiftWith.impl.Op.type.94f032.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.type.94f032.2: type = fn_type @Cpp.long_long.as.RightShiftWith.impl.Op.1, @Cpp.long_long.as.RightShiftWith.impl.8e7(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.0261ea.2: %Cpp.long_long.as.RightShiftWith.impl.Op.type.94f032.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %RightShiftWith.facet.4d9: %RightShiftWith.type.18a = facet_value %Cpp.long_long, (%RightShiftWith.impl_witness.1a5) [concrete]
+// CHECK:STDOUT:   %.f6a: type = fn_type_with_self_type %RightShiftWith.Op.type.c0c, %RightShiftWith.facet.4d9 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.fa8301.1: <specific function> = specific_function %Cpp.long_long.as.RightShiftWith.impl.Op.0261ea.2, @Cpp.long_long.as.RightShiftWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.fa8301.2: <specific function> = specific_function %Cpp.long_long.as.RightShiftWith.impl.Op.0261ea.1, @Cpp.long_long.as.RightShiftWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.556: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.74f, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d48: %ImplicitAs.type.2ad = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.556) [concrete]
+// CHECK:STDOUT:   %.567: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.d48 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method.288: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ca0: @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert.type (%Core.IntLiteral.as.As.impl.Convert.type.09e) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert (constants.%Core.IntLiteral.as.As.impl.Convert.dbe)]
+// CHECK:STDOUT:   %As.impl_witness_table.9fc = impl_witness_table (%Core.import_ref.ca0), @Core.IntLiteral.as.As.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.1 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.cea: @Cpp.long_long.as.BitAndWith.impl.f59.%Cpp.long_long.as.BitAndWith.impl.Op.type.2 (%Cpp.long_long.as.BitAndWith.impl.Op.type.fc814e.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitAndWith.impl.f59.%Cpp.long_long.as.BitAndWith.impl.Op.2 (constants.%Cpp.long_long.as.BitAndWith.impl.Op.691e38.1)]
+// CHECK:STDOUT:   %BitAndWith.impl_witness_table.300 = impl_witness_table (%Core.import_ref.ce3a05.1, %Core.import_ref.cea), @Cpp.long_long.as.BitAndWith.impl.f59 [concrete]
+// CHECK:STDOUT:   %Core.Op.bf8: @Cpp.long_long.as.BitAndWith.impl.f59.%Cpp.long_long.as.BitAndWith.impl.Op.type.1 (%Cpp.long_long.as.BitAndWith.impl.Op.type.fc814e.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitAndWith.impl.f59.%Cpp.long_long.as.BitAndWith.impl.Op.1 (constants.%Cpp.long_long.as.BitAndWith.impl.Op.691e38.2)]
+// CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
+// CHECK:STDOUT:   %Core.import_ref.4f4: %i64.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.b19 = impl_witness_table (%Core.import_ref.4f4), @i64.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.3 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.eac: @Cpp.long_long.as.BitOrWith.impl.c9b.%Cpp.long_long.as.BitOrWith.impl.Op.type.2 (%Cpp.long_long.as.BitOrWith.impl.Op.type.19efa0.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitOrWith.impl.c9b.%Cpp.long_long.as.BitOrWith.impl.Op.2 (constants.%Cpp.long_long.as.BitOrWith.impl.Op.a5c104.1)]
+// CHECK:STDOUT:   %BitOrWith.impl_witness_table.4ae = impl_witness_table (%Core.import_ref.ce3a05.3, %Core.import_ref.eac), @Cpp.long_long.as.BitOrWith.impl.c9b [concrete]
+// CHECK:STDOUT:   %Core.Op.364: @Cpp.long_long.as.BitOrWith.impl.c9b.%Cpp.long_long.as.BitOrWith.impl.Op.type.1 (%Cpp.long_long.as.BitOrWith.impl.Op.type.19efa0.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitOrWith.impl.c9b.%Cpp.long_long.as.BitOrWith.impl.Op.1 (constants.%Cpp.long_long.as.BitOrWith.impl.Op.a5c104.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.5 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.d181: @Cpp.long_long.as.BitXorWith.impl.3a7.%Cpp.long_long.as.BitXorWith.impl.Op.type.2 (%Cpp.long_long.as.BitXorWith.impl.Op.type.bece73.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitXorWith.impl.3a7.%Cpp.long_long.as.BitXorWith.impl.Op.2 (constants.%Cpp.long_long.as.BitXorWith.impl.Op.4a09b2.1)]
+// CHECK:STDOUT:   %BitXorWith.impl_witness_table.766 = impl_witness_table (%Core.import_ref.ce3a05.5, %Core.import_ref.d181), @Cpp.long_long.as.BitXorWith.impl.3a7 [concrete]
+// CHECK:STDOUT:   %Core.Op.08d: @Cpp.long_long.as.BitXorWith.impl.3a7.%Cpp.long_long.as.BitXorWith.impl.Op.type.1 (%Cpp.long_long.as.BitXorWith.impl.Op.type.bece73.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitXorWith.impl.3a7.%Cpp.long_long.as.BitXorWith.impl.Op.1 (constants.%Cpp.long_long.as.BitXorWith.impl.Op.4a09b2.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.7 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.c4f: @Cpp.long_long.as.LeftShiftWith.impl.93e.%Cpp.long_long.as.LeftShiftWith.impl.Op.type.2 (%Cpp.long_long.as.LeftShiftWith.impl.Op.type.1e8c9e.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.LeftShiftWith.impl.93e.%Cpp.long_long.as.LeftShiftWith.impl.Op.2 (constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.436dd3.1)]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness_table.17a = impl_witness_table (%Core.import_ref.ce3a05.7, %Core.import_ref.c4f), @Cpp.long_long.as.LeftShiftWith.impl.93e [concrete]
+// CHECK:STDOUT:   %Core.Op.e43: @Cpp.long_long.as.LeftShiftWith.impl.93e.%Cpp.long_long.as.LeftShiftWith.impl.Op.type.1 (%Cpp.long_long.as.LeftShiftWith.impl.Op.type.1e8c9e.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.LeftShiftWith.impl.93e.%Cpp.long_long.as.LeftShiftWith.impl.Op.1 (constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.436dd3.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.9 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.60ac: @Cpp.long_long.as.RightShiftWith.impl.8e7.%Cpp.long_long.as.RightShiftWith.impl.Op.type.2 (%Cpp.long_long.as.RightShiftWith.impl.Op.type.65f3e2.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.RightShiftWith.impl.8e7.%Cpp.long_long.as.RightShiftWith.impl.Op.2 (constants.%Cpp.long_long.as.RightShiftWith.impl.Op.bf4ea4.1)]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness_table.00a = impl_witness_table (%Core.import_ref.ce3a05.9, %Core.import_ref.60ac), @Cpp.long_long.as.RightShiftWith.impl.8e7 [concrete]
+// CHECK:STDOUT:   %Core.Op.bae: @Cpp.long_long.as.RightShiftWith.impl.8e7.%Cpp.long_long.as.RightShiftWith.impl.Op.type.1 (%Cpp.long_long.as.RightShiftWith.impl.Op.type.65f3e2.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.RightShiftWith.impl.8e7.%Cpp.long_long.as.RightShiftWith.impl.Op.1 (constants.%Cpp.long_long.as.RightShiftWith.impl.Op.bf4ea4.2)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @BitWiseHeterogeneousLongLongLeftSide() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = value_binding_pattern a [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc10_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc10: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10(%int_1.loc10) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.2: %Cpp.long_long = converted %int_1.loc10, %.loc10_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %a: %Cpp.long_long = value_binding a, %.loc10_26.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc12: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc12_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc12: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc12: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc12: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc12_25.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc12_25.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_25.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc12_25: <specific function> = specific_function %impl.elem0.loc12_25.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc12_25.2: <bound method> = bound_method %int_1.loc12, %specific_fn.loc12_25 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc12: init %i64 = call %bound_method.loc12_25.2(%int_1.loc12) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_25.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc12 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_25.2: %i64 = converted %int_1.loc12, %.loc12_25.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc12: %.69f = impl_witness_access constants.%BitAndWith.impl_witness.85b, element1 [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.8819bd.2]
+// CHECK:STDOUT:   %bound_method.loc12_20.1: <bound method> = bound_method %a.ref.loc12_18, %impl.elem1.loc12
+// CHECK:STDOUT:   %ImplicitAs.facet.loc12_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc12_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc12_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc12_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc12_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc12_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc12_20: <specific function> = specific_function %impl.elem1.loc12, @Cpp.long_long.as.BitAndWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.944ed2.1]
+// CHECK:STDOUT:   %bound_method.loc12_20.2: <bound method> = bound_method %a.ref.loc12_18, %specific_fn.loc12_20
+// CHECK:STDOUT:   %.loc12_20.3: %Cpp.long_long.as.BitAndWith.impl.Op.type.46a434.1 = specific_constant imports.%Core.Op.bf8, @Cpp.long_long.as.BitAndWith.impl.f59(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.8819bd.1]
+// CHECK:STDOUT:   %Op.ref.loc12: %Cpp.long_long.as.BitAndWith.impl.Op.type.46a434.1 = name_ref Op, %.loc12_20.3 [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.8819bd.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.bound.loc12: <bound method> = bound_method %a.ref.loc12_18, %Op.ref.loc12
+// CHECK:STDOUT:   %impl.elem0.loc12_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_20.3: <bound method> = bound_method %.loc12_25.2, %impl.elem0.loc12_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12_20: init %Cpp.long_long = call %bound_method.loc12_20.3(%.loc12_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_20.5: %Cpp.long_long = converted %.loc12_25.2, %.loc12_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.loc12: <specific function> = specific_function %Op.ref.loc12, @Cpp.long_long.as.BitAndWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.944ed2.2]
+// CHECK:STDOUT:   %bound_method.loc12_20.4: <bound method> = bound_method %a.ref.loc12_18, %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.loc12
+// CHECK:STDOUT:   %impl.elem0.loc12_25.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_25.3: <bound method> = bound_method %.loc12_25.2, %impl.elem0.loc12_25.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12_25: init %Cpp.long_long = call %bound_method.loc12_25.3(%.loc12_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_25.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12_25 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_25.4: %Cpp.long_long = converted %.loc12_25.2, %.loc12_25.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.call.loc12: init %Cpp.long_long = call %bound_method.loc12_20.4(%a.ref.loc12_18, %.loc12_25.4)
+// CHECK:STDOUT:   %a.ref.loc12_34: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc12: <specific function> = specific_function %AssertSameType.ref.loc12, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc12_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitAndWith.impl.Op.call.loc12
+// CHECK:STDOUT:   %.loc12_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitAndWith.impl.Op.call.loc12, %.loc12_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc12: init %empty_tuple.type = call %AssertSameType.specific_fn.loc12(%.loc12_20.7, %a.ref.loc12_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc13: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc13_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc13: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc13: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc13: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc13_25.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc13_25.1: <bound method> = bound_method %int_1.loc13, %impl.elem0.loc13_25.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc13_25: <specific function> = specific_function %impl.elem0.loc13_25.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc13_25.2: <bound method> = bound_method %int_1.loc13, %specific_fn.loc13_25 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc13: init %i64 = call %bound_method.loc13_25.2(%int_1.loc13) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_25.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc13 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_25.2: %i64 = converted %int_1.loc13, %.loc13_25.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc13: %.6dd = impl_witness_access constants.%BitOrWith.impl_witness.da7, element1 [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.2]
+// CHECK:STDOUT:   %bound_method.loc13_20.1: <bound method> = bound_method %a.ref.loc13_18, %impl.elem1.loc13
+// CHECK:STDOUT:   %ImplicitAs.facet.loc13_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc13_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc13_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc13_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc13_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc13_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc13_20: <specific function> = specific_function %impl.elem1.loc13, @Cpp.long_long.as.BitOrWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.381f46.1]
+// CHECK:STDOUT:   %bound_method.loc13_20.2: <bound method> = bound_method %a.ref.loc13_18, %specific_fn.loc13_20
+// CHECK:STDOUT:   %.loc13_20.3: %Cpp.long_long.as.BitOrWith.impl.Op.type.d3ab21.1 = specific_constant imports.%Core.Op.364, @Cpp.long_long.as.BitOrWith.impl.c9b(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.1]
+// CHECK:STDOUT:   %Op.ref.loc13: %Cpp.long_long.as.BitOrWith.impl.Op.type.d3ab21.1 = name_ref Op, %.loc13_20.3 [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.bound.loc13: <bound method> = bound_method %a.ref.loc13_18, %Op.ref.loc13
+// CHECK:STDOUT:   %impl.elem0.loc13_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_20.3: <bound method> = bound_method %.loc13_25.2, %impl.elem0.loc13_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13_20: init %Cpp.long_long = call %bound_method.loc13_20.3(%.loc13_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_20.5: %Cpp.long_long = converted %.loc13_25.2, %.loc13_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.loc13: <specific function> = specific_function %Op.ref.loc13, @Cpp.long_long.as.BitOrWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.381f46.2]
+// CHECK:STDOUT:   %bound_method.loc13_20.4: <bound method> = bound_method %a.ref.loc13_18, %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.loc13
+// CHECK:STDOUT:   %impl.elem0.loc13_25.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_25.3: <bound method> = bound_method %.loc13_25.2, %impl.elem0.loc13_25.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13_25: init %Cpp.long_long = call %bound_method.loc13_25.3(%.loc13_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_25.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13_25 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_25.4: %Cpp.long_long = converted %.loc13_25.2, %.loc13_25.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.call.loc13: init %Cpp.long_long = call %bound_method.loc13_20.4(%a.ref.loc13_18, %.loc13_25.4)
+// CHECK:STDOUT:   %a.ref.loc13_34: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc13: <specific function> = specific_function %AssertSameType.ref.loc13, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc13_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitOrWith.impl.Op.call.loc13
+// CHECK:STDOUT:   %.loc13_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitOrWith.impl.Op.call.loc13, %.loc13_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc13: init %empty_tuple.type = call %AssertSameType.specific_fn.loc13(%.loc13_20.7, %a.ref.loc13_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc14: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc14_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc14: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc14: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc14: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc14_25.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc14_25.1: <bound method> = bound_method %int_1.loc14, %impl.elem0.loc14_25.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc14_25: <specific function> = specific_function %impl.elem0.loc14_25.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc14_25.2: <bound method> = bound_method %int_1.loc14, %specific_fn.loc14_25 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc14: init %i64 = call %bound_method.loc14_25.2(%int_1.loc14) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc14_25.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc14 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc14_25.2: %i64 = converted %int_1.loc14, %.loc14_25.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc14: %.a1e = impl_witness_access constants.%BitXorWith.impl_witness.d73, element1 [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.8e4513.2]
+// CHECK:STDOUT:   %bound_method.loc14_20.1: <bound method> = bound_method %a.ref.loc14_18, %impl.elem1.loc14
+// CHECK:STDOUT:   %ImplicitAs.facet.loc14_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc14_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc14_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc14_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc14_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc14_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc14_20: <specific function> = specific_function %impl.elem1.loc14, @Cpp.long_long.as.BitXorWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.741c0a.1]
+// CHECK:STDOUT:   %bound_method.loc14_20.2: <bound method> = bound_method %a.ref.loc14_18, %specific_fn.loc14_20
+// CHECK:STDOUT:   %.loc14_20.3: %Cpp.long_long.as.BitXorWith.impl.Op.type.5edc0b.1 = specific_constant imports.%Core.Op.08d, @Cpp.long_long.as.BitXorWith.impl.3a7(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.8e4513.1]
+// CHECK:STDOUT:   %Op.ref.loc14: %Cpp.long_long.as.BitXorWith.impl.Op.type.5edc0b.1 = name_ref Op, %.loc14_20.3 [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.8e4513.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.bound.loc14: <bound method> = bound_method %a.ref.loc14_18, %Op.ref.loc14
+// CHECK:STDOUT:   %impl.elem0.loc14_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc14_20.3: <bound method> = bound_method %.loc14_25.2, %impl.elem0.loc14_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc14_20: init %Cpp.long_long = call %bound_method.loc14_20.3(%.loc14_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc14_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_20.5: %Cpp.long_long = converted %.loc14_25.2, %.loc14_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.loc14: <specific function> = specific_function %Op.ref.loc14, @Cpp.long_long.as.BitXorWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.741c0a.2]
+// CHECK:STDOUT:   %bound_method.loc14_20.4: <bound method> = bound_method %a.ref.loc14_18, %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.loc14
+// CHECK:STDOUT:   %impl.elem0.loc14_25.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc14_25.3: <bound method> = bound_method %.loc14_25.2, %impl.elem0.loc14_25.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc14_25: init %Cpp.long_long = call %bound_method.loc14_25.3(%.loc14_25.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_25.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc14_25 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_25.4: %Cpp.long_long = converted %.loc14_25.2, %.loc14_25.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.call.loc14: init %Cpp.long_long = call %bound_method.loc14_20.4(%a.ref.loc14_18, %.loc14_25.4)
+// CHECK:STDOUT:   %a.ref.loc14_34: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc14: <specific function> = specific_function %AssertSameType.ref.loc14, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc14_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitXorWith.impl.Op.call.loc14
+// CHECK:STDOUT:   %.loc14_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitXorWith.impl.Op.call.loc14, %.loc14_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc14: init %empty_tuple.type = call %AssertSameType.specific_fn.loc14(%.loc14_20.7, %a.ref.loc14_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc15: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc15_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc15: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc15: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc15_26.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc15_26.1: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15_26.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc15_26: <specific function> = specific_function %impl.elem0.loc15_26.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_26.2: <bound method> = bound_method %int_1.loc15, %specific_fn.loc15_26 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc15: init %i64 = call %bound_method.loc15_26.2(%int_1.loc15) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_26.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc15 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_26.2: %i64 = converted %int_1.loc15, %.loc15_26.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc15: %.730 = impl_witness_access constants.%LeftShiftWith.impl_witness.78f, element1 [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.2]
+// CHECK:STDOUT:   %bound_method.loc15_20.1: <bound method> = bound_method %a.ref.loc15_18, %impl.elem1.loc15
+// CHECK:STDOUT:   %ImplicitAs.facet.loc15_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc15_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc15_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc15_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc15_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc15_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc15_20: <specific function> = specific_function %impl.elem1.loc15, @Cpp.long_long.as.LeftShiftWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.db6da6.1]
+// CHECK:STDOUT:   %bound_method.loc15_20.2: <bound method> = bound_method %a.ref.loc15_18, %specific_fn.loc15_20
+// CHECK:STDOUT:   %.loc15_20.3: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.392305.1 = specific_constant imports.%Core.Op.e43, @Cpp.long_long.as.LeftShiftWith.impl.93e(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.1]
+// CHECK:STDOUT:   %Op.ref.loc15: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.392305.1 = name_ref Op, %.loc15_20.3 [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.bound.loc15: <bound method> = bound_method %a.ref.loc15_18, %Op.ref.loc15
+// CHECK:STDOUT:   %impl.elem0.loc15_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc15_20.3: <bound method> = bound_method %.loc15_26.2, %impl.elem0.loc15_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc15_20: init %Cpp.long_long = call %bound_method.loc15_20.3(%.loc15_26.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc15_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_20.5: %Cpp.long_long = converted %.loc15_26.2, %.loc15_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.loc15: <specific function> = specific_function %Op.ref.loc15, @Cpp.long_long.as.LeftShiftWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.db6da6.2]
+// CHECK:STDOUT:   %bound_method.loc15_20.4: <bound method> = bound_method %a.ref.loc15_18, %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.loc15
+// CHECK:STDOUT:   %impl.elem0.loc15_26.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc15_26.3: <bound method> = bound_method %.loc15_26.2, %impl.elem0.loc15_26.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc15_26: init %Cpp.long_long = call %bound_method.loc15_26.3(%.loc15_26.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_26.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc15_26 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_26.4: %Cpp.long_long = converted %.loc15_26.2, %.loc15_26.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc15: init %Cpp.long_long = call %bound_method.loc15_20.4(%a.ref.loc15_18, %.loc15_26.4)
+// CHECK:STDOUT:   %a.ref.loc15_35: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc15: <specific function> = specific_function %AssertSameType.ref.loc15, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc15_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc15
+// CHECK:STDOUT:   %.loc15_20.7: %Cpp.long_long = converted %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc15, %.loc15_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc15: init %empty_tuple.type = call %AssertSameType.specific_fn.loc15(%.loc15_20.7, %a.ref.loc15_35)
+// CHECK:STDOUT:   %AssertSameType.ref.loc16: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc16_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc16: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc16: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc16: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc16_26.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc16_26.1: <bound method> = bound_method %int_1.loc16, %impl.elem0.loc16_26.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc16_26: <specific function> = specific_function %impl.elem0.loc16_26.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc16_26.2: <bound method> = bound_method %int_1.loc16, %specific_fn.loc16_26 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc16: init %i64 = call %bound_method.loc16_26.2(%int_1.loc16) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc16_26.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc16 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc16_26.2: %i64 = converted %int_1.loc16, %.loc16_26.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem1.loc16: %.6ec = impl_witness_access constants.%RightShiftWith.impl_witness.707, element1 [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.b17816.2]
+// CHECK:STDOUT:   %bound_method.loc16_20.1: <bound method> = bound_method %a.ref.loc16_18, %impl.elem1.loc16
+// CHECK:STDOUT:   %ImplicitAs.facet.loc16_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc16_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc16_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc16_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc16_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc16_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc16_20: <specific function> = specific_function %impl.elem1.loc16, @Cpp.long_long.as.RightShiftWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.bee934.1]
+// CHECK:STDOUT:   %bound_method.loc16_20.2: <bound method> = bound_method %a.ref.loc16_18, %specific_fn.loc16_20
+// CHECK:STDOUT:   %.loc16_20.3: %Cpp.long_long.as.RightShiftWith.impl.Op.type.947ba1.1 = specific_constant imports.%Core.Op.bae, @Cpp.long_long.as.RightShiftWith.impl.8e7(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.b17816.1]
+// CHECK:STDOUT:   %Op.ref.loc16: %Cpp.long_long.as.RightShiftWith.impl.Op.type.947ba1.1 = name_ref Op, %.loc16_20.3 [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.b17816.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.bound.loc16: <bound method> = bound_method %a.ref.loc16_18, %Op.ref.loc16
+// CHECK:STDOUT:   %impl.elem0.loc16_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc16_20.3: <bound method> = bound_method %.loc16_26.2, %impl.elem0.loc16_20 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc16_20: init %Cpp.long_long = call %bound_method.loc16_20.3(%.loc16_26.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc16_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_20.5: %Cpp.long_long = converted %.loc16_26.2, %.loc16_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.loc16: <specific function> = specific_function %Op.ref.loc16, @Cpp.long_long.as.RightShiftWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.bee934.2]
+// CHECK:STDOUT:   %bound_method.loc16_20.4: <bound method> = bound_method %a.ref.loc16_18, %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.loc16
+// CHECK:STDOUT:   %impl.elem0.loc16_26.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc16_26.3: <bound method> = bound_method %.loc16_26.2, %impl.elem0.loc16_26.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc16_26: init %Cpp.long_long = call %bound_method.loc16_26.3(%.loc16_26.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_26.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc16_26 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_26.4: %Cpp.long_long = converted %.loc16_26.2, %.loc16_26.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc16: init %Cpp.long_long = call %bound_method.loc16_20.4(%a.ref.loc16_18, %.loc16_26.4)
+// CHECK:STDOUT:   %a.ref.loc16_35: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc16: <specific function> = specific_function %AssertSameType.ref.loc16, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc16_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc16
+// CHECK:STDOUT:   %.loc16_20.7: %Cpp.long_long = converted %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc16, %.loc16_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc16: init %empty_tuple.type = call %AssertSameType.specific_fn.loc16(%.loc16_20.7, %a.ref.loc16_35)
+// CHECK:STDOUT:   %AssertSameType.ref.loc18: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc18_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc18: %.be5 = impl_witness_access constants.%BitAndWith.impl_witness.83a, element1 [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.b2e429.2]
+// CHECK:STDOUT:   %bound_method.loc18_20.1: <bound method> = bound_method %a.ref.loc18_18, %impl.elem1.loc18
+// CHECK:STDOUT:   %ImplicitAs.facet.loc18_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc18_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc18_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc18_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc18_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc18_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc18: <specific function> = specific_function %impl.elem1.loc18, @Cpp.long_long.as.BitAndWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.87f720.1]
+// CHECK:STDOUT:   %bound_method.loc18_20.2: <bound method> = bound_method %a.ref.loc18_18, %specific_fn.loc18
+// CHECK:STDOUT:   %.loc18_20.3: %Cpp.long_long.as.BitAndWith.impl.Op.type.454427.1 = specific_constant imports.%Core.Op.bf8, @Cpp.long_long.as.BitAndWith.impl.f59(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.b2e429.1]
+// CHECK:STDOUT:   %Op.ref.loc18: %Cpp.long_long.as.BitAndWith.impl.Op.type.454427.1 = name_ref Op, %.loc18_20.3 [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.b2e429.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.bound.loc18: <bound method> = bound_method %a.ref.loc18_18, %Op.ref.loc18
+// CHECK:STDOUT:   %impl.elem0.loc18_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc18_20.3: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18_20: init %Cpp.long_long = call %bound_method.loc18_20.3(%int_1.loc18) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_20.5: %Cpp.long_long = converted %int_1.loc18, %.loc18_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.loc18: <specific function> = specific_function %Op.ref.loc18, @Cpp.long_long.as.BitAndWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.87f720.2]
+// CHECK:STDOUT:   %bound_method.loc18_20.4: <bound method> = bound_method %a.ref.loc18_18, %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.loc18
+// CHECK:STDOUT:   %impl.elem0.loc18_22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc18_22: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18_22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18_22: init %Cpp.long_long = call %bound_method.loc18_22(%int_1.loc18) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_22.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18_22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_22.2: %Cpp.long_long = converted %int_1.loc18, %.loc18_22.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.call.loc18: init %Cpp.long_long = call %bound_method.loc18_20.4(%a.ref.loc18_18, %.loc18_22.2)
+// CHECK:STDOUT:   %a.ref.loc18_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc18: <specific function> = specific_function %AssertSameType.ref.loc18, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc18_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitAndWith.impl.Op.call.loc18
+// CHECK:STDOUT:   %.loc18_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitAndWith.impl.Op.call.loc18, %.loc18_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc18: init %empty_tuple.type = call %AssertSameType.specific_fn.loc18(%.loc18_20.7, %a.ref.loc18_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc19: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc19_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc19: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc19: %.35b = impl_witness_access constants.%BitOrWith.impl_witness.dc3, element1 [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.58469f.2]
+// CHECK:STDOUT:   %bound_method.loc19_20.1: <bound method> = bound_method %a.ref.loc19_18, %impl.elem1.loc19
+// CHECK:STDOUT:   %ImplicitAs.facet.loc19_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc19_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc19_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc19_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc19_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc19_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc19: <specific function> = specific_function %impl.elem1.loc19, @Cpp.long_long.as.BitOrWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.c253d2.1]
+// CHECK:STDOUT:   %bound_method.loc19_20.2: <bound method> = bound_method %a.ref.loc19_18, %specific_fn.loc19
+// CHECK:STDOUT:   %.loc19_20.3: %Cpp.long_long.as.BitOrWith.impl.Op.type.2b2898.1 = specific_constant imports.%Core.Op.364, @Cpp.long_long.as.BitOrWith.impl.c9b(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.58469f.1]
+// CHECK:STDOUT:   %Op.ref.loc19: %Cpp.long_long.as.BitOrWith.impl.Op.type.2b2898.1 = name_ref Op, %.loc19_20.3 [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.58469f.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.bound.loc19: <bound method> = bound_method %a.ref.loc19_18, %Op.ref.loc19
+// CHECK:STDOUT:   %impl.elem0.loc19_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc19_20.3: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19_20: init %Cpp.long_long = call %bound_method.loc19_20.3(%int_1.loc19) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_20.5: %Cpp.long_long = converted %int_1.loc19, %.loc19_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.loc19: <specific function> = specific_function %Op.ref.loc19, @Cpp.long_long.as.BitOrWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.c253d2.2]
+// CHECK:STDOUT:   %bound_method.loc19_20.4: <bound method> = bound_method %a.ref.loc19_18, %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.loc19
+// CHECK:STDOUT:   %impl.elem0.loc19_22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc19_22: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19_22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19_22: init %Cpp.long_long = call %bound_method.loc19_22(%int_1.loc19) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_22.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19_22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_22.2: %Cpp.long_long = converted %int_1.loc19, %.loc19_22.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.call.loc19: init %Cpp.long_long = call %bound_method.loc19_20.4(%a.ref.loc19_18, %.loc19_22.2)
+// CHECK:STDOUT:   %a.ref.loc19_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc19: <specific function> = specific_function %AssertSameType.ref.loc19, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc19_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitOrWith.impl.Op.call.loc19
+// CHECK:STDOUT:   %.loc19_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitOrWith.impl.Op.call.loc19, %.loc19_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc19: init %empty_tuple.type = call %AssertSameType.specific_fn.loc19(%.loc19_20.7, %a.ref.loc19_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc20: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc20_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc20: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc20: %.ce8 = impl_witness_access constants.%BitXorWith.impl_witness.943, element1 [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.b0b042.2]
+// CHECK:STDOUT:   %bound_method.loc20_20.1: <bound method> = bound_method %a.ref.loc20_18, %impl.elem1.loc20
+// CHECK:STDOUT:   %ImplicitAs.facet.loc20_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc20_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc20_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc20_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc20_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc20_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc20: <specific function> = specific_function %impl.elem1.loc20, @Cpp.long_long.as.BitXorWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.3d8d22.1]
+// CHECK:STDOUT:   %bound_method.loc20_20.2: <bound method> = bound_method %a.ref.loc20_18, %specific_fn.loc20
+// CHECK:STDOUT:   %.loc20_20.3: %Cpp.long_long.as.BitXorWith.impl.Op.type.23f010.1 = specific_constant imports.%Core.Op.08d, @Cpp.long_long.as.BitXorWith.impl.3a7(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.b0b042.1]
+// CHECK:STDOUT:   %Op.ref.loc20: %Cpp.long_long.as.BitXorWith.impl.Op.type.23f010.1 = name_ref Op, %.loc20_20.3 [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.b0b042.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.bound.loc20: <bound method> = bound_method %a.ref.loc20_18, %Op.ref.loc20
+// CHECK:STDOUT:   %impl.elem0.loc20_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc20_20.3: <bound method> = bound_method %int_1.loc20, %impl.elem0.loc20_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20_20: init %Cpp.long_long = call %bound_method.loc20_20.3(%int_1.loc20) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_20.5: %Cpp.long_long = converted %int_1.loc20, %.loc20_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.loc20: <specific function> = specific_function %Op.ref.loc20, @Cpp.long_long.as.BitXorWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.3d8d22.2]
+// CHECK:STDOUT:   %bound_method.loc20_20.4: <bound method> = bound_method %a.ref.loc20_18, %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.loc20
+// CHECK:STDOUT:   %impl.elem0.loc20_22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc20_22: <bound method> = bound_method %int_1.loc20, %impl.elem0.loc20_22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20_22: init %Cpp.long_long = call %bound_method.loc20_22(%int_1.loc20) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_22.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20_22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_22.2: %Cpp.long_long = converted %int_1.loc20, %.loc20_22.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.call.loc20: init %Cpp.long_long = call %bound_method.loc20_20.4(%a.ref.loc20_18, %.loc20_22.2)
+// CHECK:STDOUT:   %a.ref.loc20_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc20: <specific function> = specific_function %AssertSameType.ref.loc20, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc20_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitXorWith.impl.Op.call.loc20
+// CHECK:STDOUT:   %.loc20_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitXorWith.impl.Op.call.loc20, %.loc20_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc20: init %empty_tuple.type = call %AssertSameType.specific_fn.loc20(%.loc20_20.7, %a.ref.loc20_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc21: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc21_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc21: %.b37 = impl_witness_access constants.%LeftShiftWith.impl_witness.0f1, element1 [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.5502e8.2]
+// CHECK:STDOUT:   %bound_method.loc21_20.1: <bound method> = bound_method %a.ref.loc21_18, %impl.elem1.loc21
+// CHECK:STDOUT:   %ImplicitAs.facet.loc21_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc21_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc21_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc21_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc21_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc21_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem1.loc21, @Cpp.long_long.as.LeftShiftWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.b9b4ae.1]
+// CHECK:STDOUT:   %bound_method.loc21_20.2: <bound method> = bound_method %a.ref.loc21_18, %specific_fn.loc21
+// CHECK:STDOUT:   %.loc21_20.3: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.7ec0de.1 = specific_constant imports.%Core.Op.e43, @Cpp.long_long.as.LeftShiftWith.impl.93e(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.5502e8.1]
+// CHECK:STDOUT:   %Op.ref.loc21: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.7ec0de.1 = name_ref Op, %.loc21_20.3 [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.5502e8.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.bound.loc21: <bound method> = bound_method %a.ref.loc21_18, %Op.ref.loc21
+// CHECK:STDOUT:   %impl.elem0.loc21_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc21_20.3: <bound method> = bound_method %int_1.loc21, %impl.elem0.loc21_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21_20: init %Cpp.long_long = call %bound_method.loc21_20.3(%int_1.loc21) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_20.5: %Cpp.long_long = converted %int_1.loc21, %.loc21_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.loc21: <specific function> = specific_function %Op.ref.loc21, @Cpp.long_long.as.LeftShiftWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.b9b4ae.2]
+// CHECK:STDOUT:   %bound_method.loc21_20.4: <bound method> = bound_method %a.ref.loc21_18, %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.loc21
+// CHECK:STDOUT:   %impl.elem0.loc21_23: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc21_23: <bound method> = bound_method %int_1.loc21, %impl.elem0.loc21_23 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21_23: init %Cpp.long_long = call %bound_method.loc21_23(%int_1.loc21) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_23.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21_23 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_23.2: %Cpp.long_long = converted %int_1.loc21, %.loc21_23.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc21: init %Cpp.long_long = call %bound_method.loc21_20.4(%a.ref.loc21_18, %.loc21_23.2)
+// CHECK:STDOUT:   %a.ref.loc21_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc21: <specific function> = specific_function %AssertSameType.ref.loc21, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc21_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc21
+// CHECK:STDOUT:   %.loc21_20.7: %Cpp.long_long = converted %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc21, %.loc21_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc21: init %empty_tuple.type = call %AssertSameType.specific_fn.loc21(%.loc21_20.7, %a.ref.loc21_26)
+// CHECK:STDOUT:   %AssertSameType.ref.loc22: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc22_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc22: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem1.loc22: %.f6a = impl_witness_access constants.%RightShiftWith.impl_witness.1a5, element1 [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.0261ea.2]
+// CHECK:STDOUT:   %bound_method.loc22_20.1: <bound method> = bound_method %a.ref.loc22_18, %impl.elem1.loc22
+// CHECK:STDOUT:   %ImplicitAs.facet.loc22_20.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc22_20.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc22_20.1 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc22_20.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %.loc22_20.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc22_20.2 [concrete = constants.%ImplicitAs.facet.d52]
+// CHECK:STDOUT:   %specific_fn.loc22: <specific function> = specific_function %impl.elem1.loc22, @Cpp.long_long.as.RightShiftWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.fa8301.1]
+// CHECK:STDOUT:   %bound_method.loc22_20.2: <bound method> = bound_method %a.ref.loc22_18, %specific_fn.loc22
+// CHECK:STDOUT:   %.loc22_20.3: %Cpp.long_long.as.RightShiftWith.impl.Op.type.94f032.1 = specific_constant imports.%Core.Op.bae, @Cpp.long_long.as.RightShiftWith.impl.8e7(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.0261ea.1]
+// CHECK:STDOUT:   %Op.ref.loc22: %Cpp.long_long.as.RightShiftWith.impl.Op.type.94f032.1 = name_ref Op, %.loc22_20.3 [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.0261ea.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.bound.loc22: <bound method> = bound_method %a.ref.loc22_18, %Op.ref.loc22
+// CHECK:STDOUT:   %impl.elem0.loc22_20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc22_20.3: <bound method> = bound_method %int_1.loc22, %impl.elem0.loc22_20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22_20: init %Cpp.long_long = call %bound_method.loc22_20.3(%int_1.loc22) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_20.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22_20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_20.5: %Cpp.long_long = converted %int_1.loc22, %.loc22_20.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.loc22: <specific function> = specific_function %Op.ref.loc22, @Cpp.long_long.as.RightShiftWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.fa8301.2]
+// CHECK:STDOUT:   %bound_method.loc22_20.4: <bound method> = bound_method %a.ref.loc22_18, %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.loc22
+// CHECK:STDOUT:   %impl.elem0.loc22_23: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc22_23: <bound method> = bound_method %int_1.loc22, %impl.elem0.loc22_23 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22_23: init %Cpp.long_long = call %bound_method.loc22_23(%int_1.loc22) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_23.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22_23 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_23.2: %Cpp.long_long = converted %int_1.loc22, %.loc22_23.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc22: init %Cpp.long_long = call %bound_method.loc22_20.4(%a.ref.loc22_18, %.loc22_23.2)
+// CHECK:STDOUT:   %a.ref.loc22_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc22: <specific function> = specific_function %AssertSameType.ref.loc22, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc22_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc22
+// CHECK:STDOUT:   %.loc22_20.7: %Cpp.long_long = converted %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc22, %.loc22_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc22: init %empty_tuple.type = call %AssertSameType.specific_fn.loc22(%.loc22_20.7, %a.ref.loc22_26)
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %b.patt: %pattern_type.95b = value_binding_pattern b [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc24: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc24_10: type = splice_block %i64.loc24 [concrete = constants.%i64] {
+// CHECK:STDOUT:     %int_64.loc24: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:     %i64.loc24: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc24: %.567 = impl_witness_access constants.%ImplicitAs.impl_witness.556, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.57d]
+// CHECK:STDOUT:   %bound_method.loc24_16.1: <bound method> = bound_method %int_1.loc24, %impl.elem0.loc24 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102]
+// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem0.loc24, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc24_16.2: <bound method> = bound_method %int_1.loc24, %specific_fn.loc24 [concrete = constants.%bound_method.288]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc24: init %i64 = call %bound_method.loc24_16.2(%int_1.loc24) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc24_16.1: %i64 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc24 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc24_16.2: %i64 = converted %int_1.loc24, %.loc24_16.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %b: %i64 = value_binding b, %.loc24_16.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc25: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc25_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc25: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc25: %.69f = impl_witness_access constants.%BitAndWith.impl_witness.85b, element1 [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.8819bd.2]
+// CHECK:STDOUT:   %bound_method.loc25_20.1: <bound method> = bound_method %a.ref.loc25_18, %impl.elem1.loc25
+// CHECK:STDOUT:   %ImplicitAs.facet.loc25_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc25_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc25_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc25_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc25_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc25_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc25: <specific function> = specific_function %impl.elem1.loc25, @Cpp.long_long.as.BitAndWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.944ed2.1]
+// CHECK:STDOUT:   %bound_method.loc25_20.2: <bound method> = bound_method %a.ref.loc25_18, %specific_fn.loc25
+// CHECK:STDOUT:   %.loc25_20.3: %Cpp.long_long.as.BitAndWith.impl.Op.type.46a434.1 = specific_constant imports.%Core.Op.bf8, @Cpp.long_long.as.BitAndWith.impl.f59(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.8819bd.1]
+// CHECK:STDOUT:   %Op.ref.loc25: %Cpp.long_long.as.BitAndWith.impl.Op.type.46a434.1 = name_ref Op, %.loc25_20.3 [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.8819bd.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.bound.loc25: <bound method> = bound_method %a.ref.loc25_18, %Op.ref.loc25
+// CHECK:STDOUT:   %impl.elem0.loc25_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc25_20.3: <bound method> = bound_method %b.ref.loc25, %impl.elem0.loc25_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc25_20: init %Cpp.long_long = call %bound_method.loc25_20.3(%b.ref.loc25)
+// CHECK:STDOUT:   %.loc25_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc25_20
+// CHECK:STDOUT:   %.loc25_20.5: %Cpp.long_long = converted %b.ref.loc25, %.loc25_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.loc25: <specific function> = specific_function %Op.ref.loc25, @Cpp.long_long.as.BitAndWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.944ed2.2]
+// CHECK:STDOUT:   %bound_method.loc25_20.4: <bound method> = bound_method %a.ref.loc25_18, %Cpp.long_long.as.BitAndWith.impl.Op.specific_fn.loc25
+// CHECK:STDOUT:   %impl.elem0.loc25_22: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc25_22: <bound method> = bound_method %b.ref.loc25, %impl.elem0.loc25_22
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc25_22: init %Cpp.long_long = call %bound_method.loc25_22(%b.ref.loc25)
+// CHECK:STDOUT:   %.loc25_22.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc25_22
+// CHECK:STDOUT:   %.loc25_22.2: %Cpp.long_long = converted %b.ref.loc25, %.loc25_22.1
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndWith.impl.Op.call.loc25: init %Cpp.long_long = call %bound_method.loc25_20.4(%a.ref.loc25_18, %.loc25_22.2)
+// CHECK:STDOUT:   %a.ref.loc25_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc25: <specific function> = specific_function %AssertSameType.ref.loc25, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc25_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitAndWith.impl.Op.call.loc25
+// CHECK:STDOUT:   %.loc25_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitAndWith.impl.Op.call.loc25, %.loc25_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc25: init %empty_tuple.type = call %AssertSameType.specific_fn.loc25(%.loc25_20.7, %a.ref.loc25_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc26: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc26_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc26: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc26: %.6dd = impl_witness_access constants.%BitOrWith.impl_witness.da7, element1 [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.2]
+// CHECK:STDOUT:   %bound_method.loc26_20.1: <bound method> = bound_method %a.ref.loc26_18, %impl.elem1.loc26
+// CHECK:STDOUT:   %ImplicitAs.facet.loc26_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc26_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc26_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc26_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc26_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc26_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc26: <specific function> = specific_function %impl.elem1.loc26, @Cpp.long_long.as.BitOrWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.381f46.1]
+// CHECK:STDOUT:   %bound_method.loc26_20.2: <bound method> = bound_method %a.ref.loc26_18, %specific_fn.loc26
+// CHECK:STDOUT:   %.loc26_20.3: %Cpp.long_long.as.BitOrWith.impl.Op.type.d3ab21.1 = specific_constant imports.%Core.Op.364, @Cpp.long_long.as.BitOrWith.impl.c9b(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.1]
+// CHECK:STDOUT:   %Op.ref.loc26: %Cpp.long_long.as.BitOrWith.impl.Op.type.d3ab21.1 = name_ref Op, %.loc26_20.3 [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.7a35d3.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.bound.loc26: <bound method> = bound_method %a.ref.loc26_18, %Op.ref.loc26
+// CHECK:STDOUT:   %impl.elem0.loc26_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc26_20.3: <bound method> = bound_method %b.ref.loc26, %impl.elem0.loc26_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc26_20: init %Cpp.long_long = call %bound_method.loc26_20.3(%b.ref.loc26)
+// CHECK:STDOUT:   %.loc26_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc26_20
+// CHECK:STDOUT:   %.loc26_20.5: %Cpp.long_long = converted %b.ref.loc26, %.loc26_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.loc26: <specific function> = specific_function %Op.ref.loc26, @Cpp.long_long.as.BitOrWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.381f46.2]
+// CHECK:STDOUT:   %bound_method.loc26_20.4: <bound method> = bound_method %a.ref.loc26_18, %Cpp.long_long.as.BitOrWith.impl.Op.specific_fn.loc26
+// CHECK:STDOUT:   %impl.elem0.loc26_22: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc26_22: <bound method> = bound_method %b.ref.loc26, %impl.elem0.loc26_22
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc26_22: init %Cpp.long_long = call %bound_method.loc26_22(%b.ref.loc26)
+// CHECK:STDOUT:   %.loc26_22.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc26_22
+// CHECK:STDOUT:   %.loc26_22.2: %Cpp.long_long = converted %b.ref.loc26, %.loc26_22.1
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrWith.impl.Op.call.loc26: init %Cpp.long_long = call %bound_method.loc26_20.4(%a.ref.loc26_18, %.loc26_22.2)
+// CHECK:STDOUT:   %a.ref.loc26_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc26: <specific function> = specific_function %AssertSameType.ref.loc26, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc26_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitOrWith.impl.Op.call.loc26
+// CHECK:STDOUT:   %.loc26_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitOrWith.impl.Op.call.loc26, %.loc26_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc26: init %empty_tuple.type = call %AssertSameType.specific_fn.loc26(%.loc26_20.7, %a.ref.loc26_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc27: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc27_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc27: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc27: %.a1e = impl_witness_access constants.%BitXorWith.impl_witness.d73, element1 [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.8e4513.2]
+// CHECK:STDOUT:   %bound_method.loc27_20.1: <bound method> = bound_method %a.ref.loc27_18, %impl.elem1.loc27
+// CHECK:STDOUT:   %ImplicitAs.facet.loc27_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc27_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc27_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc27_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc27_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc27_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc27: <specific function> = specific_function %impl.elem1.loc27, @Cpp.long_long.as.BitXorWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.741c0a.1]
+// CHECK:STDOUT:   %bound_method.loc27_20.2: <bound method> = bound_method %a.ref.loc27_18, %specific_fn.loc27
+// CHECK:STDOUT:   %.loc27_20.3: %Cpp.long_long.as.BitXorWith.impl.Op.type.5edc0b.1 = specific_constant imports.%Core.Op.08d, @Cpp.long_long.as.BitXorWith.impl.3a7(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.8e4513.1]
+// CHECK:STDOUT:   %Op.ref.loc27: %Cpp.long_long.as.BitXorWith.impl.Op.type.5edc0b.1 = name_ref Op, %.loc27_20.3 [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.8e4513.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.bound.loc27: <bound method> = bound_method %a.ref.loc27_18, %Op.ref.loc27
+// CHECK:STDOUT:   %impl.elem0.loc27_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc27_20.3: <bound method> = bound_method %b.ref.loc27, %impl.elem0.loc27_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc27_20: init %Cpp.long_long = call %bound_method.loc27_20.3(%b.ref.loc27)
+// CHECK:STDOUT:   %.loc27_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc27_20
+// CHECK:STDOUT:   %.loc27_20.5: %Cpp.long_long = converted %b.ref.loc27, %.loc27_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.loc27: <specific function> = specific_function %Op.ref.loc27, @Cpp.long_long.as.BitXorWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.741c0a.2]
+// CHECK:STDOUT:   %bound_method.loc27_20.4: <bound method> = bound_method %a.ref.loc27_18, %Cpp.long_long.as.BitXorWith.impl.Op.specific_fn.loc27
+// CHECK:STDOUT:   %impl.elem0.loc27_22: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc27_22: <bound method> = bound_method %b.ref.loc27, %impl.elem0.loc27_22
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc27_22: init %Cpp.long_long = call %bound_method.loc27_22(%b.ref.loc27)
+// CHECK:STDOUT:   %.loc27_22.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc27_22
+// CHECK:STDOUT:   %.loc27_22.2: %Cpp.long_long = converted %b.ref.loc27, %.loc27_22.1
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorWith.impl.Op.call.loc27: init %Cpp.long_long = call %bound_method.loc27_20.4(%a.ref.loc27_18, %.loc27_22.2)
+// CHECK:STDOUT:   %a.ref.loc27_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc27: <specific function> = specific_function %AssertSameType.ref.loc27, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc27_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.BitXorWith.impl.Op.call.loc27
+// CHECK:STDOUT:   %.loc27_20.7: %Cpp.long_long = converted %Cpp.long_long.as.BitXorWith.impl.Op.call.loc27, %.loc27_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc27: init %empty_tuple.type = call %AssertSameType.specific_fn.loc27(%.loc27_20.7, %a.ref.loc27_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc28: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc28_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc28: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc28: %.730 = impl_witness_access constants.%LeftShiftWith.impl_witness.78f, element1 [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.2]
+// CHECK:STDOUT:   %bound_method.loc28_20.1: <bound method> = bound_method %a.ref.loc28_18, %impl.elem1.loc28
+// CHECK:STDOUT:   %ImplicitAs.facet.loc28_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc28_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc28_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc28_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc28_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc28_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc28: <specific function> = specific_function %impl.elem1.loc28, @Cpp.long_long.as.LeftShiftWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.db6da6.1]
+// CHECK:STDOUT:   %bound_method.loc28_20.2: <bound method> = bound_method %a.ref.loc28_18, %specific_fn.loc28
+// CHECK:STDOUT:   %.loc28_20.3: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.392305.1 = specific_constant imports.%Core.Op.e43, @Cpp.long_long.as.LeftShiftWith.impl.93e(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.1]
+// CHECK:STDOUT:   %Op.ref.loc28: %Cpp.long_long.as.LeftShiftWith.impl.Op.type.392305.1 = name_ref Op, %.loc28_20.3 [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.b726d7.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.bound.loc28: <bound method> = bound_method %a.ref.loc28_18, %Op.ref.loc28
+// CHECK:STDOUT:   %impl.elem0.loc28_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc28_20.3: <bound method> = bound_method %b.ref.loc28, %impl.elem0.loc28_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc28_20: init %Cpp.long_long = call %bound_method.loc28_20.3(%b.ref.loc28)
+// CHECK:STDOUT:   %.loc28_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc28_20
+// CHECK:STDOUT:   %.loc28_20.5: %Cpp.long_long = converted %b.ref.loc28, %.loc28_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.loc28: <specific function> = specific_function %Op.ref.loc28, @Cpp.long_long.as.LeftShiftWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.db6da6.2]
+// CHECK:STDOUT:   %bound_method.loc28_20.4: <bound method> = bound_method %a.ref.loc28_18, %Cpp.long_long.as.LeftShiftWith.impl.Op.specific_fn.loc28
+// CHECK:STDOUT:   %impl.elem0.loc28_23: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc28_23: <bound method> = bound_method %b.ref.loc28, %impl.elem0.loc28_23
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc28_23: init %Cpp.long_long = call %bound_method.loc28_23(%b.ref.loc28)
+// CHECK:STDOUT:   %.loc28_23.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc28_23
+// CHECK:STDOUT:   %.loc28_23.2: %Cpp.long_long = converted %b.ref.loc28, %.loc28_23.1
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc28: init %Cpp.long_long = call %bound_method.loc28_20.4(%a.ref.loc28_18, %.loc28_23.2)
+// CHECK:STDOUT:   %a.ref.loc28_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc28: <specific function> = specific_function %AssertSameType.ref.loc28, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc28_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc28
+// CHECK:STDOUT:   %.loc28_20.7: %Cpp.long_long = converted %Cpp.long_long.as.LeftShiftWith.impl.Op.call.loc28, %.loc28_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc28: init %empty_tuple.type = call %AssertSameType.specific_fn.loc28(%.loc28_20.7, %a.ref.loc28_26)
+// CHECK:STDOUT:   %AssertSameType.ref.loc29: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc29_18: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc29: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc29: %.6ec = impl_witness_access constants.%RightShiftWith.impl_witness.707, element1 [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.b17816.2]
+// CHECK:STDOUT:   %bound_method.loc29_20.1: <bound method> = bound_method %a.ref.loc29_18, %impl.elem1.loc29
+// CHECK:STDOUT:   %ImplicitAs.facet.loc29_20.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc29_20.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc29_20.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc29_20.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc29_20.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc29_20.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem1.loc29, @Cpp.long_long.as.RightShiftWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.bee934.1]
+// CHECK:STDOUT:   %bound_method.loc29_20.2: <bound method> = bound_method %a.ref.loc29_18, %specific_fn.loc29
+// CHECK:STDOUT:   %.loc29_20.3: %Cpp.long_long.as.RightShiftWith.impl.Op.type.947ba1.1 = specific_constant imports.%Core.Op.bae, @Cpp.long_long.as.RightShiftWith.impl.8e7(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.b17816.1]
+// CHECK:STDOUT:   %Op.ref.loc29: %Cpp.long_long.as.RightShiftWith.impl.Op.type.947ba1.1 = name_ref Op, %.loc29_20.3 [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.b17816.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.bound.loc29: <bound method> = bound_method %a.ref.loc29_18, %Op.ref.loc29
+// CHECK:STDOUT:   %impl.elem0.loc29_20: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc29_20.3: <bound method> = bound_method %b.ref.loc29, %impl.elem0.loc29_20
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc29_20: init %Cpp.long_long = call %bound_method.loc29_20.3(%b.ref.loc29)
+// CHECK:STDOUT:   %.loc29_20.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc29_20
+// CHECK:STDOUT:   %.loc29_20.5: %Cpp.long_long = converted %b.ref.loc29, %.loc29_20.4
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.loc29: <specific function> = specific_function %Op.ref.loc29, @Cpp.long_long.as.RightShiftWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.bee934.2]
+// CHECK:STDOUT:   %bound_method.loc29_20.4: <bound method> = bound_method %a.ref.loc29_18, %Cpp.long_long.as.RightShiftWith.impl.Op.specific_fn.loc29
+// CHECK:STDOUT:   %impl.elem0.loc29_23: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc29_23: <bound method> = bound_method %b.ref.loc29, %impl.elem0.loc29_23
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc29_23: init %Cpp.long_long = call %bound_method.loc29_23(%b.ref.loc29)
+// CHECK:STDOUT:   %.loc29_23.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc29_23
+// CHECK:STDOUT:   %.loc29_23.2: %Cpp.long_long = converted %b.ref.loc29, %.loc29_23.1
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc29: init %Cpp.long_long = call %bound_method.loc29_20.4(%a.ref.loc29_18, %.loc29_23.2)
+// CHECK:STDOUT:   %a.ref.loc29_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc29: <specific function> = specific_function %AssertSameType.ref.loc29, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc29_20.6: %Cpp.long_long = value_of_initializer %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc29
+// CHECK:STDOUT:   %.loc29_20.7: %Cpp.long_long = converted %Cpp.long_long.as.RightShiftWith.impl.Op.call.loc29, %.loc29_20.6
+// CHECK:STDOUT:   %AssertSameType.call.loc29: init %empty_tuple.type = call %AssertSameType.specific_fn.loc29(%.loc29_20.7, %a.ref.loc29_26)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- bitwise_heterogeneous_long_long_right_side.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %AssertSameType.type: type = fn_type @AssertSameType [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %AssertSameType: %AssertSameType.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %int_64: Core.IntLiteral = int_value 64 [concrete]
+// CHECK:STDOUT:   %i64: type = class_type @Int, @Int(%int_64) [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.2ad: type = facet_type <@ImplicitAs, @ImplicitAs(%i64)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.94e: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i64) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %As.type.229: type = facet_type <@As, @As(%i64)> [concrete]
+// CHECK:STDOUT:   %As.Convert.type.d57: type = fn_type @As.Convert, @As(%i64) [concrete]
+// CHECK:STDOUT:   %To.fe9: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.09e: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.dbe: %Core.IntLiteral.as.As.impl.Convert.type.09e = struct_value () [symbolic]
+// CHECK:STDOUT:   %As.impl_witness.c71: <witness> = impl_witness imports.%As.impl_witness_table.9fc, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.cee: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.a54: %Core.IntLiteral.as.As.impl.Convert.type.cee = struct_value () [concrete]
+// CHECK:STDOUT:   %As.facet: %As.type.229 = facet_value Core.IntLiteral, (%As.impl_witness.c71) [concrete]
+// CHECK:STDOUT:   %.aba: type = fn_type_with_self_type %As.Convert.type.d57, %As.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.a54 [concrete]
+// CHECK:STDOUT:   %pattern_type.95b: type = pattern_type %i64 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.As.impl.Convert.a54, @Core.IntLiteral.as.As.impl.Convert(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method.41b: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_1.41a: %i64 = int_value 1 [concrete]
+// CHECK:STDOUT:   %BitAndWith.type.97f: type = facet_type <@BitAndWith, @BitAndWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitAndWith.Op.type.c6c: type = fn_type @BitAndWith.Op, @BitAndWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.ea5: %ImplicitAs.type.a03 = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.e1600b.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.1, @T.binding.as_type.as.BitAndWith.impl.972(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.183211.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.e1600b.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.e1600b.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.2, @T.binding.as_type.as.BitAndWith.impl.972(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.183211.2: %T.binding.as_type.as.BitAndWith.impl.Op.type.e1600b.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.1b3: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.b19 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.c59: %ImplicitAs.type.a03 = facet_value %i64, (%ImplicitAs.impl_witness.1b3) [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.668: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.1b6, @T.binding.as_type.as.BitAndWith.impl.972(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.d0d4e3.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.2, @T.binding.as_type.as.BitAndWith.impl.972(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.77d50f.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.d0d4e3.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.d0d4e3.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.1, @T.binding.as_type.as.BitAndWith.impl.972(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.77d50f.2: %T.binding.as_type.as.BitAndWith.impl.Op.type.d0d4e3.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitAndWith.facet.ed4: %BitAndWith.type.97f = facet_value %i64, (%BitAndWith.impl_witness.668) [concrete]
+// CHECK:STDOUT:   %.14d: type = fn_type_with_self_type %BitAndWith.Op.type.c6c, %BitAndWith.facet.ed4 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound.733cd6.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitAndWith.impl.Op.77d50f.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.16125d.1: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.77d50f.2, @T.binding.as_type.as.BitAndWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.ba7306.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.16125d.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound.733cd6.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitAndWith.impl.Op.77d50f.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.16125d.2: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.77d50f.1, @T.binding.as_type.as.BitAndWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.ba7306.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.16125d.2 [concrete]
+// CHECK:STDOUT:   %.b29: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.c59 [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.type: type = fn_type @i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert: %i64.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.41a, %i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %BitOrWith.type.d59: type = facet_type <@BitOrWith, @BitOrWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitOrWith.Op.type.c9c: type = fn_type @BitOrWith.Op, @BitOrWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.type.aeba4a.1: type = fn_type @T.binding.as_type.as.BitOrWith.impl.Op.1, @T.binding.as_type.as.BitOrWith.impl.a9d(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bafb09.1: %T.binding.as_type.as.BitOrWith.impl.Op.type.aeba4a.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.type.aeba4a.2: type = fn_type @T.binding.as_type.as.BitOrWith.impl.Op.2, @T.binding.as_type.as.BitOrWith.impl.a9d(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bafb09.2: %T.binding.as_type.as.BitOrWith.impl.Op.type.aeba4a.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitOrWith.impl_witness.771: <witness> = impl_witness imports.%BitOrWith.impl_witness_table.54a, @T.binding.as_type.as.BitOrWith.impl.a9d(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.type.2c510c.1: type = fn_type @T.binding.as_type.as.BitOrWith.impl.Op.2, @T.binding.as_type.as.BitOrWith.impl.a9d(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.9b8362.1: %T.binding.as_type.as.BitOrWith.impl.Op.type.2c510c.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.type.2c510c.2: type = fn_type @T.binding.as_type.as.BitOrWith.impl.Op.1, @T.binding.as_type.as.BitOrWith.impl.a9d(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.9b8362.2: %T.binding.as_type.as.BitOrWith.impl.Op.type.2c510c.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitOrWith.facet.794: %BitOrWith.type.d59 = facet_value %i64, (%BitOrWith.impl_witness.771) [concrete]
+// CHECK:STDOUT:   %.a4a: type = fn_type_with_self_type %BitOrWith.Op.type.c9c, %BitOrWith.facet.794 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bound.40f9e4.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitOrWith.impl.Op.9b8362.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.bd6228.1: <specific function> = specific_function %T.binding.as_type.as.BitOrWith.impl.Op.9b8362.2, @T.binding.as_type.as.BitOrWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.55f403.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.bd6228.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bound.40f9e4.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitOrWith.impl.Op.9b8362.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.bd6228.2: <specific function> = specific_function %T.binding.as_type.as.BitOrWith.impl.Op.9b8362.1, @T.binding.as_type.as.BitOrWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.55f403.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.bd6228.2 [concrete]
+// CHECK:STDOUT:   %BitXorWith.type.b7e: type = facet_type <@BitXorWith, @BitXorWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitXorWith.Op.type.1d5: type = fn_type @BitXorWith.Op, @BitXorWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.type.ac630d.1: type = fn_type @T.binding.as_type.as.BitXorWith.impl.Op.1, @T.binding.as_type.as.BitXorWith.impl.0e9(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.ffb1c4.1: %T.binding.as_type.as.BitXorWith.impl.Op.type.ac630d.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.type.ac630d.2: type = fn_type @T.binding.as_type.as.BitXorWith.impl.Op.2, @T.binding.as_type.as.BitXorWith.impl.0e9(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.ffb1c4.2: %T.binding.as_type.as.BitXorWith.impl.Op.type.ac630d.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitXorWith.impl_witness.28f: <witness> = impl_witness imports.%BitXorWith.impl_witness_table.2f7, @T.binding.as_type.as.BitXorWith.impl.0e9(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.type.02ef16.1: type = fn_type @T.binding.as_type.as.BitXorWith.impl.Op.2, @T.binding.as_type.as.BitXorWith.impl.0e9(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.f03227.1: %T.binding.as_type.as.BitXorWith.impl.Op.type.02ef16.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.type.02ef16.2: type = fn_type @T.binding.as_type.as.BitXorWith.impl.Op.1, @T.binding.as_type.as.BitXorWith.impl.0e9(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.f03227.2: %T.binding.as_type.as.BitXorWith.impl.Op.type.02ef16.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitXorWith.facet.e2c: %BitXorWith.type.b7e = facet_value %i64, (%BitXorWith.impl_witness.28f) [concrete]
+// CHECK:STDOUT:   %.f37: type = fn_type_with_self_type %BitXorWith.Op.type.1d5, %BitXorWith.facet.e2c [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.bound.6bfecd.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitXorWith.impl.Op.f03227.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.bae3fa.1: <specific function> = specific_function %T.binding.as_type.as.BitXorWith.impl.Op.f03227.2, @T.binding.as_type.as.BitXorWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.b2ba8d.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.bae3fa.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.bound.6bfecd.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitXorWith.impl.Op.f03227.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.bae3fa.2: <specific function> = specific_function %T.binding.as_type.as.BitXorWith.impl.Op.f03227.1, @T.binding.as_type.as.BitXorWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.b2ba8d.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.bae3fa.2 [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.type.091: type = facet_type <@LeftShiftWith, @LeftShiftWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.Op.type.5df: type = fn_type @LeftShiftWith.Op, @LeftShiftWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.type.3ecd57.1: type = fn_type @T.binding.as_type.as.LeftShiftWith.impl.Op.1, @T.binding.as_type.as.LeftShiftWith.impl.b8c(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.3ee0c1.1: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.3ecd57.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.type.3ecd57.2: type = fn_type @T.binding.as_type.as.LeftShiftWith.impl.Op.2, @T.binding.as_type.as.LeftShiftWith.impl.b8c(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.3ee0c1.2: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.3ecd57.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness.95c: <witness> = impl_witness imports.%LeftShiftWith.impl_witness_table.6dc, @T.binding.as_type.as.LeftShiftWith.impl.b8c(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.type.c82b93.1: type = fn_type @T.binding.as_type.as.LeftShiftWith.impl.Op.2, @T.binding.as_type.as.LeftShiftWith.impl.b8c(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.1: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.c82b93.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.type.c82b93.2: type = fn_type @T.binding.as_type.as.LeftShiftWith.impl.Op.1, @T.binding.as_type.as.LeftShiftWith.impl.b8c(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.2: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.c82b93.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.facet.3b6: %LeftShiftWith.type.091 = facet_value %i64, (%LeftShiftWith.impl_witness.95c) [concrete]
+// CHECK:STDOUT:   %.3c0: type = fn_type_with_self_type %LeftShiftWith.Op.type.5df, %LeftShiftWith.facet.3b6 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.bound.9bca52.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.c7ed9a.1: <specific function> = specific_function %T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.2, @T.binding.as_type.as.LeftShiftWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.2b7c80.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.c7ed9a.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.bound.9bca52.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.c7ed9a.2: <specific function> = specific_function %T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.1, @T.binding.as_type.as.LeftShiftWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.2b7c80.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.c7ed9a.2 [concrete]
+// CHECK:STDOUT:   %RightShiftWith.type.382: type = facet_type <@RightShiftWith, @RightShiftWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %RightShiftWith.Op.type.202: type = fn_type @RightShiftWith.Op, @RightShiftWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.type.e5d568.1: type = fn_type @T.binding.as_type.as.RightShiftWith.impl.Op.1, @T.binding.as_type.as.RightShiftWith.impl.677(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.e94511.1: %T.binding.as_type.as.RightShiftWith.impl.Op.type.e5d568.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.type.e5d568.2: type = fn_type @T.binding.as_type.as.RightShiftWith.impl.Op.2, @T.binding.as_type.as.RightShiftWith.impl.677(%T.ea5) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.e94511.2: %T.binding.as_type.as.RightShiftWith.impl.Op.type.e5d568.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness.015: <witness> = impl_witness imports.%RightShiftWith.impl_witness_table.6b8, @T.binding.as_type.as.RightShiftWith.impl.677(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.type.ff07c1.1: type = fn_type @T.binding.as_type.as.RightShiftWith.impl.Op.2, @T.binding.as_type.as.RightShiftWith.impl.677(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.513286.1: %T.binding.as_type.as.RightShiftWith.impl.Op.type.ff07c1.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.type.ff07c1.2: type = fn_type @T.binding.as_type.as.RightShiftWith.impl.Op.1, @T.binding.as_type.as.RightShiftWith.impl.677(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.513286.2: %T.binding.as_type.as.RightShiftWith.impl.Op.type.ff07c1.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %RightShiftWith.facet.532: %RightShiftWith.type.382 = facet_value %i64, (%RightShiftWith.impl_witness.015) [concrete]
+// CHECK:STDOUT:   %.c72: type = fn_type_with_self_type %RightShiftWith.Op.type.202, %RightShiftWith.facet.532 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.bound.1bfdb6.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.RightShiftWith.impl.Op.513286.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.7142b6.1: <specific function> = specific_function %T.binding.as_type.as.RightShiftWith.impl.Op.513286.2, @T.binding.as_type.as.RightShiftWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.cba0de.1: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.7142b6.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.bound.1bfdb6.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.RightShiftWith.impl.Op.513286.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.7142b6.2: <specific function> = specific_function %T.binding.as_type.as.RightShiftWith.impl.Op.513286.1, @T.binding.as_type.as.RightShiftWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %bound_method.cba0de.2: <bound method> = bound_method %int_1.41a, %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.7142b6.2 [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.d64: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.1b6, @T.binding.as_type.as.BitAndWith.impl.972(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.41163c.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.2, @T.binding.as_type.as.BitAndWith.impl.972(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.41163c.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.41163c.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.1, @T.binding.as_type.as.BitAndWith.impl.972(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.2: %T.binding.as_type.as.BitAndWith.impl.Op.type.41163c.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitAndWith.facet.da7: %BitAndWith.type.97f = facet_value Core.IntLiteral, (%BitAndWith.impl_witness.d64) [concrete]
+// CHECK:STDOUT:   %.47c: type = fn_type_with_self_type %BitAndWith.Op.type.c6c, %BitAndWith.facet.da7 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound.d8a3c5.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.a59d01.1: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.2, @T.binding.as_type.as.BitAndWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.a03ffd.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.a59d01.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound.d8a3c5.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.a59d01.2: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.1, @T.binding.as_type.as.BitAndWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.a03ffd.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.a59d01.2 [concrete]
+// CHECK:STDOUT:   %BitOrWith.impl_witness.502: <witness> = impl_witness imports.%BitOrWith.impl_witness_table.54a, @T.binding.as_type.as.BitOrWith.impl.a9d(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.type.30a2d8.1: type = fn_type @T.binding.as_type.as.BitOrWith.impl.Op.2, @T.binding.as_type.as.BitOrWith.impl.a9d(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.1: %T.binding.as_type.as.BitOrWith.impl.Op.type.30a2d8.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.type.30a2d8.2: type = fn_type @T.binding.as_type.as.BitOrWith.impl.Op.1, @T.binding.as_type.as.BitOrWith.impl.a9d(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.2: %T.binding.as_type.as.BitOrWith.impl.Op.type.30a2d8.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitOrWith.facet.9bb: %BitOrWith.type.d59 = facet_value Core.IntLiteral, (%BitOrWith.impl_witness.502) [concrete]
+// CHECK:STDOUT:   %.82a: type = fn_type_with_self_type %BitOrWith.Op.type.c9c, %BitOrWith.facet.9bb [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bound.df7ea0.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.caa89a.1: <specific function> = specific_function %T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.2, @T.binding.as_type.as.BitOrWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.c36bb1.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.caa89a.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bound.df7ea0.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.caa89a.2: <specific function> = specific_function %T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.1, @T.binding.as_type.as.BitOrWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.c36bb1.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.caa89a.2 [concrete]
+// CHECK:STDOUT:   %BitXorWith.impl_witness.f51: <witness> = impl_witness imports.%BitXorWith.impl_witness_table.2f7, @T.binding.as_type.as.BitXorWith.impl.0e9(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.type.5acb01.1: type = fn_type @T.binding.as_type.as.BitXorWith.impl.Op.2, @T.binding.as_type.as.BitXorWith.impl.0e9(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.1: %T.binding.as_type.as.BitXorWith.impl.Op.type.5acb01.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.type.5acb01.2: type = fn_type @T.binding.as_type.as.BitXorWith.impl.Op.1, @T.binding.as_type.as.BitXorWith.impl.0e9(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.2: %T.binding.as_type.as.BitXorWith.impl.Op.type.5acb01.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitXorWith.facet.289: %BitXorWith.type.b7e = facet_value Core.IntLiteral, (%BitXorWith.impl_witness.f51) [concrete]
+// CHECK:STDOUT:   %.012: type = fn_type_with_self_type %BitXorWith.Op.type.1d5, %BitXorWith.facet.289 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.bound.01bd1e.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.0f91c3.1: <specific function> = specific_function %T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.2, @T.binding.as_type.as.BitXorWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.55c9d3.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.0f91c3.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.bound.01bd1e.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.0f91c3.2: <specific function> = specific_function %T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.1, @T.binding.as_type.as.BitXorWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.55c9d3.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.0f91c3.2 [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness.399: <witness> = impl_witness imports.%LeftShiftWith.impl_witness_table.6dc, @T.binding.as_type.as.LeftShiftWith.impl.b8c(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.type.407181.1: type = fn_type @T.binding.as_type.as.LeftShiftWith.impl.Op.2, @T.binding.as_type.as.LeftShiftWith.impl.b8c(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.1: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.407181.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.type.407181.2: type = fn_type @T.binding.as_type.as.LeftShiftWith.impl.Op.1, @T.binding.as_type.as.LeftShiftWith.impl.b8c(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.2: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.407181.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %LeftShiftWith.facet.8de: %LeftShiftWith.type.091 = facet_value Core.IntLiteral, (%LeftShiftWith.impl_witness.399) [concrete]
+// CHECK:STDOUT:   %.8cf: type = fn_type_with_self_type %LeftShiftWith.Op.type.5df, %LeftShiftWith.facet.8de [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.bound.481050.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.3f9028.1: <specific function> = specific_function %T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.2, @T.binding.as_type.as.LeftShiftWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.9fc9b7.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.3f9028.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.bound.481050.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.3f9028.2: <specific function> = specific_function %T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.1, @T.binding.as_type.as.LeftShiftWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.9fc9b7.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.3f9028.2 [concrete]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness.464: <witness> = impl_witness imports.%RightShiftWith.impl_witness_table.6b8, @T.binding.as_type.as.RightShiftWith.impl.677(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.type.82e117.1: type = fn_type @T.binding.as_type.as.RightShiftWith.impl.Op.2, @T.binding.as_type.as.RightShiftWith.impl.677(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.1: %T.binding.as_type.as.RightShiftWith.impl.Op.type.82e117.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.type.82e117.2: type = fn_type @T.binding.as_type.as.RightShiftWith.impl.Op.1, @T.binding.as_type.as.RightShiftWith.impl.677(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.2: %T.binding.as_type.as.RightShiftWith.impl.Op.type.82e117.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %RightShiftWith.facet.e35: %RightShiftWith.type.382 = facet_value Core.IntLiteral, (%RightShiftWith.impl_witness.464) [concrete]
+// CHECK:STDOUT:   %.543: type = fn_type_with_self_type %RightShiftWith.Op.type.202, %RightShiftWith.facet.e35 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.bound.d5049d.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.2 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.3d7026.1: <specific function> = specific_function %T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.2, @T.binding.as_type.as.RightShiftWith.impl.Op.1(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.dacc1a.1: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.3d7026.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.bound.d5049d.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.1 [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.3d7026.2: <specific function> = specific_function %T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.1, @T.binding.as_type.as.RightShiftWith.impl.Op.2(%ImplicitAs.facet.d52) [concrete]
+// CHECK:STDOUT:   %bound_method.dacc1a.2: <bound method> = bound_method %int_1.5b8, %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.3d7026.2 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.556: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.74f, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d48: %ImplicitAs.type.2ad = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.556) [concrete]
+// CHECK:STDOUT:   %.567: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.d48 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method.288: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ca0: @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert.type (%Core.IntLiteral.as.As.impl.Convert.type.09e) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert (constants.%Core.IntLiteral.as.As.impl.Convert.dbe)]
+// CHECK:STDOUT:   %As.impl_witness_table.9fc = impl_witness_table (%Core.import_ref.ca0), @Core.IntLiteral.as.As.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.2 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.b80: @T.binding.as_type.as.BitAndWith.impl.972.%T.binding.as_type.as.BitAndWith.impl.Op.type.2 (%T.binding.as_type.as.BitAndWith.impl.Op.type.e1600b.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.BitAndWith.impl.972.%T.binding.as_type.as.BitAndWith.impl.Op.2 (constants.%T.binding.as_type.as.BitAndWith.impl.Op.183211.1)]
+// CHECK:STDOUT:   %BitAndWith.impl_witness_table.1b6 = impl_witness_table (%Core.import_ref.ce3a05.2, %Core.import_ref.b80), @T.binding.as_type.as.BitAndWith.impl.972 [concrete]
+// CHECK:STDOUT:   %Core.Op.f87: @T.binding.as_type.as.BitAndWith.impl.972.%T.binding.as_type.as.BitAndWith.impl.Op.type.1 (%T.binding.as_type.as.BitAndWith.impl.Op.type.e1600b.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.BitAndWith.impl.972.%T.binding.as_type.as.BitAndWith.impl.Op.1 (constants.%T.binding.as_type.as.BitAndWith.impl.Op.183211.2)]
+// CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
+// CHECK:STDOUT:   %Core.import_ref.4f4: %i64.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.b19 = impl_witness_table (%Core.import_ref.4f4), @i64.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.4 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.d80: @T.binding.as_type.as.BitOrWith.impl.a9d.%T.binding.as_type.as.BitOrWith.impl.Op.type.2 (%T.binding.as_type.as.BitOrWith.impl.Op.type.aeba4a.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.BitOrWith.impl.a9d.%T.binding.as_type.as.BitOrWith.impl.Op.2 (constants.%T.binding.as_type.as.BitOrWith.impl.Op.bafb09.1)]
+// CHECK:STDOUT:   %BitOrWith.impl_witness_table.54a = impl_witness_table (%Core.import_ref.ce3a05.4, %Core.import_ref.d80), @T.binding.as_type.as.BitOrWith.impl.a9d [concrete]
+// CHECK:STDOUT:   %Core.Op.eb3: @T.binding.as_type.as.BitOrWith.impl.a9d.%T.binding.as_type.as.BitOrWith.impl.Op.type.1 (%T.binding.as_type.as.BitOrWith.impl.Op.type.aeba4a.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.BitOrWith.impl.a9d.%T.binding.as_type.as.BitOrWith.impl.Op.1 (constants.%T.binding.as_type.as.BitOrWith.impl.Op.bafb09.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.6 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.720: @T.binding.as_type.as.BitXorWith.impl.0e9.%T.binding.as_type.as.BitXorWith.impl.Op.type.2 (%T.binding.as_type.as.BitXorWith.impl.Op.type.ac630d.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.BitXorWith.impl.0e9.%T.binding.as_type.as.BitXorWith.impl.Op.2 (constants.%T.binding.as_type.as.BitXorWith.impl.Op.ffb1c4.1)]
+// CHECK:STDOUT:   %BitXorWith.impl_witness_table.2f7 = impl_witness_table (%Core.import_ref.ce3a05.6, %Core.import_ref.720), @T.binding.as_type.as.BitXorWith.impl.0e9 [concrete]
+// CHECK:STDOUT:   %Core.Op.06a: @T.binding.as_type.as.BitXorWith.impl.0e9.%T.binding.as_type.as.BitXorWith.impl.Op.type.1 (%T.binding.as_type.as.BitXorWith.impl.Op.type.ac630d.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.BitXorWith.impl.0e9.%T.binding.as_type.as.BitXorWith.impl.Op.1 (constants.%T.binding.as_type.as.BitXorWith.impl.Op.ffb1c4.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.8 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.cd3: @T.binding.as_type.as.LeftShiftWith.impl.b8c.%T.binding.as_type.as.LeftShiftWith.impl.Op.type.2 (%T.binding.as_type.as.LeftShiftWith.impl.Op.type.3ecd57.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.LeftShiftWith.impl.b8c.%T.binding.as_type.as.LeftShiftWith.impl.Op.2 (constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.3ee0c1.1)]
+// CHECK:STDOUT:   %LeftShiftWith.impl_witness_table.6dc = impl_witness_table (%Core.import_ref.ce3a05.8, %Core.import_ref.cd3), @T.binding.as_type.as.LeftShiftWith.impl.b8c [concrete]
+// CHECK:STDOUT:   %Core.Op.0db: @T.binding.as_type.as.LeftShiftWith.impl.b8c.%T.binding.as_type.as.LeftShiftWith.impl.Op.type.1 (%T.binding.as_type.as.LeftShiftWith.impl.Op.type.3ecd57.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.LeftShiftWith.impl.b8c.%T.binding.as_type.as.LeftShiftWith.impl.Op.1 (constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.3ee0c1.2)]
+// CHECK:STDOUT:   %Core.import_ref.ce3a05.10 = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.64d: @T.binding.as_type.as.RightShiftWith.impl.677.%T.binding.as_type.as.RightShiftWith.impl.Op.type.2 (%T.binding.as_type.as.RightShiftWith.impl.Op.type.e5d568.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.RightShiftWith.impl.677.%T.binding.as_type.as.RightShiftWith.impl.Op.2 (constants.%T.binding.as_type.as.RightShiftWith.impl.Op.e94511.1)]
+// CHECK:STDOUT:   %RightShiftWith.impl_witness_table.6b8 = impl_witness_table (%Core.import_ref.ce3a05.10, %Core.import_ref.64d), @T.binding.as_type.as.RightShiftWith.impl.677 [concrete]
+// CHECK:STDOUT:   %Core.Op.db5: @T.binding.as_type.as.RightShiftWith.impl.677.%T.binding.as_type.as.RightShiftWith.impl.Op.type.1 (%T.binding.as_type.as.RightShiftWith.impl.Op.type.e5d568.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @T.binding.as_type.as.RightShiftWith.impl.677.%T.binding.as_type.as.RightShiftWith.impl.Op.1 (constants.%T.binding.as_type.as.RightShiftWith.impl.Op.e94511.2)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @BitWiseHeterogeneousLongLongRightSide() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = value_binding_pattern a [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc10_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc10: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10(%int_1.loc10) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.2: %Cpp.long_long = converted %int_1.loc10, %.loc10_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %a: %Cpp.long_long = value_binding a, %.loc10_26.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc12: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc12: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc12: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc12: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc12_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc12_21.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc12_21: <specific function> = specific_function %impl.elem0.loc12_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc12_21.2: <bound method> = bound_method %int_1.loc12, %specific_fn.loc12_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc12: init %i64 = call %bound_method.loc12_21.2(%int_1.loc12) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc12 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_21.2: %i64 = converted %int_1.loc12, %.loc12_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %a.ref.loc12_31: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc12: %.14d = impl_witness_access constants.%BitAndWith.impl_witness.668, element1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.77d50f.2]
+// CHECK:STDOUT:   %bound_method.loc12_29.1: <bound method> = bound_method %.loc12_21.2, %impl.elem1.loc12 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.bound.733cd6.1]
+// CHECK:STDOUT:   %specific_fn.loc12_29: <specific function> = specific_function %impl.elem1.loc12, @T.binding.as_type.as.BitAndWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.16125d.1]
+// CHECK:STDOUT:   %bound_method.loc12_29.2: <bound method> = bound_method %.loc12_21.2, %specific_fn.loc12_29 [concrete = constants.%bound_method.ba7306.1]
+// CHECK:STDOUT:   %.loc12_29.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.d0d4e3.1 = specific_constant imports.%Core.Op.f87, @T.binding.as_type.as.BitAndWith.impl.972(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.77d50f.1]
+// CHECK:STDOUT:   %Op.ref.loc12: %T.binding.as_type.as.BitAndWith.impl.Op.type.d0d4e3.1 = name_ref Op, %.loc12_29.1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.77d50f.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound.loc12: <bound method> = bound_method %.loc12_21.2, %Op.ref.loc12 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.bound.733cd6.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.loc12: <specific function> = specific_function %Op.ref.loc12, @T.binding.as_type.as.BitAndWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.16125d.2]
+// CHECK:STDOUT:   %bound_method.loc12_29.3: <bound method> = bound_method %.loc12_21.2, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.loc12 [concrete = constants.%bound_method.ba7306.2]
+// CHECK:STDOUT:   %impl.elem0.loc12_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_21.3: <bound method> = bound_method %.loc12_21.2, %impl.elem0.loc12_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12: init %Cpp.long_long = call %bound_method.loc12_21.3(%.loc12_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_21.4: %Cpp.long_long = converted %.loc12_21.2, %.loc12_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.call.loc12: init %Cpp.long_long = call %bound_method.loc12_29.3(%.loc12_21.4, %a.ref.loc12_31)
+// CHECK:STDOUT:   %a.ref.loc12_34: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc12: <specific function> = specific_function %AssertSameType.ref.loc12, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc12_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitAndWith.impl.Op.call.loc12
+// CHECK:STDOUT:   %.loc12_29.3: %Cpp.long_long = converted %T.binding.as_type.as.BitAndWith.impl.Op.call.loc12, %.loc12_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc12: init %empty_tuple.type = call %AssertSameType.specific_fn.loc12(%.loc12_29.3, %a.ref.loc12_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc13: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc13: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc13: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc13: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc13_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc13_21.1: <bound method> = bound_method %int_1.loc13, %impl.elem0.loc13_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc13_21: <specific function> = specific_function %impl.elem0.loc13_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc13_21.2: <bound method> = bound_method %int_1.loc13, %specific_fn.loc13_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc13: init %i64 = call %bound_method.loc13_21.2(%int_1.loc13) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc13 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_21.2: %i64 = converted %int_1.loc13, %.loc13_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %a.ref.loc13_31: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc13: %.a4a = impl_witness_access constants.%BitOrWith.impl_witness.771, element1 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.9b8362.2]
+// CHECK:STDOUT:   %bound_method.loc13_29.1: <bound method> = bound_method %.loc13_21.2, %impl.elem1.loc13 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.bound.40f9e4.1]
+// CHECK:STDOUT:   %specific_fn.loc13_29: <specific function> = specific_function %impl.elem1.loc13, @T.binding.as_type.as.BitOrWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.bd6228.1]
+// CHECK:STDOUT:   %bound_method.loc13_29.2: <bound method> = bound_method %.loc13_21.2, %specific_fn.loc13_29 [concrete = constants.%bound_method.55f403.1]
+// CHECK:STDOUT:   %.loc13_29.1: %T.binding.as_type.as.BitOrWith.impl.Op.type.2c510c.1 = specific_constant imports.%Core.Op.eb3, @T.binding.as_type.as.BitOrWith.impl.a9d(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.9b8362.1]
+// CHECK:STDOUT:   %Op.ref.loc13: %T.binding.as_type.as.BitOrWith.impl.Op.type.2c510c.1 = name_ref Op, %.loc13_29.1 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.9b8362.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bound.loc13: <bound method> = bound_method %.loc13_21.2, %Op.ref.loc13 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.bound.40f9e4.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.loc13: <specific function> = specific_function %Op.ref.loc13, @T.binding.as_type.as.BitOrWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.bd6228.2]
+// CHECK:STDOUT:   %bound_method.loc13_29.3: <bound method> = bound_method %.loc13_21.2, %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.loc13 [concrete = constants.%bound_method.55f403.2]
+// CHECK:STDOUT:   %impl.elem0.loc13_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_21.3: <bound method> = bound_method %.loc13_21.2, %impl.elem0.loc13_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13: init %Cpp.long_long = call %bound_method.loc13_21.3(%.loc13_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_21.4: %Cpp.long_long = converted %.loc13_21.2, %.loc13_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.call.loc13: init %Cpp.long_long = call %bound_method.loc13_29.3(%.loc13_21.4, %a.ref.loc13_31)
+// CHECK:STDOUT:   %a.ref.loc13_34: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc13: <specific function> = specific_function %AssertSameType.ref.loc13, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc13_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitOrWith.impl.Op.call.loc13
+// CHECK:STDOUT:   %.loc13_29.3: %Cpp.long_long = converted %T.binding.as_type.as.BitOrWith.impl.Op.call.loc13, %.loc13_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc13: init %empty_tuple.type = call %AssertSameType.specific_fn.loc13(%.loc13_29.3, %a.ref.loc13_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc14: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc14: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc14: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc14: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc14_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc14_21.1: <bound method> = bound_method %int_1.loc14, %impl.elem0.loc14_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc14_21: <specific function> = specific_function %impl.elem0.loc14_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc14_21.2: <bound method> = bound_method %int_1.loc14, %specific_fn.loc14_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc14: init %i64 = call %bound_method.loc14_21.2(%int_1.loc14) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc14_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc14 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc14_21.2: %i64 = converted %int_1.loc14, %.loc14_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %a.ref.loc14_31: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc14: %.f37 = impl_witness_access constants.%BitXorWith.impl_witness.28f, element1 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.f03227.2]
+// CHECK:STDOUT:   %bound_method.loc14_29.1: <bound method> = bound_method %.loc14_21.2, %impl.elem1.loc14 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.bound.6bfecd.1]
+// CHECK:STDOUT:   %specific_fn.loc14_29: <specific function> = specific_function %impl.elem1.loc14, @T.binding.as_type.as.BitXorWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.bae3fa.1]
+// CHECK:STDOUT:   %bound_method.loc14_29.2: <bound method> = bound_method %.loc14_21.2, %specific_fn.loc14_29 [concrete = constants.%bound_method.b2ba8d.1]
+// CHECK:STDOUT:   %.loc14_29.1: %T.binding.as_type.as.BitXorWith.impl.Op.type.02ef16.1 = specific_constant imports.%Core.Op.06a, @T.binding.as_type.as.BitXorWith.impl.0e9(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.f03227.1]
+// CHECK:STDOUT:   %Op.ref.loc14: %T.binding.as_type.as.BitXorWith.impl.Op.type.02ef16.1 = name_ref Op, %.loc14_29.1 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.f03227.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.bound.loc14: <bound method> = bound_method %.loc14_21.2, %Op.ref.loc14 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.bound.6bfecd.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.loc14: <specific function> = specific_function %Op.ref.loc14, @T.binding.as_type.as.BitXorWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.bae3fa.2]
+// CHECK:STDOUT:   %bound_method.loc14_29.3: <bound method> = bound_method %.loc14_21.2, %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.loc14 [concrete = constants.%bound_method.b2ba8d.2]
+// CHECK:STDOUT:   %impl.elem0.loc14_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc14_21.3: <bound method> = bound_method %.loc14_21.2, %impl.elem0.loc14_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc14: init %Cpp.long_long = call %bound_method.loc14_21.3(%.loc14_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc14 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc14_21.4: %Cpp.long_long = converted %.loc14_21.2, %.loc14_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.call.loc14: init %Cpp.long_long = call %bound_method.loc14_29.3(%.loc14_21.4, %a.ref.loc14_31)
+// CHECK:STDOUT:   %a.ref.loc14_34: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc14: <specific function> = specific_function %AssertSameType.ref.loc14, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc14_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitXorWith.impl.Op.call.loc14
+// CHECK:STDOUT:   %.loc14_29.3: %Cpp.long_long = converted %T.binding.as_type.as.BitXorWith.impl.Op.call.loc14, %.loc14_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc14: init %empty_tuple.type = call %AssertSameType.specific_fn.loc14(%.loc14_29.3, %a.ref.loc14_34)
+// CHECK:STDOUT:   %AssertSameType.ref.loc15: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc15: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc15: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc15_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc15_21.1: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc15_21: <specific function> = specific_function %impl.elem0.loc15_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_21.2: <bound method> = bound_method %int_1.loc15, %specific_fn.loc15_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc15: init %i64 = call %bound_method.loc15_21.2(%int_1.loc15) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc15 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_21.2: %i64 = converted %int_1.loc15, %.loc15_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %a.ref.loc15_32: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc15: %.3c0 = impl_witness_access constants.%LeftShiftWith.impl_witness.95c, element1 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.2]
+// CHECK:STDOUT:   %bound_method.loc15_29.1: <bound method> = bound_method %.loc15_21.2, %impl.elem1.loc15 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.bound.9bca52.1]
+// CHECK:STDOUT:   %specific_fn.loc15_29: <specific function> = specific_function %impl.elem1.loc15, @T.binding.as_type.as.LeftShiftWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.c7ed9a.1]
+// CHECK:STDOUT:   %bound_method.loc15_29.2: <bound method> = bound_method %.loc15_21.2, %specific_fn.loc15_29 [concrete = constants.%bound_method.2b7c80.1]
+// CHECK:STDOUT:   %.loc15_29.1: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.c82b93.1 = specific_constant imports.%Core.Op.0db, @T.binding.as_type.as.LeftShiftWith.impl.b8c(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.1]
+// CHECK:STDOUT:   %Op.ref.loc15: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.c82b93.1 = name_ref Op, %.loc15_29.1 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.bound.loc15: <bound method> = bound_method %.loc15_21.2, %Op.ref.loc15 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.bound.9bca52.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.loc15: <specific function> = specific_function %Op.ref.loc15, @T.binding.as_type.as.LeftShiftWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.c7ed9a.2]
+// CHECK:STDOUT:   %bound_method.loc15_29.3: <bound method> = bound_method %.loc15_21.2, %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.loc15 [concrete = constants.%bound_method.2b7c80.2]
+// CHECK:STDOUT:   %impl.elem0.loc15_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc15_21.3: <bound method> = bound_method %.loc15_21.2, %impl.elem0.loc15_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc15: init %Cpp.long_long = call %bound_method.loc15_21.3(%.loc15_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc15 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_21.4: %Cpp.long_long = converted %.loc15_21.2, %.loc15_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc15: init %Cpp.long_long = call %bound_method.loc15_29.3(%.loc15_21.4, %a.ref.loc15_32)
+// CHECK:STDOUT:   %a.ref.loc15_35: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc15: <specific function> = specific_function %AssertSameType.ref.loc15, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc15_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc15
+// CHECK:STDOUT:   %.loc15_29.3: %Cpp.long_long = converted %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc15, %.loc15_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc15: init %empty_tuple.type = call %AssertSameType.specific_fn.loc15(%.loc15_29.3, %a.ref.loc15_35)
+// CHECK:STDOUT:   %AssertSameType.ref.loc16: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc16: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc16: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc16: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc16_21.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc16_21.1: <bound method> = bound_method %int_1.loc16, %impl.elem0.loc16_21.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc16_21: <specific function> = specific_function %impl.elem0.loc16_21.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc16_21.2: <bound method> = bound_method %int_1.loc16, %specific_fn.loc16_21 [concrete = constants.%bound_method.41b]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc16: init %i64 = call %bound_method.loc16_21.2(%int_1.loc16) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc16_21.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc16 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc16_21.2: %i64 = converted %int_1.loc16, %.loc16_21.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %a.ref.loc16_32: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc16: %.c72 = impl_witness_access constants.%RightShiftWith.impl_witness.015, element1 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.513286.2]
+// CHECK:STDOUT:   %bound_method.loc16_29.1: <bound method> = bound_method %.loc16_21.2, %impl.elem1.loc16 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.bound.1bfdb6.1]
+// CHECK:STDOUT:   %specific_fn.loc16_29: <specific function> = specific_function %impl.elem1.loc16, @T.binding.as_type.as.RightShiftWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.7142b6.1]
+// CHECK:STDOUT:   %bound_method.loc16_29.2: <bound method> = bound_method %.loc16_21.2, %specific_fn.loc16_29 [concrete = constants.%bound_method.cba0de.1]
+// CHECK:STDOUT:   %.loc16_29.1: %T.binding.as_type.as.RightShiftWith.impl.Op.type.ff07c1.1 = specific_constant imports.%Core.Op.db5, @T.binding.as_type.as.RightShiftWith.impl.677(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.513286.1]
+// CHECK:STDOUT:   %Op.ref.loc16: %T.binding.as_type.as.RightShiftWith.impl.Op.type.ff07c1.1 = name_ref Op, %.loc16_29.1 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.513286.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.bound.loc16: <bound method> = bound_method %.loc16_21.2, %Op.ref.loc16 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.bound.1bfdb6.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.loc16: <specific function> = specific_function %Op.ref.loc16, @T.binding.as_type.as.RightShiftWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.7142b6.2]
+// CHECK:STDOUT:   %bound_method.loc16_29.3: <bound method> = bound_method %.loc16_21.2, %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.loc16 [concrete = constants.%bound_method.cba0de.2]
+// CHECK:STDOUT:   %impl.elem0.loc16_21.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc16_21.3: <bound method> = bound_method %.loc16_21.2, %impl.elem0.loc16_21.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc16: init %Cpp.long_long = call %bound_method.loc16_21.3(%.loc16_21.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_21.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc16 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_21.4: %Cpp.long_long = converted %.loc16_21.2, %.loc16_21.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc16: init %Cpp.long_long = call %bound_method.loc16_29.3(%.loc16_21.4, %a.ref.loc16_32)
+// CHECK:STDOUT:   %a.ref.loc16_35: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc16: <specific function> = specific_function %AssertSameType.ref.loc16, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc16_29.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc16
+// CHECK:STDOUT:   %.loc16_29.3: %Cpp.long_long = converted %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc16, %.loc16_29.2
+// CHECK:STDOUT:   %AssertSameType.call.loc16: init %empty_tuple.type = call %AssertSameType.specific_fn.loc16(%.loc16_29.3, %a.ref.loc16_35)
+// CHECK:STDOUT:   %AssertSameType.ref.loc18: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %a.ref.loc18_22: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc18: %.47c = impl_witness_access constants.%BitAndWith.impl_witness.d64, element1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.2]
+// CHECK:STDOUT:   %bound_method.loc18_20.1: <bound method> = bound_method %int_1.loc18, %impl.elem1.loc18 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.bound.d8a3c5.1]
+// CHECK:STDOUT:   %specific_fn.loc18: <specific function> = specific_function %impl.elem1.loc18, @T.binding.as_type.as.BitAndWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.a59d01.1]
+// CHECK:STDOUT:   %bound_method.loc18_20.2: <bound method> = bound_method %int_1.loc18, %specific_fn.loc18 [concrete = constants.%bound_method.a03ffd.1]
+// CHECK:STDOUT:   %.loc18_20.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.41163c.1 = specific_constant imports.%Core.Op.f87, @T.binding.as_type.as.BitAndWith.impl.972(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.1]
+// CHECK:STDOUT:   %Op.ref.loc18: %T.binding.as_type.as.BitAndWith.impl.Op.type.41163c.1 = name_ref Op, %.loc18_20.1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.23dbf6.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound.loc18: <bound method> = bound_method %int_1.loc18, %Op.ref.loc18 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.bound.d8a3c5.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.loc18: <specific function> = specific_function %Op.ref.loc18, @T.binding.as_type.as.BitAndWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.a59d01.2]
+// CHECK:STDOUT:   %bound_method.loc18_20.3: <bound method> = bound_method %int_1.loc18, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.loc18 [concrete = constants.%bound_method.a03ffd.2]
+// CHECK:STDOUT:   %impl.elem0.loc18: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc18_18: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18: init %Cpp.long_long = call %bound_method.loc18_18(%int_1.loc18) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc18 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_18.2: %Cpp.long_long = converted %int_1.loc18, %.loc18_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.call.loc18: init %Cpp.long_long = call %bound_method.loc18_20.3(%.loc18_18.2, %a.ref.loc18_22)
+// CHECK:STDOUT:   %a.ref.loc18_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc18: <specific function> = specific_function %AssertSameType.ref.loc18, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc18_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitAndWith.impl.Op.call.loc18
+// CHECK:STDOUT:   %.loc18_20.3: %Cpp.long_long = converted %T.binding.as_type.as.BitAndWith.impl.Op.call.loc18, %.loc18_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc18: init %empty_tuple.type = call %AssertSameType.specific_fn.loc18(%.loc18_20.3, %a.ref.loc18_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc19: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc19: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %a.ref.loc19_22: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc19: %.82a = impl_witness_access constants.%BitOrWith.impl_witness.502, element1 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.2]
+// CHECK:STDOUT:   %bound_method.loc19_20.1: <bound method> = bound_method %int_1.loc19, %impl.elem1.loc19 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.bound.df7ea0.1]
+// CHECK:STDOUT:   %specific_fn.loc19: <specific function> = specific_function %impl.elem1.loc19, @T.binding.as_type.as.BitOrWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.caa89a.1]
+// CHECK:STDOUT:   %bound_method.loc19_20.2: <bound method> = bound_method %int_1.loc19, %specific_fn.loc19 [concrete = constants.%bound_method.c36bb1.1]
+// CHECK:STDOUT:   %.loc19_20.1: %T.binding.as_type.as.BitOrWith.impl.Op.type.30a2d8.1 = specific_constant imports.%Core.Op.eb3, @T.binding.as_type.as.BitOrWith.impl.a9d(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.1]
+// CHECK:STDOUT:   %Op.ref.loc19: %T.binding.as_type.as.BitOrWith.impl.Op.type.30a2d8.1 = name_ref Op, %.loc19_20.1 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.c03bdc.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bound.loc19: <bound method> = bound_method %int_1.loc19, %Op.ref.loc19 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.bound.df7ea0.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.loc19: <specific function> = specific_function %Op.ref.loc19, @T.binding.as_type.as.BitOrWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.caa89a.2]
+// CHECK:STDOUT:   %bound_method.loc19_20.3: <bound method> = bound_method %int_1.loc19, %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.loc19 [concrete = constants.%bound_method.c36bb1.2]
+// CHECK:STDOUT:   %impl.elem0.loc19: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc19_18: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19: init %Cpp.long_long = call %bound_method.loc19_18(%int_1.loc19) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc19 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_18.2: %Cpp.long_long = converted %int_1.loc19, %.loc19_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.call.loc19: init %Cpp.long_long = call %bound_method.loc19_20.3(%.loc19_18.2, %a.ref.loc19_22)
+// CHECK:STDOUT:   %a.ref.loc19_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc19: <specific function> = specific_function %AssertSameType.ref.loc19, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc19_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitOrWith.impl.Op.call.loc19
+// CHECK:STDOUT:   %.loc19_20.3: %Cpp.long_long = converted %T.binding.as_type.as.BitOrWith.impl.Op.call.loc19, %.loc19_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc19: init %empty_tuple.type = call %AssertSameType.specific_fn.loc19(%.loc19_20.3, %a.ref.loc19_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc20: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc20: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %a.ref.loc20_22: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc20: %.012 = impl_witness_access constants.%BitXorWith.impl_witness.f51, element1 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.2]
+// CHECK:STDOUT:   %bound_method.loc20_20.1: <bound method> = bound_method %int_1.loc20, %impl.elem1.loc20 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.bound.01bd1e.1]
+// CHECK:STDOUT:   %specific_fn.loc20: <specific function> = specific_function %impl.elem1.loc20, @T.binding.as_type.as.BitXorWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.0f91c3.1]
+// CHECK:STDOUT:   %bound_method.loc20_20.2: <bound method> = bound_method %int_1.loc20, %specific_fn.loc20 [concrete = constants.%bound_method.55c9d3.1]
+// CHECK:STDOUT:   %.loc20_20.1: %T.binding.as_type.as.BitXorWith.impl.Op.type.5acb01.1 = specific_constant imports.%Core.Op.06a, @T.binding.as_type.as.BitXorWith.impl.0e9(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.1]
+// CHECK:STDOUT:   %Op.ref.loc20: %T.binding.as_type.as.BitXorWith.impl.Op.type.5acb01.1 = name_ref Op, %.loc20_20.1 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.b5e49f.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.bound.loc20: <bound method> = bound_method %int_1.loc20, %Op.ref.loc20 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.bound.01bd1e.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.loc20: <specific function> = specific_function %Op.ref.loc20, @T.binding.as_type.as.BitXorWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.0f91c3.2]
+// CHECK:STDOUT:   %bound_method.loc20_20.3: <bound method> = bound_method %int_1.loc20, %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.loc20 [concrete = constants.%bound_method.55c9d3.2]
+// CHECK:STDOUT:   %impl.elem0.loc20: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc20_18: <bound method> = bound_method %int_1.loc20, %impl.elem0.loc20 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20: init %Cpp.long_long = call %bound_method.loc20_18(%int_1.loc20) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc20 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc20_18.2: %Cpp.long_long = converted %int_1.loc20, %.loc20_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.call.loc20: init %Cpp.long_long = call %bound_method.loc20_20.3(%.loc20_18.2, %a.ref.loc20_22)
+// CHECK:STDOUT:   %a.ref.loc20_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc20: <specific function> = specific_function %AssertSameType.ref.loc20, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc20_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitXorWith.impl.Op.call.loc20
+// CHECK:STDOUT:   %.loc20_20.3: %Cpp.long_long = converted %T.binding.as_type.as.BitXorWith.impl.Op.call.loc20, %.loc20_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc20: init %empty_tuple.type = call %AssertSameType.specific_fn.loc20(%.loc20_20.3, %a.ref.loc20_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc21: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc21: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %a.ref.loc21_23: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc21: %.8cf = impl_witness_access constants.%LeftShiftWith.impl_witness.399, element1 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.2]
+// CHECK:STDOUT:   %bound_method.loc21_20.1: <bound method> = bound_method %int_1.loc21, %impl.elem1.loc21 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.bound.481050.1]
+// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem1.loc21, @T.binding.as_type.as.LeftShiftWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.3f9028.1]
+// CHECK:STDOUT:   %bound_method.loc21_20.2: <bound method> = bound_method %int_1.loc21, %specific_fn.loc21 [concrete = constants.%bound_method.9fc9b7.1]
+// CHECK:STDOUT:   %.loc21_20.1: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.407181.1 = specific_constant imports.%Core.Op.0db, @T.binding.as_type.as.LeftShiftWith.impl.b8c(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.1]
+// CHECK:STDOUT:   %Op.ref.loc21: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.407181.1 = name_ref Op, %.loc21_20.1 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.e1a1d9.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.bound.loc21: <bound method> = bound_method %int_1.loc21, %Op.ref.loc21 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.bound.481050.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.loc21: <specific function> = specific_function %Op.ref.loc21, @T.binding.as_type.as.LeftShiftWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.3f9028.2]
+// CHECK:STDOUT:   %bound_method.loc21_20.3: <bound method> = bound_method %int_1.loc21, %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.loc21 [concrete = constants.%bound_method.9fc9b7.2]
+// CHECK:STDOUT:   %impl.elem0.loc21: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc21_18: <bound method> = bound_method %int_1.loc21, %impl.elem0.loc21 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21: init %Cpp.long_long = call %bound_method.loc21_18(%int_1.loc21) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc21 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc21_18.2: %Cpp.long_long = converted %int_1.loc21, %.loc21_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc21: init %Cpp.long_long = call %bound_method.loc21_20.3(%.loc21_18.2, %a.ref.loc21_23)
+// CHECK:STDOUT:   %a.ref.loc21_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc21: <specific function> = specific_function %AssertSameType.ref.loc21, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc21_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc21
+// CHECK:STDOUT:   %.loc21_20.3: %Cpp.long_long = converted %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc21, %.loc21_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc21: init %empty_tuple.type = call %AssertSameType.specific_fn.loc21(%.loc21_20.3, %a.ref.loc21_26)
+// CHECK:STDOUT:   %AssertSameType.ref.loc22: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %int_1.loc22: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %a.ref.loc22_23: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc22: %.543 = impl_witness_access constants.%RightShiftWith.impl_witness.464, element1 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.2]
+// CHECK:STDOUT:   %bound_method.loc22_20.1: <bound method> = bound_method %int_1.loc22, %impl.elem1.loc22 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.bound.d5049d.1]
+// CHECK:STDOUT:   %specific_fn.loc22: <specific function> = specific_function %impl.elem1.loc22, @T.binding.as_type.as.RightShiftWith.impl.Op.1(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.3d7026.1]
+// CHECK:STDOUT:   %bound_method.loc22_20.2: <bound method> = bound_method %int_1.loc22, %specific_fn.loc22 [concrete = constants.%bound_method.dacc1a.1]
+// CHECK:STDOUT:   %.loc22_20.1: %T.binding.as_type.as.RightShiftWith.impl.Op.type.82e117.1 = specific_constant imports.%Core.Op.db5, @T.binding.as_type.as.RightShiftWith.impl.677(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.1]
+// CHECK:STDOUT:   %Op.ref.loc22: %T.binding.as_type.as.RightShiftWith.impl.Op.type.82e117.1 = name_ref Op, %.loc22_20.1 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.88b7d8.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.bound.loc22: <bound method> = bound_method %int_1.loc22, %Op.ref.loc22 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.bound.d5049d.2]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.loc22: <specific function> = specific_function %Op.ref.loc22, @T.binding.as_type.as.RightShiftWith.impl.Op.2(constants.%ImplicitAs.facet.d52) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.3d7026.2]
+// CHECK:STDOUT:   %bound_method.loc22_20.3: <bound method> = bound_method %int_1.loc22, %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.loc22 [concrete = constants.%bound_method.dacc1a.2]
+// CHECK:STDOUT:   %impl.elem0.loc22: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc22_18: <bound method> = bound_method %int_1.loc22, %impl.elem0.loc22 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22: init %Cpp.long_long = call %bound_method.loc22_18(%int_1.loc22) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_18.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc22 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc22_18.2: %Cpp.long_long = converted %int_1.loc22, %.loc22_18.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc22: init %Cpp.long_long = call %bound_method.loc22_20.3(%.loc22_18.2, %a.ref.loc22_23)
+// CHECK:STDOUT:   %a.ref.loc22_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc22: <specific function> = specific_function %AssertSameType.ref.loc22, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc22_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc22
+// CHECK:STDOUT:   %.loc22_20.3: %Cpp.long_long = converted %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc22, %.loc22_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc22: init %empty_tuple.type = call %AssertSameType.specific_fn.loc22(%.loc22_20.3, %a.ref.loc22_26)
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %b.patt: %pattern_type.95b = value_binding_pattern b [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc24: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc24_10: type = splice_block %i64.loc24 [concrete = constants.%i64] {
+// CHECK:STDOUT:     %int_64.loc24: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:     %i64.loc24: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc24: %.567 = impl_witness_access constants.%ImplicitAs.impl_witness.556, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.57d]
+// CHECK:STDOUT:   %bound_method.loc24_16.1: <bound method> = bound_method %int_1.loc24, %impl.elem0.loc24 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102]
+// CHECK:STDOUT:   %specific_fn.loc24: <specific function> = specific_function %impl.elem0.loc24, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc24_16.2: <bound method> = bound_method %int_1.loc24, %specific_fn.loc24 [concrete = constants.%bound_method.288]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc24: init %i64 = call %bound_method.loc24_16.2(%int_1.loc24) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc24_16.1: %i64 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc24 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc24_16.2: %i64 = converted %int_1.loc24, %.loc24_16.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %b: %i64 = value_binding b, %.loc24_16.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc25: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %b.ref.loc25: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %a.ref.loc25_22: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc25: %.14d = impl_witness_access constants.%BitAndWith.impl_witness.668, element1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.77d50f.2]
+// CHECK:STDOUT:   %bound_method.loc25_20.1: <bound method> = bound_method %b.ref.loc25, %impl.elem1.loc25
+// CHECK:STDOUT:   %specific_fn.loc25: <specific function> = specific_function %impl.elem1.loc25, @T.binding.as_type.as.BitAndWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.16125d.1]
+// CHECK:STDOUT:   %bound_method.loc25_20.2: <bound method> = bound_method %b.ref.loc25, %specific_fn.loc25
+// CHECK:STDOUT:   %.loc25_20.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.d0d4e3.1 = specific_constant imports.%Core.Op.f87, @T.binding.as_type.as.BitAndWith.impl.972(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.77d50f.1]
+// CHECK:STDOUT:   %Op.ref.loc25: %T.binding.as_type.as.BitAndWith.impl.Op.type.d0d4e3.1 = name_ref Op, %.loc25_20.1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.77d50f.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound.loc25: <bound method> = bound_method %b.ref.loc25, %Op.ref.loc25
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.loc25: <specific function> = specific_function %Op.ref.loc25, @T.binding.as_type.as.BitAndWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.16125d.2]
+// CHECK:STDOUT:   %bound_method.loc25_20.3: <bound method> = bound_method %b.ref.loc25, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.loc25
+// CHECK:STDOUT:   %impl.elem0.loc25: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc25_18: <bound method> = bound_method %b.ref.loc25, %impl.elem0.loc25
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc25: init %Cpp.long_long = call %bound_method.loc25_18(%b.ref.loc25)
+// CHECK:STDOUT:   %.loc25_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc25
+// CHECK:STDOUT:   %.loc25_18.2: %Cpp.long_long = converted %b.ref.loc25, %.loc25_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.call.loc25: init %Cpp.long_long = call %bound_method.loc25_20.3(%.loc25_18.2, %a.ref.loc25_22)
+// CHECK:STDOUT:   %a.ref.loc25_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc25: <specific function> = specific_function %AssertSameType.ref.loc25, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc25_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitAndWith.impl.Op.call.loc25
+// CHECK:STDOUT:   %.loc25_20.3: %Cpp.long_long = converted %T.binding.as_type.as.BitAndWith.impl.Op.call.loc25, %.loc25_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc25: init %empty_tuple.type = call %AssertSameType.specific_fn.loc25(%.loc25_20.3, %a.ref.loc25_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc26: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %b.ref.loc26: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %a.ref.loc26_22: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc26: %.a4a = impl_witness_access constants.%BitOrWith.impl_witness.771, element1 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.9b8362.2]
+// CHECK:STDOUT:   %bound_method.loc26_20.1: <bound method> = bound_method %b.ref.loc26, %impl.elem1.loc26
+// CHECK:STDOUT:   %specific_fn.loc26: <specific function> = specific_function %impl.elem1.loc26, @T.binding.as_type.as.BitOrWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.bd6228.1]
+// CHECK:STDOUT:   %bound_method.loc26_20.2: <bound method> = bound_method %b.ref.loc26, %specific_fn.loc26
+// CHECK:STDOUT:   %.loc26_20.1: %T.binding.as_type.as.BitOrWith.impl.Op.type.2c510c.1 = specific_constant imports.%Core.Op.eb3, @T.binding.as_type.as.BitOrWith.impl.a9d(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.9b8362.1]
+// CHECK:STDOUT:   %Op.ref.loc26: %T.binding.as_type.as.BitOrWith.impl.Op.type.2c510c.1 = name_ref Op, %.loc26_20.1 [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.9b8362.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.bound.loc26: <bound method> = bound_method %b.ref.loc26, %Op.ref.loc26
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.loc26: <specific function> = specific_function %Op.ref.loc26, @T.binding.as_type.as.BitOrWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.bd6228.2]
+// CHECK:STDOUT:   %bound_method.loc26_20.3: <bound method> = bound_method %b.ref.loc26, %T.binding.as_type.as.BitOrWith.impl.Op.specific_fn.loc26
+// CHECK:STDOUT:   %impl.elem0.loc26: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc26_18: <bound method> = bound_method %b.ref.loc26, %impl.elem0.loc26
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc26: init %Cpp.long_long = call %bound_method.loc26_18(%b.ref.loc26)
+// CHECK:STDOUT:   %.loc26_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc26
+// CHECK:STDOUT:   %.loc26_18.2: %Cpp.long_long = converted %b.ref.loc26, %.loc26_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.BitOrWith.impl.Op.call.loc26: init %Cpp.long_long = call %bound_method.loc26_20.3(%.loc26_18.2, %a.ref.loc26_22)
+// CHECK:STDOUT:   %a.ref.loc26_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc26: <specific function> = specific_function %AssertSameType.ref.loc26, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc26_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitOrWith.impl.Op.call.loc26
+// CHECK:STDOUT:   %.loc26_20.3: %Cpp.long_long = converted %T.binding.as_type.as.BitOrWith.impl.Op.call.loc26, %.loc26_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc26: init %empty_tuple.type = call %AssertSameType.specific_fn.loc26(%.loc26_20.3, %a.ref.loc26_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc27: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %b.ref.loc27: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %a.ref.loc27_22: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc27: %.f37 = impl_witness_access constants.%BitXorWith.impl_witness.28f, element1 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.f03227.2]
+// CHECK:STDOUT:   %bound_method.loc27_20.1: <bound method> = bound_method %b.ref.loc27, %impl.elem1.loc27
+// CHECK:STDOUT:   %specific_fn.loc27: <specific function> = specific_function %impl.elem1.loc27, @T.binding.as_type.as.BitXorWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.bae3fa.1]
+// CHECK:STDOUT:   %bound_method.loc27_20.2: <bound method> = bound_method %b.ref.loc27, %specific_fn.loc27
+// CHECK:STDOUT:   %.loc27_20.1: %T.binding.as_type.as.BitXorWith.impl.Op.type.02ef16.1 = specific_constant imports.%Core.Op.06a, @T.binding.as_type.as.BitXorWith.impl.0e9(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.f03227.1]
+// CHECK:STDOUT:   %Op.ref.loc27: %T.binding.as_type.as.BitXorWith.impl.Op.type.02ef16.1 = name_ref Op, %.loc27_20.1 [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.f03227.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.bound.loc27: <bound method> = bound_method %b.ref.loc27, %Op.ref.loc27
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.loc27: <specific function> = specific_function %Op.ref.loc27, @T.binding.as_type.as.BitXorWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.bae3fa.2]
+// CHECK:STDOUT:   %bound_method.loc27_20.3: <bound method> = bound_method %b.ref.loc27, %T.binding.as_type.as.BitXorWith.impl.Op.specific_fn.loc27
+// CHECK:STDOUT:   %impl.elem0.loc27: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc27_18: <bound method> = bound_method %b.ref.loc27, %impl.elem0.loc27
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc27: init %Cpp.long_long = call %bound_method.loc27_18(%b.ref.loc27)
+// CHECK:STDOUT:   %.loc27_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc27
+// CHECK:STDOUT:   %.loc27_18.2: %Cpp.long_long = converted %b.ref.loc27, %.loc27_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.BitXorWith.impl.Op.call.loc27: init %Cpp.long_long = call %bound_method.loc27_20.3(%.loc27_18.2, %a.ref.loc27_22)
+// CHECK:STDOUT:   %a.ref.loc27_25: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc27: <specific function> = specific_function %AssertSameType.ref.loc27, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc27_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.BitXorWith.impl.Op.call.loc27
+// CHECK:STDOUT:   %.loc27_20.3: %Cpp.long_long = converted %T.binding.as_type.as.BitXorWith.impl.Op.call.loc27, %.loc27_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc27: init %empty_tuple.type = call %AssertSameType.specific_fn.loc27(%.loc27_20.3, %a.ref.loc27_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc28: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %b.ref.loc28: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %a.ref.loc28_23: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc28: %.3c0 = impl_witness_access constants.%LeftShiftWith.impl_witness.95c, element1 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.2]
+// CHECK:STDOUT:   %bound_method.loc28_20.1: <bound method> = bound_method %b.ref.loc28, %impl.elem1.loc28
+// CHECK:STDOUT:   %specific_fn.loc28: <specific function> = specific_function %impl.elem1.loc28, @T.binding.as_type.as.LeftShiftWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.c7ed9a.1]
+// CHECK:STDOUT:   %bound_method.loc28_20.2: <bound method> = bound_method %b.ref.loc28, %specific_fn.loc28
+// CHECK:STDOUT:   %.loc28_20.1: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.c82b93.1 = specific_constant imports.%Core.Op.0db, @T.binding.as_type.as.LeftShiftWith.impl.b8c(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.1]
+// CHECK:STDOUT:   %Op.ref.loc28: %T.binding.as_type.as.LeftShiftWith.impl.Op.type.c82b93.1 = name_ref Op, %.loc28_20.1 [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.300e5a.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.bound.loc28: <bound method> = bound_method %b.ref.loc28, %Op.ref.loc28
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.loc28: <specific function> = specific_function %Op.ref.loc28, @T.binding.as_type.as.LeftShiftWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.c7ed9a.2]
+// CHECK:STDOUT:   %bound_method.loc28_20.3: <bound method> = bound_method %b.ref.loc28, %T.binding.as_type.as.LeftShiftWith.impl.Op.specific_fn.loc28
+// CHECK:STDOUT:   %impl.elem0.loc28: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc28_18: <bound method> = bound_method %b.ref.loc28, %impl.elem0.loc28
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc28: init %Cpp.long_long = call %bound_method.loc28_18(%b.ref.loc28)
+// CHECK:STDOUT:   %.loc28_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc28
+// CHECK:STDOUT:   %.loc28_18.2: %Cpp.long_long = converted %b.ref.loc28, %.loc28_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc28: init %Cpp.long_long = call %bound_method.loc28_20.3(%.loc28_18.2, %a.ref.loc28_23)
+// CHECK:STDOUT:   %a.ref.loc28_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc28: <specific function> = specific_function %AssertSameType.ref.loc28, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc28_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc28
+// CHECK:STDOUT:   %.loc28_20.3: %Cpp.long_long = converted %T.binding.as_type.as.LeftShiftWith.impl.Op.call.loc28, %.loc28_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc28: init %empty_tuple.type = call %AssertSameType.specific_fn.loc28(%.loc28_20.3, %a.ref.loc28_26)
+// CHECK:STDOUT:   %AssertSameType.ref.loc29: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %b.ref.loc29: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %a.ref.loc29_23: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc29: %.c72 = impl_witness_access constants.%RightShiftWith.impl_witness.015, element1 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.513286.2]
+// CHECK:STDOUT:   %bound_method.loc29_20.1: <bound method> = bound_method %b.ref.loc29, %impl.elem1.loc29
+// CHECK:STDOUT:   %specific_fn.loc29: <specific function> = specific_function %impl.elem1.loc29, @T.binding.as_type.as.RightShiftWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.7142b6.1]
+// CHECK:STDOUT:   %bound_method.loc29_20.2: <bound method> = bound_method %b.ref.loc29, %specific_fn.loc29
+// CHECK:STDOUT:   %.loc29_20.1: %T.binding.as_type.as.RightShiftWith.impl.Op.type.ff07c1.1 = specific_constant imports.%Core.Op.db5, @T.binding.as_type.as.RightShiftWith.impl.677(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.513286.1]
+// CHECK:STDOUT:   %Op.ref.loc29: %T.binding.as_type.as.RightShiftWith.impl.Op.type.ff07c1.1 = name_ref Op, %.loc29_20.1 [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.513286.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.bound.loc29: <bound method> = bound_method %b.ref.loc29, %Op.ref.loc29
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.loc29: <specific function> = specific_function %Op.ref.loc29, @T.binding.as_type.as.RightShiftWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.7142b6.2]
+// CHECK:STDOUT:   %bound_method.loc29_20.3: <bound method> = bound_method %b.ref.loc29, %T.binding.as_type.as.RightShiftWith.impl.Op.specific_fn.loc29
+// CHECK:STDOUT:   %impl.elem0.loc29: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc29_18: <bound method> = bound_method %b.ref.loc29, %impl.elem0.loc29
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc29: init %Cpp.long_long = call %bound_method.loc29_18(%b.ref.loc29)
+// CHECK:STDOUT:   %.loc29_18.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc29
+// CHECK:STDOUT:   %.loc29_18.2: %Cpp.long_long = converted %b.ref.loc29, %.loc29_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc29: init %Cpp.long_long = call %bound_method.loc29_20.3(%.loc29_18.2, %a.ref.loc29_23)
+// CHECK:STDOUT:   %a.ref.loc29_26: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc29: <specific function> = specific_function %AssertSameType.ref.loc29, @AssertSameType(constants.%Cpp.long_long) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc29_20.2: %Cpp.long_long = value_of_initializer %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc29
+// CHECK:STDOUT:   %.loc29_20.3: %Cpp.long_long = converted %T.binding.as_type.as.RightShiftWith.impl.Op.call.loc29, %.loc29_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc29: init %empty_tuple.type = call %AssertSameType.specific_fn.loc29(%.loc29_20.3, %a.ref.loc29_26)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- bitwise_heterogeneous_long_long_and_i128.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %AssertSameType.type: type = fn_type @AssertSameType [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %AssertSameType: %AssertSameType.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %N: Core.IntLiteral = symbolic_binding N, 0 [symbolic]
+// CHECK:STDOUT:   %Int.fc6021.1: type = class_type @Int, @Int(%N) [symbolic]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %int_128: Core.IntLiteral = int_value 128 [concrete]
+// CHECK:STDOUT:   %i128: type = class_type @Int, @Int(%int_128) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.e19: type = facet_type <@ImplicitAs, @ImplicitAs(%i128)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.812: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i128) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %pattern_type.57d: type = pattern_type %i128 [concrete]
+// CHECK:STDOUT:   %To: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.47a: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.74f, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_128) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.74a: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_128) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.75a: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.74a = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.daa: %ImplicitAs.type.e19 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.47a) [concrete]
+// CHECK:STDOUT:   %.700: type = fn_type_with_self_type %ImplicitAs.Convert.type.812, %ImplicitAs.facet.daa [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.e09: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.75a [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.ImplicitAs.impl.Convert.75a, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(%int_128) [concrete]
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_1.611: %i128 = int_value 1 [concrete]
+// CHECK:STDOUT:   %BitAndWith.type.a54: type = facet_type <@BitAndWith, @BitAndWith(%i128)> [concrete]
+// CHECK:STDOUT:   %BitAndWith.Op.type.77e: type = fn_type @BitAndWith.Op, @BitAndWith(%i128) [concrete]
+// CHECK:STDOUT:   %BitAndWith.type.97f: type = facet_type <@BitAndWith, @BitAndWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitAndWith.Op.type.c6c: type = fn_type @BitAndWith.Op, @BitAndWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.39a54f.2: type = facet_type <@ImplicitAs, @ImplicitAs(%Int.fc6021.1)> [symbolic]
+// CHECK:STDOUT:   %U.354: %ImplicitAs.type.39a54f.2 = symbolic_binding U, 1 [symbolic]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.type.1b6537.1: type = fn_type @Int.as.BitAndWith.impl.Op.2, @Int.as.BitAndWith.impl.4ac(%N, %U.354) [symbolic]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.b9569a.1: %Int.as.BitAndWith.impl.Op.type.1b6537.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.type.1b6537.2: type = fn_type @Int.as.BitAndWith.impl.Op.3, @Int.as.BitAndWith.impl.4ac(%N, %U.354) [symbolic]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.b9569a.2: %Int.as.BitAndWith.impl.Op.type.1b6537.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.354: %ImplicitAs.type.39a54f.2 = symbolic_binding T, 1 [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.3, @T.binding.as_type.as.BitAndWith.impl.96d(%N, %T.354) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.892c6d.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.4, @T.binding.as_type.as.BitAndWith.impl.96d(%N, %T.354) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.892c6d.2: %T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.0f2: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.eb2 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.211: %ImplicitAs.type.e19 = facet_value %Cpp.long_long, (%ImplicitAs.impl_witness.0f2) [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.da1: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.5e7, @T.binding.as_type.as.BitAndWith.impl.96d(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.4c32e1.1: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.4, @T.binding.as_type.as.BitAndWith.impl.96d(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.85dfed.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.4c32e1.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.type.4c32e1.2: type = fn_type @T.binding.as_type.as.BitAndWith.impl.Op.3, @T.binding.as_type.as.BitAndWith.impl.96d(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.85dfed.2: %T.binding.as_type.as.BitAndWith.impl.Op.type.4c32e1.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitAndWith.facet.1ed: %BitAndWith.type.a54 = facet_value %Cpp.long_long, (%BitAndWith.impl_witness.da1) [concrete]
+// CHECK:STDOUT:   %.53c: type = fn_type_with_self_type %BitAndWith.Op.type.77e, %BitAndWith.facet.1ed [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.98f0dd.1: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.85dfed.2, @T.binding.as_type.as.BitAndWith.impl.Op.3(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.98f0dd.2: <specific function> = specific_function %T.binding.as_type.as.BitAndWith.impl.Op.85dfed.1, @T.binding.as_type.as.BitAndWith.impl.Op.4(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %.6e1: type = fn_type_with_self_type %ImplicitAs.Convert.type.812, %ImplicitAs.facet.211 [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.type: type = fn_type @Cpp.long_long.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert: %Cpp.long_long.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %AssertSameType.specific_fn: <specific function> = specific_function %AssertSameType, @AssertSameType(%i128) [concrete]
+// CHECK:STDOUT:   %BitAndWith.impl_witness.df1: <witness> = impl_witness imports.%BitAndWith.impl_witness_table.ebf, @Int.as.BitAndWith.impl.4ac(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.type.f78821.1: type = fn_type @Int.as.BitAndWith.impl.Op.3, @Int.as.BitAndWith.impl.4ac(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.498f57.1: %Int.as.BitAndWith.impl.Op.type.f78821.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.type.f78821.2: type = fn_type @Int.as.BitAndWith.impl.Op.2, @Int.as.BitAndWith.impl.4ac(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.498f57.2: %Int.as.BitAndWith.impl.Op.type.f78821.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitAndWith.facet.63c: %BitAndWith.type.97f = facet_value %i128, (%BitAndWith.impl_witness.df1) [concrete]
+// CHECK:STDOUT:   %.2ad: type = fn_type_with_self_type %BitAndWith.Op.type.c6c, %BitAndWith.facet.63c [concrete]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.specific_fn.a5933f.1: <specific function> = specific_function %Int.as.BitAndWith.impl.Op.498f57.2, @Int.as.BitAndWith.impl.Op.2(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.specific_fn.a5933f.2: <specific function> = specific_function %Int.as.BitAndWith.impl.Op.498f57.1, @Int.as.BitAndWith.impl.Op.3(%int_128, %ImplicitAs.facet.211) [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
+// CHECK:STDOUT:   %Core.import_ref.475cb3.2 = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.611: @Int.as.BitAndWith.impl.4ac.%Int.as.BitAndWith.impl.Op.type.2 (%Int.as.BitAndWith.impl.Op.type.1b6537.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.BitAndWith.impl.4ac.%Int.as.BitAndWith.impl.Op.2 (constants.%Int.as.BitAndWith.impl.Op.b9569a.1)]
+// CHECK:STDOUT:   %BitAndWith.impl_witness_table.ebf = impl_witness_table (%Core.import_ref.475cb3.2, %Core.import_ref.611), @Int.as.BitAndWith.impl.4ac [concrete]
+// CHECK:STDOUT:   %Core.Op.36f: @Int.as.BitAndWith.impl.4ac.%Int.as.BitAndWith.impl.Op.type.1 (%Int.as.BitAndWith.impl.Op.type.1b6537.2) = import_ref Core//prelude/types/int, Op, loaded [symbolic = @Int.as.BitAndWith.impl.4ac.%Int.as.BitAndWith.impl.Op.1 (constants.%Int.as.BitAndWith.impl.Op.b9569a.2)]
+// CHECK:STDOUT:   %Core.import_ref.475cb3.3 = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %Core.import_ref.29d: @T.binding.as_type.as.BitAndWith.impl.96d.%T.binding.as_type.as.BitAndWith.impl.Op.type.2 (%T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.1) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @T.binding.as_type.as.BitAndWith.impl.96d.%T.binding.as_type.as.BitAndWith.impl.Op.2 (constants.%T.binding.as_type.as.BitAndWith.impl.Op.892c6d.1)]
+// CHECK:STDOUT:   %BitAndWith.impl_witness_table.5e7 = impl_witness_table (%Core.import_ref.475cb3.3, %Core.import_ref.29d), @T.binding.as_type.as.BitAndWith.impl.96d [concrete]
+// CHECK:STDOUT:   %Core.Op.944: @T.binding.as_type.as.BitAndWith.impl.96d.%T.binding.as_type.as.BitAndWith.impl.Op.type.1 (%T.binding.as_type.as.BitAndWith.impl.Op.type.e95062.2) = import_ref Core//prelude/types/int, Op, loaded [symbolic = @T.binding.as_type.as.BitAndWith.impl.96d.%T.binding.as_type.as.BitAndWith.impl.Op.1 (constants.%T.binding.as_type.as.BitAndWith.impl.Op.892c6d.2)]
+// CHECK:STDOUT:   %Core.import_ref.eca: %Cpp.long_long.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.eb2 = impl_witness_table (%Core.import_ref.eca), @Cpp.long_long.as.ImplicitAs.impl.0cb [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @BitWiseHeterogeneousLongLongAndI128() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = value_binding_pattern a [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc10_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc10: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10: init %Cpp.long_long = call %bound_method.loc10(%int_1.loc10) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc10 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_26.2: %Cpp.long_long = converted %int_1.loc10, %.loc10_26.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %a: %Cpp.long_long = value_binding a, %.loc10_26.2
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %b.patt: %pattern_type.57d = value_binding_pattern b [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc11: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc11_10: type = splice_block %i128 [concrete = constants.%i128] {
+// CHECK:STDOUT:     %int_128: Core.IntLiteral = int_value 128 [concrete = constants.%int_128]
+// CHECK:STDOUT:     %i128: type = class_type @Int, @Int(constants.%int_128) [concrete = constants.%i128]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc11: %.700 = impl_witness_access constants.%ImplicitAs.impl_witness.47a, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.75a]
+// CHECK:STDOUT:   %bound_method.loc11_17.1: <bound method> = bound_method %int_1.loc11, %impl.elem0.loc11 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.e09]
+// CHECK:STDOUT:   %specific_fn.loc11: <specific function> = specific_function %impl.elem0.loc11, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(constants.%int_128) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc11_17.2: <bound method> = bound_method %int_1.loc11, %specific_fn.loc11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc11: init %i128 = call %bound_method.loc11_17.2(%int_1.loc11) [concrete = constants.%int_1.611]
+// CHECK:STDOUT:   %.loc11_17.1: %i128 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc11 [concrete = constants.%int_1.611]
+// CHECK:STDOUT:   %.loc11_17.2: %i128 = converted %int_1.loc11, %.loc11_17.1 [concrete = constants.%int_1.611]
+// CHECK:STDOUT:   %b: %i128 = value_binding b, %.loc11_17.2
+// CHECK:STDOUT:   %AssertSameType.ref.loc13: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %a.ref.loc13: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc13_22: %i128 = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem1.loc13: %.53c = impl_witness_access constants.%BitAndWith.impl_witness.da1, element1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.85dfed.2]
+// CHECK:STDOUT:   %bound_method.loc13_20.1: <bound method> = bound_method %a.ref.loc13, %impl.elem1.loc13
+// CHECK:STDOUT:   %specific_fn.loc13: <specific function> = specific_function %impl.elem1.loc13, @T.binding.as_type.as.BitAndWith.impl.Op.3(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.98f0dd.1]
+// CHECK:STDOUT:   %bound_method.loc13_20.2: <bound method> = bound_method %a.ref.loc13, %specific_fn.loc13
+// CHECK:STDOUT:   %.loc13_20.1: %T.binding.as_type.as.BitAndWith.impl.Op.type.4c32e1.1 = specific_constant imports.%Core.Op.944, @T.binding.as_type.as.BitAndWith.impl.96d(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.85dfed.1]
+// CHECK:STDOUT:   %Op.ref.loc13: %T.binding.as_type.as.BitAndWith.impl.Op.type.4c32e1.1 = name_ref Op, %.loc13_20.1 [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.85dfed.1]
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc13, %Op.ref.loc13
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc13, @T.binding.as_type.as.BitAndWith.impl.Op.4(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%T.binding.as_type.as.BitAndWith.impl.Op.specific_fn.98f0dd.2]
+// CHECK:STDOUT:   %bound_method.loc13_20.3: <bound method> = bound_method %a.ref.loc13, %T.binding.as_type.as.BitAndWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc13: %.6e1 = impl_witness_access constants.%ImplicitAs.impl_witness.0f2, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_18: <bound method> = bound_method %a.ref.loc13, %impl.elem0.loc13
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc13: init %i128 = call %bound_method.loc13_18(%a.ref.loc13)
+// CHECK:STDOUT:   %.loc13_18.1: %i128 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc13
+// CHECK:STDOUT:   %.loc13_18.2: %i128 = converted %a.ref.loc13, %.loc13_18.1
+// CHECK:STDOUT:   %T.binding.as_type.as.BitAndWith.impl.Op.call: init %i128 = call %bound_method.loc13_20.3(%.loc13_18.2, %b.ref.loc13_22)
+// CHECK:STDOUT:   %b.ref.loc13_25: %i128 = name_ref b, %b
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc13: <specific function> = specific_function %AssertSameType.ref.loc13, @AssertSameType(constants.%i128) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc13_20.2: %i128 = value_of_initializer %T.binding.as_type.as.BitAndWith.impl.Op.call
+// CHECK:STDOUT:   %.loc13_20.3: %i128 = converted %T.binding.as_type.as.BitAndWith.impl.Op.call, %.loc13_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc13: init %empty_tuple.type = call %AssertSameType.specific_fn.loc13(%.loc13_20.3, %b.ref.loc13_25)
+// CHECK:STDOUT:   %AssertSameType.ref.loc14: %AssertSameType.type = name_ref AssertSameType, file.%AssertSameType.decl [concrete = constants.%AssertSameType]
+// CHECK:STDOUT:   %b.ref.loc14_18: %i128 = name_ref b, %b
+// CHECK:STDOUT:   %a.ref.loc14: %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem1.loc14: %.2ad = impl_witness_access constants.%BitAndWith.impl_witness.df1, element1 [concrete = constants.%Int.as.BitAndWith.impl.Op.498f57.2]
+// CHECK:STDOUT:   %bound_method.loc14_20.1: <bound method> = bound_method %b.ref.loc14_18, %impl.elem1.loc14
+// CHECK:STDOUT:   %specific_fn.loc14: <specific function> = specific_function %impl.elem1.loc14, @Int.as.BitAndWith.impl.Op.2(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%Int.as.BitAndWith.impl.Op.specific_fn.a5933f.1]
+// CHECK:STDOUT:   %bound_method.loc14_20.2: <bound method> = bound_method %b.ref.loc14_18, %specific_fn.loc14
+// CHECK:STDOUT:   %.loc14_20.1: %Int.as.BitAndWith.impl.Op.type.f78821.1 = specific_constant imports.%Core.Op.36f, @Int.as.BitAndWith.impl.4ac(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%Int.as.BitAndWith.impl.Op.498f57.1]
+// CHECK:STDOUT:   %Op.ref.loc14: %Int.as.BitAndWith.impl.Op.type.f78821.1 = name_ref Op, %.loc14_20.1 [concrete = constants.%Int.as.BitAndWith.impl.Op.498f57.1]
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.bound: <bound method> = bound_method %b.ref.loc14_18, %Op.ref.loc14
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc14, @Int.as.BitAndWith.impl.Op.3(constants.%int_128, constants.%ImplicitAs.facet.211) [concrete = constants.%Int.as.BitAndWith.impl.Op.specific_fn.a5933f.2]
+// CHECK:STDOUT:   %bound_method.loc14_20.3: <bound method> = bound_method %b.ref.loc14_18, %Int.as.BitAndWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc14: %.6e1 = impl_witness_access constants.%ImplicitAs.impl_witness.0f2, element0 [concrete = constants.%Cpp.long_long.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc14_22: <bound method> = bound_method %a.ref.loc14, %impl.elem0.loc14
+// CHECK:STDOUT:   %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc14: init %i128 = call %bound_method.loc14_22(%a.ref.loc14)
+// CHECK:STDOUT:   %.loc14_22.1: %i128 = value_of_initializer %Cpp.long_long.as.ImplicitAs.impl.Convert.call.loc14
+// CHECK:STDOUT:   %.loc14_22.2: %i128 = converted %a.ref.loc14, %.loc14_22.1
+// CHECK:STDOUT:   %Int.as.BitAndWith.impl.Op.call: init %i128 = call %bound_method.loc14_20.3(%b.ref.loc14_18, %.loc14_22.2)
+// CHECK:STDOUT:   %b.ref.loc14_25: %i128 = name_ref b, %b
+// CHECK:STDOUT:   %AssertSameType.specific_fn.loc14: <specific function> = specific_function %AssertSameType.ref.loc14, @AssertSameType(constants.%i128) [concrete = constants.%AssertSameType.specific_fn]
+// CHECK:STDOUT:   %.loc14_20.2: %i128 = value_of_initializer %Int.as.BitAndWith.impl.Op.call
+// CHECK:STDOUT:   %.loc14_20.3: %i128 = converted %Int.as.BitAndWith.impl.Op.call, %.loc14_20.2
+// CHECK:STDOUT:   %AssertSameType.call.loc14: init %empty_tuple.type = call %AssertSameType.specific_fn.loc14(%.loc14_20.3, %b.ref.loc14_25)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- compound_assignment_homogeneous_long_long.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Copy.type: type = facet_type <@Copy> [concrete]
+// CHECK:STDOUT:   %T.035: %Copy.type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.ImplicitAs.impl.Convert.type.55d: type = fn_type @T.binding.as_type.as.ImplicitAs.impl.Convert, @T.binding.as_type.as.ImplicitAs.impl(%T.035) [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.as.ImplicitAs.impl.Convert.19b: %T.binding.as_type.as.ImplicitAs.impl.Convert.type.55d = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %AddAssignWith.type.2ec: type = facet_type <@AddAssignWith, @AddAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %AddAssignWith.Op.type.001: type = fn_type @AddAssignWith.Op, @AddAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %U.ea5: %ImplicitAs.type.a03 = symbolic_binding U, 0 [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.1, @Cpp.long_long.as.AddAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.1: %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.2, @Cpp.long_long.as.AddAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.2: %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Copy.impl_witness.6d4: <witness> = impl_witness imports.%Copy.impl_witness_table.804 [concrete]
+// CHECK:STDOUT:   %Copy.facet: %Copy.type = facet_value %Cpp.long_long, (%Copy.impl_witness.6d4) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.64f: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.f1e, @T.binding.as_type.as.ImplicitAs.impl(%Copy.facet) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.c8d: %ImplicitAs.type.a03 = facet_value %Cpp.long_long, (%ImplicitAs.impl_witness.64f) [concrete]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness.383: <witness> = impl_witness imports.%AddAssignWith.impl_witness_table.815, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.26466a.1: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.2, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.d128e4.1: %Cpp.long_long.as.AddAssignWith.impl.Op.type.26466a.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.26466a.2: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.1, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.d128e4.2: %Cpp.long_long.as.AddAssignWith.impl.Op.type.26466a.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddAssignWith.facet: %AddAssignWith.type.2ec = facet_value %Cpp.long_long, (%AddAssignWith.impl_witness.383) [concrete]
+// CHECK:STDOUT:   %.5a9: type = fn_type_with_self_type %AddAssignWith.Op.type.001, %AddAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.2b826b.1: <specific function> = specific_function %Cpp.long_long.as.AddAssignWith.impl.Op.d128e4.2, @Cpp.long_long.as.AddAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.2b826b.2: <specific function> = specific_function %Cpp.long_long.as.AddAssignWith.impl.Op.d128e4.1, @Cpp.long_long.as.AddAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %SubAssignWith.type.b35: type = facet_type <@SubAssignWith, @SubAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %SubAssignWith.Op.type.7fa: type = fn_type @SubAssignWith.Op, @SubAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.1: type = fn_type @Cpp.long_long.as.SubAssignWith.impl.Op.1, @Cpp.long_long.as.SubAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.7c6ec4.1: %Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.2: type = fn_type @Cpp.long_long.as.SubAssignWith.impl.Op.2, @Cpp.long_long.as.SubAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.7c6ec4.2: %Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %SubAssignWith.impl_witness.e66: <witness> = impl_witness imports.%SubAssignWith.impl_witness_table.705, @Cpp.long_long.as.SubAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.type.daa062.1: type = fn_type @Cpp.long_long.as.SubAssignWith.impl.Op.2, @Cpp.long_long.as.SubAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.07d295.1: %Cpp.long_long.as.SubAssignWith.impl.Op.type.daa062.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.type.daa062.2: type = fn_type @Cpp.long_long.as.SubAssignWith.impl.Op.1, @Cpp.long_long.as.SubAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.07d295.2: %Cpp.long_long.as.SubAssignWith.impl.Op.type.daa062.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %SubAssignWith.facet: %SubAssignWith.type.b35 = facet_value %Cpp.long_long, (%SubAssignWith.impl_witness.e66) [concrete]
+// CHECK:STDOUT:   %.9f7: type = fn_type_with_self_type %SubAssignWith.Op.type.7fa, %SubAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn.21e13f.1: <specific function> = specific_function %Cpp.long_long.as.SubAssignWith.impl.Op.07d295.2, @Cpp.long_long.as.SubAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn.21e13f.2: <specific function> = specific_function %Cpp.long_long.as.SubAssignWith.impl.Op.07d295.1, @Cpp.long_long.as.SubAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %MulAssignWith.type.112: type = facet_type <@MulAssignWith, @MulAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %MulAssignWith.Op.type.c9f: type = fn_type @MulAssignWith.Op, @MulAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.1: type = fn_type @Cpp.long_long.as.MulAssignWith.impl.Op.1, @Cpp.long_long.as.MulAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.b4560e.1: %Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.2: type = fn_type @Cpp.long_long.as.MulAssignWith.impl.Op.2, @Cpp.long_long.as.MulAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.b4560e.2: %Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %MulAssignWith.impl_witness.04a: <witness> = impl_witness imports.%MulAssignWith.impl_witness_table.32a, @Cpp.long_long.as.MulAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.type.f5880d.1: type = fn_type @Cpp.long_long.as.MulAssignWith.impl.Op.2, @Cpp.long_long.as.MulAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.0edfbc.1: %Cpp.long_long.as.MulAssignWith.impl.Op.type.f5880d.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.type.f5880d.2: type = fn_type @Cpp.long_long.as.MulAssignWith.impl.Op.1, @Cpp.long_long.as.MulAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.0edfbc.2: %Cpp.long_long.as.MulAssignWith.impl.Op.type.f5880d.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %MulAssignWith.facet: %MulAssignWith.type.112 = facet_value %Cpp.long_long, (%MulAssignWith.impl_witness.04a) [concrete]
+// CHECK:STDOUT:   %.486: type = fn_type_with_self_type %MulAssignWith.Op.type.c9f, %MulAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn.5af50b.1: <specific function> = specific_function %Cpp.long_long.as.MulAssignWith.impl.Op.0edfbc.2, @Cpp.long_long.as.MulAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn.5af50b.2: <specific function> = specific_function %Cpp.long_long.as.MulAssignWith.impl.Op.0edfbc.1, @Cpp.long_long.as.MulAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %DivAssignWith.type.45d: type = facet_type <@DivAssignWith, @DivAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %DivAssignWith.Op.type.b0c: type = fn_type @DivAssignWith.Op, @DivAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.1: type = fn_type @Cpp.long_long.as.DivAssignWith.impl.Op.1, @Cpp.long_long.as.DivAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.12b589.1: %Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.2: type = fn_type @Cpp.long_long.as.DivAssignWith.impl.Op.2, @Cpp.long_long.as.DivAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.12b589.2: %Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %DivAssignWith.impl_witness.5ff: <witness> = impl_witness imports.%DivAssignWith.impl_witness_table.9c9, @Cpp.long_long.as.DivAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.type.fa44cf.1: type = fn_type @Cpp.long_long.as.DivAssignWith.impl.Op.2, @Cpp.long_long.as.DivAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.409fa6.1: %Cpp.long_long.as.DivAssignWith.impl.Op.type.fa44cf.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.type.fa44cf.2: type = fn_type @Cpp.long_long.as.DivAssignWith.impl.Op.1, @Cpp.long_long.as.DivAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.409fa6.2: %Cpp.long_long.as.DivAssignWith.impl.Op.type.fa44cf.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %DivAssignWith.facet: %DivAssignWith.type.45d = facet_value %Cpp.long_long, (%DivAssignWith.impl_witness.5ff) [concrete]
+// CHECK:STDOUT:   %.ff7: type = fn_type_with_self_type %DivAssignWith.Op.type.b0c, %DivAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn.07c8ad.1: <specific function> = specific_function %Cpp.long_long.as.DivAssignWith.impl.Op.409fa6.2, @Cpp.long_long.as.DivAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn.07c8ad.2: <specific function> = specific_function %Cpp.long_long.as.DivAssignWith.impl.Op.409fa6.1, @Cpp.long_long.as.DivAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %ModAssignWith.type.a2e: type = facet_type <@ModAssignWith, @ModAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ModAssignWith.Op.type.ca5: type = fn_type @ModAssignWith.Op, @ModAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.1: type = fn_type @Cpp.long_long.as.ModAssignWith.impl.Op.1, @Cpp.long_long.as.ModAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.31c4bc.1: %Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.2: type = fn_type @Cpp.long_long.as.ModAssignWith.impl.Op.2, @Cpp.long_long.as.ModAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.31c4bc.2: %Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ModAssignWith.impl_witness.afa: <witness> = impl_witness imports.%ModAssignWith.impl_witness_table.fb0, @Cpp.long_long.as.ModAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.type.80b19c.1: type = fn_type @Cpp.long_long.as.ModAssignWith.impl.Op.2, @Cpp.long_long.as.ModAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.0b732b.1: %Cpp.long_long.as.ModAssignWith.impl.Op.type.80b19c.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.type.80b19c.2: type = fn_type @Cpp.long_long.as.ModAssignWith.impl.Op.1, @Cpp.long_long.as.ModAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.0b732b.2: %Cpp.long_long.as.ModAssignWith.impl.Op.type.80b19c.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %ModAssignWith.facet: %ModAssignWith.type.a2e = facet_value %Cpp.long_long, (%ModAssignWith.impl_witness.afa) [concrete]
+// CHECK:STDOUT:   %.977: type = fn_type_with_self_type %ModAssignWith.Op.type.ca5, %ModAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn.a3301b.1: <specific function> = specific_function %Cpp.long_long.as.ModAssignWith.impl.Op.0b732b.2, @Cpp.long_long.as.ModAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn.a3301b.2: <specific function> = specific_function %Cpp.long_long.as.ModAssignWith.impl.Op.0b732b.1, @Cpp.long_long.as.ModAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %BitAndAssignWith.type.9bc: type = facet_type <@BitAndAssignWith, @BitAndAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitAndAssignWith.Op.type.0ed: type = fn_type @BitAndAssignWith.Op, @BitAndAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.1: type = fn_type @Cpp.long_long.as.BitAndAssignWith.impl.Op.1, @Cpp.long_long.as.BitAndAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.6a0d28.1: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.2: type = fn_type @Cpp.long_long.as.BitAndAssignWith.impl.Op.2, @Cpp.long_long.as.BitAndAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.6a0d28.2: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitAndAssignWith.impl_witness.e8f: <witness> = impl_witness imports.%BitAndAssignWith.impl_witness_table.5cc, @Cpp.long_long.as.BitAndAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.a7c3f6.1: type = fn_type @Cpp.long_long.as.BitAndAssignWith.impl.Op.2, @Cpp.long_long.as.BitAndAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.10a9af.1: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.a7c3f6.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.a7c3f6.2: type = fn_type @Cpp.long_long.as.BitAndAssignWith.impl.Op.1, @Cpp.long_long.as.BitAndAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.10a9af.2: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.a7c3f6.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitAndAssignWith.facet: %BitAndAssignWith.type.9bc = facet_value %Cpp.long_long, (%BitAndAssignWith.impl_witness.e8f) [concrete]
+// CHECK:STDOUT:   %.391: type = fn_type_with_self_type %BitAndAssignWith.Op.type.0ed, %BitAndAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn.5df9d8.1: <specific function> = specific_function %Cpp.long_long.as.BitAndAssignWith.impl.Op.10a9af.2, @Cpp.long_long.as.BitAndAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn.5df9d8.2: <specific function> = specific_function %Cpp.long_long.as.BitAndAssignWith.impl.Op.10a9af.1, @Cpp.long_long.as.BitAndAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %BitOrAssignWith.type.219: type = facet_type <@BitOrAssignWith, @BitOrAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitOrAssignWith.Op.type.1e2: type = fn_type @BitOrAssignWith.Op, @BitOrAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.1: type = fn_type @Cpp.long_long.as.BitOrAssignWith.impl.Op.1, @Cpp.long_long.as.BitOrAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.1fac0c.1: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.2: type = fn_type @Cpp.long_long.as.BitOrAssignWith.impl.Op.2, @Cpp.long_long.as.BitOrAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.1fac0c.2: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitOrAssignWith.impl_witness.3af: <witness> = impl_witness imports.%BitOrAssignWith.impl_witness_table.a52, @Cpp.long_long.as.BitOrAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.367944.1: type = fn_type @Cpp.long_long.as.BitOrAssignWith.impl.Op.2, @Cpp.long_long.as.BitOrAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.60d957.1: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.367944.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.367944.2: type = fn_type @Cpp.long_long.as.BitOrAssignWith.impl.Op.1, @Cpp.long_long.as.BitOrAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.60d957.2: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.367944.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitOrAssignWith.facet: %BitOrAssignWith.type.219 = facet_value %Cpp.long_long, (%BitOrAssignWith.impl_witness.3af) [concrete]
+// CHECK:STDOUT:   %.bf4: type = fn_type_with_self_type %BitOrAssignWith.Op.type.1e2, %BitOrAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn.857890.1: <specific function> = specific_function %Cpp.long_long.as.BitOrAssignWith.impl.Op.60d957.2, @Cpp.long_long.as.BitOrAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn.857890.2: <specific function> = specific_function %Cpp.long_long.as.BitOrAssignWith.impl.Op.60d957.1, @Cpp.long_long.as.BitOrAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %BitXorAssignWith.type.f9d: type = facet_type <@BitXorAssignWith, @BitXorAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %BitXorAssignWith.Op.type.93f: type = fn_type @BitXorAssignWith.Op, @BitXorAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.1: type = fn_type @Cpp.long_long.as.BitXorAssignWith.impl.Op.1, @Cpp.long_long.as.BitXorAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.e7c6f2.1: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.2: type = fn_type @Cpp.long_long.as.BitXorAssignWith.impl.Op.2, @Cpp.long_long.as.BitXorAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.e7c6f2.2: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitXorAssignWith.impl_witness.56d: <witness> = impl_witness imports.%BitXorAssignWith.impl_witness_table.223, @Cpp.long_long.as.BitXorAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.d7a644.1: type = fn_type @Cpp.long_long.as.BitXorAssignWith.impl.Op.2, @Cpp.long_long.as.BitXorAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.c92629.1: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.d7a644.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.d7a644.2: type = fn_type @Cpp.long_long.as.BitXorAssignWith.impl.Op.1, @Cpp.long_long.as.BitXorAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.c92629.2: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.d7a644.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitXorAssignWith.facet: %BitXorAssignWith.type.f9d = facet_value %Cpp.long_long, (%BitXorAssignWith.impl_witness.56d) [concrete]
+// CHECK:STDOUT:   %.0cd: type = fn_type_with_self_type %BitXorAssignWith.Op.type.93f, %BitXorAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn.97edcc.1: <specific function> = specific_function %Cpp.long_long.as.BitXorAssignWith.impl.Op.c92629.2, @Cpp.long_long.as.BitXorAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn.97edcc.2: <specific function> = specific_function %Cpp.long_long.as.BitXorAssignWith.impl.Op.c92629.1, @Cpp.long_long.as.BitXorAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %LeftShiftAssignWith.type.f24: type = facet_type <@LeftShiftAssignWith, @LeftShiftAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %LeftShiftAssignWith.Op.type.6f9: type = fn_type @LeftShiftAssignWith.Op, @LeftShiftAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.1: type = fn_type @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1, @Cpp.long_long.as.LeftShiftAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.44b51c.1: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.2: type = fn_type @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2, @Cpp.long_long.as.LeftShiftAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.44b51c.2: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %LeftShiftAssignWith.impl_witness.824: <witness> = impl_witness imports.%LeftShiftAssignWith.impl_witness_table.cd9, @Cpp.long_long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.bbf90a.1: type = fn_type @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2, @Cpp.long_long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.ce8f7e.1: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.bbf90a.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.bbf90a.2: type = fn_type @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1, @Cpp.long_long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.ce8f7e.2: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.bbf90a.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %LeftShiftAssignWith.facet: %LeftShiftAssignWith.type.f24 = facet_value %Cpp.long_long, (%LeftShiftAssignWith.impl_witness.824) [concrete]
+// CHECK:STDOUT:   %.fef: type = fn_type_with_self_type %LeftShiftAssignWith.Op.type.6f9, %LeftShiftAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn.525b00.1: <specific function> = specific_function %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.ce8f7e.2, @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn.525b00.2: <specific function> = specific_function %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.ce8f7e.1, @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %RightShiftAssignWith.type.42e: type = facet_type <@RightShiftAssignWith, @RightShiftAssignWith(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %RightShiftAssignWith.Op.type.a64: type = fn_type @RightShiftAssignWith.Op, @RightShiftAssignWith(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.1: type = fn_type @Cpp.long_long.as.RightShiftAssignWith.impl.Op.1, @Cpp.long_long.as.RightShiftAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.2beecc.1: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.2: type = fn_type @Cpp.long_long.as.RightShiftAssignWith.impl.Op.2, @Cpp.long_long.as.RightShiftAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.2beecc.2: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %RightShiftAssignWith.impl_witness.d22: <witness> = impl_witness imports.%RightShiftAssignWith.impl_witness_table.074, @Cpp.long_long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.ff6b73.1: type = fn_type @Cpp.long_long.as.RightShiftAssignWith.impl.Op.2, @Cpp.long_long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.4e9b16.1: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.ff6b73.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.ff6b73.2: type = fn_type @Cpp.long_long.as.RightShiftAssignWith.impl.Op.1, @Cpp.long_long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.4e9b16.2: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.ff6b73.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %RightShiftAssignWith.facet: %RightShiftAssignWith.type.42e = facet_value %Cpp.long_long, (%RightShiftAssignWith.impl_witness.d22) [concrete]
+// CHECK:STDOUT:   %.4a3: type = fn_type_with_self_type %RightShiftAssignWith.Op.type.a64, %RightShiftAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn.df86ad.1: <specific function> = specific_function %Cpp.long_long.as.RightShiftAssignWith.impl.Op.4e9b16.2, @Cpp.long_long.as.RightShiftAssignWith.impl.Op.1(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn.df86ad.2: <specific function> = specific_function %Cpp.long_long.as.RightShiftAssignWith.impl.Op.4e9b16.1, @Cpp.long_long.as.RightShiftAssignWith.impl.Op.2(%ImplicitAs.facet.c8d) [concrete]
+// CHECK:STDOUT:   %DestroyOp.type: type = fn_type @DestroyOp [concrete]
+// CHECK:STDOUT:   %DestroyOp: %DestroyOp.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.Copy.impl.Op.type: type = fn_type @Cpp.long_long.as.Copy.impl.Op [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.Copy.impl.Op: %Cpp.long_long.as.Copy.impl.Op.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.1c6: @T.binding.as_type.as.ImplicitAs.impl.%T.binding.as_type.as.ImplicitAs.impl.Convert.type (%T.binding.as_type.as.ImplicitAs.impl.Convert.type.55d) = import_ref Core//prelude/types/cpp/int, inst{{[0-9A-F]+}} [indirect], loaded [symbolic = @T.binding.as_type.as.ImplicitAs.impl.%T.binding.as_type.as.ImplicitAs.impl.Convert (constants.%T.binding.as_type.as.ImplicitAs.impl.Convert.19b)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.f1e = impl_witness_table (%Core.import_ref.1c6), @T.binding.as_type.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.277: @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.type.2 (%Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.1)]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness_table.815 = impl_witness_table (%Core.import_ref.277), @Cpp.long_long.as.AddAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.57a: @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.type.1 (%Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.2)]
+// CHECK:STDOUT:   %Core.import_ref.7a9: %Cpp.long_long.as.Copy.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.Copy.impl.Op]
+// CHECK:STDOUT:   %Copy.impl_witness_table.804 = impl_witness_table (%Core.import_ref.7a9), @Cpp.long_long.as.Copy.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.819: @Cpp.long_long.as.SubAssignWith.impl.%Cpp.long_long.as.SubAssignWith.impl.Op.type.2 (%Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.SubAssignWith.impl.%Cpp.long_long.as.SubAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.SubAssignWith.impl.Op.7c6ec4.1)]
+// CHECK:STDOUT:   %SubAssignWith.impl_witness_table.705 = impl_witness_table (%Core.import_ref.819), @Cpp.long_long.as.SubAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.75b: @Cpp.long_long.as.SubAssignWith.impl.%Cpp.long_long.as.SubAssignWith.impl.Op.type.1 (%Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.SubAssignWith.impl.%Cpp.long_long.as.SubAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.SubAssignWith.impl.Op.7c6ec4.2)]
+// CHECK:STDOUT:   %Core.import_ref.f92: @Cpp.long_long.as.MulAssignWith.impl.%Cpp.long_long.as.MulAssignWith.impl.Op.type.2 (%Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.MulAssignWith.impl.%Cpp.long_long.as.MulAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.MulAssignWith.impl.Op.b4560e.1)]
+// CHECK:STDOUT:   %MulAssignWith.impl_witness_table.32a = impl_witness_table (%Core.import_ref.f92), @Cpp.long_long.as.MulAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.94e: @Cpp.long_long.as.MulAssignWith.impl.%Cpp.long_long.as.MulAssignWith.impl.Op.type.1 (%Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.MulAssignWith.impl.%Cpp.long_long.as.MulAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.MulAssignWith.impl.Op.b4560e.2)]
+// CHECK:STDOUT:   %Core.import_ref.b94: @Cpp.long_long.as.DivAssignWith.impl.%Cpp.long_long.as.DivAssignWith.impl.Op.type.2 (%Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.DivAssignWith.impl.%Cpp.long_long.as.DivAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.DivAssignWith.impl.Op.12b589.1)]
+// CHECK:STDOUT:   %DivAssignWith.impl_witness_table.9c9 = impl_witness_table (%Core.import_ref.b94), @Cpp.long_long.as.DivAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.ec7: @Cpp.long_long.as.DivAssignWith.impl.%Cpp.long_long.as.DivAssignWith.impl.Op.type.1 (%Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.DivAssignWith.impl.%Cpp.long_long.as.DivAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.DivAssignWith.impl.Op.12b589.2)]
+// CHECK:STDOUT:   %Core.import_ref.797: @Cpp.long_long.as.ModAssignWith.impl.%Cpp.long_long.as.ModAssignWith.impl.Op.type.2 (%Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.ModAssignWith.impl.%Cpp.long_long.as.ModAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.ModAssignWith.impl.Op.31c4bc.1)]
+// CHECK:STDOUT:   %ModAssignWith.impl_witness_table.fb0 = impl_witness_table (%Core.import_ref.797), @Cpp.long_long.as.ModAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.6fd: @Cpp.long_long.as.ModAssignWith.impl.%Cpp.long_long.as.ModAssignWith.impl.Op.type.1 (%Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.ModAssignWith.impl.%Cpp.long_long.as.ModAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.ModAssignWith.impl.Op.31c4bc.2)]
+// CHECK:STDOUT:   %Core.import_ref.e22: @Cpp.long_long.as.BitAndAssignWith.impl.%Cpp.long_long.as.BitAndAssignWith.impl.Op.type.2 (%Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitAndAssignWith.impl.%Cpp.long_long.as.BitAndAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.6a0d28.1)]
+// CHECK:STDOUT:   %BitAndAssignWith.impl_witness_table.5cc = impl_witness_table (%Core.import_ref.e22), @Cpp.long_long.as.BitAndAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.c78: @Cpp.long_long.as.BitAndAssignWith.impl.%Cpp.long_long.as.BitAndAssignWith.impl.Op.type.1 (%Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitAndAssignWith.impl.%Cpp.long_long.as.BitAndAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.6a0d28.2)]
+// CHECK:STDOUT:   %Core.import_ref.4604: @Cpp.long_long.as.BitOrAssignWith.impl.%Cpp.long_long.as.BitOrAssignWith.impl.Op.type.2 (%Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitOrAssignWith.impl.%Cpp.long_long.as.BitOrAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.1fac0c.1)]
+// CHECK:STDOUT:   %BitOrAssignWith.impl_witness_table.a52 = impl_witness_table (%Core.import_ref.4604), @Cpp.long_long.as.BitOrAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.fa0: @Cpp.long_long.as.BitOrAssignWith.impl.%Cpp.long_long.as.BitOrAssignWith.impl.Op.type.1 (%Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitOrAssignWith.impl.%Cpp.long_long.as.BitOrAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.1fac0c.2)]
+// CHECK:STDOUT:   %Core.import_ref.bb9: @Cpp.long_long.as.BitXorAssignWith.impl.%Cpp.long_long.as.BitXorAssignWith.impl.Op.type.2 (%Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitXorAssignWith.impl.%Cpp.long_long.as.BitXorAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.e7c6f2.1)]
+// CHECK:STDOUT:   %BitXorAssignWith.impl_witness_table.223 = impl_witness_table (%Core.import_ref.bb9), @Cpp.long_long.as.BitXorAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.3d4: @Cpp.long_long.as.BitXorAssignWith.impl.%Cpp.long_long.as.BitXorAssignWith.impl.Op.type.1 (%Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitXorAssignWith.impl.%Cpp.long_long.as.BitXorAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.e7c6f2.2)]
+// CHECK:STDOUT:   %Core.import_ref.db6: @Cpp.long_long.as.LeftShiftAssignWith.impl.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.2 (%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.LeftShiftAssignWith.impl.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.44b51c.1)]
+// CHECK:STDOUT:   %LeftShiftAssignWith.impl_witness_table.cd9 = impl_witness_table (%Core.import_ref.db6), @Cpp.long_long.as.LeftShiftAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.1b6: @Cpp.long_long.as.LeftShiftAssignWith.impl.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.1 (%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.LeftShiftAssignWith.impl.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.44b51c.2)]
+// CHECK:STDOUT:   %Core.import_ref.522: @Cpp.long_long.as.RightShiftAssignWith.impl.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.2 (%Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.RightShiftAssignWith.impl.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.2beecc.1)]
+// CHECK:STDOUT:   %RightShiftAssignWith.impl_witness_table.074 = impl_witness_table (%Core.import_ref.522), @Cpp.long_long.as.RightShiftAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.bcc: @Cpp.long_long.as.RightShiftAssignWith.impl.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.1 (%Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.RightShiftAssignWith.impl.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.2beecc.2)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @CompoundAssignmentHomogeneousLongLong() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = ref_binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.var_patt: %pattern_type.76e = var_pattern %a.patt [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a.var: ref %Cpp.long_long = var %a.var_patt
+// CHECK:STDOUT:   %int_1.loc8: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem0.loc8: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %int_1.loc8, %impl.elem0.loc8 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc8: init %Cpp.long_long = call %bound_method.loc8(%int_1.loc8) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc8_3: init %Cpp.long_long = converted %int_1.loc8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc8 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   assign %a.var, %.loc8_3
+// CHECK:STDOUT:   %.loc8_13: type = splice_block %long_long.ref.loc8 [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref.loc8: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref.loc8: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a: ref %Cpp.long_long = ref_binding a, %a.var
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %b.patt: %pattern_type.76e = ref_binding_pattern b [concrete]
+// CHECK:STDOUT:     %b.var_patt: %pattern_type.76e = var_pattern %b.patt [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %b.var: ref %Cpp.long_long = var %b.var_patt
+// CHECK:STDOUT:   %int_1.loc9: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem0.loc9: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc9: <bound method> = bound_method %int_1.loc9, %impl.elem0.loc9 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc9: init %Cpp.long_long = call %bound_method.loc9(%int_1.loc9) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_3: init %Cpp.long_long = converted %int_1.loc9, %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc9 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   assign %b.var, %.loc9_3
+// CHECK:STDOUT:   %.loc9_13: type = splice_block %long_long.ref.loc9 [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref.loc9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref.loc9: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %b: ref %Cpp.long_long = ref_binding b, %b.var
+// CHECK:STDOUT:   %a.ref.loc11: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc11: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc11: %.5a9 = impl_witness_access constants.%AddAssignWith.impl_witness.383, element0 [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.d128e4.2]
+// CHECK:STDOUT:   %bound_method.loc11_5.1: <bound method> = bound_method %a.ref.loc11, %impl.elem0.loc11
+// CHECK:STDOUT:   %ImplicitAs.facet.loc11_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc11_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc11_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc11_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc11_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc11_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc11: <specific function> = specific_function %impl.elem0.loc11, @Cpp.long_long.as.AddAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.2b826b.1]
+// CHECK:STDOUT:   %bound_method.loc11_5.2: <bound method> = bound_method %a.ref.loc11, %specific_fn.loc11
+// CHECK:STDOUT:   %.loc11_8: %Cpp.long_long = acquire_value %b.ref.loc11
+// CHECK:STDOUT:   %.loc11_5.3: %Cpp.long_long.as.AddAssignWith.impl.Op.type.26466a.1 = specific_constant imports.%Core.Op.57a, @Cpp.long_long.as.AddAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.d128e4.1]
+// CHECK:STDOUT:   %Op.ref.loc11: %Cpp.long_long.as.AddAssignWith.impl.Op.type.26466a.1 = name_ref Op, %.loc11_5.3 [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.d128e4.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc11, %Op.ref.loc11
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc11, @Cpp.long_long.as.AddAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.2b826b.2]
+// CHECK:STDOUT:   %bound_method.loc11_5.3: <bound method> = bound_method %a.ref.loc11, %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc11_5.3(%a.ref.loc11, %.loc11_8)
+// CHECK:STDOUT:   %a.ref.loc12: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc12: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc12: %.9f7 = impl_witness_access constants.%SubAssignWith.impl_witness.e66, element0 [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.07d295.2]
+// CHECK:STDOUT:   %bound_method.loc12_5.1: <bound method> = bound_method %a.ref.loc12, %impl.elem0.loc12
+// CHECK:STDOUT:   %ImplicitAs.facet.loc12_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc12_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc12_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc12_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc12_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc12_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc12: <specific function> = specific_function %impl.elem0.loc12, @Cpp.long_long.as.SubAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn.21e13f.1]
+// CHECK:STDOUT:   %bound_method.loc12_5.2: <bound method> = bound_method %a.ref.loc12, %specific_fn.loc12
+// CHECK:STDOUT:   %.loc12_8: %Cpp.long_long = acquire_value %b.ref.loc12
+// CHECK:STDOUT:   %.loc12_5.3: %Cpp.long_long.as.SubAssignWith.impl.Op.type.daa062.1 = specific_constant imports.%Core.Op.75b, @Cpp.long_long.as.SubAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.07d295.1]
+// CHECK:STDOUT:   %Op.ref.loc12: %Cpp.long_long.as.SubAssignWith.impl.Op.type.daa062.1 = name_ref Op, %.loc12_5.3 [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.07d295.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc12, %Op.ref.loc12
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc12, @Cpp.long_long.as.SubAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn.21e13f.2]
+// CHECK:STDOUT:   %bound_method.loc12_5.3: <bound method> = bound_method %a.ref.loc12, %Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc12_5.3(%a.ref.loc12, %.loc12_8)
+// CHECK:STDOUT:   %a.ref.loc13: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc13: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc13: %.486 = impl_witness_access constants.%MulAssignWith.impl_witness.04a, element0 [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.0edfbc.2]
+// CHECK:STDOUT:   %bound_method.loc13_5.1: <bound method> = bound_method %a.ref.loc13, %impl.elem0.loc13
+// CHECK:STDOUT:   %ImplicitAs.facet.loc13_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc13_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc13_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc13_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc13_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc13_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc13: <specific function> = specific_function %impl.elem0.loc13, @Cpp.long_long.as.MulAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn.5af50b.1]
+// CHECK:STDOUT:   %bound_method.loc13_5.2: <bound method> = bound_method %a.ref.loc13, %specific_fn.loc13
+// CHECK:STDOUT:   %.loc13_8: %Cpp.long_long = acquire_value %b.ref.loc13
+// CHECK:STDOUT:   %.loc13_5.3: %Cpp.long_long.as.MulAssignWith.impl.Op.type.f5880d.1 = specific_constant imports.%Core.Op.94e, @Cpp.long_long.as.MulAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.0edfbc.1]
+// CHECK:STDOUT:   %Op.ref.loc13: %Cpp.long_long.as.MulAssignWith.impl.Op.type.f5880d.1 = name_ref Op, %.loc13_5.3 [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.0edfbc.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc13, %Op.ref.loc13
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc13, @Cpp.long_long.as.MulAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn.5af50b.2]
+// CHECK:STDOUT:   %bound_method.loc13_5.3: <bound method> = bound_method %a.ref.loc13, %Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc13_5.3(%a.ref.loc13, %.loc13_8)
+// CHECK:STDOUT:   %a.ref.loc14: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc14: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc14: %.ff7 = impl_witness_access constants.%DivAssignWith.impl_witness.5ff, element0 [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.409fa6.2]
+// CHECK:STDOUT:   %bound_method.loc14_5.1: <bound method> = bound_method %a.ref.loc14, %impl.elem0.loc14
+// CHECK:STDOUT:   %ImplicitAs.facet.loc14_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc14_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc14_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc14_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc14_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc14_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc14: <specific function> = specific_function %impl.elem0.loc14, @Cpp.long_long.as.DivAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn.07c8ad.1]
+// CHECK:STDOUT:   %bound_method.loc14_5.2: <bound method> = bound_method %a.ref.loc14, %specific_fn.loc14
+// CHECK:STDOUT:   %.loc14_8: %Cpp.long_long = acquire_value %b.ref.loc14
+// CHECK:STDOUT:   %.loc14_5.3: %Cpp.long_long.as.DivAssignWith.impl.Op.type.fa44cf.1 = specific_constant imports.%Core.Op.ec7, @Cpp.long_long.as.DivAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.409fa6.1]
+// CHECK:STDOUT:   %Op.ref.loc14: %Cpp.long_long.as.DivAssignWith.impl.Op.type.fa44cf.1 = name_ref Op, %.loc14_5.3 [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.409fa6.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc14, %Op.ref.loc14
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc14, @Cpp.long_long.as.DivAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn.07c8ad.2]
+// CHECK:STDOUT:   %bound_method.loc14_5.3: <bound method> = bound_method %a.ref.loc14, %Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc14_5.3(%a.ref.loc14, %.loc14_8)
+// CHECK:STDOUT:   %a.ref.loc15: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc15: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc15: %.977 = impl_witness_access constants.%ModAssignWith.impl_witness.afa, element0 [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.0b732b.2]
+// CHECK:STDOUT:   %bound_method.loc15_5.1: <bound method> = bound_method %a.ref.loc15, %impl.elem0.loc15
+// CHECK:STDOUT:   %ImplicitAs.facet.loc15_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc15_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc15_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc15_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc15_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc15_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc15: <specific function> = specific_function %impl.elem0.loc15, @Cpp.long_long.as.ModAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn.a3301b.1]
+// CHECK:STDOUT:   %bound_method.loc15_5.2: <bound method> = bound_method %a.ref.loc15, %specific_fn.loc15
+// CHECK:STDOUT:   %.loc15_8: %Cpp.long_long = acquire_value %b.ref.loc15
+// CHECK:STDOUT:   %.loc15_5.3: %Cpp.long_long.as.ModAssignWith.impl.Op.type.80b19c.1 = specific_constant imports.%Core.Op.6fd, @Cpp.long_long.as.ModAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.0b732b.1]
+// CHECK:STDOUT:   %Op.ref.loc15: %Cpp.long_long.as.ModAssignWith.impl.Op.type.80b19c.1 = name_ref Op, %.loc15_5.3 [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.0b732b.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc15, %Op.ref.loc15
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc15, @Cpp.long_long.as.ModAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn.a3301b.2]
+// CHECK:STDOUT:   %bound_method.loc15_5.3: <bound method> = bound_method %a.ref.loc15, %Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc15_5.3(%a.ref.loc15, %.loc15_8)
+// CHECK:STDOUT:   %a.ref.loc17: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc17: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc17: %.391 = impl_witness_access constants.%BitAndAssignWith.impl_witness.e8f, element0 [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.10a9af.2]
+// CHECK:STDOUT:   %bound_method.loc17_5.1: <bound method> = bound_method %a.ref.loc17, %impl.elem0.loc17
+// CHECK:STDOUT:   %ImplicitAs.facet.loc17_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc17_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc17_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc17_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc17_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc17_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc17: <specific function> = specific_function %impl.elem0.loc17, @Cpp.long_long.as.BitAndAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn.5df9d8.1]
+// CHECK:STDOUT:   %bound_method.loc17_5.2: <bound method> = bound_method %a.ref.loc17, %specific_fn.loc17
+// CHECK:STDOUT:   %.loc17_8: %Cpp.long_long = acquire_value %b.ref.loc17
+// CHECK:STDOUT:   %.loc17_5.3: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.a7c3f6.1 = specific_constant imports.%Core.Op.c78, @Cpp.long_long.as.BitAndAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.10a9af.1]
+// CHECK:STDOUT:   %Op.ref.loc17: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.a7c3f6.1 = name_ref Op, %.loc17_5.3 [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.10a9af.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc17, %Op.ref.loc17
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc17, @Cpp.long_long.as.BitAndAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn.5df9d8.2]
+// CHECK:STDOUT:   %bound_method.loc17_5.3: <bound method> = bound_method %a.ref.loc17, %Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc17_5.3(%a.ref.loc17, %.loc17_8)
+// CHECK:STDOUT:   %a.ref.loc18: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc18: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc18: %.bf4 = impl_witness_access constants.%BitOrAssignWith.impl_witness.3af, element0 [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.60d957.2]
+// CHECK:STDOUT:   %bound_method.loc18_5.1: <bound method> = bound_method %a.ref.loc18, %impl.elem0.loc18
+// CHECK:STDOUT:   %ImplicitAs.facet.loc18_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc18_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc18_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc18_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc18_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc18_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc18: <specific function> = specific_function %impl.elem0.loc18, @Cpp.long_long.as.BitOrAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn.857890.1]
+// CHECK:STDOUT:   %bound_method.loc18_5.2: <bound method> = bound_method %a.ref.loc18, %specific_fn.loc18
+// CHECK:STDOUT:   %.loc18_8: %Cpp.long_long = acquire_value %b.ref.loc18
+// CHECK:STDOUT:   %.loc18_5.3: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.367944.1 = specific_constant imports.%Core.Op.fa0, @Cpp.long_long.as.BitOrAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.60d957.1]
+// CHECK:STDOUT:   %Op.ref.loc18: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.367944.1 = name_ref Op, %.loc18_5.3 [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.60d957.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc18, %Op.ref.loc18
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc18, @Cpp.long_long.as.BitOrAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn.857890.2]
+// CHECK:STDOUT:   %bound_method.loc18_5.3: <bound method> = bound_method %a.ref.loc18, %Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc18_5.3(%a.ref.loc18, %.loc18_8)
+// CHECK:STDOUT:   %a.ref.loc19: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc19: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc19: %.0cd = impl_witness_access constants.%BitXorAssignWith.impl_witness.56d, element0 [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.c92629.2]
+// CHECK:STDOUT:   %bound_method.loc19_5.1: <bound method> = bound_method %a.ref.loc19, %impl.elem0.loc19
+// CHECK:STDOUT:   %ImplicitAs.facet.loc19_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc19_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc19_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc19_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc19_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc19_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc19: <specific function> = specific_function %impl.elem0.loc19, @Cpp.long_long.as.BitXorAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn.97edcc.1]
+// CHECK:STDOUT:   %bound_method.loc19_5.2: <bound method> = bound_method %a.ref.loc19, %specific_fn.loc19
+// CHECK:STDOUT:   %.loc19_8: %Cpp.long_long = acquire_value %b.ref.loc19
+// CHECK:STDOUT:   %.loc19_5.3: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.d7a644.1 = specific_constant imports.%Core.Op.3d4, @Cpp.long_long.as.BitXorAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.c92629.1]
+// CHECK:STDOUT:   %Op.ref.loc19: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.d7a644.1 = name_ref Op, %.loc19_5.3 [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.c92629.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc19, %Op.ref.loc19
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc19, @Cpp.long_long.as.BitXorAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn.97edcc.2]
+// CHECK:STDOUT:   %bound_method.loc19_5.3: <bound method> = bound_method %a.ref.loc19, %Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc19_5.3(%a.ref.loc19, %.loc19_8)
+// CHECK:STDOUT:   %a.ref.loc20: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc20: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc20: %.fef = impl_witness_access constants.%LeftShiftAssignWith.impl_witness.824, element0 [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.ce8f7e.2]
+// CHECK:STDOUT:   %bound_method.loc20_5.1: <bound method> = bound_method %a.ref.loc20, %impl.elem0.loc20
+// CHECK:STDOUT:   %ImplicitAs.facet.loc20_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc20_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc20_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc20_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc20_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc20_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc20: <specific function> = specific_function %impl.elem0.loc20, @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn.525b00.1]
+// CHECK:STDOUT:   %bound_method.loc20_5.2: <bound method> = bound_method %a.ref.loc20, %specific_fn.loc20
+// CHECK:STDOUT:   %.loc20_9: %Cpp.long_long = acquire_value %b.ref.loc20
+// CHECK:STDOUT:   %.loc20_5.3: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.bbf90a.1 = specific_constant imports.%Core.Op.1b6, @Cpp.long_long.as.LeftShiftAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.ce8f7e.1]
+// CHECK:STDOUT:   %Op.ref.loc20: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.bbf90a.1 = name_ref Op, %.loc20_5.3 [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.ce8f7e.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc20, %Op.ref.loc20
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc20, @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn.525b00.2]
+// CHECK:STDOUT:   %bound_method.loc20_5.3: <bound method> = bound_method %a.ref.loc20, %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc20_5.3(%a.ref.loc20, %.loc20_9)
+// CHECK:STDOUT:   %a.ref.loc21: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref.loc21: ref %Cpp.long_long = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc21: %.4a3 = impl_witness_access constants.%RightShiftAssignWith.impl_witness.d22, element0 [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.4e9b16.2]
+// CHECK:STDOUT:   %bound_method.loc21_5.1: <bound method> = bound_method %a.ref.loc21, %impl.elem0.loc21
+// CHECK:STDOUT:   %ImplicitAs.facet.loc21_5.1: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc21_5.1: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc21_5.1 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc21_5.2: %ImplicitAs.type.a03 = facet_value constants.%Cpp.long_long, (constants.%ImplicitAs.impl_witness.64f) [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %.loc21_5.2: %ImplicitAs.type.a03 = converted constants.%Cpp.long_long, %ImplicitAs.facet.loc21_5.2 [concrete = constants.%ImplicitAs.facet.c8d]
+// CHECK:STDOUT:   %specific_fn.loc21: <specific function> = specific_function %impl.elem0.loc21, @Cpp.long_long.as.RightShiftAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn.df86ad.1]
+// CHECK:STDOUT:   %bound_method.loc21_5.2: <bound method> = bound_method %a.ref.loc21, %specific_fn.loc21
+// CHECK:STDOUT:   %.loc21_9: %Cpp.long_long = acquire_value %b.ref.loc21
+// CHECK:STDOUT:   %.loc21_5.3: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.ff6b73.1 = specific_constant imports.%Core.Op.bcc, @Cpp.long_long.as.RightShiftAssignWith.impl(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.4e9b16.1]
+// CHECK:STDOUT:   %Op.ref.loc21: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.ff6b73.1 = name_ref Op, %.loc21_5.3 [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.4e9b16.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc21, %Op.ref.loc21
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc21, @Cpp.long_long.as.RightShiftAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c8d) [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn.df86ad.2]
+// CHECK:STDOUT:   %bound_method.loc21_5.3: <bound method> = bound_method %a.ref.loc21, %Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc21_5.3(%a.ref.loc21, %.loc21_9)
+// CHECK:STDOUT:   %DestroyOp.bound.loc9: <bound method> = bound_method %b.var, constants.%DestroyOp
+// CHECK:STDOUT:   %DestroyOp.call.loc9: init %empty_tuple.type = call %DestroyOp.bound.loc9(%b.var)
+// CHECK:STDOUT:   %DestroyOp.bound.loc8: <bound method> = bound_method %a.var, constants.%DestroyOp
+// CHECK:STDOUT:   %DestroyOp.call.loc8: init %empty_tuple.type = call %DestroyOp.bound.loc8(%a.var)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @DestroyOp(%self.param: %Cpp.long_long) = "no_op";
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- compound_assignment_hereogeneous_long_long_and_i64.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %int_64: Core.IntLiteral = int_value 64 [concrete]
+// CHECK:STDOUT:   %i64: type = class_type @Int, @Int(%int_64) [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %As.type.229: type = facet_type <@As, @As(%i64)> [concrete]
+// CHECK:STDOUT:   %As.Convert.type.d57: type = fn_type @As.Convert, @As(%i64) [concrete]
+// CHECK:STDOUT:   %To.fe9: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.09e: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%To.fe9) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.dbe: %Core.IntLiteral.as.As.impl.Convert.type.09e = struct_value () [symbolic]
+// CHECK:STDOUT:   %As.impl_witness.c71: <witness> = impl_witness imports.%As.impl_witness_table.9fc, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.type.cee: type = fn_type @Core.IntLiteral.as.As.impl.Convert, @Core.IntLiteral.as.As.impl(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.a54: %Core.IntLiteral.as.As.impl.Convert.type.cee = struct_value () [concrete]
+// CHECK:STDOUT:   %As.facet: %As.type.229 = facet_value Core.IntLiteral, (%As.impl_witness.c71) [concrete]
+// CHECK:STDOUT:   %.aba: type = fn_type_with_self_type %As.Convert.type.d57, %As.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.a54 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.As.impl.Convert.a54, @Core.IntLiteral.as.As.impl.Convert(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.As.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_1.41a: %i64 = int_value 1 [concrete]
+// CHECK:STDOUT:   %AddAssignWith.type.d84: type = facet_type <@AddAssignWith, @AddAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %AddAssignWith.Op.type.693: type = fn_type @AddAssignWith.Op, @AddAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %U.ea5: %ImplicitAs.type.a03 = symbolic_binding U, 0 [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.1, @Cpp.long_long.as.AddAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.1: %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.2, @Cpp.long_long.as.AddAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.2: %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.1b3: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.b19 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.c59: %ImplicitAs.type.a03 = facet_value %i64, (%ImplicitAs.impl_witness.1b3) [concrete]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness.767: <witness> = impl_witness imports.%AddAssignWith.impl_witness_table.815, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.1: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.2, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.1: %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.2: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.1, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.2: %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddAssignWith.facet: %AddAssignWith.type.d84 = facet_value %Cpp.long_long, (%AddAssignWith.impl_witness.767) [concrete]
+// CHECK:STDOUT:   %.34b: type = fn_type_with_self_type %AddAssignWith.Op.type.693, %AddAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.50a783.1: <specific function> = specific_function %Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.2, @Cpp.long_long.as.AddAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %.b29: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.c59 [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.type: type = fn_type @i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert: %i64.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.41a, %i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.50a783.2: <specific function> = specific_function %Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.1, @Cpp.long_long.as.AddAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %SubAssignWith.type.d66: type = facet_type <@SubAssignWith, @SubAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %SubAssignWith.Op.type.149: type = fn_type @SubAssignWith.Op, @SubAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.1: type = fn_type @Cpp.long_long.as.SubAssignWith.impl.Op.1, @Cpp.long_long.as.SubAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.7c6ec4.1: %Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.2: type = fn_type @Cpp.long_long.as.SubAssignWith.impl.Op.2, @Cpp.long_long.as.SubAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.7c6ec4.2: %Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %SubAssignWith.impl_witness.089: <witness> = impl_witness imports.%SubAssignWith.impl_witness_table.705, @Cpp.long_long.as.SubAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.type.b97f87.1: type = fn_type @Cpp.long_long.as.SubAssignWith.impl.Op.2, @Cpp.long_long.as.SubAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.268b0a.1: %Cpp.long_long.as.SubAssignWith.impl.Op.type.b97f87.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.type.b97f87.2: type = fn_type @Cpp.long_long.as.SubAssignWith.impl.Op.1, @Cpp.long_long.as.SubAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.268b0a.2: %Cpp.long_long.as.SubAssignWith.impl.Op.type.b97f87.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %SubAssignWith.facet: %SubAssignWith.type.d66 = facet_value %Cpp.long_long, (%SubAssignWith.impl_witness.089) [concrete]
+// CHECK:STDOUT:   %.eb4: type = fn_type_with_self_type %SubAssignWith.Op.type.149, %SubAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn.39aa60.1: <specific function> = specific_function %Cpp.long_long.as.SubAssignWith.impl.Op.268b0a.2, @Cpp.long_long.as.SubAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn.39aa60.2: <specific function> = specific_function %Cpp.long_long.as.SubAssignWith.impl.Op.268b0a.1, @Cpp.long_long.as.SubAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %MulAssignWith.type.e40: type = facet_type <@MulAssignWith, @MulAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %MulAssignWith.Op.type.d2a: type = fn_type @MulAssignWith.Op, @MulAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.1: type = fn_type @Cpp.long_long.as.MulAssignWith.impl.Op.1, @Cpp.long_long.as.MulAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.b4560e.1: %Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.2: type = fn_type @Cpp.long_long.as.MulAssignWith.impl.Op.2, @Cpp.long_long.as.MulAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.b4560e.2: %Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %MulAssignWith.impl_witness.435: <witness> = impl_witness imports.%MulAssignWith.impl_witness_table.32a, @Cpp.long_long.as.MulAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.type.9015f3.1: type = fn_type @Cpp.long_long.as.MulAssignWith.impl.Op.2, @Cpp.long_long.as.MulAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.e299d7.1: %Cpp.long_long.as.MulAssignWith.impl.Op.type.9015f3.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.type.9015f3.2: type = fn_type @Cpp.long_long.as.MulAssignWith.impl.Op.1, @Cpp.long_long.as.MulAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.e299d7.2: %Cpp.long_long.as.MulAssignWith.impl.Op.type.9015f3.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %MulAssignWith.facet: %MulAssignWith.type.e40 = facet_value %Cpp.long_long, (%MulAssignWith.impl_witness.435) [concrete]
+// CHECK:STDOUT:   %.94e: type = fn_type_with_self_type %MulAssignWith.Op.type.d2a, %MulAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn.8da25e.1: <specific function> = specific_function %Cpp.long_long.as.MulAssignWith.impl.Op.e299d7.2, @Cpp.long_long.as.MulAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn.8da25e.2: <specific function> = specific_function %Cpp.long_long.as.MulAssignWith.impl.Op.e299d7.1, @Cpp.long_long.as.MulAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %DivAssignWith.type.511: type = facet_type <@DivAssignWith, @DivAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %DivAssignWith.Op.type.040: type = fn_type @DivAssignWith.Op, @DivAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.1: type = fn_type @Cpp.long_long.as.DivAssignWith.impl.Op.1, @Cpp.long_long.as.DivAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.12b589.1: %Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.2: type = fn_type @Cpp.long_long.as.DivAssignWith.impl.Op.2, @Cpp.long_long.as.DivAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.12b589.2: %Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %DivAssignWith.impl_witness.817: <witness> = impl_witness imports.%DivAssignWith.impl_witness_table.9c9, @Cpp.long_long.as.DivAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.type.868bc4.1: type = fn_type @Cpp.long_long.as.DivAssignWith.impl.Op.2, @Cpp.long_long.as.DivAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.6729c8.1: %Cpp.long_long.as.DivAssignWith.impl.Op.type.868bc4.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.type.868bc4.2: type = fn_type @Cpp.long_long.as.DivAssignWith.impl.Op.1, @Cpp.long_long.as.DivAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.6729c8.2: %Cpp.long_long.as.DivAssignWith.impl.Op.type.868bc4.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %DivAssignWith.facet: %DivAssignWith.type.511 = facet_value %Cpp.long_long, (%DivAssignWith.impl_witness.817) [concrete]
+// CHECK:STDOUT:   %.2d6: type = fn_type_with_self_type %DivAssignWith.Op.type.040, %DivAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn.a29bb8.1: <specific function> = specific_function %Cpp.long_long.as.DivAssignWith.impl.Op.6729c8.2, @Cpp.long_long.as.DivAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn.a29bb8.2: <specific function> = specific_function %Cpp.long_long.as.DivAssignWith.impl.Op.6729c8.1, @Cpp.long_long.as.DivAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %ModAssignWith.type.2c3: type = facet_type <@ModAssignWith, @ModAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %ModAssignWith.Op.type.400: type = fn_type @ModAssignWith.Op, @ModAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.1: type = fn_type @Cpp.long_long.as.ModAssignWith.impl.Op.1, @Cpp.long_long.as.ModAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.31c4bc.1: %Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.2: type = fn_type @Cpp.long_long.as.ModAssignWith.impl.Op.2, @Cpp.long_long.as.ModAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.31c4bc.2: %Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ModAssignWith.impl_witness.f7c: <witness> = impl_witness imports.%ModAssignWith.impl_witness_table.fb0, @Cpp.long_long.as.ModAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.type.afaa70.1: type = fn_type @Cpp.long_long.as.ModAssignWith.impl.Op.2, @Cpp.long_long.as.ModAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.49994b.1: %Cpp.long_long.as.ModAssignWith.impl.Op.type.afaa70.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.type.afaa70.2: type = fn_type @Cpp.long_long.as.ModAssignWith.impl.Op.1, @Cpp.long_long.as.ModAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.49994b.2: %Cpp.long_long.as.ModAssignWith.impl.Op.type.afaa70.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %ModAssignWith.facet: %ModAssignWith.type.2c3 = facet_value %Cpp.long_long, (%ModAssignWith.impl_witness.f7c) [concrete]
+// CHECK:STDOUT:   %.f4d: type = fn_type_with_self_type %ModAssignWith.Op.type.400, %ModAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn.e3c8dd.1: <specific function> = specific_function %Cpp.long_long.as.ModAssignWith.impl.Op.49994b.2, @Cpp.long_long.as.ModAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn.e3c8dd.2: <specific function> = specific_function %Cpp.long_long.as.ModAssignWith.impl.Op.49994b.1, @Cpp.long_long.as.ModAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %BitAndAssignWith.type.8af: type = facet_type <@BitAndAssignWith, @BitAndAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %BitAndAssignWith.Op.type.7f9: type = fn_type @BitAndAssignWith.Op, @BitAndAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.1: type = fn_type @Cpp.long_long.as.BitAndAssignWith.impl.Op.1, @Cpp.long_long.as.BitAndAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.6a0d28.1: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.2: type = fn_type @Cpp.long_long.as.BitAndAssignWith.impl.Op.2, @Cpp.long_long.as.BitAndAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.6a0d28.2: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitAndAssignWith.impl_witness.80c: <witness> = impl_witness imports.%BitAndAssignWith.impl_witness_table.5cc, @Cpp.long_long.as.BitAndAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.9d1673.1: type = fn_type @Cpp.long_long.as.BitAndAssignWith.impl.Op.2, @Cpp.long_long.as.BitAndAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.9241d8.1: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.9d1673.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.9d1673.2: type = fn_type @Cpp.long_long.as.BitAndAssignWith.impl.Op.1, @Cpp.long_long.as.BitAndAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.9241d8.2: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.9d1673.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitAndAssignWith.facet: %BitAndAssignWith.type.8af = facet_value %Cpp.long_long, (%BitAndAssignWith.impl_witness.80c) [concrete]
+// CHECK:STDOUT:   %.c2c: type = fn_type_with_self_type %BitAndAssignWith.Op.type.7f9, %BitAndAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn.00c338.1: <specific function> = specific_function %Cpp.long_long.as.BitAndAssignWith.impl.Op.9241d8.2, @Cpp.long_long.as.BitAndAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn.00c338.2: <specific function> = specific_function %Cpp.long_long.as.BitAndAssignWith.impl.Op.9241d8.1, @Cpp.long_long.as.BitAndAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %BitOrAssignWith.type.172: type = facet_type <@BitOrAssignWith, @BitOrAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %BitOrAssignWith.Op.type.ded: type = fn_type @BitOrAssignWith.Op, @BitOrAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.1: type = fn_type @Cpp.long_long.as.BitOrAssignWith.impl.Op.1, @Cpp.long_long.as.BitOrAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.1fac0c.1: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.2: type = fn_type @Cpp.long_long.as.BitOrAssignWith.impl.Op.2, @Cpp.long_long.as.BitOrAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.1fac0c.2: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitOrAssignWith.impl_witness.bd2: <witness> = impl_witness imports.%BitOrAssignWith.impl_witness_table.a52, @Cpp.long_long.as.BitOrAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.4196b6.1: type = fn_type @Cpp.long_long.as.BitOrAssignWith.impl.Op.2, @Cpp.long_long.as.BitOrAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.acdb6d.1: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.4196b6.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.4196b6.2: type = fn_type @Cpp.long_long.as.BitOrAssignWith.impl.Op.1, @Cpp.long_long.as.BitOrAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.acdb6d.2: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.4196b6.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitOrAssignWith.facet: %BitOrAssignWith.type.172 = facet_value %Cpp.long_long, (%BitOrAssignWith.impl_witness.bd2) [concrete]
+// CHECK:STDOUT:   %.8b2: type = fn_type_with_self_type %BitOrAssignWith.Op.type.ded, %BitOrAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn.b0c3cb.1: <specific function> = specific_function %Cpp.long_long.as.BitOrAssignWith.impl.Op.acdb6d.2, @Cpp.long_long.as.BitOrAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn.b0c3cb.2: <specific function> = specific_function %Cpp.long_long.as.BitOrAssignWith.impl.Op.acdb6d.1, @Cpp.long_long.as.BitOrAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %BitXorAssignWith.type.2c8: type = facet_type <@BitXorAssignWith, @BitXorAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %BitXorAssignWith.Op.type.9f9: type = fn_type @BitXorAssignWith.Op, @BitXorAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.1: type = fn_type @Cpp.long_long.as.BitXorAssignWith.impl.Op.1, @Cpp.long_long.as.BitXorAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.e7c6f2.1: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.2: type = fn_type @Cpp.long_long.as.BitXorAssignWith.impl.Op.2, @Cpp.long_long.as.BitXorAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.e7c6f2.2: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %BitXorAssignWith.impl_witness.f91: <witness> = impl_witness imports.%BitXorAssignWith.impl_witness_table.223, @Cpp.long_long.as.BitXorAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.7f7009.1: type = fn_type @Cpp.long_long.as.BitXorAssignWith.impl.Op.2, @Cpp.long_long.as.BitXorAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.3aa346.1: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.7f7009.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.7f7009.2: type = fn_type @Cpp.long_long.as.BitXorAssignWith.impl.Op.1, @Cpp.long_long.as.BitXorAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.3aa346.2: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.7f7009.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %BitXorAssignWith.facet: %BitXorAssignWith.type.2c8 = facet_value %Cpp.long_long, (%BitXorAssignWith.impl_witness.f91) [concrete]
+// CHECK:STDOUT:   %.9cc: type = fn_type_with_self_type %BitXorAssignWith.Op.type.9f9, %BitXorAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn.8f3086.1: <specific function> = specific_function %Cpp.long_long.as.BitXorAssignWith.impl.Op.3aa346.2, @Cpp.long_long.as.BitXorAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn.8f3086.2: <specific function> = specific_function %Cpp.long_long.as.BitXorAssignWith.impl.Op.3aa346.1, @Cpp.long_long.as.BitXorAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %LeftShiftAssignWith.type.b97: type = facet_type <@LeftShiftAssignWith, @LeftShiftAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %LeftShiftAssignWith.Op.type.d7e: type = fn_type @LeftShiftAssignWith.Op, @LeftShiftAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.1: type = fn_type @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1, @Cpp.long_long.as.LeftShiftAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.44b51c.1: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.2: type = fn_type @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2, @Cpp.long_long.as.LeftShiftAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.44b51c.2: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %LeftShiftAssignWith.impl_witness.c81: <witness> = impl_witness imports.%LeftShiftAssignWith.impl_witness_table.cd9, @Cpp.long_long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.21cdd1.1: type = fn_type @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2, @Cpp.long_long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.e91293.1: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.21cdd1.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.21cdd1.2: type = fn_type @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1, @Cpp.long_long.as.LeftShiftAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.e91293.2: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.21cdd1.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %LeftShiftAssignWith.facet: %LeftShiftAssignWith.type.b97 = facet_value %Cpp.long_long, (%LeftShiftAssignWith.impl_witness.c81) [concrete]
+// CHECK:STDOUT:   %.334: type = fn_type_with_self_type %LeftShiftAssignWith.Op.type.d7e, %LeftShiftAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn.1c7fb8.1: <specific function> = specific_function %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.e91293.2, @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn.1c7fb8.2: <specific function> = specific_function %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.e91293.1, @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %RightShiftAssignWith.type.721: type = facet_type <@RightShiftAssignWith, @RightShiftAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %RightShiftAssignWith.Op.type.c23: type = fn_type @RightShiftAssignWith.Op, @RightShiftAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.1: type = fn_type @Cpp.long_long.as.RightShiftAssignWith.impl.Op.1, @Cpp.long_long.as.RightShiftAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.2beecc.1: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.2: type = fn_type @Cpp.long_long.as.RightShiftAssignWith.impl.Op.2, @Cpp.long_long.as.RightShiftAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.2beecc.2: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %RightShiftAssignWith.impl_witness.1b7: <witness> = impl_witness imports.%RightShiftAssignWith.impl_witness_table.074, @Cpp.long_long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.0ddf2d.1: type = fn_type @Cpp.long_long.as.RightShiftAssignWith.impl.Op.2, @Cpp.long_long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.efc522.1: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.0ddf2d.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.0ddf2d.2: type = fn_type @Cpp.long_long.as.RightShiftAssignWith.impl.Op.1, @Cpp.long_long.as.RightShiftAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.efc522.2: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.0ddf2d.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %RightShiftAssignWith.facet: %RightShiftAssignWith.type.721 = facet_value %Cpp.long_long, (%RightShiftAssignWith.impl_witness.1b7) [concrete]
+// CHECK:STDOUT:   %.f4a: type = fn_type_with_self_type %RightShiftAssignWith.Op.type.c23, %RightShiftAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn.1c2239.1: <specific function> = specific_function %Cpp.long_long.as.RightShiftAssignWith.impl.Op.efc522.2, @Cpp.long_long.as.RightShiftAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn.1c2239.2: <specific function> = specific_function %Cpp.long_long.as.RightShiftAssignWith.impl.Op.efc522.1, @Cpp.long_long.as.RightShiftAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %DestroyOp.type: type = fn_type @DestroyOp [concrete]
+// CHECK:STDOUT:   %DestroyOp: %DestroyOp.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.ca0: @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert.type (%Core.IntLiteral.as.As.impl.Convert.type.09e) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.As.impl.%Core.IntLiteral.as.As.impl.Convert (constants.%Core.IntLiteral.as.As.impl.Convert.dbe)]
+// CHECK:STDOUT:   %As.impl_witness_table.9fc = impl_witness_table (%Core.import_ref.ca0), @Core.IntLiteral.as.As.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.277: @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.type.2 (%Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.1)]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness_table.815 = impl_witness_table (%Core.import_ref.277), @Cpp.long_long.as.AddAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.57a: @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.type.1 (%Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.2)]
+// CHECK:STDOUT:   %Core.import_ref.4f4: %i64.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.b19 = impl_witness_table (%Core.import_ref.4f4), @i64.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.819: @Cpp.long_long.as.SubAssignWith.impl.%Cpp.long_long.as.SubAssignWith.impl.Op.type.2 (%Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.SubAssignWith.impl.%Cpp.long_long.as.SubAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.SubAssignWith.impl.Op.7c6ec4.1)]
+// CHECK:STDOUT:   %SubAssignWith.impl_witness_table.705 = impl_witness_table (%Core.import_ref.819), @Cpp.long_long.as.SubAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.75b: @Cpp.long_long.as.SubAssignWith.impl.%Cpp.long_long.as.SubAssignWith.impl.Op.type.1 (%Cpp.long_long.as.SubAssignWith.impl.Op.type.092242.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.SubAssignWith.impl.%Cpp.long_long.as.SubAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.SubAssignWith.impl.Op.7c6ec4.2)]
+// CHECK:STDOUT:   %Core.import_ref.f92: @Cpp.long_long.as.MulAssignWith.impl.%Cpp.long_long.as.MulAssignWith.impl.Op.type.2 (%Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.MulAssignWith.impl.%Cpp.long_long.as.MulAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.MulAssignWith.impl.Op.b4560e.1)]
+// CHECK:STDOUT:   %MulAssignWith.impl_witness_table.32a = impl_witness_table (%Core.import_ref.f92), @Cpp.long_long.as.MulAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.94e: @Cpp.long_long.as.MulAssignWith.impl.%Cpp.long_long.as.MulAssignWith.impl.Op.type.1 (%Cpp.long_long.as.MulAssignWith.impl.Op.type.d6e66c.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.MulAssignWith.impl.%Cpp.long_long.as.MulAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.MulAssignWith.impl.Op.b4560e.2)]
+// CHECK:STDOUT:   %Core.import_ref.b94: @Cpp.long_long.as.DivAssignWith.impl.%Cpp.long_long.as.DivAssignWith.impl.Op.type.2 (%Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.DivAssignWith.impl.%Cpp.long_long.as.DivAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.DivAssignWith.impl.Op.12b589.1)]
+// CHECK:STDOUT:   %DivAssignWith.impl_witness_table.9c9 = impl_witness_table (%Core.import_ref.b94), @Cpp.long_long.as.DivAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.ec7: @Cpp.long_long.as.DivAssignWith.impl.%Cpp.long_long.as.DivAssignWith.impl.Op.type.1 (%Cpp.long_long.as.DivAssignWith.impl.Op.type.93a446.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.DivAssignWith.impl.%Cpp.long_long.as.DivAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.DivAssignWith.impl.Op.12b589.2)]
+// CHECK:STDOUT:   %Core.import_ref.797: @Cpp.long_long.as.ModAssignWith.impl.%Cpp.long_long.as.ModAssignWith.impl.Op.type.2 (%Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.ModAssignWith.impl.%Cpp.long_long.as.ModAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.ModAssignWith.impl.Op.31c4bc.1)]
+// CHECK:STDOUT:   %ModAssignWith.impl_witness_table.fb0 = impl_witness_table (%Core.import_ref.797), @Cpp.long_long.as.ModAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.6fd: @Cpp.long_long.as.ModAssignWith.impl.%Cpp.long_long.as.ModAssignWith.impl.Op.type.1 (%Cpp.long_long.as.ModAssignWith.impl.Op.type.92274d.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.ModAssignWith.impl.%Cpp.long_long.as.ModAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.ModAssignWith.impl.Op.31c4bc.2)]
+// CHECK:STDOUT:   %Core.import_ref.e22: @Cpp.long_long.as.BitAndAssignWith.impl.%Cpp.long_long.as.BitAndAssignWith.impl.Op.type.2 (%Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitAndAssignWith.impl.%Cpp.long_long.as.BitAndAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.6a0d28.1)]
+// CHECK:STDOUT:   %BitAndAssignWith.impl_witness_table.5cc = impl_witness_table (%Core.import_ref.e22), @Cpp.long_long.as.BitAndAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.c78: @Cpp.long_long.as.BitAndAssignWith.impl.%Cpp.long_long.as.BitAndAssignWith.impl.Op.type.1 (%Cpp.long_long.as.BitAndAssignWith.impl.Op.type.4d9ef1.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitAndAssignWith.impl.%Cpp.long_long.as.BitAndAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.6a0d28.2)]
+// CHECK:STDOUT:   %Core.import_ref.4604: @Cpp.long_long.as.BitOrAssignWith.impl.%Cpp.long_long.as.BitOrAssignWith.impl.Op.type.2 (%Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitOrAssignWith.impl.%Cpp.long_long.as.BitOrAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.1fac0c.1)]
+// CHECK:STDOUT:   %BitOrAssignWith.impl_witness_table.a52 = impl_witness_table (%Core.import_ref.4604), @Cpp.long_long.as.BitOrAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.fa0: @Cpp.long_long.as.BitOrAssignWith.impl.%Cpp.long_long.as.BitOrAssignWith.impl.Op.type.1 (%Cpp.long_long.as.BitOrAssignWith.impl.Op.type.609f8c.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitOrAssignWith.impl.%Cpp.long_long.as.BitOrAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.1fac0c.2)]
+// CHECK:STDOUT:   %Core.import_ref.bb9: @Cpp.long_long.as.BitXorAssignWith.impl.%Cpp.long_long.as.BitXorAssignWith.impl.Op.type.2 (%Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.BitXorAssignWith.impl.%Cpp.long_long.as.BitXorAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.e7c6f2.1)]
+// CHECK:STDOUT:   %BitXorAssignWith.impl_witness_table.223 = impl_witness_table (%Core.import_ref.bb9), @Cpp.long_long.as.BitXorAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.3d4: @Cpp.long_long.as.BitXorAssignWith.impl.%Cpp.long_long.as.BitXorAssignWith.impl.Op.type.1 (%Cpp.long_long.as.BitXorAssignWith.impl.Op.type.85327b.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.BitXorAssignWith.impl.%Cpp.long_long.as.BitXorAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.e7c6f2.2)]
+// CHECK:STDOUT:   %Core.import_ref.db6: @Cpp.long_long.as.LeftShiftAssignWith.impl.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.2 (%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.LeftShiftAssignWith.impl.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.44b51c.1)]
+// CHECK:STDOUT:   %LeftShiftAssignWith.impl_witness_table.cd9 = impl_witness_table (%Core.import_ref.db6), @Cpp.long_long.as.LeftShiftAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.1b6: @Cpp.long_long.as.LeftShiftAssignWith.impl.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.1 (%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.3faef3.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.LeftShiftAssignWith.impl.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.44b51c.2)]
+// CHECK:STDOUT:   %Core.import_ref.522: @Cpp.long_long.as.RightShiftAssignWith.impl.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.2 (%Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.RightShiftAssignWith.impl.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.2beecc.1)]
+// CHECK:STDOUT:   %RightShiftAssignWith.impl_witness_table.074 = impl_witness_table (%Core.import_ref.522), @Cpp.long_long.as.RightShiftAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.bcc: @Cpp.long_long.as.RightShiftAssignWith.impl.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.1 (%Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.6ccfae.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.RightShiftAssignWith.impl.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.2beecc.2)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @CompoundAssignmentLongLongAndI64() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = ref_binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.var_patt: %pattern_type.76e = var_pattern %a.patt [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a.var: ref %Cpp.long_long = var %a.var_patt
+// CHECK:STDOUT:   %int_1.loc8: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem0.loc8: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %int_1.loc8, %impl.elem0.loc8 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call: init %Cpp.long_long = call %bound_method.loc8(%int_1.loc8) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc8_3: init %Cpp.long_long = converted %int_1.loc8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.call [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   assign %a.var, %.loc8_3
+// CHECK:STDOUT:   %.loc8_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a: ref %Cpp.long_long = ref_binding a, %a.var
+// CHECK:STDOUT:   %a.ref.loc9: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc9: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc9: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc9: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc9_11.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc9_11.1: <bound method> = bound_method %int_1.loc9, %impl.elem0.loc9_11.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc9_11: <specific function> = specific_function %impl.elem0.loc9_11.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc9_11.2: <bound method> = bound_method %int_1.loc9, %specific_fn.loc9_11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc9: init %i64 = call %bound_method.loc9_11.2(%int_1.loc9) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc9_11.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc9 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc9_11.2: %i64 = converted %int_1.loc9, %.loc9_11.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc9_5.1: %.34b = impl_witness_access constants.%AddAssignWith.impl_witness.767, element0 [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.2]
+// CHECK:STDOUT:   %bound_method.loc9_5.1: <bound method> = bound_method %a.ref.loc9, %impl.elem0.loc9_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc9_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc9_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc9_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc9_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc9_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc9_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc9_5: <specific function> = specific_function %impl.elem0.loc9_5.1, @Cpp.long_long.as.AddAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.50a783.1]
+// CHECK:STDOUT:   %bound_method.loc9_5.2: <bound method> = bound_method %a.ref.loc9, %specific_fn.loc9_5
+// CHECK:STDOUT:   %.loc9_5.3: %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.1 = specific_constant imports.%Core.Op.57a, @Cpp.long_long.as.AddAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.1]
+// CHECK:STDOUT:   %Op.ref.loc9: %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.1 = name_ref Op, %.loc9_5.3 [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc9, %Op.ref.loc9
+// CHECK:STDOUT:   %impl.elem0.loc9_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc9_5.3: <bound method> = bound_method %.loc9_11.2, %impl.elem0.loc9_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc9_5: init %Cpp.long_long = call %bound_method.loc9_5.3(%.loc9_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc9_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_5.5: %Cpp.long_long = converted %.loc9_11.2, %.loc9_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc9, @Cpp.long_long.as.AddAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.50a783.2]
+// CHECK:STDOUT:   %bound_method.loc9_5.4: <bound method> = bound_method %a.ref.loc9, %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc9_11.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc9_11.3: <bound method> = bound_method %.loc9_11.2, %impl.elem0.loc9_11.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc9_11: init %Cpp.long_long = call %bound_method.loc9_11.3(%.loc9_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_11.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc9_11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_11.4: %Cpp.long_long = converted %.loc9_11.2, %.loc9_11.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc9_5.4(%a.ref.loc9, %.loc9_11.4)
+// CHECK:STDOUT:   %a.ref.loc10: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc10: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc10: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc10: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc10_11.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc10_11.1: <bound method> = bound_method %int_1.loc10, %impl.elem0.loc10_11.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc10_11: <specific function> = specific_function %impl.elem0.loc10_11.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc10_11.2: <bound method> = bound_method %int_1.loc10, %specific_fn.loc10_11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc10: init %i64 = call %bound_method.loc10_11.2(%int_1.loc10) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc10_11.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc10 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc10_11.2: %i64 = converted %int_1.loc10, %.loc10_11.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc10_5.1: %.eb4 = impl_witness_access constants.%SubAssignWith.impl_witness.089, element0 [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.268b0a.2]
+// CHECK:STDOUT:   %bound_method.loc10_5.1: <bound method> = bound_method %a.ref.loc10, %impl.elem0.loc10_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc10_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc10_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc10_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc10_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc10_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc10_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc10_5: <specific function> = specific_function %impl.elem0.loc10_5.1, @Cpp.long_long.as.SubAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn.39aa60.1]
+// CHECK:STDOUT:   %bound_method.loc10_5.2: <bound method> = bound_method %a.ref.loc10, %specific_fn.loc10_5
+// CHECK:STDOUT:   %.loc10_5.3: %Cpp.long_long.as.SubAssignWith.impl.Op.type.b97f87.1 = specific_constant imports.%Core.Op.75b, @Cpp.long_long.as.SubAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.268b0a.1]
+// CHECK:STDOUT:   %Op.ref.loc10: %Cpp.long_long.as.SubAssignWith.impl.Op.type.b97f87.1 = name_ref Op, %.loc10_5.3 [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.268b0a.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc10, %Op.ref.loc10
+// CHECK:STDOUT:   %impl.elem0.loc10_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc10_5.3: <bound method> = bound_method %.loc10_11.2, %impl.elem0.loc10_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc10_5: init %Cpp.long_long = call %bound_method.loc10_5.3(%.loc10_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc10_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_5.5: %Cpp.long_long = converted %.loc10_11.2, %.loc10_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc10, @Cpp.long_long.as.SubAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn.39aa60.2]
+// CHECK:STDOUT:   %bound_method.loc10_5.4: <bound method> = bound_method %a.ref.loc10, %Cpp.long_long.as.SubAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc10_11.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc10_11.3: <bound method> = bound_method %.loc10_11.2, %impl.elem0.loc10_11.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc10_11: init %Cpp.long_long = call %bound_method.loc10_11.3(%.loc10_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_11.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc10_11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc10_11.4: %Cpp.long_long = converted %.loc10_11.2, %.loc10_11.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.SubAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc10_5.4(%a.ref.loc10, %.loc10_11.4)
+// CHECK:STDOUT:   %a.ref.loc11: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc11: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc11: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc11: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc11_11.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc11_11.1: <bound method> = bound_method %int_1.loc11, %impl.elem0.loc11_11.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc11_11: <specific function> = specific_function %impl.elem0.loc11_11.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc11_11.2: <bound method> = bound_method %int_1.loc11, %specific_fn.loc11_11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc11: init %i64 = call %bound_method.loc11_11.2(%int_1.loc11) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc11_11.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc11 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc11_11.2: %i64 = converted %int_1.loc11, %.loc11_11.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc11_5.1: %.94e = impl_witness_access constants.%MulAssignWith.impl_witness.435, element0 [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.e299d7.2]
+// CHECK:STDOUT:   %bound_method.loc11_5.1: <bound method> = bound_method %a.ref.loc11, %impl.elem0.loc11_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc11_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc11_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc11_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc11_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc11_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc11_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc11_5: <specific function> = specific_function %impl.elem0.loc11_5.1, @Cpp.long_long.as.MulAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn.8da25e.1]
+// CHECK:STDOUT:   %bound_method.loc11_5.2: <bound method> = bound_method %a.ref.loc11, %specific_fn.loc11_5
+// CHECK:STDOUT:   %.loc11_5.3: %Cpp.long_long.as.MulAssignWith.impl.Op.type.9015f3.1 = specific_constant imports.%Core.Op.94e, @Cpp.long_long.as.MulAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.e299d7.1]
+// CHECK:STDOUT:   %Op.ref.loc11: %Cpp.long_long.as.MulAssignWith.impl.Op.type.9015f3.1 = name_ref Op, %.loc11_5.3 [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.e299d7.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc11, %Op.ref.loc11
+// CHECK:STDOUT:   %impl.elem0.loc11_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc11_5.3: <bound method> = bound_method %.loc11_11.2, %impl.elem0.loc11_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc11_5: init %Cpp.long_long = call %bound_method.loc11_5.3(%.loc11_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc11_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_5.5: %Cpp.long_long = converted %.loc11_11.2, %.loc11_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc11, @Cpp.long_long.as.MulAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn.8da25e.2]
+// CHECK:STDOUT:   %bound_method.loc11_5.4: <bound method> = bound_method %a.ref.loc11, %Cpp.long_long.as.MulAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc11_11.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc11_11.3: <bound method> = bound_method %.loc11_11.2, %impl.elem0.loc11_11.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc11_11: init %Cpp.long_long = call %bound_method.loc11_11.3(%.loc11_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_11.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc11_11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc11_11.4: %Cpp.long_long = converted %.loc11_11.2, %.loc11_11.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.MulAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc11_5.4(%a.ref.loc11, %.loc11_11.4)
+// CHECK:STDOUT:   %a.ref.loc12: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc12: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc12: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc12: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc12_11.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc12_11.1: <bound method> = bound_method %int_1.loc12, %impl.elem0.loc12_11.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc12_11: <specific function> = specific_function %impl.elem0.loc12_11.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc12_11.2: <bound method> = bound_method %int_1.loc12, %specific_fn.loc12_11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc12: init %i64 = call %bound_method.loc12_11.2(%int_1.loc12) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_11.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc12 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc12_11.2: %i64 = converted %int_1.loc12, %.loc12_11.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc12_5.1: %.2d6 = impl_witness_access constants.%DivAssignWith.impl_witness.817, element0 [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.6729c8.2]
+// CHECK:STDOUT:   %bound_method.loc12_5.1: <bound method> = bound_method %a.ref.loc12, %impl.elem0.loc12_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc12_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc12_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc12_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc12_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc12_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc12_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc12_5: <specific function> = specific_function %impl.elem0.loc12_5.1, @Cpp.long_long.as.DivAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn.a29bb8.1]
+// CHECK:STDOUT:   %bound_method.loc12_5.2: <bound method> = bound_method %a.ref.loc12, %specific_fn.loc12_5
+// CHECK:STDOUT:   %.loc12_5.3: %Cpp.long_long.as.DivAssignWith.impl.Op.type.868bc4.1 = specific_constant imports.%Core.Op.ec7, @Cpp.long_long.as.DivAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.6729c8.1]
+// CHECK:STDOUT:   %Op.ref.loc12: %Cpp.long_long.as.DivAssignWith.impl.Op.type.868bc4.1 = name_ref Op, %.loc12_5.3 [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.6729c8.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc12, %Op.ref.loc12
+// CHECK:STDOUT:   %impl.elem0.loc12_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_5.3: <bound method> = bound_method %.loc12_11.2, %impl.elem0.loc12_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12_5: init %Cpp.long_long = call %bound_method.loc12_5.3(%.loc12_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_5.5: %Cpp.long_long = converted %.loc12_11.2, %.loc12_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc12, @Cpp.long_long.as.DivAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn.a29bb8.2]
+// CHECK:STDOUT:   %bound_method.loc12_5.4: <bound method> = bound_method %a.ref.loc12, %Cpp.long_long.as.DivAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc12_11.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc12_11.3: <bound method> = bound_method %.loc12_11.2, %impl.elem0.loc12_11.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc12_11: init %Cpp.long_long = call %bound_method.loc12_11.3(%.loc12_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_11.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc12_11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc12_11.4: %Cpp.long_long = converted %.loc12_11.2, %.loc12_11.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.DivAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc12_5.4(%a.ref.loc12, %.loc12_11.4)
+// CHECK:STDOUT:   %a.ref.loc13: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc13: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc13: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc13: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc13_11.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc13_11.1: <bound method> = bound_method %int_1.loc13, %impl.elem0.loc13_11.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc13_11: <specific function> = specific_function %impl.elem0.loc13_11.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc13_11.2: <bound method> = bound_method %int_1.loc13, %specific_fn.loc13_11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc13: init %i64 = call %bound_method.loc13_11.2(%int_1.loc13) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_11.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc13 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc13_11.2: %i64 = converted %int_1.loc13, %.loc13_11.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc13_5.1: %.f4d = impl_witness_access constants.%ModAssignWith.impl_witness.f7c, element0 [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.49994b.2]
+// CHECK:STDOUT:   %bound_method.loc13_5.1: <bound method> = bound_method %a.ref.loc13, %impl.elem0.loc13_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc13_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc13_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc13_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc13_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc13_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc13_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc13_5: <specific function> = specific_function %impl.elem0.loc13_5.1, @Cpp.long_long.as.ModAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn.e3c8dd.1]
+// CHECK:STDOUT:   %bound_method.loc13_5.2: <bound method> = bound_method %a.ref.loc13, %specific_fn.loc13_5
+// CHECK:STDOUT:   %.loc13_5.3: %Cpp.long_long.as.ModAssignWith.impl.Op.type.afaa70.1 = specific_constant imports.%Core.Op.6fd, @Cpp.long_long.as.ModAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.49994b.1]
+// CHECK:STDOUT:   %Op.ref.loc13: %Cpp.long_long.as.ModAssignWith.impl.Op.type.afaa70.1 = name_ref Op, %.loc13_5.3 [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.49994b.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc13, %Op.ref.loc13
+// CHECK:STDOUT:   %impl.elem0.loc13_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_5.3: <bound method> = bound_method %.loc13_11.2, %impl.elem0.loc13_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13_5: init %Cpp.long_long = call %bound_method.loc13_5.3(%.loc13_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_5.5: %Cpp.long_long = converted %.loc13_11.2, %.loc13_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc13, @Cpp.long_long.as.ModAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn.e3c8dd.2]
+// CHECK:STDOUT:   %bound_method.loc13_5.4: <bound method> = bound_method %a.ref.loc13, %Cpp.long_long.as.ModAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc13_11.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc13_11.3: <bound method> = bound_method %.loc13_11.2, %impl.elem0.loc13_11.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc13_11: init %Cpp.long_long = call %bound_method.loc13_11.3(%.loc13_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_11.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc13_11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc13_11.4: %Cpp.long_long = converted %.loc13_11.2, %.loc13_11.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.ModAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc13_5.4(%a.ref.loc13, %.loc13_11.4)
+// CHECK:STDOUT:   %a.ref.loc15: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc15: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc15: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc15: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc15_11.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc15_11.1: <bound method> = bound_method %int_1.loc15, %impl.elem0.loc15_11.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc15_11: <specific function> = specific_function %impl.elem0.loc15_11.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc15_11.2: <bound method> = bound_method %int_1.loc15, %specific_fn.loc15_11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc15: init %i64 = call %bound_method.loc15_11.2(%int_1.loc15) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_11.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc15 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc15_11.2: %i64 = converted %int_1.loc15, %.loc15_11.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc15_5.1: %.c2c = impl_witness_access constants.%BitAndAssignWith.impl_witness.80c, element0 [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.9241d8.2]
+// CHECK:STDOUT:   %bound_method.loc15_5.1: <bound method> = bound_method %a.ref.loc15, %impl.elem0.loc15_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc15_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc15_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc15_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc15_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc15_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc15_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc15_5: <specific function> = specific_function %impl.elem0.loc15_5.1, @Cpp.long_long.as.BitAndAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn.00c338.1]
+// CHECK:STDOUT:   %bound_method.loc15_5.2: <bound method> = bound_method %a.ref.loc15, %specific_fn.loc15_5
+// CHECK:STDOUT:   %.loc15_5.3: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.9d1673.1 = specific_constant imports.%Core.Op.c78, @Cpp.long_long.as.BitAndAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.9241d8.1]
+// CHECK:STDOUT:   %Op.ref.loc15: %Cpp.long_long.as.BitAndAssignWith.impl.Op.type.9d1673.1 = name_ref Op, %.loc15_5.3 [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.9241d8.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc15, %Op.ref.loc15
+// CHECK:STDOUT:   %impl.elem0.loc15_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc15_5.3: <bound method> = bound_method %.loc15_11.2, %impl.elem0.loc15_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc15_5: init %Cpp.long_long = call %bound_method.loc15_5.3(%.loc15_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc15_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_5.5: %Cpp.long_long = converted %.loc15_11.2, %.loc15_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc15, @Cpp.long_long.as.BitAndAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn.00c338.2]
+// CHECK:STDOUT:   %bound_method.loc15_5.4: <bound method> = bound_method %a.ref.loc15, %Cpp.long_long.as.BitAndAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc15_11.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc15_11.3: <bound method> = bound_method %.loc15_11.2, %impl.elem0.loc15_11.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc15_11: init %Cpp.long_long = call %bound_method.loc15_11.3(%.loc15_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_11.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc15_11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc15_11.4: %Cpp.long_long = converted %.loc15_11.2, %.loc15_11.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitAndAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc15_5.4(%a.ref.loc15, %.loc15_11.4)
+// CHECK:STDOUT:   %a.ref.loc16: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc16: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc16: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc16: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc16_11.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc16_11.1: <bound method> = bound_method %int_1.loc16, %impl.elem0.loc16_11.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc16_11: <specific function> = specific_function %impl.elem0.loc16_11.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc16_11.2: <bound method> = bound_method %int_1.loc16, %specific_fn.loc16_11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc16: init %i64 = call %bound_method.loc16_11.2(%int_1.loc16) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc16_11.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc16 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc16_11.2: %i64 = converted %int_1.loc16, %.loc16_11.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc16_5.1: %.8b2 = impl_witness_access constants.%BitOrAssignWith.impl_witness.bd2, element0 [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.acdb6d.2]
+// CHECK:STDOUT:   %bound_method.loc16_5.1: <bound method> = bound_method %a.ref.loc16, %impl.elem0.loc16_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc16_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc16_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc16_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc16_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc16_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc16_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc16_5: <specific function> = specific_function %impl.elem0.loc16_5.1, @Cpp.long_long.as.BitOrAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn.b0c3cb.1]
+// CHECK:STDOUT:   %bound_method.loc16_5.2: <bound method> = bound_method %a.ref.loc16, %specific_fn.loc16_5
+// CHECK:STDOUT:   %.loc16_5.3: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.4196b6.1 = specific_constant imports.%Core.Op.fa0, @Cpp.long_long.as.BitOrAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.acdb6d.1]
+// CHECK:STDOUT:   %Op.ref.loc16: %Cpp.long_long.as.BitOrAssignWith.impl.Op.type.4196b6.1 = name_ref Op, %.loc16_5.3 [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.acdb6d.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc16, %Op.ref.loc16
+// CHECK:STDOUT:   %impl.elem0.loc16_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc16_5.3: <bound method> = bound_method %.loc16_11.2, %impl.elem0.loc16_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc16_5: init %Cpp.long_long = call %bound_method.loc16_5.3(%.loc16_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc16_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_5.5: %Cpp.long_long = converted %.loc16_11.2, %.loc16_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc16, @Cpp.long_long.as.BitOrAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn.b0c3cb.2]
+// CHECK:STDOUT:   %bound_method.loc16_5.4: <bound method> = bound_method %a.ref.loc16, %Cpp.long_long.as.BitOrAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc16_11.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc16_11.3: <bound method> = bound_method %.loc16_11.2, %impl.elem0.loc16_11.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc16_11: init %Cpp.long_long = call %bound_method.loc16_11.3(%.loc16_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_11.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc16_11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc16_11.4: %Cpp.long_long = converted %.loc16_11.2, %.loc16_11.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitOrAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc16_5.4(%a.ref.loc16, %.loc16_11.4)
+// CHECK:STDOUT:   %a.ref.loc17: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc17: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc17: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc17: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc17_11.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc17_11.1: <bound method> = bound_method %int_1.loc17, %impl.elem0.loc17_11.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc17_11: <specific function> = specific_function %impl.elem0.loc17_11.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc17_11.2: <bound method> = bound_method %int_1.loc17, %specific_fn.loc17_11 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc17: init %i64 = call %bound_method.loc17_11.2(%int_1.loc17) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc17_11.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc17 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc17_11.2: %i64 = converted %int_1.loc17, %.loc17_11.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc17_5.1: %.9cc = impl_witness_access constants.%BitXorAssignWith.impl_witness.f91, element0 [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.3aa346.2]
+// CHECK:STDOUT:   %bound_method.loc17_5.1: <bound method> = bound_method %a.ref.loc17, %impl.elem0.loc17_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc17_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc17_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc17_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc17_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc17_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc17_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc17_5: <specific function> = specific_function %impl.elem0.loc17_5.1, @Cpp.long_long.as.BitXorAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn.8f3086.1]
+// CHECK:STDOUT:   %bound_method.loc17_5.2: <bound method> = bound_method %a.ref.loc17, %specific_fn.loc17_5
+// CHECK:STDOUT:   %.loc17_5.3: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.7f7009.1 = specific_constant imports.%Core.Op.3d4, @Cpp.long_long.as.BitXorAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.3aa346.1]
+// CHECK:STDOUT:   %Op.ref.loc17: %Cpp.long_long.as.BitXorAssignWith.impl.Op.type.7f7009.1 = name_ref Op, %.loc17_5.3 [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.3aa346.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc17, %Op.ref.loc17
+// CHECK:STDOUT:   %impl.elem0.loc17_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc17_5.3: <bound method> = bound_method %.loc17_11.2, %impl.elem0.loc17_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc17_5: init %Cpp.long_long = call %bound_method.loc17_5.3(%.loc17_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc17_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc17_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc17_5.5: %Cpp.long_long = converted %.loc17_11.2, %.loc17_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc17, @Cpp.long_long.as.BitXorAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn.8f3086.2]
+// CHECK:STDOUT:   %bound_method.loc17_5.4: <bound method> = bound_method %a.ref.loc17, %Cpp.long_long.as.BitXorAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc17_11.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc17_11.3: <bound method> = bound_method %.loc17_11.2, %impl.elem0.loc17_11.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc17_11: init %Cpp.long_long = call %bound_method.loc17_11.3(%.loc17_11.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc17_11.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc17_11 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc17_11.4: %Cpp.long_long = converted %.loc17_11.2, %.loc17_11.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.BitXorAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc17_5.4(%a.ref.loc17, %.loc17_11.4)
+// CHECK:STDOUT:   %a.ref.loc18: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc18: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc18: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc18: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc18_12.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc18_12.1: <bound method> = bound_method %int_1.loc18, %impl.elem0.loc18_12.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc18_12: <specific function> = specific_function %impl.elem0.loc18_12.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc18_12.2: <bound method> = bound_method %int_1.loc18, %specific_fn.loc18_12 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc18: init %i64 = call %bound_method.loc18_12.2(%int_1.loc18) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc18_12.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc18 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc18_12.2: %i64 = converted %int_1.loc18, %.loc18_12.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc18_5.1: %.334 = impl_witness_access constants.%LeftShiftAssignWith.impl_witness.c81, element0 [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.e91293.2]
+// CHECK:STDOUT:   %bound_method.loc18_5.1: <bound method> = bound_method %a.ref.loc18, %impl.elem0.loc18_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc18_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc18_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc18_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc18_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc18_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc18_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc18_5: <specific function> = specific_function %impl.elem0.loc18_5.1, @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn.1c7fb8.1]
+// CHECK:STDOUT:   %bound_method.loc18_5.2: <bound method> = bound_method %a.ref.loc18, %specific_fn.loc18_5
+// CHECK:STDOUT:   %.loc18_5.3: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.21cdd1.1 = specific_constant imports.%Core.Op.1b6, @Cpp.long_long.as.LeftShiftAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.e91293.1]
+// CHECK:STDOUT:   %Op.ref.loc18: %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.type.21cdd1.1 = name_ref Op, %.loc18_5.3 [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.e91293.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc18, %Op.ref.loc18
+// CHECK:STDOUT:   %impl.elem0.loc18_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc18_5.3: <bound method> = bound_method %.loc18_12.2, %impl.elem0.loc18_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc18_5: init %Cpp.long_long = call %bound_method.loc18_5.3(%.loc18_12.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc18_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_5.5: %Cpp.long_long = converted %.loc18_12.2, %.loc18_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc18, @Cpp.long_long.as.LeftShiftAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn.1c7fb8.2]
+// CHECK:STDOUT:   %bound_method.loc18_5.4: <bound method> = bound_method %a.ref.loc18, %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc18_12.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc18_12.3: <bound method> = bound_method %.loc18_12.2, %impl.elem0.loc18_12.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc18_12: init %Cpp.long_long = call %bound_method.loc18_12.3(%.loc18_12.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_12.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc18_12 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc18_12.4: %Cpp.long_long = converted %.loc18_12.2, %.loc18_12.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.LeftShiftAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc18_5.4(%a.ref.loc18, %.loc18_12.4)
+// CHECK:STDOUT:   %a.ref.loc19: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc19: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %int_64.loc19: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:   %i64.loc19: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   %impl.elem0.loc19_12.1: %.aba = impl_witness_access constants.%As.impl_witness.c71, element0 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.a54]
+// CHECK:STDOUT:   %bound_method.loc19_12.1: <bound method> = bound_method %int_1.loc19, %impl.elem0.loc19_12.1 [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.bound]
+// CHECK:STDOUT:   %specific_fn.loc19_12: <specific function> = specific_function %impl.elem0.loc19_12.1, @Core.IntLiteral.as.As.impl.Convert(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.As.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc19_12.2: <bound method> = bound_method %int_1.loc19, %specific_fn.loc19_12 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.As.impl.Convert.call.loc19: init %i64 = call %bound_method.loc19_12.2(%int_1.loc19) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc19_12.1: %i64 = value_of_initializer %Core.IntLiteral.as.As.impl.Convert.call.loc19 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc19_12.2: %i64 = converted %int_1.loc19, %.loc19_12.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %impl.elem0.loc19_5.1: %.f4a = impl_witness_access constants.%RightShiftAssignWith.impl_witness.1b7, element0 [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.efc522.2]
+// CHECK:STDOUT:   %bound_method.loc19_5.1: <bound method> = bound_method %a.ref.loc19, %impl.elem0.loc19_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc19_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc19_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc19_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc19_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc19_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc19_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc19_5: <specific function> = specific_function %impl.elem0.loc19_5.1, @Cpp.long_long.as.RightShiftAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn.1c2239.1]
+// CHECK:STDOUT:   %bound_method.loc19_5.2: <bound method> = bound_method %a.ref.loc19, %specific_fn.loc19_5
+// CHECK:STDOUT:   %.loc19_5.3: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.0ddf2d.1 = specific_constant imports.%Core.Op.bcc, @Cpp.long_long.as.RightShiftAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.efc522.1]
+// CHECK:STDOUT:   %Op.ref.loc19: %Cpp.long_long.as.RightShiftAssignWith.impl.Op.type.0ddf2d.1 = name_ref Op, %.loc19_5.3 [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.efc522.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref.loc19, %Op.ref.loc19
+// CHECK:STDOUT:   %impl.elem0.loc19_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc19_5.3: <bound method> = bound_method %.loc19_12.2, %impl.elem0.loc19_5.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc19_5: init %Cpp.long_long = call %bound_method.loc19_5.3(%.loc19_12.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc19_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_5.5: %Cpp.long_long = converted %.loc19_12.2, %.loc19_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref.loc19, @Cpp.long_long.as.RightShiftAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn.1c2239.2]
+// CHECK:STDOUT:   %bound_method.loc19_5.4: <bound method> = bound_method %a.ref.loc19, %Cpp.long_long.as.RightShiftAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc19_12.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc19_12.3: <bound method> = bound_method %.loc19_12.2, %impl.elem0.loc19_12.2 [concrete = constants.%i64.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc19_12: init %Cpp.long_long = call %bound_method.loc19_12.3(%.loc19_12.2) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_12.3: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc19_12 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc19_12.4: %Cpp.long_long = converted %.loc19_12.2, %.loc19_12.3 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.RightShiftAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc19_5.4(%a.ref.loc19, %.loc19_12.4)
+// CHECK:STDOUT:   %DestroyOp.bound: <bound method> = bound_method %a.var, constants.%DestroyOp
+// CHECK:STDOUT:   %DestroyOp.call: init %empty_tuple.type = call %DestroyOp.bound(%a.var)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @DestroyOp(%self.param: %Cpp.long_long) = "no_op";
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- compound_assignment_heterogeneous_long_long_and_int_literal.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %AddAssignWith.type.761: type = facet_type <@AddAssignWith, @AddAssignWith(Core.IntLiteral)> [concrete]
+// CHECK:STDOUT:   %AddAssignWith.Op.type.4fd: type = fn_type @AddAssignWith.Op, @AddAssignWith(Core.IntLiteral) [concrete]
+// CHECK:STDOUT:   %U.ea5: %ImplicitAs.type.a03 = symbolic_binding U, 0 [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.1, @Cpp.long_long.as.AddAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.1: %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.2, @Cpp.long_long.as.AddAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.2: %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness.e3f: <witness> = impl_witness imports.%AddAssignWith.impl_witness_table.815, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.11fd63.1: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.2, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.d69079.1: %Cpp.long_long.as.AddAssignWith.impl.Op.type.11fd63.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.11fd63.2: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.1, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.d69079.2: %Cpp.long_long.as.AddAssignWith.impl.Op.type.11fd63.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddAssignWith.facet: %AddAssignWith.type.761 = facet_value %Cpp.long_long, (%AddAssignWith.impl_witness.e3f) [concrete]
+// CHECK:STDOUT:   %.344: type = fn_type_with_self_type %AddAssignWith.Op.type.4fd, %AddAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.918060.1: <specific function> = specific_function %Cpp.long_long.as.AddAssignWith.impl.Op.d69079.2, @Cpp.long_long.as.AddAssignWith.impl.Op.1(%ImplicitAs.facet) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.918060.2: <specific function> = specific_function %Cpp.long_long.as.AddAssignWith.impl.Op.d69079.1, @Cpp.long_long.as.AddAssignWith.impl.Op.2(%ImplicitAs.facet) [concrete]
+// CHECK:STDOUT:   %DestroyOp.type: type = fn_type @DestroyOp [concrete]
+// CHECK:STDOUT:   %DestroyOp: %DestroyOp.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.277: @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.type.2 (%Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.1)]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness_table.815 = impl_witness_table (%Core.import_ref.277), @Cpp.long_long.as.AddAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.57a: @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.type.1 (%Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.2)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @CompoundAssignmentLongLongAndIntLiteral() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = ref_binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.var_patt: %pattern_type.76e = var_pattern %a.patt [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a.var: ref %Cpp.long_long = var %a.var_patt
+// CHECK:STDOUT:   %int_1.loc8: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem0.loc8: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %int_1.loc8, %impl.elem0.loc8 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc8: init %Cpp.long_long = call %bound_method.loc8(%int_1.loc8) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc8_3: init %Cpp.long_long = converted %int_1.loc8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc8 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   assign %a.var, %.loc8_3
+// CHECK:STDOUT:   %.loc8_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a: ref %Cpp.long_long = ref_binding a, %a.var
+// CHECK:STDOUT:   %a.ref: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %int_1.loc9: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem0.loc9_5.1: %.344 = impl_witness_access constants.%AddAssignWith.impl_witness.e3f, element0 [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.d69079.2]
+// CHECK:STDOUT:   %bound_method.loc9_5.1: <bound method> = bound_method %a.ref, %impl.elem0.loc9_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc9_5.1: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet]
+// CHECK:STDOUT:   %.loc9_5.1: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc9_5.1 [concrete = constants.%ImplicitAs.facet]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc9_5.2: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (constants.%ImplicitAs.impl_witness.82e) [concrete = constants.%ImplicitAs.facet]
+// CHECK:STDOUT:   %.loc9_5.2: %ImplicitAs.type.a03 = converted Core.IntLiteral, %ImplicitAs.facet.loc9_5.2 [concrete = constants.%ImplicitAs.facet]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0.loc9_5.1, @Cpp.long_long.as.AddAssignWith.impl.Op.1(constants.%ImplicitAs.facet) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.918060.1]
+// CHECK:STDOUT:   %bound_method.loc9_5.2: <bound method> = bound_method %a.ref, %specific_fn
+// CHECK:STDOUT:   %.loc9_5.3: %Cpp.long_long.as.AddAssignWith.impl.Op.type.11fd63.1 = specific_constant imports.%Core.Op.57a, @Cpp.long_long.as.AddAssignWith.impl(constants.%ImplicitAs.facet) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.d69079.1]
+// CHECK:STDOUT:   %Op.ref: %Cpp.long_long.as.AddAssignWith.impl.Op.type.11fd63.1 = name_ref Op, %.loc9_5.3 [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.d69079.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref, %Op.ref
+// CHECK:STDOUT:   %impl.elem0.loc9_5.2: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc9_5.3: <bound method> = bound_method %int_1.loc9, %impl.elem0.loc9_5.2 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc9_5: init %Cpp.long_long = call %bound_method.loc9_5.3(%int_1.loc9) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_5.4: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc9_5 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_5.5: %Cpp.long_long = converted %int_1.loc9, %.loc9_5.4 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref, @Cpp.long_long.as.AddAssignWith.impl.Op.2(constants.%ImplicitAs.facet) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.918060.2]
+// CHECK:STDOUT:   %bound_method.loc9_5.4: <bound method> = bound_method %a.ref, %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc9_8: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc9_8: <bound method> = bound_method %int_1.loc9, %impl.elem0.loc9_8 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc9_8: init %Cpp.long_long = call %bound_method.loc9_8(%int_1.loc9) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_8.1: %Cpp.long_long = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc9_8 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc9_8.2: %Cpp.long_long = converted %int_1.loc9, %.loc9_8.1 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc9_5.4(%a.ref, %.loc9_8.2)
+// CHECK:STDOUT:   %DestroyOp.bound: <bound method> = bound_method %a.var, constants.%DestroyOp
+// CHECK:STDOUT:   %DestroyOp.call: init %empty_tuple.type = call %DestroyOp.bound(%a.var)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @DestroyOp(%self.param: %Cpp.long_long) = "no_op";
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- compound_assignment_heterogeneous_long_long_and_runtime_i64.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %int_64: Core.IntLiteral = int_value 64 [concrete]
+// CHECK:STDOUT:   %i64: type = class_type @Int, @Int(%int_64) [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.2ad: type = facet_type <@ImplicitAs, @ImplicitAs(%i64)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.94e: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%i64) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d52: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.d52 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.1 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.a20 [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %pattern_type.95b: type = pattern_type %i64 [concrete]
+// CHECK:STDOUT:   %To: Core.IntLiteral = symbolic_binding To, 0 [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%To) [symbolic]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.556: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.74f, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert.2, @Core.IntLiteral.as.ImplicitAs.impl.b2d(%int_64) [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.b78 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.d48: %ImplicitAs.type.2ad = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.556) [concrete]
+// CHECK:STDOUT:   %.567: type = fn_type_with_self_type %ImplicitAs.Convert.type.94e, %ImplicitAs.facet.d48 [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Core.IntLiteral.as.ImplicitAs.impl.Convert.57d, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(%int_64) [concrete]
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %int_1.41a: %i64 = int_value 1 [concrete]
+// CHECK:STDOUT:   %AddAssignWith.type.d84: type = facet_type <@AddAssignWith, @AddAssignWith(%i64)> [concrete]
+// CHECK:STDOUT:   %AddAssignWith.Op.type.693: type = fn_type @AddAssignWith.Op, @AddAssignWith(%i64) [concrete]
+// CHECK:STDOUT:   %U.ea5: %ImplicitAs.type.a03 = symbolic_binding U, 0 [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.1, @Cpp.long_long.as.AddAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.1: %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.2, @Cpp.long_long.as.AddAssignWith.impl(%U.ea5) [symbolic]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.2: %Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2 = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.1b3: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.b19 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.c59: %ImplicitAs.type.a03 = facet_value %i64, (%ImplicitAs.impl_witness.1b3) [concrete]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness.767: <witness> = impl_witness imports.%AddAssignWith.impl_witness_table.815, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.1: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.2, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.1: %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.2: type = fn_type @Cpp.long_long.as.AddAssignWith.impl.Op.1, @Cpp.long_long.as.AddAssignWith.impl(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.2: %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %AddAssignWith.facet: %AddAssignWith.type.d84 = facet_value %Cpp.long_long, (%AddAssignWith.impl_witness.767) [concrete]
+// CHECK:STDOUT:   %.34b: type = fn_type_with_self_type %AddAssignWith.Op.type.693, %AddAssignWith.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.50a783.1: <specific function> = specific_function %Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.2, @Cpp.long_long.as.AddAssignWith.impl.Op.1(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %.b29: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet.c59 [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.type: type = fn_type @i64.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert: %i64.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.50a783.2: <specific function> = specific_function %Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.1, @Cpp.long_long.as.AddAssignWith.impl.Op.2(%ImplicitAs.facet.c59) [concrete]
+// CHECK:STDOUT:   %DestroyOp.type: type = fn_type @DestroyOp [concrete]
+// CHECK:STDOUT:   %DestroyOp: %DestroyOp.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type.aba = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.42d: @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert.type (%Core.IntLiteral.as.ImplicitAs.impl.Convert.type.4e6) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Core.IntLiteral.as.ImplicitAs.impl.b2d.%Core.IntLiteral.as.ImplicitAs.impl.Convert (constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.3c2)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.74f = impl_witness_table (%Core.import_ref.42d), @Core.IntLiteral.as.ImplicitAs.impl.b2d [concrete]
+// CHECK:STDOUT:   %Core.import_ref.277: @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.type.2 (%Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.1) = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.2 (constants.%Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.1)]
+// CHECK:STDOUT:   %AddAssignWith.impl_witness_table.815 = impl_witness_table (%Core.import_ref.277), @Cpp.long_long.as.AddAssignWith.impl [concrete]
+// CHECK:STDOUT:   %Core.Op.57a: @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.type.1 (%Cpp.long_long.as.AddAssignWith.impl.Op.type.3e35db.2) = import_ref Core//prelude/types/cpp/int, Op, loaded [symbolic = @Cpp.long_long.as.AddAssignWith.impl.%Cpp.long_long.as.AddAssignWith.impl.Op.1 (constants.%Cpp.long_long.as.AddAssignWith.impl.Op.cf74e0.2)]
+// CHECK:STDOUT:   %Core.import_ref.4f4: %i64.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.b19 = impl_witness_table (%Core.import_ref.4f4), @i64.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @CompoundAssignmentLongLongAndRuntimeI64() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = ref_binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.var_patt: %pattern_type.76e = var_pattern %a.patt [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a.var: ref %Cpp.long_long = var %a.var_patt
+// CHECK:STDOUT:   %int_1.loc8: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem0.loc8: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.a20]
+// CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %int_1.loc8, %impl.elem0.loc8 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.aae]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc8: init %Cpp.long_long = call %bound_method.loc8(%int_1.loc8) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc8_3: init %Cpp.long_long = converted %int_1.loc8, %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc8 [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   assign %a.var, %.loc8_3
+// CHECK:STDOUT:   %.loc8_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a: ref %Cpp.long_long = ref_binding a, %a.var
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %b.patt: %pattern_type.95b = value_binding_pattern b [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %int_1.loc9: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %.loc9_10: type = splice_block %i64 [concrete = constants.%i64] {
+// CHECK:STDOUT:     %int_64: Core.IntLiteral = int_value 64 [concrete = constants.%int_64]
+// CHECK:STDOUT:     %i64: type = class_type @Int, @Int(constants.%int_64) [concrete = constants.%i64]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %impl.elem0.loc9: %.567 = impl_witness_access constants.%ImplicitAs.impl_witness.556, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.57d]
+// CHECK:STDOUT:   %bound_method.loc9_16.1: <bound method> = bound_method %int_1.loc9, %impl.elem0.loc9 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound.102]
+// CHECK:STDOUT:   %specific_fn.loc9: <specific function> = specific_function %impl.elem0.loc9, @Core.IntLiteral.as.ImplicitAs.impl.Convert.2(constants.%int_64) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc9_16.2: <bound method> = bound_method %int_1.loc9, %specific_fn.loc9 [concrete = constants.%bound_method]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc9: init %i64 = call %bound_method.loc9_16.2(%int_1.loc9) [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc9_16.1: %i64 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call.loc9 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %.loc9_16.2: %i64 = converted %int_1.loc9, %.loc9_16.1 [concrete = constants.%int_1.41a]
+// CHECK:STDOUT:   %b: %i64 = value_binding b, %.loc9_16.2
+// CHECK:STDOUT:   %a.ref: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %b.ref: %i64 = name_ref b, %b
+// CHECK:STDOUT:   %impl.elem0.loc10_5.1: %.34b = impl_witness_access constants.%AddAssignWith.impl_witness.767, element0 [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.2]
+// CHECK:STDOUT:   %bound_method.loc10_5.1: <bound method> = bound_method %a.ref, %impl.elem0.loc10_5.1
+// CHECK:STDOUT:   %ImplicitAs.facet.loc10_5.1: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc10_5.1: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc10_5.1 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %ImplicitAs.facet.loc10_5.2: %ImplicitAs.type.a03 = facet_value constants.%i64, (constants.%ImplicitAs.impl_witness.1b3) [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %.loc10_5.2: %ImplicitAs.type.a03 = converted constants.%i64, %ImplicitAs.facet.loc10_5.2 [concrete = constants.%ImplicitAs.facet.c59]
+// CHECK:STDOUT:   %specific_fn.loc10: <specific function> = specific_function %impl.elem0.loc10_5.1, @Cpp.long_long.as.AddAssignWith.impl.Op.1(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.50a783.1]
+// CHECK:STDOUT:   %bound_method.loc10_5.2: <bound method> = bound_method %a.ref, %specific_fn.loc10
+// CHECK:STDOUT:   %.loc10_5.3: %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.1 = specific_constant imports.%Core.Op.57a, @Cpp.long_long.as.AddAssignWith.impl(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.1]
+// CHECK:STDOUT:   %Op.ref: %Cpp.long_long.as.AddAssignWith.impl.Op.type.2293dc.1 = name_ref Op, %.loc10_5.3 [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.fa1912.1]
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.bound: <bound method> = bound_method %a.ref, %Op.ref
+// CHECK:STDOUT:   %impl.elem0.loc10_5.2: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc10_5.3: <bound method> = bound_method %b.ref, %impl.elem0.loc10_5.2
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc10_5: init %Cpp.long_long = call %bound_method.loc10_5.3(%b.ref)
+// CHECK:STDOUT:   %.loc10_5.4: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc10_5
+// CHECK:STDOUT:   %.loc10_5.5: %Cpp.long_long = converted %b.ref, %.loc10_5.4
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn: <specific function> = specific_function %Op.ref, @Cpp.long_long.as.AddAssignWith.impl.Op.2(constants.%ImplicitAs.facet.c59) [concrete = constants.%Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn.50a783.2]
+// CHECK:STDOUT:   %bound_method.loc10_5.4: <bound method> = bound_method %a.ref, %Cpp.long_long.as.AddAssignWith.impl.Op.specific_fn
+// CHECK:STDOUT:   %impl.elem0.loc10_8: %.b29 = impl_witness_access constants.%ImplicitAs.impl_witness.1b3, element0 [concrete = constants.%i64.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc10_8: <bound method> = bound_method %b.ref, %impl.elem0.loc10_8
+// CHECK:STDOUT:   %i64.as.ImplicitAs.impl.Convert.call.loc10_8: init %Cpp.long_long = call %bound_method.loc10_8(%b.ref)
+// CHECK:STDOUT:   %.loc10_8.1: %Cpp.long_long = value_of_initializer %i64.as.ImplicitAs.impl.Convert.call.loc10_8
+// CHECK:STDOUT:   %.loc10_8.2: %Cpp.long_long = converted %b.ref, %.loc10_8.1
+// CHECK:STDOUT:   %Cpp.long_long.as.AddAssignWith.impl.Op.call: init %empty_tuple.type = call %bound_method.loc10_5.4(%a.ref, %.loc10_8.2)
+// CHECK:STDOUT:   %DestroyOp.bound: <bound method> = bound_method %a.var, constants.%DestroyOp
+// CHECK:STDOUT:   %DestroyOp.call: init %empty_tuple.type = call %DestroyOp.bound(%a.var)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @DestroyOp(%self.param: %Cpp.long_long) = "no_op";
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- increment_decrement_long_long.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %Cpp.long_long: type = class_type @LongLong64 [concrete]
+// CHECK:STDOUT:   %pattern_type.76e: type = pattern_type %Cpp.long_long [concrete]
+// CHECK:STDOUT:   %int_1.5b8: Core.IntLiteral = int_value 1 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.a03: type = facet_type <@ImplicitAs, @ImplicitAs(%Cpp.long_long)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.Convert.type.6e4: type = fn_type @ImplicitAs.Convert, @ImplicitAs(%Cpp.long_long) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.82e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.896 [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.a03 = facet_value Core.IntLiteral, (%ImplicitAs.impl_witness.82e) [concrete]
+// CHECK:STDOUT:   %.a93: type = fn_type_with_self_type %ImplicitAs.Convert.type.6e4, %ImplicitAs.facet [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.type: type = fn_type @Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %int_1.5b8, %Core.IntLiteral.as.ImplicitAs.impl.Convert [concrete]
+// CHECK:STDOUT:   %int_1.092: %Cpp.long_long = int_value 1 [concrete]
+// CHECK:STDOUT:   %Inc.type: type = facet_type <@Inc> [concrete]
+// CHECK:STDOUT:   %Inc.Op.type: type = fn_type @Inc.Op [concrete]
+// CHECK:STDOUT:   %Inc.impl_witness: <witness> = impl_witness imports.%Inc.impl_witness_table [concrete]
+// CHECK:STDOUT:   %Inc.facet: %Inc.type = facet_value %Cpp.long_long, (%Inc.impl_witness) [concrete]
+// CHECK:STDOUT:   %.905: type = fn_type_with_self_type %Inc.Op.type, %Inc.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.Inc.impl.Op.type: type = fn_type @Cpp.long_long.as.Inc.impl.Op [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.Inc.impl.Op: %Cpp.long_long.as.Inc.impl.Op.type = struct_value () [concrete]
+// CHECK:STDOUT:   %Dec.type: type = facet_type <@Dec> [concrete]
+// CHECK:STDOUT:   %Dec.Op.type: type = fn_type @Dec.Op [concrete]
+// CHECK:STDOUT:   %Dec.impl_witness: <witness> = impl_witness imports.%Dec.impl_witness_table [concrete]
+// CHECK:STDOUT:   %Dec.facet: %Dec.type = facet_value %Cpp.long_long, (%Dec.impl_witness) [concrete]
+// CHECK:STDOUT:   %.ba0: type = fn_type_with_self_type %Dec.Op.type, %Dec.facet [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.Dec.impl.Op.type: type = fn_type @Cpp.long_long.as.Dec.impl.Op [concrete]
+// CHECK:STDOUT:   %Cpp.long_long.as.Dec.impl.Op: %Cpp.long_long.as.Dec.impl.Op.type = struct_value () [concrete]
+// CHECK:STDOUT:   %DestroyOp.type: type = fn_type @DestroyOp [concrete]
+// CHECK:STDOUT:   %DestroyOp: %DestroyOp.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .long_long = constants.%Cpp.long_long
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.import_ref.d64: %Core.IntLiteral.as.ImplicitAs.impl.Convert.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.896 = impl_witness_table (%Core.import_ref.d64), @Core.IntLiteral.as.ImplicitAs.impl.a26 [concrete]
+// CHECK:STDOUT:   %Core.import_ref.af8: %Cpp.long_long.as.Inc.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.Inc.impl.Op]
+// CHECK:STDOUT:   %Inc.impl_witness_table = impl_witness_table (%Core.import_ref.af8), @Cpp.long_long.as.Inc.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.3350f: %Cpp.long_long.as.Dec.impl.Op.type = import_ref Core//prelude/types/cpp/int, loc{{\d+_\d+}}, loaded [concrete = constants.%Cpp.long_long.as.Dec.impl.Op]
+// CHECK:STDOUT:   %Dec.impl_witness_table = impl_witness_table (%Core.import_ref.3350f), @Cpp.long_long.as.Dec.impl [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @IncrementDecrementLongLong() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.76e = ref_binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.var_patt: %pattern_type.76e = var_pattern %a.patt [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a.var: ref %Cpp.long_long = var %a.var_patt
+// CHECK:STDOUT:   %int_1: Core.IntLiteral = int_value 1 [concrete = constants.%int_1.5b8]
+// CHECK:STDOUT:   %impl.elem0.loc8: %.a93 = impl_witness_access constants.%ImplicitAs.impl_witness.82e, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert]
+// CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %int_1, %impl.elem0.loc8 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:   %Core.IntLiteral.as.ImplicitAs.impl.Convert.call: init %Cpp.long_long = call %bound_method.loc8(%int_1) [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   %.loc8_3: init %Cpp.long_long = converted %int_1, %Core.IntLiteral.as.ImplicitAs.impl.Convert.call [concrete = constants.%int_1.092]
+// CHECK:STDOUT:   assign %a.var, %.loc8_3
+// CHECK:STDOUT:   %.loc8_13: type = splice_block %long_long.ref [concrete = constants.%Cpp.long_long] {
+// CHECK:STDOUT:     %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %long_long.ref: type = name_ref long_long, constants.%Cpp.long_long [concrete = constants.%Cpp.long_long]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a: ref %Cpp.long_long = ref_binding a, %a.var
+// CHECK:STDOUT:   %a.ref.loc9: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem0.loc9: %.905 = impl_witness_access constants.%Inc.impl_witness, element0 [concrete = constants.%Cpp.long_long.as.Inc.impl.Op]
+// CHECK:STDOUT:   %bound_method.loc9: <bound method> = bound_method %a.ref.loc9, %impl.elem0.loc9
+// CHECK:STDOUT:   %Cpp.long_long.as.Inc.impl.Op.call: init %empty_tuple.type = call %bound_method.loc9(%a.ref.loc9)
+// CHECK:STDOUT:   %a.ref.loc10: ref %Cpp.long_long = name_ref a, %a
+// CHECK:STDOUT:   %impl.elem0.loc10: %.ba0 = impl_witness_access constants.%Dec.impl_witness, element0 [concrete = constants.%Cpp.long_long.as.Dec.impl.Op]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %a.ref.loc10, %impl.elem0.loc10
+// CHECK:STDOUT:   %Cpp.long_long.as.Dec.impl.Op.call: init %empty_tuple.type = call %bound_method.loc10(%a.ref.loc10)
+// CHECK:STDOUT:   %DestroyOp.bound: <bound method> = bound_method %a.var, constants.%DestroyOp
+// CHECK:STDOUT:   %DestroyOp.call: init %empty_tuple.type = call %DestroyOp.bound(%a.var)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @DestroyOp(%self.param: %Cpp.long_long) = "no_op";
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- unsigned_long_long.carbon
 // CHECK:STDOUT:


### PR DESCRIPTION
Adds arithmetic and bitwise operators, compound assignments, and increment/decrement operations for CppCompat.LongLong64.

Context: https://github.com/carbon-language/carbon-lang/issues/6275.

Part of https://github.com/carbon-language/carbon-lang/issues/5263.
