### PR TITLE
Introduce ExprCategory::Dependent

### DIFF
--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -1537,6 +1537,10 @@ auto CategoryConverter::DoStep(const SemIR::InstId expr_id,
     case SemIR::ExprCategory::Error:
       return Done{SemIR::ErrorInst::InstId};
 
+    case SemIR::ExprCategory::Dependent:
+      context_.TODO(expr_id, "Support symbolic expression forms");
+      return Done{SemIR::ErrorInst::InstId};
+
     case SemIR::ExprCategory::InPlaceInitializing:
     case SemIR::ExprCategory::ReprInitializing:
       if (target_.is_initializer()) {

--- a/toolchain/check/cpp/type_mapping.cpp
+++ b/toolchain/check/cpp/type_mapping.cpp
@@ -520,6 +520,7 @@ static auto InventPrimitiveClangArg(Context& context, FormInfo form)
       break;
 
     case SemIR::ExprCategory::Mixed:
+    case SemIR::ExprCategory::Dependent:
       CARBON_FATAL("Argument does not have primitive form");
   }
 

--- a/toolchain/lower/aggregate.cpp
+++ b/toolchain/lower/aggregate.cpp
@@ -56,6 +56,7 @@ auto GetAggregateElement(FunctionContext& context, SemIR::InstId aggr_inst_id,
     case SemIR::ExprCategory::ReprInitializing:
     case SemIR::ExprCategory::InPlaceInitializing:
     case SemIR::ExprCategory::Mixed:
+    case SemIR::ExprCategory::Dependent:
       CARBON_FATAL(
           "Unexpected expression category for aggregate access into {0}",
           context.sem_ir().insts().Get(aggr_inst_id));

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -199,6 +199,7 @@ auto FileContext::GetConstant(SemIR::ConstantId const_id,
     case SemIR::ExprCategory::Pattern:
     case SemIR::ExprCategory::Mixed:
     case SemIR::ExprCategory::RefTagged:
+    case SemIR::ExprCategory::Dependent:
       CARBON_FATAL("Unexpected category {0} for lowered constant {1}", cat,
                    sem_ir().insts().Get(const_inst_id));
   };

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -293,6 +293,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,
         case SemIR::ExprCategory::NotExpr:
         case SemIR::ExprCategory::Error:
         case SemIR::ExprCategory::Pattern:
+        case SemIR::ExprCategory::Dependent:
           CARBON_FATAL("Unexpected category for `return` expression");
       }
       context.builder().CreateRet(value);

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -1026,6 +1026,7 @@ auto Formatter::FormatNameAndForm(InstId inst_id, Inst inst) -> void {
       case ExprCategory::Pattern:
       case ExprCategory::Mixed:
       case ExprCategory::RefTagged:
+      case ExprCategory::Dependent:
         FormatTypeOfInst(inst_id);
         break;
       case ExprCategory::DurableRef:

--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -88,6 +88,8 @@ enum class ExprCategory : int8_t {
   // and struct literals, where the subexpressions for different elements can
   // have different categories.
   Mixed,
+  // The category of this instruction is dependent because its form is symbolic.
+  Dependent,
   // This instruction is a `RefTagExpr`, and so its semantics (including its
   // expression category) depends on the usage context.
   RefTagged,


### PR DESCRIPTION
This is needed to model things like the category of `x` in the body of `fn Foo(F:! Core.Form, x:? F)`, where the category of `x` is determined by the concrete value of `F` (see #5389 for the design of `:?` bindings).

This will be used in a follow-up PR.