### PR TITLE
Replace `convert_checked` with `convert` in some `ImplicitAs` impls

### DIFF
--- a/core/prelude/types/cpp/int.carbon
+++ b/core/prelude/types/cpp/int.carbon
@@ -93,7 +93,7 @@ final impl CppCompat.ULong32 as ImplicitAs(IntLiteral()) {
 
 // TODO: ImplicitAs from UInt(N) to ULong32 if N < 32.
 impl u32 as ImplicitAs(CppCompat.ULong32) {
-  fn Convert[self: Self]() -> CppCompat.ULong32 = "int.convert_checked";
+  fn Convert[self: Self]() -> CppCompat.ULong32 = "int.convert";
 }
 
 // TODO: ImplicitAs from ULong32 to UInt(N) if N > 32.
@@ -142,7 +142,7 @@ final impl CppCompat.ULongLong64 as ImplicitAs(IntLiteral()) {
 
 // TODO: ImplicitAs from UInt(N) to ULongLong64 if N < 64.
 impl u64 as ImplicitAs(CppCompat.ULongLong64) {
-  fn Convert[self: Self]() -> CppCompat.ULongLong64 = "int.convert_checked";
+  fn Convert[self: Self]() -> CppCompat.ULongLong64 = "int.convert";
 }
 
 // TODO: ImplicitAs from ULongLong64 to UInt(N) if N > 64.


### PR DESCRIPTION
`convert_checked` is for conversions that are checked at compile time. Since these conversions do not require a constant value they should use `checked` instead.

(Split out from https://github.com/carbon-language/carbon-lang/pull/6673, explanation of convert/convert_checked derived from the [Jan 20, 2026 meeting notes](https://docs.google.com/document/d/1YlxEOJ0r-o19o19TCJbFl4Ln1U88yn_Vj23y1Hr5vTk/edit?tab=t.tjeylv584s7j#heading=h.ih31dlc0ma58).)

