### PR TITLE
Support if expressions in `eval fn`.

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -2572,7 +2572,7 @@ auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
 class FunctionExecContext : public EvalContext {
  public:
   // A block argument passed to `BranchWithArg`.
-  struct BlockArg {
+  struct BlockArgValue {
     SemIR::InstBlockId block_id = SemIR::InstBlockId::None;
     SemIR::ConstantId arg_id = SemIR::ConstantId::None;
   };
@@ -2611,12 +2611,16 @@ class FunctionExecContext : public EvalContext {
     return blocks_.back().consume_front();
   }
 
-  // Sets the most recent block argument seen by a `BranchWithArg`. This can
-  // later be retrieved by a `BlockArg`.
-  auto SetLastBlockArg(BlockArg arg) -> void { last_block_arg_ = arg; }
+  // Sets the most recent block argument value provided by a `BranchWithArg`.
+  // This can later be retrieved by a `BlockArg`.
+  auto SetMostRecentBlockArgValue(BlockArgValue arg) -> void {
+    most_recent_block_arg_value_ = arg;
+  }
 
-  // Returns the most recent block argument seen by a `BranchWithArg`.
-  auto last_block_arg() const -> BlockArg { return last_block_arg_; }
+  // Returns the most recent block argument value provided by a `BranchWithArg`.
+  auto most_recent_block_arg_value() const -> BlockArgValue {
+    return most_recent_block_arg_value_;
+  }
 
  private:
   // The stack of code blocks that we are currently evaluating. This is kept as
@@ -2628,11 +2632,11 @@ class FunctionExecContext : public EvalContext {
   // The arguments in the function call.
   llvm::ArrayRef<SemIR::InstId> args_;
 
-  // The last `BranchWithArg` argument seen. We assume that we only need to
-  // track one of these, as the branch target will invoke `BlockArg` before the
-  // next `BranchWithArg` happens. We will need to track more than one of these
-  // if that ever changes.
-  BlockArg last_block_arg_;
+  // The block argument provided by the most recently executed `BranchWithArg`.
+  // We assume that we only need to track one of these, as the branch target
+  // will invoke `BlockArg` before the next `BranchWithArg` happens. We will
+  // need to track more than one of these if that ever changes.
+  BlockArgValue most_recent_block_arg_value_;
 };
 
 // Handles the result of executing an instruction in a function. Returns an
@@ -2690,9 +2694,11 @@ auto TryExecTypedInst<SemIR::BlockArg>(FunctionExecContext& eval_context,
                                        SemIR::InstId inst_id, SemIR::Inst inst)
     -> SemIR::ConstantId {
   auto block_arg = inst.As<SemIR::BlockArg>();
-  CARBON_CHECK(block_arg.block_id == eval_context.last_block_arg().block_id,
-               "BlockArg does not refer to most recent BranchWithArg");
-  eval_context.locals().Update(inst_id, eval_context.last_block_arg().arg_id);
+  CARBON_CHECK(
+      block_arg.block_id == eval_context.most_recent_block_arg_value().block_id,
+      "BlockArg does not refer to most recent BranchWithArg");
+  eval_context.locals().Update(
+      inst_id, eval_context.most_recent_block_arg_value().arg_id);
   return SemIR::ConstantId::None;
 }
 
@@ -2727,7 +2733,7 @@ auto TryExecTypedInst<SemIR::BranchWithArg>(FunctionExecContext& eval_context,
                                             SemIR::Inst inst)
     -> SemIR::ConstantId {
   auto branch = inst.As<SemIR::BranchWithArg>();
-  eval_context.SetLastBlockArg(
+  eval_context.SetMostRecentBlockArgValue(
       {.block_id = branch.target_id,
        .arg_id = eval_context.GetConstantValue(branch.arg_id)});
   eval_context.BranchTo(branch.target_id);

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -2571,6 +2571,12 @@ auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
 // control flow and (eventually) side effects and mutable state.
 class FunctionExecContext : public EvalContext {
  public:
+  // A block argument passed to `BranchWithArg`.
+  struct BlockArg {
+    SemIR::InstBlockId block_id = SemIR::InstBlockId::None;
+    SemIR::ConstantId arg_id = SemIR::ConstantId::None;
+  };
+
   FunctionExecContext(Context* context, SemIR::LocId loc_id,
                       SemIR::SpecificId specific_id,
                       Map<SemIR::InstId, SemIR::ConstantId>* locals,
@@ -2579,22 +2585,54 @@ class FunctionExecContext : public EvalContext {
                     LocalEvalInfo{.locals = locals}),
         args_(context->inst_blocks().Get(args_id)) {}
 
-  // Returns the instructions to execute to complete this function invocation.
-  // In order to support `splice_block`, this is a stack of blocks. When the
-  // innermost block is complete, it will be popped and the next outer block
-  // will execute.
-  auto blocks() -> llvm::SmallVectorImpl<llvm::ArrayRef<SemIR::InstId>>& {
-    return blocks_;
-  }
-
   // Returns the argument values supplied in the call to the function.
   auto args() const -> llvm::ArrayRef<SemIR::InstId> { return args_; }
 
   using EvalContext::locals;
 
+  // Branch control flow to the given block. This replaces the innermost block
+  // in the block stack, but doesn't affect any enclosing blocks.
+  auto BranchTo(SemIR::InstBlockId block_id) -> void {
+    blocks_.back() = inst_blocks().Get(block_id);
+  }
+
+  // Push a new block to be executed immediately. After the block finishes,
+  // control will resume after the current instruction.
+  auto PushBlock(SemIR::InstBlockId block_id) -> void {
+    blocks_.push_back(inst_blocks().Get(block_id));
+  }
+
+  // Pops and returns the next instruction to be executed.
+  auto PopNextInstId() -> SemIR::InstId {
+    while (blocks_.back().empty()) {
+      blocks_.pop_back();
+      CARBON_CHECK(!blocks_.empty(), "Fell off end of function");
+    }
+    return blocks_.back().consume_front();
+  }
+
+  // Sets the most recent block argument seen by a `BranchWithArg`. This can
+  // later be retrieved by a `BlockArg`.
+  auto SetLastBlockArg(BlockArg arg) -> void { last_block_arg_ = arg; }
+
+  // Returns the most recent block argument seen by a `BranchWithArg`.
+  auto last_block_arg() const -> BlockArg { return last_block_arg_; }
+
  private:
+  // The stack of code blocks that we are currently evaluating. This is kept as
+  // a stack so that we can schedule the function body to execute after the decl
+  // block and so that we can handle `SpliceBlock`s. When the innermost block is
+  // complete, it will be popped and the next outer block will execute.
   llvm::SmallVector<llvm::ArrayRef<SemIR::InstId>, 4> blocks_;
+
+  // The arguments in the function call.
   llvm::ArrayRef<SemIR::InstId> args_;
+
+  // The last `BranchWithArg` argument seen. We assume that we only need to
+  // track one of these, as the branch target will invoke `BlockArg` before the
+  // next `BranchWithArg` happens. We will need to track more than one of these
+  // if that ever changes.
+  BlockArg last_block_arg_;
 };
 
 // Handles the result of executing an instruction in a function. Returns an
@@ -2648,12 +2686,22 @@ static auto TryExecTypedInst(FunctionExecContext& eval_context,
 }
 
 template <>
+auto TryExecTypedInst<SemIR::BlockArg>(FunctionExecContext& eval_context,
+                                       SemIR::InstId inst_id, SemIR::Inst inst)
+    -> SemIR::ConstantId {
+  auto block_arg = inst.As<SemIR::BlockArg>();
+  CARBON_CHECK(block_arg.block_id == eval_context.last_block_arg().block_id,
+               "BlockArg does not refer to most recent BranchWithArg");
+  eval_context.locals().Update(inst_id, eval_context.last_block_arg().arg_id);
+  return SemIR::ConstantId::None;
+}
+
+template <>
 auto TryExecTypedInst<SemIR::Branch>(FunctionExecContext& eval_context,
                                      SemIR::InstId /*inst_id*/,
                                      SemIR::Inst inst) -> SemIR::ConstantId {
   auto branch = inst.As<SemIR::Branch>();
-  eval_context.blocks().back() =
-      eval_context.context().inst_blocks().Get(branch.target_id);
+  eval_context.BranchTo(branch.target_id);
   return SemIR::ConstantId::None;
 }
 
@@ -2668,13 +2716,23 @@ auto TryExecTypedInst<SemIR::BranchIf>(FunctionExecContext& eval_context,
   }
   auto cond = eval_context.insts().GetAs<SemIR::BoolLiteral>(cond_id);
   if (cond.value == SemIR::BoolValue::True) {
-    eval_context.blocks().back() =
-        eval_context.context().inst_blocks().Get(branch_if.target_id);
+    eval_context.BranchTo(branch_if.target_id);
   }
   return SemIR::ConstantId::None;
 }
 
-// TODO: BranchWithArg and BlockArg.
+template <>
+auto TryExecTypedInst<SemIR::BranchWithArg>(FunctionExecContext& eval_context,
+                                            SemIR::InstId /*inst_id*/,
+                                            SemIR::Inst inst)
+    -> SemIR::ConstantId {
+  auto branch = inst.As<SemIR::BranchWithArg>();
+  eval_context.SetLastBlockArg(
+      {.block_id = branch.target_id,
+       .arg_id = eval_context.GetConstantValue(branch.arg_id)});
+  eval_context.BranchTo(branch.target_id);
+  return SemIR::ConstantId::None;
+}
 
 template <>
 auto TryExecTypedInst<SemIR::Return>(FunctionExecContext& eval_context,
@@ -2717,8 +2775,7 @@ auto TryExecTypedInst<SemIR::SpliceBlock>(FunctionExecContext& eval_context,
                                           SemIR::Inst inst)
     -> SemIR::ConstantId {
   auto splice_block = inst.As<SemIR::SpliceBlock>();
-  eval_context.blocks().push_back(
-      eval_context.context().inst_blocks().Get(splice_block.block_id));
+  eval_context.PushBlock(splice_block.block_id);
   // TODO: Copy the values from the result_id instruction to the result of
   // the splice_block instruction once the spliced block finishes.
   return SemIR::ConstantId::None;
@@ -2825,25 +2882,15 @@ static auto TryEvalCall(EvalContext& outer_eval_context, SemIR::LocId loc_id,
       });
 
   // Execute the function decl block followed by the body.
-  auto push_block = [&](SemIR::InstBlockId block_id) {
-    eval_context.blocks().push_back(
-        eval_context.context().inst_blocks().Get(block_id));
-  };
-  push_block(function.body_block_ids.front());
-  push_block(eval_context.insts()
-                 .GetAs<SemIR::FunctionDecl>(function.definition_id)
-                 .decl_block_id);
+  eval_context.PushBlock(function.body_block_ids.front());
+  eval_context.PushBlock(eval_context.insts()
+                             .GetAs<SemIR::FunctionDecl>(function.definition_id)
+                             .decl_block_id);
 
   // Execute the blocks. This is mostly expression evaluation, with special
   // handling for control flow and parameters.
   while (true) {
-    if (eval_context.blocks().back().empty()) {
-      eval_context.blocks().pop_back();
-      CARBON_CHECK(!eval_context.blocks().empty(), "Fell off end of function");
-      continue;
-    }
-
-    auto inst_id = eval_context.blocks().back().consume_front();
+    auto inst_id = eval_context.PopNextInstId();
     auto inst = eval_context.context().insts().Get(inst_id);
     if (auto result = TryExecInst(eval_context, inst_id, inst);
         result.has_value()) {

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -2613,13 +2613,13 @@ class FunctionExecContext : public EvalContext {
 
   // Sets the most recent block argument value provided by a `BranchWithArg`.
   // This can later be retrieved by a `BlockArg`.
-  auto SetMostRecentBlockArgValue(BlockArgValue arg) -> void {
-    most_recent_block_arg_value_ = arg;
+  auto SetCurrentBlockArgValue(BlockArgValue arg) -> void {
+    current_block_arg_value_ = arg;
   }
 
   // Returns the most recent block argument value provided by a `BranchWithArg`.
-  auto most_recent_block_arg_value() const -> BlockArgValue {
-    return most_recent_block_arg_value_;
+  auto current_block_arg_value() const -> BlockArgValue {
+    return current_block_arg_value_;
   }
 
  private:
@@ -2636,7 +2636,7 @@ class FunctionExecContext : public EvalContext {
   // We assume that we only need to track one of these, as the branch target
   // will invoke `BlockArg` before the next `BranchWithArg` happens. We will
   // need to track more than one of these if that ever changes.
-  BlockArgValue most_recent_block_arg_value_;
+  BlockArgValue current_block_arg_value_;
 };
 
 // Handles the result of executing an instruction in a function. Returns an
@@ -2695,10 +2695,10 @@ auto TryExecTypedInst<SemIR::BlockArg>(FunctionExecContext& eval_context,
     -> SemIR::ConstantId {
   auto block_arg = inst.As<SemIR::BlockArg>();
   CARBON_CHECK(
-      block_arg.block_id == eval_context.most_recent_block_arg_value().block_id,
+      block_arg.block_id == eval_context.current_block_arg_value().block_id,
       "BlockArg does not refer to most recent BranchWithArg");
-  eval_context.locals().Update(
-      inst_id, eval_context.most_recent_block_arg_value().arg_id);
+  eval_context.locals().Update(inst_id,
+                               eval_context.current_block_arg_value().arg_id);
   return SemIR::ConstantId::None;
 }
 
@@ -2733,7 +2733,7 @@ auto TryExecTypedInst<SemIR::BranchWithArg>(FunctionExecContext& eval_context,
                                             SemIR::Inst inst)
     -> SemIR::ConstantId {
   auto branch = inst.As<SemIR::BranchWithArg>();
-  eval_context.SetMostRecentBlockArgValue(
+  eval_context.SetCurrentBlockArgValue(
       {.block_id = branch.target_id,
        .arg_id = eval_context.GetConstantValue(branch.arg_id)});
   eval_context.BranchTo(branch.target_id);

--- a/toolchain/check/testdata/eval/branch.carbon
+++ b/toolchain/check/testdata/eval/branch.carbon
@@ -38,31 +38,19 @@ var a: F(true) = MakeA();
 var b: F(false) = MakeB();
 //@dump-sem-ir-end
 
-// --- fail_todo_if_expression_in_eval_fn.carbon
+// --- if_expression_in_eval_fn.carbon
 
 library "[[@TEST_NAME]]";
 import library "types";
 
 eval fn F(b: bool) -> type {
-  // CHECK:STDERR: fail_todo_if_expression_in_eval_fn.carbon:[[@LINE+3]]:10: error: expression is runtime; expected constant [EvalRequiresConstantValue]
-  // CHECK:STDERR:   return if b then A else B;
-  // CHECK:STDERR:          ^~~~
   return if b then A else B;
 }
 
-// CHECK:STDERR: fail_todo_if_expression_in_eval_fn.carbon:[[@LINE+7]]:8: note: in call to F here [InCallToEvalFn]
-// CHECK:STDERR: var a: F(true) = MakeA();
-// CHECK:STDERR:        ^~~~~~~
-// CHECK:STDERR:
-// CHECK:STDERR: fail_todo_if_expression_in_eval_fn.carbon:[[@LINE-7]]:10: error: expression is runtime; expected constant [EvalRequiresConstantValue]
-// CHECK:STDERR:   return if b then A else B;
-// CHECK:STDERR:          ^~~~
+//@dump-sem-ir-begin
 var a: F(true) = MakeA();
-// CHECK:STDERR: fail_todo_if_expression_in_eval_fn.carbon:[[@LINE+4]]:8: note: in call to F here [InCallToEvalFn]
-// CHECK:STDERR: var b: F(false) = MakeB();
-// CHECK:STDERR:        ^~~~~~~~
-// CHECK:STDERR:
 var b: F(false) = MakeB();
+//@dump-sem-ir-end
 
 // --- fail_todo_if_expression_direct.carbon
 
@@ -136,6 +124,70 @@ var b: if false then A else B = MakeB();
 // CHECK:STDOUT:   %MakeB.ref: %MakeB.type = name_ref MakeB, imports.%Main.MakeB [concrete = constants.%MakeB]
 // CHECK:STDOUT:   %.loc15: ref %B = splice_block file.%b.var [concrete = file.%b.var] {}
 // CHECK:STDOUT:   %MakeB.call: init %B to %.loc15 = call %MakeB.ref()
+// CHECK:STDOUT:   assign file.%b.var, %MakeB.call
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- if_expression_in_eval_fn.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %A: type = class_type @A [concrete]
+// CHECK:STDOUT:   %B: type = class_type @B [concrete]
+// CHECK:STDOUT:   %true: bool = bool_literal true [concrete]
+// CHECK:STDOUT:   %pattern_type.1ab: type = pattern_type %A [concrete]
+// CHECK:STDOUT:   %MakeA.type: type = fn_type @MakeA [concrete]
+// CHECK:STDOUT:   %MakeA: %MakeA.type = struct_value () [concrete]
+// CHECK:STDOUT:   %false: bool = bool_literal false [concrete]
+// CHECK:STDOUT:   %pattern_type.1f4: type = pattern_type %B [concrete]
+// CHECK:STDOUT:   %MakeB.type: type = fn_type @MakeB [concrete]
+// CHECK:STDOUT:   %MakeB: %MakeB.type = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Main.MakeA: %MakeA.type = import_ref Main//types, MakeA, loaded [concrete = constants.%MakeA]
+// CHECK:STDOUT:   %Main.MakeB: %MakeB.type = import_ref Main//types, MakeB, loaded [concrete = constants.%MakeB]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %a.patt: %pattern_type.1ab = ref_binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.var_patt: %pattern_type.1ab = var_pattern %a.patt [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a.var: ref %A = var %a.var_patt [concrete]
+// CHECK:STDOUT:   %.loc10_14.1: type = splice_block %.loc10_14.3 [concrete = constants.%A] {
+// CHECK:STDOUT:     %F.ref.loc10: %F.type = name_ref F, %F.decl [concrete = constants.%F]
+// CHECK:STDOUT:     %true: bool = bool_literal true [concrete = constants.%true]
+// CHECK:STDOUT:     %F.call.loc10: init type = call %F.ref.loc10(%true) [concrete = constants.%A]
+// CHECK:STDOUT:     %.loc10_14.2: type = value_of_initializer %F.call.loc10 [concrete = constants.%A]
+// CHECK:STDOUT:     %.loc10_14.3: type = converted %F.call.loc10, %.loc10_14.2 [concrete = constants.%A]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %a: ref %A = ref_binding a, %a.var [concrete = %a.var]
+// CHECK:STDOUT:   name_binding_decl {
+// CHECK:STDOUT:     %b.patt: %pattern_type.1f4 = ref_binding_pattern b [concrete]
+// CHECK:STDOUT:     %b.var_patt: %pattern_type.1f4 = var_pattern %b.patt [concrete]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %b.var: ref %B = var %b.var_patt [concrete]
+// CHECK:STDOUT:   %.loc11_15.1: type = splice_block %.loc11_15.3 [concrete = constants.%B] {
+// CHECK:STDOUT:     %F.ref.loc11: %F.type = name_ref F, %F.decl [concrete = constants.%F]
+// CHECK:STDOUT:     %false: bool = bool_literal false [concrete = constants.%false]
+// CHECK:STDOUT:     %F.call.loc11: init type = call %F.ref.loc11(%false) [concrete = constants.%B]
+// CHECK:STDOUT:     %.loc11_15.2: type = value_of_initializer %F.call.loc11 [concrete = constants.%B]
+// CHECK:STDOUT:     %.loc11_15.3: type = converted %F.call.loc11, %.loc11_15.2 [concrete = constants.%B]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %b: ref %B = ref_binding b, %b.var [concrete = %b.var]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @__global_init() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %MakeA.ref: %MakeA.type = name_ref MakeA, imports.%Main.MakeA [concrete = constants.%MakeA]
+// CHECK:STDOUT:   %.loc10: ref %A = splice_block file.%a.var [concrete = file.%a.var] {}
+// CHECK:STDOUT:   %MakeA.call: init %A to %.loc10 = call %MakeA.ref()
+// CHECK:STDOUT:   assign file.%a.var, %MakeA.call
+// CHECK:STDOUT:   %MakeB.ref: %MakeB.type = name_ref MakeB, imports.%Main.MakeB [concrete = constants.%MakeB]
+// CHECK:STDOUT:   %.loc11: ref %B = splice_block file.%b.var [concrete = file.%b.var] {}
+// CHECK:STDOUT:   %MakeB.call: init %B to %.loc11 = call %MakeB.ref()
 // CHECK:STDOUT:   assign file.%b.var, %MakeB.call
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }


### PR DESCRIPTION
Add support for `BranchWithArg` and `BlockArg` during compile-time function execution. We only track the most recent block arg value for now, because that's all we need -- we never look at a block argument for any block other than the current one.

Also refactor `FunctionExecContext` to better encapsulate the blocks list.