### PR TITLE
Fix usage of IDs with wrong SemIR::File.

### DIFF
--- a/toolchain/sem_ir/expr_info.cpp
+++ b/toolchain/sem_ir/expr_info.cpp
@@ -22,9 +22,8 @@ static auto AsAnyInstId(Inst::ArgAndKind arg) -> InstId {
   return arg.As<SemIR::AbsoluteInstId>();
 }
 
-auto GetExprCategory(const File& file, InstId inst_id) -> ExprCategory {
-  const File* ir = &file;
-
+static auto GetExprCategoryImpl(const File* ir, InstId inst_id)
+    -> ExprCategory {
   // The overall expression category if the current instruction is a value
   // expression.
   ExprCategory value_category = ExprCategory::Value;
@@ -58,21 +57,21 @@ auto GetExprCategory(const File& file, InstId inst_id) -> ExprCategory {
         inst_id = import_ir_inst.inst_id();
         return std::nullopt;
       } else if constexpr (std::same_as<TypedInstT, Call>) {
-        auto callee = GetCallee(file, inst.callee_id);
+        auto callee = GetCallee(*ir, inst.callee_id);
         CARBON_KIND_SWITCH(callee) {
           case CARBON_KIND(SemIR::CalleeError _): {
             return ExprCategory::Error;
           }
           case CARBON_KIND(SemIR::CalleeFunction callee_function): {
             const auto& function =
-                file.functions().Get(callee_function.function_id);
+                ir->functions().Get(callee_function.function_id);
             auto return_form_id = function.GetDeclaredReturnForm(
-                file, callee_function.resolved_specific_id);
+                *ir, callee_function.resolved_specific_id);
             if (!return_form_id.has_value()) {
               // Treat as equivalent to `-> ()`.
               return ExprCategory::Initializing;
             }
-            auto return_form = file.insts().Get(return_form_id);
+            auto return_form = ir->insts().Get(return_form_id);
             CARBON_KIND_SWITCH(return_form) {
               case CARBON_KIND(InitForm _):
                 return ExprCategory::Initializing;
@@ -135,6 +134,10 @@ auto GetExprCategory(const File& file, InstId inst_id) -> ExprCategory {
       }
     }
   }
+}
+
+auto GetExprCategory(const File& file, InstId inst_id) -> ExprCategory {
+  return GetExprCategoryImpl(&file, inst_id);
 }
 
 auto FindReturnSlotArgForInitializer(const File& sem_ir, InstId init_id,

--- a/toolchain/sem_ir/generic.cpp
+++ b/toolchain/sem_ir/generic.cpp
@@ -89,8 +89,8 @@ static auto GetConstantInSpecific(const File& specific_ir,
     CARBON_CHECK(
         specific_ir.generics().GetSelfSpecific(
             specific_ir.specifics().Get(specific_id).generic_id) == specific_id,
-        "Queried {0} in {1} for {2} before it was resolved.", symbolic.index,
-        specific_id,
+        "Queried {0} {1} in {2} for generic {3} before it was resolved.",
+        symbolic.index, const_ir.insts().Get(symbolic.inst_id), specific_id,
         specific_ir.insts().Get(
             specific_ir.generics().Get(specific.generic_id).decl_id));
     // TODO: Make sure this is the same value that we put in the self specific


### PR DESCRIPTION
Found by inspection; I haven't found a way to cause this to manifest, and I'm not sure it's possible. Refactor slightly to make it harder for this bug to recur.

Also make a CHECK a bit more informative. (Unrelated, but I was investigating a failure of that CHECK when I found this.)