### PR TITLE
Fix access to members of required interface from parent

### DIFF
--- a/toolchain/check/handle_require.cpp
+++ b/toolchain/check/handle_require.cpp
@@ -7,6 +7,7 @@
 #include "toolchain/check/convert.h"
 #include "toolchain/check/generic.h"
 #include "toolchain/check/handle.h"
+#include "toolchain/check/impl_lookup.h"
 #include "toolchain/check/inst.h"
 #include "toolchain/check/interface.h"
 #include "toolchain/check/modifiers.h"
@@ -301,14 +302,29 @@ auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
   require_impls_decl.require_impls_id = require_impls_id;
   ReplaceInstBeforeConstantUse(context, decl_id, require_impls_decl);
 
-  // Add constraint's impl witness id to the self's witness table if self is
-  // an interface.
+  // Add constraint's witnesses to the self's witness table if self is an
+  // interface.
   SemIR::TypeIterator type_iter(&context.sem_ir());
   type_iter.Add(context.constant_values().GetConstantTypeInstId(self_inst_id));
   if (extend || FindSelf(context, type_iter)) {
-    if (auto parent_interface = context.insts().TryGetAs<SemIR::InterfaceDecl>(
-            context.name_scopes().Get(parent_scope_id).inst_id())) {
-      BuildAssociatedEntity(context, parent_interface->interface_id, decl_id);
+    if (auto parent_interface_decl =
+            context.insts().TryGetAs<SemIR::InterfaceDecl>(
+                context.name_scopes().Get(parent_scope_id).inst_id())) {
+      auto required_impls_from_constraint = GetRequiredImplsFromConstraint(
+          context, node_id,
+          context.constant_values().Get(
+              context.name_scopes().Get(parent_scope_id).inst_id()),
+          context.constant_values().Get(constraint_inst_id));
+      if (required_impls_from_constraint.has_value()) {
+        auto [required_impls, other_requirements] =
+            *required_impls_from_constraint;
+        if (!other_requirements) {
+          for (auto _ : required_impls) {
+            BuildAssociatedEntity(context, parent_interface_decl->interface_id,
+                                  decl_id);
+          }
+        }
+      }
     }
   }
 

--- a/toolchain/check/handle_require.cpp
+++ b/toolchain/check/handle_require.cpp
@@ -113,40 +113,38 @@ auto HandleParseNode(Context& context, Parse::RequireTypeImplsId node_id)
   return true;
 }
 
+static auto FindSelf(Context& context, SemIR::TypeIterator& type_iter) -> bool {
+  while (true) {
+    auto step = type_iter.Next();
+    if (step.Is<SemIR::TypeIterator::Step::Done>()) {
+      break;
+    }
+    CARBON_KIND_SWITCH(step.any) {
+      case CARBON_KIND(SemIR::TypeIterator::Step::Error _): {
+        // Don't generate more diagnostics.
+        return true;
+      }
+      case CARBON_KIND(SemIR::TypeIterator::Step::SymbolicBinding bind): {
+        if (context.entity_names().Get(bind.entity_name_id).name_id ==
+            SemIR::NameId::SelfType) {
+          return true;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return false;
+}
+
 static auto TypeStructureReferencesSelf(
     Context& context, SemIR::LocId loc_id, SemIR::TypeInstId inst_id,
     const SemIR::IdentifiedFacetType& identified_facet_type) -> bool {
-  auto find_self = [&](SemIR::TypeIterator& type_iter) -> bool {
-    while (true) {
-      auto step = type_iter.Next();
-      if (step.Is<SemIR::TypeIterator::Step::Done>()) {
-        break;
-      }
-      CARBON_KIND_SWITCH(step.any) {
-        case CARBON_KIND(SemIR::TypeIterator::Step::Error _): {
-          // Don't generate more diagnostics.
-          return true;
-        }
-        case CARBON_KIND(SemIR::TypeIterator::Step::SymbolicBinding bind): {
-          if (context.entity_names().Get(bind.entity_name_id).name_id ==
-              SemIR::NameId::SelfType) {
-            return true;
-          }
-          break;
-        }
-        default:
-          break;
-      }
-    }
-    return false;
-  };
-
-  {
-    SemIR::TypeIterator type_iter(&context.sem_ir());
-    type_iter.Add(context.constant_values().GetConstantTypeInstId(inst_id));
-    if (find_self(type_iter)) {
-      return true;
-    }
+  SemIR::TypeIterator type_iter(&context.sem_ir());
+  type_iter.Add(context.constant_values().GetConstantTypeInstId(inst_id));
+  if (FindSelf(context, type_iter)) {
+    return true;
   }
 
   if (identified_facet_type.required_impls().empty()) {
@@ -163,7 +161,7 @@ static auto TypeStructureReferencesSelf(
   for (auto [_, specific_interface] : identified_facet_type.required_impls()) {
     SemIR::TypeIterator type_iter(&context.sem_ir());
     type_iter.Add(specific_interface);
-    if (!find_self(type_iter)) {
+    if (!FindSelf(context, type_iter)) {
       // TODO: The IdentifiedFacetType loses the location (since it's
       // canonical), but it would be nice to somehow point this diagnostic at
       // the particular interface in the facet type that is missing `Self`.
@@ -303,13 +301,11 @@ auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
   require_impls_decl.require_impls_id = require_impls_id;
   ReplaceInstBeforeConstantUse(context, decl_id, require_impls_decl);
 
-  // Add constraint's impl witness id to the self's witness table if self is an
-  // interface.
-  auto self_facet =
-      context.insts().TryGetAs<SemIR::FacetAccessType>(self_inst_id);
-  if (extend ||
-      (self_facet.has_value() &&
-       self_facet->facet_value_inst_id == GetSelfInstId(context, node_id))) {
+  // Add constraint's impl witness id to the self's witness table if self is
+  // an interface.
+  SemIR::TypeIterator type_iter(&context.sem_ir());
+  type_iter.Add(context.constant_values().GetConstantTypeInstId(self_inst_id));
+  if (extend || FindSelf(context, type_iter)) {
     if (auto parent_interface = context.insts().TryGetAs<SemIR::InterfaceDecl>(
             context.name_scopes().Get(parent_scope_id).inst_id())) {
       BuildAssociatedEntity(context, parent_interface->interface_id, decl_id);

--- a/toolchain/check/handle_require.cpp
+++ b/toolchain/check/handle_require.cpp
@@ -8,6 +8,7 @@
 #include "toolchain/check/generic.h"
 #include "toolchain/check/handle.h"
 #include "toolchain/check/inst.h"
+#include "toolchain/check/interface.h"
 #include "toolchain/check/modifiers.h"
 #include "toolchain/check/name_lookup.h"
 #include "toolchain/check/subst.h"
@@ -16,6 +17,7 @@
 #include "toolchain/diagnostics/diagnostic.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/interface.h"
 #include "toolchain/sem_ir/named_constraint.h"
 #include "toolchain/sem_ir/type_iterator.h"
 #include "toolchain/sem_ir/typed_insts.h"
@@ -51,6 +53,18 @@ auto HandleParseNode(Context& context, Parse::RequireIntroducerId node_id)
   return true;
 }
 
+static auto GetSelfInstId(Context& context, SemIR::LocId loc_id)
+    -> SemIR::InstId {
+  auto scope_id = context.scope_stack().PeekNameScopeId();
+  auto lookup_result =
+      LookupNameInExactScope(context, loc_id, SemIR::NameId::SelfType, scope_id,
+                             context.name_scopes().Get(scope_id),
+                             /*is_being_declared=*/false);
+  CARBON_CHECK(lookup_result.is_found());
+
+  return lookup_result.target_inst_id();
+}
+
 auto HandleParseNode(Context& context, Parse::RequireDefaultSelfImplsId node_id)
     -> bool {
   auto scope_inst_id =
@@ -60,14 +74,7 @@ auto HandleParseNode(Context& context, Parse::RequireDefaultSelfImplsId node_id)
     return true;
   }
 
-  auto scope_id = context.scope_stack().PeekNameScopeId();
-  auto lookup_result =
-      LookupNameInExactScope(context, node_id, SemIR::NameId::SelfType,
-                             scope_id, context.name_scopes().Get(scope_id),
-                             /*is_being_declared=*/false);
-  CARBON_CHECK(lookup_result.is_found());
-
-  auto self_inst_id = lookup_result.target_inst_id();
+  auto self_inst_id = GetSelfInstId(context, node_id);
   auto self_type_id = context.insts().Get(self_inst_id).type_id();
   if (self_type_id == SemIR::ErrorInst::TypeId) {
     context.node_stack().Push(node_id, SemIR::ErrorInst::TypeInstId);
@@ -283,17 +290,31 @@ auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
                               .require_impls_id = SemIR::RequireImplsId::None,
                               .decl_block_id = decl_block_id};
   auto decl_id = AddPlaceholderInst(context, node_id, require_impls_decl);
+  auto parent_scope_id = context.scope_stack().PeekNameScopeId();
   auto require_impls_id = context.require_impls().Add(
       {.self_id = self_inst_id,
        .facet_type_inst_id =
            context.types().GetAsTypeInstId(constraint_inst_id),
        .extend_self = extend,
        .decl_id = decl_id,
-       .parent_scope_id = context.scope_stack().PeekNameScopeId(),
+       .parent_scope_id = parent_scope_id,
        .generic_id = BuildGenericDecl(context, decl_id)});
 
   require_impls_decl.require_impls_id = require_impls_id;
   ReplaceInstBeforeConstantUse(context, decl_id, require_impls_decl);
+
+  // Add constraint's impl witness id to the self's witness table if self is an
+  // interface.
+  auto self_facet =
+      context.insts().TryGetAs<SemIR::FacetAccessType>(self_inst_id);
+  if (extend ||
+      (self_facet.has_value() &&
+       self_facet->facet_value_inst_id == GetSelfInstId(context, node_id))) {
+    if (auto parent_interface = context.insts().TryGetAs<SemIR::InterfaceDecl>(
+            context.name_scopes().Get(parent_scope_id).inst_id())) {
+      BuildAssociatedEntity(context, parent_interface->interface_id, decl_id);
+    }
+  }
 
   // We look for a complete type after BuildGenericDecl, so that the resulting
   // RequireCompleteType instruction is part of the enclosing interface or named

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -660,6 +660,14 @@ auto FinishImplWitness(Context& context, const SemIR::Impl& impl) -> void {
       }
       case CARBON_KIND(SemIR::RequireImplsDecl require_impls_decl): {
         // Adds witnness_id of the `require` constraint to the table.
+        if (context.types().IsFacetType(
+                context.insts().Get(impl.self_id).type_id())) {
+          // In some blanket impls cases, we end-up creating a cycle of
+          // LookupImplWitness. Ignore blanket impls to prevent those cases. We
+          // might need to lookup and add these witness_ids in a later stage.
+          witness_value = SemIR::ErrorInst::InstId;
+          break;
+        }
         if (!last_child_witnesses.empty()) {
           witness_value = last_child_witnesses.pop_back_val();
           break;

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -657,6 +657,39 @@ auto FinishImplWitness(Context& context, const SemIR::Impl& impl) -> void {
         // These are set to their final values already.
         break;
       }
+      case CARBON_KIND(SemIR::RequireImplsDecl require_impls_decl): {
+        // Adds witnness_id of the `require` constraint to the table.
+        auto require_impls =
+            context.require_impls().Get(require_impls_decl.require_impls_id);
+        auto self_facet_value =
+            GetConstantFacetValueForType(context, impl.self_id);
+        auto require_impls_specific =
+            GetRequireImplsSpecificFromEnclosingSpecificWithSelfFacetValue(
+                context, require_impls, impl.interface.specific_id,
+                self_facet_value);
+
+        // Get the witness id of the constraint.
+        auto self_const_id = GetConstantValueInRequireImplsSpecific(
+            context, require_impls_specific, require_impls.self_id);
+        auto facet_type_const_id = GetConstantValueInRequireImplsSpecific(
+            context, require_impls_specific, require_impls.facet_type_inst_id);
+        auto result = LookupImplWitness(
+            context, SemIR::LocId(impl.definition_id), self_const_id,
+            facet_type_const_id, /*lookup_require_decls=*/false);
+
+        if (result.has_value()) {
+          auto witness_block =
+              context.inst_blocks().Get(result.inst_block_id());
+          if (witness_block.size() > 1) {
+            context.TODO(impl.definition_id,
+                         "Handle constraints with multiple witnesses.");
+          }
+          witness_value = witness_block.back();
+        } else {
+          witness_value = SemIR::ErrorInst::InstId;
+        }
+        break;
+      }
       default:
         CARBON_CHECK(decl_id == SemIR::ErrorInst::InstId,
                      "Unexpected kind of associated entity {0}", decl);

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -704,7 +704,8 @@ auto CheckRequireDeclsSatisfied(Context& context, SemIR::LocId loc_id,
         context, require_specific, require.facet_type_inst_id);
 
     auto result =
-        LookupImplWitness(context, loc_id, self_const_id, facet_type_const_id);
+        LookupImplWitness(context, loc_id, self_const_id, facet_type_const_id,
+                          /*lookup_require_decls=*/false);
     // TODO: If the facet type contains 2 interfaces, and one is not `impl`ed,
     // it would be nice to diagnose which one was not `impl`ed, but that
     // requires LookupImplWitness to return a partial result, or take a

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -608,6 +608,7 @@ auto FinishImplWitness(Context& context, const SemIR::Impl& impl) -> void {
   auto assoc_entities =
       context.inst_blocks().Get(interface.associated_entities_id);
   llvm::SmallVector<SemIR::InstId> used_decl_ids;
+  llvm::SmallVector<SemIR::InstId> last_child_witnesses;
 
   for (auto [assoc_entity, witness_value] :
        llvm::zip_equal(assoc_entities, witness_block)) {
@@ -659,6 +660,11 @@ auto FinishImplWitness(Context& context, const SemIR::Impl& impl) -> void {
       }
       case CARBON_KIND(SemIR::RequireImplsDecl require_impls_decl): {
         // Adds witnness_id of the `require` constraint to the table.
+        if (!last_child_witnesses.empty()) {
+          witness_value = last_child_witnesses.pop_back_val();
+          break;
+        }
+
         auto require_impls =
             context.require_impls().Get(require_impls_decl.require_impls_id);
         auto self_facet_value =
@@ -680,11 +686,10 @@ auto FinishImplWitness(Context& context, const SemIR::Impl& impl) -> void {
         if (result.has_value()) {
           auto witness_block =
               context.inst_blocks().Get(result.inst_block_id());
-          if (witness_block.size() > 1) {
-            context.TODO(impl.definition_id,
-                         "Handle constraints with multiple witnesses.");
-          }
-          witness_value = witness_block.back();
+          auto witness_array = witness_block.take_front(witness_block.size());
+          last_child_witnesses.append(witness_array.rbegin(),
+                                      witness_array.rend());
+          witness_value = last_child_witnesses.pop_back_val();
         } else {
           witness_value = SemIR::ErrorInst::InstId;
         }

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -660,8 +660,7 @@ auto FinishImplWitness(Context& context, const SemIR::Impl& impl) -> void {
       }
       case CARBON_KIND(SemIR::RequireImplsDecl require_impls_decl): {
         // Adds witnness_id of the `require` constraint to the table.
-        if (context.types().IsFacetType(
-                context.insts().Get(impl.self_id).type_id())) {
+        if (context.constant_values().Get(impl.self_id).is_symbolic()) {
           // In some blanket impls cases, we end-up creating a cycle of
           // LookupImplWitness. Ignore blanket impls to prevent those cases. We
           // might need to lookup and add these witness_ids in a later stage.

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -636,9 +636,9 @@ static auto LookupImplWitnessInRequireDecls(
         .query_self_const_id = query_self_const_id,
         .query_facet_type_const_id = parent_const_id,
     });
-    auto parent_witness_id =
-        GetOrAddLookupImplWitness(context, loc_id, query_self_const_id,
-                                  parent_required_impls[0].specific_interface);
+    auto parent_witness_id = GetOrAddLookupImplWitness(
+        context, loc_id, parent_required_impls[0].self_facet_value,
+        parent_required_impls[0].specific_interface);
     stack.pop_back();
 
     if (parent_witness_id.has_value()) {
@@ -770,7 +770,7 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
 
   llvm::SmallVector<SemIR::InstId> result_witness_ids;
   llvm::SmallVector<SemIR::SpecificInterface> found_specific_interfaces;
-  if (lookup_require_decls) {
+  if (lookup_require_decls && query_self_const_id.is_symbolic()) {
     LookupImplWitnessInRequireDecls(context, loc_id, query_self_const_id,
                                     req_impls, result_witness_ids,
                                     found_specific_interfaces);

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -593,13 +593,15 @@ static auto LookupImplWitnessInRequireDecls(
     const llvm::ArrayRef<SemIR::IdentifiedFacetType::RequiredImpl>&
         required_impls,
     llvm::SmallVector<SemIR::InstId>& result_witness_ids,
-    llvm::SmallVector<SemIR::SpecificInterface>& verified_specific_interfaces)
+    llvm::SmallVector<SemIR::SpecificInterface>& found_specific_interfaces)
     -> void {
   if (required_impls.empty()) {
     return;
   }
 
-  for (const auto& require_impls : context.require_impls().values()) {
+  // TODO: Implement this without iterating through every declaration.
+  for (const auto& [require_impls_id, require_impls] :
+       context.require_impls().enumerate()) {
     auto parent_id =
         context.name_scopes().Get(require_impls.parent_scope_id).inst_id();
     auto parent_const_id = context.constant_values().Get(parent_id);
@@ -643,6 +645,17 @@ static auto LookupImplWitnessInRequireDecls(
       // self-type implements the facet type that the `require` is declared in.
       // Now check if any constraint in the `require` matches any of the
       // `required_impls`.
+      auto parent_interface_decl =
+          context.insts().TryGetAs<SemIR::InterfaceDecl>(parent_id);
+      if (!parent_interface_decl.has_value() ||
+          !parent_interface_decl->interface_id.has_value()) {
+        continue;
+      }
+      const auto& parent_interface =
+          context.interfaces().Get(parent_interface_decl->interface_id);
+      auto parent_assoc_entities =
+          context.inst_blocks().Get(parent_interface.associated_entities_id);
+
       auto require_impls_facet_const_id =
           context.constant_values().Get(require_impls.facet_type_inst_id);
       auto require_facet_required_impls_from_constraint =
@@ -662,19 +675,49 @@ static auto LookupImplWitnessInRequireDecls(
 
       // Add parent witness for every new requirement it satisfies.
       for (const auto& required_impl : required_impls) {
-        auto not_already_found = verified_specific_interfaces.empty() ||
-                                 std::find(verified_specific_interfaces.begin(),
-                                           verified_specific_interfaces.end(),
+        auto not_already_found = found_specific_interfaces.empty() ||
+                                 std::find(found_specific_interfaces.begin(),
+                                           found_specific_interfaces.end(),
                                            required_impl.specific_interface) ==
-                                     verified_specific_interfaces.end();
+                                     found_specific_interfaces.end();
         if (not_already_found) {
           for (const auto& require_facet_required_impl :
                require_facet_required_impls) {
             if (required_impl.specific_interface.interface_id ==
                 require_facet_required_impl.specific_interface.interface_id) {
-              result_witness_ids.push_back(parent_witness_id);
-              verified_specific_interfaces.push_back(
-                  required_impl.specific_interface);
+              // Search the parent interface's associated entities to find the
+              // witness table index assigned to this specific 'require'
+              // declaration. This index is used to retrieve the required
+              // sub-witness at runtime.
+              auto element_index = 0;
+              auto element_found = false;
+              for (auto assoc_entity : parent_assoc_entities) {
+                if (auto require_impls_decl =
+                        context.insts().TryGetAs<SemIR::RequireImplsDecl>(
+                            assoc_entity)) {
+                  if (require_impls_decl->require_impls_id ==
+                      require_impls_id) {
+                    element_found = true;
+                    break;
+                  }
+                }
+                element_index++;
+              }
+              if (element_found) {
+                // Emit an ImplWitnessAccess instruction to extract the
+                // sub-witness for the required interface from the parent
+                // witness table. The resulting instruction has WitnessType,
+                // representing the resolved sub-requirement.
+                result_witness_ids.push_back(
+                    AddInst(context, loc_id,
+                            SemIR::ImplWitnessAccess{
+                                .type_id = GetSingletonType(
+                                    context, SemIR::WitnessType::TypeInstId),
+                                .witness_id = parent_witness_id,
+                                .index = SemIR::ElementIndex(element_index)}));
+                found_specific_interfaces.push_back(
+                    required_impl.specific_interface);
+              }
             }
           }
         }
@@ -726,11 +769,11 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
   }
 
   llvm::SmallVector<SemIR::InstId> result_witness_ids;
-  llvm::SmallVector<SemIR::SpecificInterface> verified_specific_interfaces;
+  llvm::SmallVector<SemIR::SpecificInterface> found_specific_interfaces;
   if (lookup_require_decls) {
     LookupImplWitnessInRequireDecls(context, loc_id, query_self_const_id,
                                     req_impls, result_witness_ids,
-                                    verified_specific_interfaces);
+                                    found_specific_interfaces);
   }
 
   auto& stack = context.impl_lookup_stack();
@@ -746,11 +789,10 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
   for (const auto& req_impl : req_impls) {
     // TODO: Since both `interfaces` and `query_self_const_id` are sorted lists,
     // do an O(N+M) merge instead of O(N*M) nested loops.
-    if (verified_specific_interfaces.empty() ||
-        std::find(verified_specific_interfaces.begin(),
-                  verified_specific_interfaces.end(),
-                  req_impl.specific_interface) ==
-            verified_specific_interfaces.end()) {
+    if (found_specific_interfaces.empty() ||
+        std::find(
+            found_specific_interfaces.begin(), found_specific_interfaces.end(),
+            req_impl.specific_interface) == found_specific_interfaces.end()) {
       auto result_witness_id =
           GetOrAddLookupImplWitness(context, loc_id, req_impl.self_facet_value,
                                     req_impl.specific_interface);

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -29,6 +29,7 @@
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/impl.h"
 #include "toolchain/sem_ir/inst.h"
+#include "toolchain/sem_ir/inst_categories.h"
 #include "toolchain/sem_ir/inst_kind.h"
 #include "toolchain/sem_ir/interface.h"
 #include "toolchain/sem_ir/specific_interface.h"
@@ -692,13 +693,32 @@ static auto LookupImplWitnessInRequireDecls(
               auto element_index = 0;
               auto element_found = false;
               for (auto assoc_entity : parent_assoc_entities) {
+                const auto& assoc_entity_inst =
+                    context.insts().Get(assoc_entity);
                 if (auto require_impls_decl =
-                        context.insts().TryGetAs<SemIR::RequireImplsDecl>(
-                            assoc_entity)) {
+                        assoc_entity_inst.TryAs<SemIR::RequireImplsDecl>()) {
                   if (require_impls_decl->require_impls_id ==
                       require_impls_id) {
                     element_found = true;
                     break;
+                  }
+                } else if (auto import_ref =
+                               assoc_entity_inst.TryAs<SemIR::AnyImportRef>()) {
+                  auto import_ir_inst = context.import_ir_insts().Get(
+                      import_ref->import_ir_inst_id);
+                  const auto* import_sem_ir =
+                      context.import_irs().Get(import_ir_inst.ir_id()).sem_ir;
+                  if (auto require_impls_decl =
+                          import_sem_ir->insts()
+                              .TryGetAs<SemIR::RequireImplsDecl>(
+                                  import_ir_inst.inst_id())) {
+                    // TODO: This check always fails, find a way to verify the
+                    // associated entity is the same `require` declaration.
+                    if (require_impls_decl->require_impls_id ==
+                        require_impls_id) {
+                      element_found = true;
+                      break;
+                    }
                   }
                 }
                 element_index++;

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -204,17 +204,11 @@ static auto FindAndDiagnoseImplLookupCycle(
   return false;
 }
 
-struct RequiredImplsFromConstraint {
-  llvm::ArrayRef<SemIR::IdentifiedFacetType::RequiredImpl> req_impls;
-  bool other_requirements;
-};
-
 // Gets the set of `SpecificInterface`s that are required by a facet type
 // (as a constant value), and any special requirements.
-static auto GetRequiredImplsFromConstraint(
-    Context& context, SemIR::LocId loc_id,
-    SemIR::ConstantId query_self_const_id,
-    SemIR::ConstantId query_facet_type_const_id)
+auto GetRequiredImplsFromConstraint(Context& context, SemIR::LocId loc_id,
+                                    SemIR::ConstantId query_self_const_id,
+                                    SemIR::ConstantId query_facet_type_const_id)
     -> std::optional<RequiredImplsFromConstraint> {
   auto facet_type_inst_id =
       context.constant_values().GetInstId(query_facet_type_const_id);

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -24,10 +24,14 @@
 #include "toolchain/check/type.h"
 #include "toolchain/check/type_completion.h"
 #include "toolchain/check/type_structure.h"
+#include "toolchain/sem_ir/constant.h"
 #include "toolchain/sem_ir/facet_type_info.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/impl.h"
 #include "toolchain/sem_ir/inst.h"
+#include "toolchain/sem_ir/inst_kind.h"
+#include "toolchain/sem_ir/interface.h"
+#include "toolchain/sem_ir/specific_interface.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
 namespace Carbon::Check {
@@ -581,6 +585,104 @@ static auto GetOrAddLookupImplWitness(Context& context, SemIR::LocId loc_id,
   return context.constant_values().GetInstId(witness_const_id);
 }
 
+// Performs a lookup to locate the witnesses for a specific
+// interface by searching through the `require` declarations of a type's known
+// constraints.
+static auto LookupImplWitnessInRequireDecls(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::ConstantId query_self_const_id,
+    const llvm::ArrayRef<SemIR::IdentifiedFacetType::RequiredImpl>&
+        required_impls,
+    llvm::SmallVector<SemIR::InstId>& result_witness_ids,
+    llvm::SmallVector<SemIR::SpecificInterface>& verified_specific_interfaces)
+    -> void {
+  if (required_impls.empty()) {
+    return;
+  }
+
+  for (const auto& require_impls : context.require_impls().values()) {
+    auto parent_id =
+        context.name_scopes().Get(require_impls.parent_scope_id).inst_id();
+    auto parent_const_id = context.constant_values().Get(parent_id);
+    if (!context.types().IsFacetType(
+            context.insts().Get(parent_id).type_id())) {
+      continue;
+    }
+    if (!require_impls.extend_self &&
+        context.constant_values().Get(require_impls.self_id) ==
+            parent_const_id) {
+      continue;
+    }
+
+    // Check if self-type implements the facet-type that the `require` is
+    // declared in.
+    auto parent_required_impls_from_constraint = GetRequiredImplsFromConstraint(
+        context, loc_id, query_self_const_id, parent_const_id);
+    if (!parent_required_impls_from_constraint.has_value()) {
+      continue;
+    }
+    auto [parent_required_impls, other_requirements] =
+        *parent_required_impls_from_constraint;
+    if (other_requirements || parent_required_impls.size() != 1 ||
+        FindAndDiagnoseImplLookupCycle(context, context.impl_lookup_stack(),
+                                       loc_id, query_self_const_id,
+                                       parent_const_id)) {
+      continue;
+    }
+
+    auto& stack = context.impl_lookup_stack();
+    stack.push_back({
+        .query_self_const_id = query_self_const_id,
+        .query_facet_type_const_id = parent_const_id,
+    });
+    auto parent_witness_id =
+        GetOrAddLookupImplWitness(context, loc_id, query_self_const_id,
+                                  parent_required_impls[0].specific_interface);
+    stack.pop_back();
+
+    if (parent_witness_id.has_value()) {
+      // self-type implements the facet type that the `require` is declared in.
+      // Now check the `require` if it implements any of the `required_impls`.
+      auto require_impls_facet_const_id =
+          context.constant_values().Get(require_impls.facet_type_inst_id);
+      auto require_facet_required_impls_from_constraint =
+          GetRequiredImplsFromConstraint(context, loc_id, parent_const_id,
+                                         require_impls_facet_const_id);
+      if (!require_facet_required_impls_from_constraint.has_value()) {
+        continue;
+      }
+      auto [require_facet_required_impls, other_requirements] =
+          *require_facet_required_impls_from_constraint;
+      if (other_requirements || require_facet_required_impls.empty() ||
+          FindAndDiagnoseImplLookupCycle(context, context.impl_lookup_stack(),
+                                         loc_id, parent_const_id,
+                                         require_impls_facet_const_id)) {
+        continue;
+      }
+
+      // Add parent witness for every new requirement it satisfies.
+      for (const auto& required_impl : required_impls) {
+        auto not_already_found = verified_specific_interfaces.empty() ||
+                                 std::find(verified_specific_interfaces.begin(),
+                                           verified_specific_interfaces.end(),
+                                           required_impl.specific_interface) ==
+                                     verified_specific_interfaces.end();
+        if (not_already_found) {
+          for (const auto& require_facet_required_impl :
+               require_facet_required_impls) {
+            if (required_impl.specific_interface.interface_id ==
+                require_facet_required_impl.specific_interface.interface_id) {
+              result_witness_ids.push_back(parent_witness_id);
+              verified_specific_interfaces.push_back(
+                  required_impl.specific_interface);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
                        SemIR::ConstantId query_self_const_id,
                        SemIR::ConstantId query_facet_type_const_id)
@@ -623,6 +725,12 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
     return SemIR::InstBlockIdOrError::MakeError();
   }
 
+  llvm::SmallVector<SemIR::InstId> result_witness_ids;
+  llvm::SmallVector<SemIR::SpecificInterface> verified_specific_interfaces;
+  LookupImplWitnessInRequireDecls(context, loc_id, query_self_const_id,
+                                  req_impls, result_witness_ids,
+                                  verified_specific_interfaces);
+
   auto& stack = context.impl_lookup_stack();
   stack.push_back({
       .query_self_const_id = query_self_const_id,
@@ -633,21 +741,27 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
   // Every consumer of a facet type needs to agree on the order of interfaces
   // used for its witnesses, which is done by following the order in the
   // IdentifiedFacetType.
-  llvm::SmallVector<SemIR::InstId> result_witness_ids;
   for (const auto& req_impl : req_impls) {
     // TODO: Since both `interfaces` and `query_self_const_id` are sorted lists,
     // do an O(N+M) merge instead of O(N*M) nested loops.
-    auto result_witness_id =
-        GetOrAddLookupImplWitness(context, loc_id, req_impl.self_facet_value,
-                                  req_impl.specific_interface);
-    if (result_witness_id.has_value()) {
-      result_witness_ids.push_back(result_witness_id);
-    } else {
-      // At least one queried interface in the facet type has no witness for the
-      // given type, we can stop looking for more.
-      break;
+    if (verified_specific_interfaces.empty() ||
+        std::find(verified_specific_interfaces.begin(),
+                  verified_specific_interfaces.end(),
+                  req_impl.specific_interface) ==
+            verified_specific_interfaces.end()) {
+      auto result_witness_id =
+          GetOrAddLookupImplWitness(context, loc_id, req_impl.self_facet_value,
+                                    req_impl.specific_interface);
+      if (result_witness_id.has_value()) {
+        result_witness_ids.push_back(result_witness_id);
+      } else {
+        // At least one queried interface in the facet type has no witness for
+        // the given type, we can stop looking for more.
+        break;
+      }
     }
   }
+
   stack.pop_back();
 
   // All interfaces in the query facet type must have been found to be available

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -585,9 +585,8 @@ static auto GetOrAddLookupImplWitness(Context& context, SemIR::LocId loc_id,
   return context.constant_values().GetInstId(witness_const_id);
 }
 
-// Performs a lookup to locate the witnesses for a specific
-// interface by searching through the `require` declarations of a type's known
-// constraints.
+// Performs a lookup to locate the witnesses by searching through the `require`
+// declarations of a type's known constraints.
 static auto LookupImplWitnessInRequireDecls(
     Context& context, SemIR::LocId loc_id,
     SemIR::ConstantId query_self_const_id,
@@ -642,7 +641,8 @@ static auto LookupImplWitnessInRequireDecls(
 
     if (parent_witness_id.has_value()) {
       // self-type implements the facet type that the `require` is declared in.
-      // Now check the `require` if it implements any of the `required_impls`.
+      // Now check if any constraint in the `require` matches any of the
+      // `required_impls`.
       auto require_impls_facet_const_id =
           context.constant_values().Get(require_impls.facet_type_inst_id);
       auto require_facet_required_impls_from_constraint =
@@ -685,8 +685,8 @@ static auto LookupImplWitnessInRequireDecls(
 
 auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
                        SemIR::ConstantId query_self_const_id,
-                       SemIR::ConstantId query_facet_type_const_id)
-    -> SemIR::InstBlockIdOrError {
+                       SemIR::ConstantId query_facet_type_const_id,
+                       bool lookup_require_decls) -> SemIR::InstBlockIdOrError {
   if (query_self_const_id == SemIR::ErrorInst::ConstantId ||
       query_facet_type_const_id == SemIR::ErrorInst::ConstantId) {
     return SemIR::InstBlockIdOrError::MakeError();
@@ -727,9 +727,11 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
 
   llvm::SmallVector<SemIR::InstId> result_witness_ids;
   llvm::SmallVector<SemIR::SpecificInterface> verified_specific_interfaces;
-  LookupImplWitnessInRequireDecls(context, loc_id, query_self_const_id,
-                                  req_impls, result_witness_ids,
-                                  verified_specific_interfaces);
+  if (lookup_require_decls) {
+    LookupImplWitnessInRequireDecls(context, loc_id, query_self_const_id,
+                                    req_impls, result_witness_ids,
+                                    verified_specific_interfaces);
+  }
 
   auto& stack = context.impl_lookup_stack();
   stack.push_back({

--- a/toolchain/check/impl_lookup.h
+++ b/toolchain/check/impl_lookup.h
@@ -36,7 +36,8 @@ namespace Carbon::Check {
 //   produced, either in this function or before.
 auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
                        SemIR::ConstantId query_self_const_id,
-                       SemIR::ConstantId query_facet_type_const_id)
+                       SemIR::ConstantId query_facet_type_const_id,
+                       bool lookup_require_decls = true)
     -> SemIR::InstBlockIdOrError;
 
 // Returns whether the query matches against the given impl. This is like a

--- a/toolchain/check/impl_lookup.h
+++ b/toolchain/check/impl_lookup.h
@@ -14,6 +14,18 @@
 
 namespace Carbon::Check {
 
+struct RequiredImplsFromConstraint {
+  llvm::ArrayRef<SemIR::IdentifiedFacetType::RequiredImpl> req_impls;
+  bool other_requirements;
+};
+
+// Gets the set of `SpecificInterface`s that are required by a facet type
+// (as a constant value), and any special requirements.
+auto GetRequiredImplsFromConstraint(Context& context, SemIR::LocId loc_id,
+                                    SemIR::ConstantId query_self_const_id,
+                                    SemIR::ConstantId query_facet_type_const_id)
+    -> std::optional<RequiredImplsFromConstraint>;
+
 // Looks up the witnesses to use for a type value or facet value, and a facet
 // type naming a set of interfaces required to be implemented for that type, as
 // well as possible constraints on those interfaces.

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -1366,6 +1366,8 @@ static auto AddAssociatedEntities(ImportContext& context,
                        inst_id)) {
       import_name_id =
           context.import_entity_names().Get(import_ref->entity_name_id).name_id;
+    } else if (context.import_insts().Is<SemIR::RequireImplsDecl>(inst_id)) {
+      // Require declarations do not have name id.
     } else {
       // We don't need `GetWithAttachedType` here because we don't access the
       // type.

--- a/toolchain/check/testdata/facet/require_import.carbon
+++ b/toolchain/check/testdata/facet/require_import.carbon
@@ -39,6 +39,10 @@ library "[[@TEST_NAME]]";
 import library "a";
 
 fn F(B:! Y) {
+  // TODO: We find the name F, but then fail to do impl lookup for `F` in `B:!
+  // Y` since the identified facet type doesn't include Z. We need to be able to
+  // find a symbolic facet from the require decl in Y during impl lookup.
+  //
   // CHECK:STDERR: fail_todo_symbolic_facet_interface_requires_interface.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Z(B)` in type `B` that does not implement that interface [MissingImplInMemberAccess]
   // CHECK:STDERR:   B.F();
   // CHECK:STDERR:   ^~~

--- a/toolchain/check/testdata/facet/require_import.carbon
+++ b/toolchain/check/testdata/facet/require_import.carbon
@@ -33,12 +33,16 @@ fn F(A:! X, B:! Y) {
   A.F();
 }
 
-// --- symbolic_facet_interface_requires_interface.carbon
+// --- fail_todo_symbolic_facet_interface_requires_interface.carbon
 library "[[@TEST_NAME]]";
 
 import library "a";
 
 fn F(B:! Y) {
+  // CHECK:STDERR: fail_todo_symbolic_facet_interface_requires_interface.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Z(B)` in type `B` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   B.F();
+  // CHECK:STDERR:   ^~~
+  // CHECK:STDERR:
   B.F();
 }
 
@@ -118,6 +122,7 @@ fn F(B:! Y) {
 // CHECK:STDOUT:   %Main.import_ref.8c7: %Y.type = import_ref Main//a, loc7_13, loaded [symbolic = constants.%Self.d4d]
 // CHECK:STDOUT:   %Main.import_ref.3e2c97.1 = import_ref Main//a, loc7_13, unloaded
 // CHECK:STDOUT:   %Main.import_ref.80a = import_ref Main//a, loc8_31, unloaded
+// CHECK:STDOUT:   %Main. = import_ref Main//a, <none>, unloaded
 // CHECK:STDOUT:   %Main.import_ref.5847cb.3 = import_ref Main//a, loc4_9, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -172,7 +177,7 @@ fn F(B:! Y) {
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = imports.%Main.import_ref.3e2c97.1
 // CHECK:STDOUT:   extend imports.%Main.import_ref.80a
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (imports.%Main.)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Y.Self.binding.as_type.impls.Z.type.require {

--- a/toolchain/check/testdata/facet/require_import.carbon
+++ b/toolchain/check/testdata/facet/require_import.carbon
@@ -33,20 +33,12 @@ fn F(A:! X, B:! Y) {
   A.F();
 }
 
-// --- fail_todo_symbolic_facet_interface_requires_interface.carbon
+// --- symbolic_facet_interface_requires_interface.carbon
 library "[[@TEST_NAME]]";
 
 import library "a";
 
 fn F(B:! Y) {
-  // TODO: We find the name F, but then fail to do impl lookup for `F` in `B:!
-  // Y` since the identified facet type doesn't include Z. We need to be able to
-  // find a symbolic facet from the require decl in Y during impl lookup.
-  //
-  // CHECK:STDERR: fail_todo_symbolic_facet_interface_requires_interface.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Z(B)` in type `B` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   B.F();
-  // CHECK:STDERR:   ^~~
-  // CHECK:STDERR:
   B.F();
 }
 

--- a/toolchain/check/testdata/facet/require_satisified.carbon
+++ b/toolchain/check/testdata/facet/require_satisified.carbon
@@ -140,6 +140,10 @@ impl () as Z1(A);
 impl () as Z2(B);
 
 // So no error here.
+// CHECK:STDERR: require_for_generic_interfaces.carbon:[[@LINE+4]]:1: error: semantics TODO: `Handle constraints with multiple witnesses.` [SemanticsTodo]
+// CHECK:STDERR: impl () as Y(A) {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 impl () as Y(A) {}
 
 impl () as Z1(A) {}
@@ -184,75 +188,3 @@ impl C as Z(());
 impl () as Y(Self) {}
 
 impl C as Z(()) {}
-
-// --- impl_requires_itself_cycle.carbon
-library "[[@TEST_NAME]]";
-
-interface A { fn AA(); }
-interface B {
-  require impls A;
-}
-interface C {
-  require impls B;
-}
-
-impl forall [T:! B] T as A { fn AA() {} }
-
-// When we get to the definition we check that anything B requires is satisfied.
-// - The interface B requires A, so we must check T impls A.
-// - The impl for A requires T impls B.
-// - This impl is what provides T impls B.
-impl forall [T:! C] T as B {}
-
-fn F(T:! C) {
-  // If things go wrong, we find the impl `T as B`, but inside its definition is
-  // a lookup for `T as A`, which (through deducing `T`) includes a lookup for
-  // `T as B`. This creates a cycle of evaluating `T as B` recursively.
-  //
-  // This was solved by doing the check for requirements of `B` outside the
-  // definition of `T as B`.
-  // https://discord.com/channels/655572317891461132/941071822756143115/1463189087598022861
-  T.(A.AA)();
-}
-
-// --- fail_impl_requires_itself_cycle_with_monomorphization_error.carbon
-library "[[@TEST_NAME]]";
-
-class W(T:! type) {
-  adapt {};
-}
-
-interface A(N:! Core.IntLiteral()) {
-  // CHECK:STDERR: fail_impl_requires_itself_cycle_with_monomorphization_error.carbon:[[@LINE+3]]:26: error: array bound of -1 is negative [ArrayBoundNegative]
-  // CHECK:STDERR:   fn AA() -> W(array((), N));
-  // CHECK:STDERR:                          ^
-  fn AA() -> W(array((), N));
-}
-interface B(N:! Core.IntLiteral()) {
-  require impls A(N);
-}
-interface C(N:! Core.IntLiteral()) {
-  require impls B(N);
-}
-
-impl forall [N:! Core.IntLiteral(), T:! B(N)] T as A(N) {
-  fn AA() -> W(array((), N)) { return {} as W(array((), N)); }
-}
-
-impl forall [N:! Core.IntLiteral(), T:! C(N)] T as B(N) {
-  // The definition here does not contain the lookups verifying that C(N) impls
-  // `A(N)`, so they do not get re-evaluated for a specific `N`. That doesn't
-  // prevent us from producing a reasonable diagnostic when that `N` causes an
-  // error in the specific use of this impl, which we use to get from `C(N)` to
-  // `A(N)` (in the deduction of `T` in the impl as `A(N)`). The error just
-  // happens where we use `N` in `A(N)` instead of inside the verification that
-  // `T as B(N)` implies `T as A(N)`.
-}
-
-fn F(T:! C(-1)) {
-  // CHECK:STDERR: fail_impl_requires_itself_cycle_with_monomorphization_error.carbon:[[@LINE+4]]:3: note: in `AA()` used here [ResolvingSpecificHere]
-  // CHECK:STDERR:   T.(A(-1).AA)();
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~
-  // CHECK:STDERR:
-  T.(A(-1).AA)();
-}

--- a/toolchain/check/testdata/facet/require_satisified.carbon
+++ b/toolchain/check/testdata/facet/require_satisified.carbon
@@ -140,10 +140,6 @@ impl () as Z1(A);
 impl () as Z2(B);
 
 // So no error here.
-// CHECK:STDERR: require_for_generic_interfaces.carbon:[[@LINE+4]]:1: error: semantics TODO: `Handle constraints with multiple witnesses.` [SemanticsTodo]
-// CHECK:STDERR: impl () as Y(A) {}
-// CHECK:STDERR: ^~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
 impl () as Y(A) {}
 
 impl () as Z1(A) {}
@@ -188,3 +184,75 @@ impl C as Z(());
 impl () as Y(Self) {}
 
 impl C as Z(()) {}
+
+// --- impl_requires_itself_cycle.carbon
+library "[[@TEST_NAME]]";
+
+interface A { fn AA(); }
+interface B {
+  require impls A;
+}
+interface C {
+  require impls B;
+}
+
+impl forall [T:! B] T as A { fn AA() {} }
+
+// When we get to the definition we check that anything B requires is satisfied.
+// - The interface B requires A, so we must check T impls A.
+// - The impl for A requires T impls B.
+// - This impl is what provides T impls B.
+impl forall [T:! C] T as B {}
+
+fn F(T:! C) {
+  // If things go wrong, we find the impl `T as B`, but inside its definition is
+  // a lookup for `T as A`, which (through deducing `T`) includes a lookup for
+  // `T as B`. This creates a cycle of evaluating `T as B` recursively.
+  //
+  // This was solved by doing the check for requirements of `B` outside the
+  // definition of `T as B`.
+  // https://discord.com/channels/655572317891461132/941071822756143115/1463189087598022861
+  T.(A.AA)();
+}
+
+// --- fail_impl_requires_itself_cycle_with_monomorphization_error.carbon
+library "[[@TEST_NAME]]";
+
+class W(T:! type) {
+  adapt {};
+}
+
+interface A(N:! Core.IntLiteral()) {
+  // CHECK:STDERR: fail_impl_requires_itself_cycle_with_monomorphization_error.carbon:[[@LINE+3]]:26: error: array bound of -1 is negative [ArrayBoundNegative]
+  // CHECK:STDERR:   fn AA() -> W(array((), N));
+  // CHECK:STDERR:                          ^
+  fn AA() -> W(array((), N));
+}
+interface B(N:! Core.IntLiteral()) {
+  require impls A(N);
+}
+interface C(N:! Core.IntLiteral()) {
+  require impls B(N);
+}
+
+impl forall [N:! Core.IntLiteral(), T:! B(N)] T as A(N) {
+  fn AA() -> W(array((), N)) { return {} as W(array((), N)); }
+}
+
+impl forall [N:! Core.IntLiteral(), T:! C(N)] T as B(N) {
+  // The definition here does not contain the lookups verifying that C(N) impls
+  // `A(N)`, so they do not get re-evaluated for a specific `N`. That doesn't
+  // prevent us from producing a reasonable diagnostic when that `N` causes an
+  // error in the specific use of this impl, which we use to get from `C(N)` to
+  // `A(N)` (in the deduction of `T` in the impl as `A(N)`). The error just
+  // happens where we use `N` in `A(N)` instead of inside the verification that
+  // `T as B(N)` implies `T as A(N)`.
+}
+
+fn F(T:! C(-1)) {
+  // CHECK:STDERR: fail_impl_requires_itself_cycle_with_monomorphization_error.carbon:[[@LINE+4]]:3: note: in `AA()` used here [ResolvingSpecificHere]
+  // CHECK:STDERR:   T.(A(-1).AA)();
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  T.(A(-1).AA)();
+}

--- a/toolchain/check/testdata/impl/import_generic.carbon
+++ b/toolchain/check/testdata/impl/import_generic.carbon
@@ -201,6 +201,8 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   %J.type.04e: type = facet_type <@J, @J(%T)> [symbolic]
 // CHECK:STDOUT:   %Self.a60: %J.type.04e = symbolic_binding Self, 1 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self.a60 [symbolic]
+// CHECK:STDOUT:   %J.assoc_type: type = assoc_entity_type @J, @J(%T) [symbolic]
+// CHECK:STDOUT:   %assoc0: %J.assoc_type = assoc_entity element0, @J.%J.Self.binding.as_type.impls.I.type.require.decl [symbolic]
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type.1ab [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -247,6 +249,8 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %J.type: type = facet_type <@J, @J(%T.loc4_13.1)> [symbolic = %J.type (constants.%J.type.04e)]
 // CHECK:STDOUT:   %Self.loc4_23.2: @J.%J.type (%J.type.04e) = symbolic_binding Self, 1 [symbolic = %Self.loc4_23.2 (constants.%Self.a60)]
+// CHECK:STDOUT:   %J.assoc_type: type = assoc_entity_type @J, @J(%T.loc4_13.1) [symbolic = %J.assoc_type (constants.%J.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc5_28.2: @J.%J.assoc_type (%J.assoc_type) = assoc_entity element0, %J.Self.binding.as_type.impls.I.type.require.decl [symbolic = %assoc0.loc5_28.2 (constants.%assoc0)]
 // CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%T.loc4_13.1)> [symbolic = %I.type (constants.%I.type.1ab)]
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type [symbolic = %require_complete (constants.%require_complete)]
 // CHECK:STDOUT:
@@ -260,6 +264,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:       %T.ref: type = name_ref T, @J.%T.loc4_13.2 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %I.type.loc5_27.1: type = facet_type <@I, @I(constants.%T)> [symbolic = %I.type.loc5_27.2 (constants.%I.type.1ab)]
 // CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc5_28.1: @J.%J.assoc_type (%J.assoc_type) = assoc_entity element0, %J.Self.binding.as_type.impls.I.type.require.decl [symbolic = %assoc0.loc5_28.2 (constants.%assoc0)]
 // CHECK:STDOUT:     %.loc5: type = specific_constant @J.Self.binding.as_type.impls.I.type.require.%I.type.loc5_27.1, @J.Self.binding.as_type.impls.I.type.require(constants.%T, constants.%Self.a60) [symbolic = %I.type (constants.%I.type.1ab)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
@@ -267,7 +272,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:     .I = <poisoned>
 // CHECK:STDOUT:     .T = <poisoned>
 // CHECK:STDOUT:     extend %.loc5
-// CHECK:STDOUT:     witness = ()
+// CHECK:STDOUT:     witness = (%J.Self.binding.as_type.impls.I.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @J.Self.binding.as_type.impls.I.type.require {
@@ -325,11 +330,15 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   %Self.c25: %J.type.04e = symbolic_binding Self, 1 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 1, %Self.c25 [symbolic]
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type.1ab [symbolic]
+// CHECK:STDOUT:   %J.assoc_type.4de: type = assoc_entity_type @J, @J(%T) [symbolic]
+// CHECK:STDOUT:   %assoc0.d5d: %J.assoc_type.4de = assoc_entity element0, imports.%Main.import_ref.b94 [symbolic]
 // CHECK:STDOUT:   %J.type.d6f: type = facet_type <@J, @J(%empty_struct_type)> [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness @C.as.J.impl.%J.impl_witness_table [concrete]
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
 // CHECK:STDOUT:   %C.type.facet: %type = facet_value %C, () [concrete]
 // CHECK:STDOUT:   %Self.9e4: %J.type.d6f = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %J.assoc_type.5d0: type = assoc_entity_type @J, @J(%empty_struct_type) [concrete]
+// CHECK:STDOUT:   %assoc0.961: %J.assoc_type.5d0 = assoc_entity element0, imports.%Main.import_ref.b94 [concrete]
 // CHECK:STDOUT:   %complete_type.5b1: <witness> = complete_type_witness %I.type.ab5 [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -338,13 +347,18 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   %Main.J: %J.type.885 = import_ref Main//basic_import_generic_interface, J, loaded [concrete = constants.%J.generic]
 // CHECK:STDOUT:   %Main.import_ref.3fa = import_ref Main//basic_import_generic_interface, loc3_23, unloaded
 // CHECK:STDOUT:   %Main.import_ref.b3bc94.1: type = import_ref Main//basic_import_generic_interface, loc3_13, loaded [symbolic = @I.%T (constants.%T)]
+// CHECK:STDOUT:   %J.Self.binding.as_type.impls.I.type.require.decl = require_decl @J.Self.binding.as_type.impls.I.type.require [concrete] {
+// CHECK:STDOUT:     require imports.%Main.import_ref.2ff impls imports.%Main.import_ref.358
+// CHECK:STDOUT:   } {}
 // CHECK:STDOUT:   %Main.import_ref.2ff: type = import_ref Main//basic_import_generic_interface, loc5_18, loaded [symbolic = @J.Self.binding.as_type.impls.I.type.require.%Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:   %Main.import_ref.358: type = import_ref Main//basic_import_generic_interface, loc5_27, loaded [symbolic = @J.Self.binding.as_type.impls.I.type.require.%I.type (constants.%I.type.1ab)]
 // CHECK:STDOUT:   %Main.import_ref.b3bc94.2: type = import_ref Main//basic_import_generic_interface, loc4_13, loaded [symbolic = @J.%T (constants.%T)]
 // CHECK:STDOUT:   %Main.import_ref.99f: @J.%J.type (%J.type.04e) = import_ref Main//basic_import_generic_interface, loc4_23, loaded [symbolic = @J.%Self (constants.%Self.c25)]
 // CHECK:STDOUT:   %Main.import_ref.e9be38.1 = import_ref Main//basic_import_generic_interface, loc4_23, unloaded
 // CHECK:STDOUT:   %Main.import_ref.b55 = import_ref Main//basic_import_generic_interface, loc5_28, unloaded
+// CHECK:STDOUT:   %Main.: invalid = import_ref Main//basic_import_generic_interface, <none>, loaded [concrete = %J.Self.binding.as_type.impls.I.type.require.decl]
 // CHECK:STDOUT:   %Main.import_ref.b3bc94.3: type = import_ref Main//basic_import_generic_interface, loc4_13, loaded [symbolic = @J.%T (constants.%T)]
+// CHECK:STDOUT:   %Main.import_ref.b94 = import_ref Main//basic_import_generic_interface, loc5_28, unloaded
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -394,6 +408,8 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %J.type: type = facet_type <@J, @J(%T)> [symbolic = %J.type (constants.%J.type.04e)]
 // CHECK:STDOUT:   %Self: @J.%J.type (%J.type.04e) = symbolic_binding Self, 1 [symbolic = %Self (constants.%Self.c25)]
+// CHECK:STDOUT:   %J.assoc_type: type = assoc_entity_type @J, @J(%T) [symbolic = %J.assoc_type (constants.%J.assoc_type.4de)]
+// CHECK:STDOUT:   %assoc0: @J.%J.assoc_type (%J.assoc_type.4de) = assoc_entity element0, imports.%Main.import_ref.b94 [symbolic = %assoc0 (constants.%assoc0.d5d)]
 // CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%T)> [symbolic = %I.type (constants.%I.type.1ab)]
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %I.type [symbolic = %require_complete (constants.%require_complete)]
 // CHECK:STDOUT:
@@ -401,7 +417,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = imports.%Main.import_ref.e9be38.1
 // CHECK:STDOUT:     extend imports.%Main.import_ref.b55
-// CHECK:STDOUT:     witness = ()
+// CHECK:STDOUT:     witness = (imports.%Main.)
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @J.Self.binding.as_type.impls.I.type.require {
@@ -427,7 +443,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @C.as.J.impl: %C.ref as %J.type {
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (), @C.as.J.impl [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (constants.%I.impl_witness), @C.as.J.impl [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -476,6 +492,8 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %J.type => constants.%J.type.d6f
 // CHECK:STDOUT:   %Self => constants.%Self.9e4
+// CHECK:STDOUT:   %J.assoc_type => constants.%J.assoc_type.5d0
+// CHECK:STDOUT:   %assoc0 => constants.%assoc0.961
 // CHECK:STDOUT:   %I.type => constants.%I.type.ab5
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.5b1
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/impl/import_generic.carbon
+++ b/toolchain/check/testdata/impl/import_generic.carbon
@@ -443,7 +443,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @C.as.J.impl: %C.ref as %J.type {
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (<error>), @C.as.J.impl [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (constants.%I.impl_witness), @C.as.J.impl [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/impl/import_generic.carbon
+++ b/toolchain/check/testdata/impl/import_generic.carbon
@@ -443,7 +443,7 @@ impl forall [T:! type] D as N(T*) {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: impl @C.as.J.impl: %C.ref as %J.type {
-// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (constants.%I.impl_witness), @C.as.J.impl [concrete]
+// CHECK:STDOUT:   %J.impl_witness_table = impl_witness_table (<error>), @C.as.J.impl [concrete]
 // CHECK:STDOUT:   %J.impl_witness: <witness> = impl_witness %J.impl_witness_table [concrete = constants.%J.impl_witness]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:

--- a/toolchain/check/testdata/impl/incomplete.carbon
+++ b/toolchain/check/testdata/impl/incomplete.carbon
@@ -748,13 +748,13 @@ interface B {
 // CHECK:STDOUT:   %X.assoc_type: type = assoc_entity_type @X [concrete]
 // CHECK:STDOUT:   %assoc0: %X.assoc_type = assoc_entity element0, @X.%X1 [concrete]
 // CHECK:STDOUT:   %Self.binding.as_type.806: type = symbolic_binding_type Self, 0, %Self.e52 [symbolic]
-// CHECK:STDOUT:   %assoc1: %X.assoc_type = assoc_entity element1, @X.%X.Self.binding.as_type.impls.Y.type.require.decl [concrete]
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %facet_value: %type = facet_value %X.type, () [concrete]
+// CHECK:STDOUT:   %assoc1: %X.assoc_type = assoc_entity element1, @X.%X.Self.binding.as_type.impls.Y.type.require.decl [concrete]
 // CHECK:STDOUT:   %.Self.c39: %type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %.Self.637: %X.type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %.Self.binding.as_type: type = symbolic_binding_type .Self, %.Self.637 [symbolic_self]
 // CHECK:STDOUT:   %X.lookup_impl_witness: <witness> = lookup_impl_witness %.Self.637, @X [symbolic_self]
-// CHECK:STDOUT:   %facet_value: %type = facet_value %X.type, () [concrete]
 // CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %X.lookup_impl_witness, element0 [symbolic_self]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %empty_struct: %empty_struct_type = struct_value () [concrete]
@@ -886,14 +886,14 @@ interface B {
 // CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type.806
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @Y.Self.binding.as_type.impls.Z.type.require(constants.%.Self.637) {
-// CHECK:STDOUT:   %Self => constants.%.Self.637
-// CHECK:STDOUT:   %Self.binding.as_type => constants.%.Self.binding.as_type
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
 // CHECK:STDOUT: specific @Y.Self.binding.as_type.impls.Z.type.require(constants.%facet_value) {
 // CHECK:STDOUT:   %Self => constants.%facet_value
 // CHECK:STDOUT:   %Self.binding.as_type => constants.%X.type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Y.Self.binding.as_type.impls.Z.type.require(constants.%.Self.637) {
+// CHECK:STDOUT:   %Self => constants.%.Self.637
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%.Self.binding.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @X1(constants.%.Self.637) {}

--- a/toolchain/check/testdata/impl/incomplete.carbon
+++ b/toolchain/check/testdata/impl/incomplete.carbon
@@ -748,6 +748,7 @@ interface B {
 // CHECK:STDOUT:   %X.assoc_type: type = assoc_entity_type @X [concrete]
 // CHECK:STDOUT:   %assoc0: %X.assoc_type = assoc_entity element0, @X.%X1 [concrete]
 // CHECK:STDOUT:   %Self.binding.as_type.806: type = symbolic_binding_type Self, 0, %Self.e52 [symbolic]
+// CHECK:STDOUT:   %assoc1: %X.assoc_type = assoc_entity element1, @X.%X.Self.binding.as_type.impls.Y.type.require.decl [concrete]
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
 // CHECK:STDOUT:   %.Self.c39: %type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %.Self.637: %X.type = symbolic_binding .Self [symbolic_self]
@@ -810,12 +811,13 @@ interface B {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @X.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type.806)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc1: %X.assoc_type = assoc_entity element1, %X.Self.binding.as_type.impls.Y.type.require.decl [concrete = constants.%assoc1]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .X1 = @X1.%assoc0
 // CHECK:STDOUT:   .Y = <poisoned>
-// CHECK:STDOUT:   witness = (%X1)
+// CHECK:STDOUT:   witness = (%X1, %X.Self.binding.as_type.impls.Y.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @X.Self.binding.as_type.impls.Y.type.require {

--- a/toolchain/check/testdata/impl/incomplete.carbon
+++ b/toolchain/check/testdata/impl/incomplete.carbon
@@ -753,6 +753,7 @@ interface B {
 // CHECK:STDOUT:   %.Self.637: %X.type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %.Self.binding.as_type: type = symbolic_binding_type .Self, %.Self.637 [symbolic_self]
 // CHECK:STDOUT:   %X.lookup_impl_witness: <witness> = lookup_impl_witness %.Self.637, @X [symbolic_self]
+// CHECK:STDOUT:   %facet_value: %type = facet_value %X.type, () [concrete]
 // CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %X.lookup_impl_witness, element0 [symbolic_self]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %empty_struct: %empty_struct_type = struct_value () [concrete]
@@ -881,6 +882,16 @@ interface B {
 // CHECK:STDOUT: specific @X.Self.binding.as_type.impls.Y.type.require(constants.%Self.e52) {
 // CHECK:STDOUT:   %Self => constants.%Self.e52
 // CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type.806
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Y.Self.binding.as_type.impls.Z.type.require(constants.%.Self.637) {
+// CHECK:STDOUT:   %Self => constants.%.Self.637
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%.Self.binding.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Y.Self.binding.as_type.impls.Z.type.require(constants.%facet_value) {
+// CHECK:STDOUT:   %Self => constants.%facet_value
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%X.type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @X1(constants.%.Self.637) {}

--- a/toolchain/check/testdata/interface/incomplete.carbon
+++ b/toolchain/check/testdata/interface/incomplete.carbon
@@ -353,6 +353,8 @@ interface A(T:! type) {
 // CHECK:STDOUT:   %A.type: type = facet_type <@A> [concrete]
 // CHECK:STDOUT:   %Self: %A.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self [symbolic]
+// CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A [concrete]
+// CHECK:STDOUT:   %assoc0: %A.assoc_type = assoc_entity element0, @A.%A.Self.binding.as_type.impls.A.type.require.decl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -370,11 +372,12 @@ interface A(T:! type) {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @A.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc0: %A.assoc_type = assoc_entity element0, %A.Self.binding.as_type.impls.A.type.require.decl [concrete = constants.%assoc0]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .A = <poisoned>
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (%A.Self.binding.as_type.impls.A.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT: }
@@ -404,6 +407,8 @@ interface A(T:! type) {
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %empty_struct: %empty_struct_type = struct_value () [concrete]
 // CHECK:STDOUT:   %A.type.69e: type = facet_type <@A, @A(%empty_struct_type)> [concrete]
+// CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A, @A(%T) [symbolic]
+// CHECK:STDOUT:   %assoc0: %A.assoc_type = assoc_entity element0, @A.%A.Self.binding.as_type.impls.A.type.require.decl [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
@@ -424,6 +429,8 @@ interface A(T:! type) {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %A.type: type = facet_type <@A, @A(%T.loc3_13.1)> [symbolic = %A.type (constants.%A.type.ade)]
 // CHECK:STDOUT:   %Self.loc3_23.2: @A.%A.type (%A.type.ade) = symbolic_binding Self, 1 [symbolic = %Self.loc3_23.2 (constants.%Self)]
+// CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A, @A(%T.loc3_13.1) [symbolic = %A.assoc_type (constants.%A.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc11_29.2: @A.%A.assoc_type (%A.assoc_type) = assoc_entity element0, %A.Self.binding.as_type.impls.A.type.require.decl [symbolic = %assoc0.loc11_29.2 (constants.%assoc0)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.loc3_23.1: @A.%A.type (%A.type.ade) = symbolic_binding Self, 1 [symbolic = %Self.loc3_23.2 (constants.%Self)]
@@ -436,11 +443,12 @@ interface A(T:! type) {
 // CHECK:STDOUT:       %.loc11_28: type = converted %.loc11_27, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
 // CHECK:STDOUT:       %A.type.loc11_28: type = facet_type <@A, @A(constants.%empty_struct_type)> [concrete = constants.%A.type.69e]
 // CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc11_29.1: @A.%A.assoc_type (%A.assoc_type) = assoc_entity element0, %A.Self.binding.as_type.impls.A.type.require.decl [symbolic = %assoc0.loc11_29.2 (constants.%assoc0)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = %Self.loc3_23.1
 // CHECK:STDOUT:     .A = <poisoned>
-// CHECK:STDOUT:     witness = ()
+// CHECK:STDOUT:     witness = (%A.Self.binding.as_type.impls.A.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:   }

--- a/toolchain/check/testdata/interface/require.carbon
+++ b/toolchain/check/testdata/interface/require.carbon
@@ -299,6 +299,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Z.type: type = facet_type <@Z> [concrete]
 // CHECK:STDOUT:   %Self.c59: %Z.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.c59 [symbolic]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z [concrete]
+// CHECK:STDOUT:   %assoc0.40d: %Z.assoc_type = assoc_entity element0, @Z.%Z.Self.binding.as_type.impls.Y.type.require.decl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -316,6 +318,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc0: %Z.assoc_type = assoc_entity element0, %Z.Self.binding.as_type.impls.Y.type.require.decl [concrete = constants.%assoc0.40d]
 // CHECK:STDOUT:   %.loc9: type = specific_constant @Z.Self.binding.as_type.impls.Y.type.require.%Y.ref, @Z.Self.binding.as_type.impls.Y.type.require(constants.%Self.c59) [concrete = constants.%Y.type]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -323,7 +326,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   .Y = <poisoned>
 // CHECK:STDOUT:   .YY = <poisoned>
 // CHECK:STDOUT:   extend %.loc9
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (%Z.Self.binding.as_type.impls.Y.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.Self.binding.as_type.impls.Y.type.require {
@@ -350,6 +353,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Self.c59: %Z.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.c59 [symbolic]
 // CHECK:STDOUT:   %Y.type.432: type = facet_type <@Y, @Y(%Self.binding.as_type)> [symbolic]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z [concrete]
+// CHECK:STDOUT:   %assoc0.84d: %Z.assoc_type = assoc_entity element0, @Z.%Z.Self.binding.as_type.impls.Y.type.require.decl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -371,6 +376,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:     %.loc9: type = converted %Self.ref, %Self.as_type.loc9_30 [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.type.loc9_30.1: type = facet_type <@Y, @Y(constants.%Self.binding.as_type)> [symbolic = %Y.type.loc9_30.2 (constants.%Y.type.432)]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc0: %Z.assoc_type = assoc_entity element0, %Z.Self.binding.as_type.impls.Y.type.require.decl [concrete = constants.%assoc0.84d]
 // CHECK:STDOUT:   %.loc9: type = specific_constant @Z.Self.binding.as_type.impls.Y.type.require.%Y.type.loc9_30.1, @Z.Self.binding.as_type.impls.Y.type.require(constants.%Self.c59) [symbolic = constants.%Y.type.432]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -378,7 +384,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   .Y = <poisoned>
 // CHECK:STDOUT:   .YY = <poisoned>
 // CHECK:STDOUT:   extend %.loc9
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (%Z.Self.binding.as_type.impls.Y.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.Self.binding.as_type.impls.Y.type.require {
@@ -405,6 +411,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Z.type: type = facet_type <@Z> [concrete]
 // CHECK:STDOUT:   %Self.c59: %Z.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.c59 [symbolic]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z [concrete]
+// CHECK:STDOUT:   %assoc0.a7f: %Z.assoc_type = assoc_entity element0, @Z.%Z.Self.binding.as_type.impls.Y.type.require.decl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -422,11 +430,12 @@ interface Z(T:! type) {
 // CHECK:STDOUT:     %Self.as_type: type = facet_access_type @Z.%Self [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc0: %Z.assoc_type = assoc_entity element0, %Z.Self.binding.as_type.impls.Y.type.require.decl [concrete = constants.%assoc0.a7f]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .Y = <poisoned>
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (%Z.Self.binding.as_type.impls.Y.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.Self.binding.as_type.impls.Y.type.require {
@@ -451,6 +460,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Z.type: type = facet_type <@Z> [concrete]
 // CHECK:STDOUT:   %Self.c59: %Z.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.c59 [symbolic]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z [concrete]
+// CHECK:STDOUT:   %assoc0.a7f: %Z.assoc_type = assoc_entity element0, @Z.%Z.Self.binding.as_type.impls.Y.type.require.decl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -470,11 +481,12 @@ interface Z(T:! type) {
 // CHECK:STDOUT:     %.loc9: type = converted %Self.ref, %Self.as_type [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc0: %Z.assoc_type = assoc_entity element0, %Z.Self.binding.as_type.impls.Y.type.require.decl [concrete = constants.%assoc0.a7f]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .Y = <poisoned>
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (%Z.Self.binding.as_type.impls.Y.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.Self.binding.as_type.impls.Y.type.require {
@@ -502,6 +514,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Self.c59: %Z.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.c59 [symbolic]
 // CHECK:STDOUT:   %C.42e: type = class_type @C, @C(%Self.binding.as_type) [symbolic]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z [concrete]
+// CHECK:STDOUT:   %assoc0: %Z.assoc_type = assoc_entity element0, @Z.%Z.C.impls.Y.type.require.decl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -523,12 +537,13 @@ interface Z(T:! type) {
 // CHECK:STDOUT:     %C.loc9_17.1: type = class_type @C, @C(constants.%Self.binding.as_type) [symbolic = %C.loc9_17.2 (constants.%C.42e)]
 // CHECK:STDOUT:     %Y.ref: type = name_ref Y, file.%Y.decl [concrete = constants.%Y.type]
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc0: %Z.assoc_type = assoc_entity element0, %Z.C.impls.Y.type.require.decl [concrete = constants.%assoc0]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .C = <poisoned>
 // CHECK:STDOUT:   .Y = <poisoned>
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (%Z.C.impls.Y.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.C.impls.Y.type.require {
@@ -553,7 +568,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Y.type: type = facet_type <@Y> [concrete]
 // CHECK:STDOUT:   %Y.assoc_type: type = assoc_entity_type @Y [concrete]
-// CHECK:STDOUT:   %assoc0: %Y.assoc_type = assoc_entity element0, @Y.%Y1 [concrete]
+// CHECK:STDOUT:   %assoc0.8e0: %Y.assoc_type = assoc_entity element0, @Y.%Y1 [concrete]
 // CHECK:STDOUT:   %Z.type: type = facet_type <@Z> [concrete]
 // CHECK:STDOUT:   %Self.c59: %Z.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.c59 [symbolic]
@@ -564,6 +579,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %Y.lookup_impl_witness, element0 [symbolic_self]
 // CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
 // CHECK:STDOUT:   %Y_where.type: type = facet_type <@Y where %impl.elem0 = %empty_tuple.type> [concrete]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z [concrete]
+// CHECK:STDOUT:   %assoc0.195: %Z.assoc_type = assoc_entity element0, @Z.%Z.Self.binding.as_type.impls.Y_where.type.require.decl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -584,7 +601,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:     %.Self.ref: %Y.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.binding.as_type]
 // CHECK:STDOUT:     %.loc7_25: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.binding.as_type]
-// CHECK:STDOUT:     %Y1.ref: %Y.assoc_type = name_ref Y1, @Y1.%assoc0 [concrete = constants.%assoc0]
+// CHECK:STDOUT:     %Y1.ref: %Y.assoc_type = name_ref Y1, @Y1.%assoc0 [concrete = constants.%assoc0.8e0]
 // CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%Y.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
 // CHECK:STDOUT:     %.loc7_32.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
 // CHECK:STDOUT:     %.loc7_32.2: type = converted %.loc7_32.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
@@ -593,11 +610,12 @@ interface Z(T:! type) {
 // CHECK:STDOUT:       requirement_rewrite %impl.elem0, %.loc7_32.2
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc0: %Z.assoc_type = assoc_entity element0, %Z.Self.binding.as_type.impls.Y_where.type.require.decl [concrete = constants.%assoc0.195]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .Y = <poisoned>
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (%Z.Self.binding.as_type.impls.Y_where.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.Self.binding.as_type.impls.Y_where.type.require {
@@ -703,7 +721,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Y.type: type = facet_type <@Y> [concrete]
 // CHECK:STDOUT:   %Y.assoc_type: type = assoc_entity_type @Y [concrete]
-// CHECK:STDOUT:   %assoc0: %Y.assoc_type = assoc_entity element0, @Y.%Y1 [concrete]
+// CHECK:STDOUT:   %assoc0.8e0: %Y.assoc_type = assoc_entity element0, @Y.%Y1 [concrete]
 // CHECK:STDOUT:   %Z.type: type = facet_type <@Z> [concrete]
 // CHECK:STDOUT:   %Self.c59: %Z.type = symbolic_binding Self, 0 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.c59 [symbolic]
@@ -712,6 +730,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Y.lookup_impl_witness: <witness> = lookup_impl_witness %.Self, @Y [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %Y.lookup_impl_witness, element0 [symbolic_self]
 // CHECK:STDOUT:   %Y_where.type: type = facet_type <@Y where %impl.elem0 = %Self.binding.as_type> [symbolic]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z [concrete]
+// CHECK:STDOUT:   %assoc0.89b: %Z.assoc_type = assoc_entity element0, @Z.%Z.Self.binding.as_type.impls.Y_where.type.require.decl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -732,7 +752,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:     %.Self.ref: %Y.type = name_ref .Self, %.Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:     %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.binding.as_type]
 // CHECK:STDOUT:     %.loc10_25: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.binding.as_type]
-// CHECK:STDOUT:     %Y1.ref: %Y.assoc_type = name_ref Y1, @Y1.%assoc0 [concrete = constants.%assoc0]
+// CHECK:STDOUT:     %Y1.ref: %Y.assoc_type = name_ref Y1, @Y1.%assoc0 [concrete = constants.%assoc0.8e0]
 // CHECK:STDOUT:     %impl.elem0: type = impl_witness_access constants.%Y.lookup_impl_witness, element0 [symbolic_self = constants.%impl.elem0]
 // CHECK:STDOUT:     %Self.ref: %Z.type = name_ref Self, @Z.%Self [symbolic = %Self (constants.%Self.c59)]
 // CHECK:STDOUT:     %Self.as_type.loc10_31: type = facet_access_type %Self.ref [symbolic = %Self.binding.as_type (constants.%Self.binding.as_type)]
@@ -742,11 +762,12 @@ interface Z(T:! type) {
 // CHECK:STDOUT:       requirement_rewrite %impl.elem0, %.loc10_31
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %assoc0: %Z.assoc_type = assoc_entity element0, %Z.Self.binding.as_type.impls.Y_where.type.require.decl [concrete = constants.%assoc0.89b]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
 // CHECK:STDOUT:   .Self = %Self
 // CHECK:STDOUT:   .Y = <poisoned>
-// CHECK:STDOUT:   witness = ()
+// CHECK:STDOUT:   witness = (%Z.Self.binding.as_type.impls.Y_where.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @Z.Self.binding.as_type.impls.Y_where.type.require {
@@ -776,6 +797,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Z.type.0ed: type = facet_type <@Z, @Z(%T)> [symbolic]
 // CHECK:STDOUT:   %Self.822: %Z.type.0ed = symbolic_binding Self, 1 [symbolic]
 // CHECK:STDOUT:   %Self.binding.as_type.b37: type = symbolic_binding_type Self, 1, %Self.822 [symbolic]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z, @Z(%T) [symbolic]
+// CHECK:STDOUT:   %assoc0.801: %Z.assoc_type = assoc_entity element0, @Z.%Z.Self.binding.as_type.impls.Z.type.require.decl [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -796,6 +819,8 @@ interface Z(T:! type) {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Z.type: type = facet_type <@Z, @Z(%T.loc8_13.1)> [symbolic = %Z.type (constants.%Z.type.0ed)]
 // CHECK:STDOUT:   %Self.loc8_23.2: @Z.%Z.type (%Z.type.0ed) = symbolic_binding Self, 1 [symbolic = %Self.loc8_23.2 (constants.%Self.822)]
+// CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z, @Z(%T.loc8_13.1) [symbolic = %Z.assoc_type (constants.%Z.assoc_type)]
+// CHECK:STDOUT:   %assoc0.loc11_21.2: @Z.%Z.assoc_type (%Z.assoc_type) = assoc_entity element0, %Z.Self.binding.as_type.impls.Z.type.require.decl [symbolic = %assoc0.loc11_21.2 (constants.%assoc0.801)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   interface {
 // CHECK:STDOUT:     %Self.loc8_23.1: @Z.%Z.type (%Z.type.0ed) = symbolic_binding Self, 1 [symbolic = %Self.loc8_23.2 (constants.%Self.822)]
@@ -807,12 +832,13 @@ interface Z(T:! type) {
 // CHECK:STDOUT:       %T.ref: type = name_ref T, @Z.%T.loc8_13.2 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:       %Z.type.loc11_20: type = facet_type <@Z, @Z(constants.%T)> [symbolic = %Z.type.loc11_11 (constants.%Z.type.0ed)]
 // CHECK:STDOUT:     }
+// CHECK:STDOUT:     %assoc0.loc11_21.1: @Z.%Z.assoc_type (%Z.assoc_type) = assoc_entity element0, %Z.Self.binding.as_type.impls.Z.type.require.decl [symbolic = %assoc0.loc11_21.2 (constants.%assoc0.801)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = %Self.loc8_23.1
 // CHECK:STDOUT:     .Z = <poisoned>
 // CHECK:STDOUT:     .T = <poisoned>
-// CHECK:STDOUT:     witness = ()
+// CHECK:STDOUT:     witness = (%Z.Self.binding.as_type.impls.Z.type.require.decl)
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !requires:
 // CHECK:STDOUT:     @Z.Self.binding.as_type.impls.Z.type.require {

--- a/toolchain/check/testdata/interface/require.carbon
+++ b/toolchain/check/testdata/interface/require.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interface/require.carbon
 
-// --- fail_todo_extend.carbon
+// --- extend.carbon
 library "[[@TEST_NAME]]";
 
 interface Y {
@@ -24,29 +24,13 @@ interface Z {
 //@dump-sem-ir-end
 
 fn F(T:! Z, t:! T) {
-  // TODO: We find the name `YY`, but then fail to do impl lookup for `Y` in
-  // `T:! Z` since the identified facet type doesn't include `Y`. The
-  // identified facet type needs to include extends inside interfaces?
-
-  // CHECK:STDERR: fail_todo_extend.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Y` in type `T` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   T.YY();
-  // CHECK:STDERR:   ^~~~
-  // CHECK:STDERR:
   T.YY();
-  // CHECK:STDERR: fail_todo_extend.carbon:[[@LINE+4]]:3: error: cannot convert type `T` that implements `Z` into type implementing `Y` [ConversionFailureFacetToFacet]
-  // CHECK:STDERR:   T.(Y.YY)();
-  // CHECK:STDERR:   ^~~~~~~~
-  // CHECK:STDERR:
   T.(Y.YY)();
 
-  // CHECK:STDERR: fail_todo_extend.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Y` in type `T` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   t.YY();
-  // CHECK:STDERR:   ^~~~
-  // CHECK:STDERR:
   t.YY();
 }
 
-// --- fail_todo_extend_with_self.carbon
+// --- extend_with_self.carbon
 library "[[@TEST_NAME]]";
 
 interface Y(T:! type) {
@@ -60,23 +44,11 @@ interface Z {
 //@dump-sem-ir-end
 
 fn F(T:! Z) {
-  // TODO: We find the name `YY`, but then fail to do impl lookup for `Y` in
-  // `T:! Z` since the identified facet type doesn't include `Y`. The
-  // identified facet type needs to include extends inside interfaces?
-  //
-  // CHECK:STDERR: fail_todo_extend_with_self.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Y(T)` in type `T` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   T.YY();
-  // CHECK:STDERR:   ^~~~
-  // CHECK:STDERR:
   T.YY();
-  // CHECK:STDERR: fail_todo_extend_with_self.carbon:[[@LINE+4]]:3: error: cannot convert type `T` that implements `Z` into type implementing `Y(T)` [ConversionFailureFacetToFacet]
-  // CHECK:STDERR:   T.(Y(T).YY)();
-  // CHECK:STDERR:   ^~~~~~~~~~~
-  // CHECK:STDERR:
   T.(Y(T).YY)();
 }
 
-// --- fail_todo_implicit_self_impls.carbon
+// --- implicit_self_impls.carbon
 library "[[@TEST_NAME]]";
 
 interface Y {
@@ -90,14 +62,10 @@ interface Z {
 //@dump-sem-ir-end
 
 fn F(T:! Z) {
-  // CHECK:STDERR: fail_todo_implicit_self_impls.carbon:[[@LINE+4]]:3: error: cannot convert type `T` that implements `Z` into type implementing `Y` [ConversionFailureFacetToFacet]
-  // CHECK:STDERR:   T.(Y.YY)();
-  // CHECK:STDERR:   ^~~~~~~~
-  // CHECK:STDERR:
   T.(Y.YY)();
 }
 
-// --- fail_todo_explicit_self_impls.carbon
+// --- explicit_self_impls.carbon
 library "[[@TEST_NAME]]";
 
 interface Y {
@@ -111,10 +79,6 @@ interface Z {
 //@dump-sem-ir-end
 
 fn F(T:! Z) {
-  // CHECK:STDERR: fail_todo_explicit_self_impls.carbon:[[@LINE+4]]:3: error: cannot convert type `T` that implements `Z` into type implementing `Y` [ConversionFailureFacetToFacet]
-  // CHECK:STDERR:   T.(Y.YY)();
-  // CHECK:STDERR:   ^~~~~~~~
-  // CHECK:STDERR:
   T.(Y.YY)();
 }
 
@@ -328,7 +292,7 @@ interface Z(T:! type) {
 }
 //@dump-sem-ir-end
 
-// CHECK:STDOUT: --- fail_todo_extend.carbon
+// CHECK:STDOUT: --- extend.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Y.type: type = facet_type <@Y> [concrete]
@@ -377,7 +341,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_todo_extend_with_self.carbon
+// CHECK:STDOUT: --- extend_with_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Y.type.82b: type = generic_interface_type @Y [concrete]
@@ -434,7 +398,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Y.type.loc9_30.2 => constants.%Y.type.432
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_todo_implicit_self_impls.carbon
+// CHECK:STDOUT: --- implicit_self_impls.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Y.type: type = facet_type <@Y> [concrete]
@@ -480,7 +444,7 @@ interface Z(T:! type) {
 // CHECK:STDOUT:   %Self.binding.as_type => constants.%Self.binding.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_todo_explicit_self_impls.carbon
+// CHECK:STDOUT: --- explicit_self_impls.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %Y.type: type = facet_type <@Y> [concrete]

--- a/toolchain/check/testdata/named_constraint/require.carbon
+++ b/toolchain/check/testdata/named_constraint/require.carbon
@@ -624,6 +624,11 @@ fn F() {
 // CHECK:STDOUT:   %Self.binding.as_type => constants.%T.binding.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: specific @Z.Self.binding.as_type.impls.Y.type.require(constants.%Y.facet) {
+// CHECK:STDOUT:   %Self => constants.%Y.facet
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%T.binding.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- extend_with_self.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -756,6 +761,12 @@ fn F() {
 // CHECK:STDOUT:   %Y.type.loc9_30.2 => constants.%Y.type.55c
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: specific @Z.Self.binding.as_type.impls.Y.type.require(constants.%Y.facet) {
+// CHECK:STDOUT:   %Self => constants.%Y.facet
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%T.binding.as_type
+// CHECK:STDOUT:   %Y.type.loc9_30.2 => constants.%Y.type.55c
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- implicit_self_impls.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -765,6 +776,8 @@ fn F() {
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.550 [symbolic]
 // CHECK:STDOUT:   %T: %Z.type = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type: type = symbolic_binding_type T, 0, %T [symbolic]
+// CHECK:STDOUT:   %Y.lookup_impl_witness: <witness> = lookup_impl_witness %T, @Y [symbolic]
+// CHECK:STDOUT:   %Y.facet: %Y.type = facet_value %T.binding.as_type, (%Y.lookup_impl_witness) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -808,6 +821,11 @@ fn F() {
 // CHECK:STDOUT:   %Self.binding.as_type => constants.%T.binding.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: specific @Z.Self.binding.as_type.impls.Y.type.require(constants.%Y.facet) {
+// CHECK:STDOUT:   %Self => constants.%Y.facet
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%T.binding.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- explicit_self_impls.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
@@ -817,6 +835,8 @@ fn F() {
 // CHECK:STDOUT:   %Self.binding.as_type: type = symbolic_binding_type Self, 0, %Self.550 [symbolic]
 // CHECK:STDOUT:   %T: %Z.type = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %T.binding.as_type: type = symbolic_binding_type T, 0, %T [symbolic]
+// CHECK:STDOUT:   %Y.lookup_impl_witness: <witness> = lookup_impl_witness %T, @Y [symbolic]
+// CHECK:STDOUT:   %Y.facet: %Y.type = facet_value %T.binding.as_type, (%Y.lookup_impl_witness) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -859,6 +879,11 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Z.Self.binding.as_type.impls.Y.type.require(constants.%T) {
 // CHECK:STDOUT:   %Self => constants.%T
+// CHECK:STDOUT:   %Self.binding.as_type => constants.%T.binding.as_type
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @Z.Self.binding.as_type.impls.Y.type.require(constants.%Y.facet) {
+// CHECK:STDOUT:   %Self => constants.%Y.facet
 // CHECK:STDOUT:   %Self.binding.as_type => constants.%T.binding.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/interface/require.carbon
+++ b/toolchain/lower/testdata/interface/require.carbon
@@ -40,15 +40,13 @@ impl C as A {
 
 impl C as B {}
 
-fn Main() -> i32 {
-    var c: C = {};
+fn Run() -> i32 {
+    var c: C;
     return TakesB(c);
 }
 
 // CHECK:STDOUT: ; ModuleID = 'require.carbon'
 // CHECK:STDOUT: source_filename = "require.carbon"
-// CHECK:STDOUT:
-// CHECK:STDOUT: @C.val.loc44_5 = internal constant {} zeroinitializer
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @"_CF1.C.Main:A.Main"(ptr %self) #0 !dbg !4 {
@@ -63,20 +61,16 @@ fn Main() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define i32 @_CMain.Main() #0 !dbg !16 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !16 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !19
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !19
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @C.val.loc44_5, i64 0, i1 false), !dbg !19
 // CHECK:STDOUT:   %TakesB.call = call i32 @_CTakesB.Main.28c67e05fd10f829(ptr %c.var), !dbg !20
 // CHECK:STDOUT:   ret i32 %TakesB.call, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr i32 @_CTakesB.Main.28c67e05fd10f829(ptr %x) #0 !dbg !22 {
@@ -94,7 +88,6 @@ fn Main() -> i32 {
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
 // CHECK:STDOUT: attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-// CHECK:STDOUT: attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!2}
@@ -115,7 +108,7 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !13 = !{!14}
 // CHECK:STDOUT: !14 = !DILocalVariable(arg: 1, scope: !12, type: !8)
 // CHECK:STDOUT: !15 = !DILocation(line: 37, column: 9, scope: !12)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "Main", linkageName: "_CMain.Main", scope: null, file: !3, line: 43, type: !17, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 43, type: !17, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
 // CHECK:STDOUT: !18 = !{!7}
 // CHECK:STDOUT: !19 = !DILocation(line: 44, column: 5, scope: !16)

--- a/toolchain/lower/testdata/interface/require.carbon
+++ b/toolchain/lower/testdata/interface/require.carbon
@@ -1,0 +1,133 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/interface/require.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/interface/require.carbon
+
+interface A {
+    fn F1[self: Self]() -> i32;
+    fn F2[self: Self]() -> i32;
+}
+
+interface B {
+    require impls A;
+}
+
+fn TakesA[T:! A](x: T) -> i32 {
+    return x.F2();
+}
+
+fn TakesB[T:! B](x: T) -> i32 {
+    return TakesA(x);
+}
+
+class C {}
+
+impl C as A {
+    fn F1[self: C]() -> i32 {
+        return 86;
+    }
+    fn F2[self: C]() -> i32 {
+        return 42;
+    }
+}
+
+impl C as B {}
+
+fn Main() -> i32 {
+    var c: C = {};
+    return TakesB(c);
+}
+
+// CHECK:STDOUT: ; ModuleID = 'require.carbon'
+// CHECK:STDOUT: source_filename = "require.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @C.val.loc44_5 = internal constant {} zeroinitializer
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define i32 @"_CF1.C.Main:A.Main"(ptr %self) #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret i32 86, !dbg !11
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define i32 @"_CF2.C.Main:A.Main"(ptr %self) #0 !dbg !12 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret i32 42, !dbg !15
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define i32 @_CMain.Main() #0 !dbg !16 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !19
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !19
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @C.val.loc44_5, i64 0, i1 false), !dbg !19
+// CHECK:STDOUT:   %TakesB.call = call i32 @_CTakesB.Main.28c67e05fd10f829(ptr %c.var), !dbg !20
+// CHECK:STDOUT:   ret i32 %TakesB.call, !dbg !21
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr i32 @_CTakesB.Main.28c67e05fd10f829(ptr %x) #0 !dbg !22 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %TakesA.call = call i32 @_CTakesA.Main.b6d50ff22524203f(ptr %x), !dbg !25
+// CHECK:STDOUT:   ret i32 %TakesA.call, !dbg !26
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr i32 @_CTakesA.Main.b6d50ff22524203f(ptr %x) #0 !dbg !27 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %A.F2.call = call i32 @"_CF2.C.Main:A.Main"(ptr %x), !dbg !30
+// CHECK:STDOUT:   ret i32 %A.F2.call, !dbg !31
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "require.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F1", linkageName: "_CF1.C.Main:A.Main", scope: null, file: !3, line: 33, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !9)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{!7, !8}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 8)
+// CHECK:STDOUT: !9 = !{!10}
+// CHECK:STDOUT: !10 = !DILocalVariable(arg: 1, scope: !4, type: !8)
+// CHECK:STDOUT: !11 = !DILocation(line: 34, column: 9, scope: !4)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "F2", linkageName: "_CF2.C.Main:A.Main", scope: null, file: !3, line: 36, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !13)
+// CHECK:STDOUT: !13 = !{!14}
+// CHECK:STDOUT: !14 = !DILocalVariable(arg: 1, scope: !12, type: !8)
+// CHECK:STDOUT: !15 = !DILocation(line: 37, column: 9, scope: !12)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "Main", linkageName: "_CMain.Main", scope: null, file: !3, line: 43, type: !17, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
+// CHECK:STDOUT: !18 = !{!7}
+// CHECK:STDOUT: !19 = !DILocation(line: 44, column: 5, scope: !16)
+// CHECK:STDOUT: !20 = !DILocation(line: 45, column: 12, scope: !16)
+// CHECK:STDOUT: !21 = !DILocation(line: 45, column: 5, scope: !16)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "TakesB", linkageName: "_CTakesB.Main.28c67e05fd10f829", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !23)
+// CHECK:STDOUT: !23 = !{!24}
+// CHECK:STDOUT: !24 = !DILocalVariable(arg: 1, scope: !22, type: !8)
+// CHECK:STDOUT: !25 = !DILocation(line: 27, column: 12, scope: !22)
+// CHECK:STDOUT: !26 = !DILocation(line: 27, column: 5, scope: !22)
+// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "TakesA", linkageName: "_CTakesA.Main.b6d50ff22524203f", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !28)
+// CHECK:STDOUT: !28 = !{!29}
+// CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !8)
+// CHECK:STDOUT: !30 = !DILocation(line: 23, column: 12, scope: !27)
+// CHECK:STDOUT: !31 = !DILocation(line: 23, column: 5, scope: !27)


### PR DESCRIPTION
Currently accessing to the members of a required interface from parent fails with conversion or member not found errors. For instance: 
```carbon
interface A { fn F(); }
interface B {
    require impls A;
}
fn Call(T:! B)  {
    T.(A.F)(); // this currently fails with a conversion error.
}
```

This PR fixes this by adding `B`'s witness table a pointer to the witness of `A`. This allows `LookupImplWitness` to check the `require` declarations of available bounds (like `B`) when searching for a witness of `A`. If found, it returns an access to `A`'s witness derived from `B`'s witness table.

Assisted-by: Gemini 3 Pro
