### PR TITLE
Fix SIGSEGV when comparing member without self

### DIFF
--- a/toolchain/check/testdata/class/fail_unbound_field.carbon
+++ b/toolchain/check/testdata/class/fail_unbound_field.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/full.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -18,6 +18,14 @@ class Class {
     // CHECK:STDERR:            ^~~~~
     // CHECK:STDERR:
     return field;
+  }
+
+  fn IsZero() -> bool {
+    // CHECK:STDERR: fail_unbound_field.carbon:[[@LINE+4]]:12: error: cannot access member of interface `Core.EqWith(Core.IntLiteral)` in type `<unbound element of class Class>` that does not implement that interface [MissingImplInMemberAccess]
+    // CHECK:STDERR:     return field == 0;
+    // CHECK:STDERR:            ^~~~~~~~~~
+    // CHECK:STDERR:
+    return field == 0;
   }
 }
 

--- a/toolchain/sem_ir/type_iterator.cpp
+++ b/toolchain/sem_ir/type_iterator.cpp
@@ -104,6 +104,7 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
     case NamespaceType::Kind:
     case RequireSpecificDefinitionType::Kind:
     case TypeType::Kind:
+    case UnboundElementType::Kind:
     case WitnessType::Kind: {
       return Step::ConcreteType{.type_id = type_id};
     }


### PR DESCRIPTION
This fixes a crash when a member is compared without `self.`.

**Repro:**
```carbon
class Stack {
  fn Empty[self: Self]() -> bool {
    return size == 0;
  }

  var size: i32;
}
```

Prior to this change, this path crashed with a fatal in [type_iterator.cpp](https://github.com/carbon-language/carbon-lang/blob/7938d9a8d0556498754feb12695776702984c235/toolchain/sem_ir/type_iterator.cpp) due to an unhandled type instruction.

This was caused by `TypeIterator::ProcessTypeId` not handling `UnboundElementType`.

**What changed:**
- Handle `UnboundElementType` in `TypeIterator::ProcessTypeId`.
- Added a regression check in [fail_unbound_field.carbon](https://github.com/carbon-language/carbon-lang/blob/7938d9a8d0556498754feb12695776702984c235/toolchain/check/testdata/class/fail_unbound_field.carbon) for `field == 0`.

Closes #6703 
