### PR TITLE
Ask Clang to emit C++ global variables.

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -126,7 +126,8 @@ auto FileContext::LowerDefinitions() -> void {
           const_id.is_constant()) {
         llvm_var = cast<llvm::GlobalVariable>(GetConstant(const_id, inst_id));
       } else {
-        llvm_var = BuildGlobalVariableDecl(*var);
+        // We should never be emitting a definition for a C++ global variable.
+        llvm_var = BuildNonCppGlobalVariableDecl(*var);
       }
 
       // Convert the declaration of this variable into a definition by adding an
@@ -1168,6 +1169,26 @@ auto FileContext::BuildType(SemIR::InstId inst_id) -> LoweredTypes {
 }
 
 auto FileContext::BuildGlobalVariableDecl(SemIR::VarStorage var_storage)
+    -> llvm::Constant* {
+  auto var_name_id =
+      SemIR::GetFirstBindingNameFromPatternId(sem_ir(), var_storage.pattern_id);
+  if (auto cpp_global_var_id =
+          sem_ir().cpp_global_vars().Lookup({.entity_name_id = var_name_id});
+      cpp_global_var_id.has_value()) {
+    SemIR::ClangDeclId clang_decl_id =
+        sem_ir().cpp_global_vars().Get(cpp_global_var_id).clang_decl_id;
+    CARBON_CHECK(clang_decl_id.has_value(),
+                 "CppGlobalVar should have a clang_decl_id");
+    return cpp_code_generator_->GetAddrOfGlobal(
+        cast<clang::VarDecl>(
+            sem_ir().clang_decls().Get(clang_decl_id).key.decl),
+        /*isForDefinition=*/false);
+  }
+
+  return BuildNonCppGlobalVariableDecl(var_storage);
+}
+
+auto FileContext::BuildNonCppGlobalVariableDecl(SemIR::VarStorage var_storage)
     -> llvm::GlobalVariable* {
   Mangler m(*this);
   auto mangled_name = m.MangleGlobalVariable(var_storage.pattern_id);

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -167,6 +167,11 @@ class FileContext {
   // Builds the global for the given instruction, which should then be cached by
   // the caller.
   auto BuildGlobalVariableDecl(SemIR::VarStorage var_storage)
+      -> llvm::Constant*;
+
+  // Builds the global for the given instruction which is known to not be
+  // imported from C++.
+  auto BuildNonCppGlobalVariableDecl(SemIR::VarStorage var_storage)
       -> llvm::GlobalVariable*;
 
   // Builds the definition for the given function. If the function is only a

--- a/toolchain/lower/mangler.cpp
+++ b/toolchain/lower/mangler.cpp
@@ -172,6 +172,9 @@ auto Mangler::Mangle(SemIR::FunctionId function_id,
     CARBON_CHECK(!specific_id.has_value(), "entry point should not be generic");
     return "main";
   }
+
+  // TODO: We should never need to do this: Clang should emit C++ function
+  // declarations for us.
   if (function.clang_decl_id.has_value()) {
     CARBON_CHECK(function.special_function_kind !=
                      SemIR::Function::SpecialFunctionKind::HasCppThunk,
@@ -179,6 +182,7 @@ auto Mangler::Mangle(SemIR::FunctionId function_id,
     const auto& clang_decl = sem_ir().clang_decls().Get(function.clang_decl_id);
     return MangleCppClang(cast<clang::NamedDecl>(clang_decl.key.decl));
   }
+
   RawStringOstream os;
   os << "_C";
 
@@ -230,16 +234,11 @@ auto Mangler::MangleGlobalVariable(SemIR::InstId pattern_id) -> std::string {
     return std::string();
   }
 
-  SemIR::CppGlobalVarId cpp_global_var_id =
-      sem_ir().cpp_global_vars().Lookup({.entity_name_id = var_name_id});
-  if (cpp_global_var_id.has_value()) {
-    SemIR::ClangDeclId clang_decl_id =
-        sem_ir().cpp_global_vars().Get(cpp_global_var_id).clang_decl_id;
-    CARBON_CHECK(clang_decl_id.has_value(),
-                 "CppGlobalVar should have a clang_decl_id");
-    return MangleCppClang(cast<clang::NamedDecl>(
-        sem_ir().clang_decls().Get(clang_decl_id).key.decl));
-  }
+  CARBON_CHECK(!sem_ir()
+                    .cpp_global_vars()
+                    .Lookup({.entity_name_id = var_name_id})
+                    .has_value(),
+               "Mangling a C++ variable");
 
   RawStringOstream os;
   os << "_C";

--- a/toolchain/lower/testdata/interop/cpp/extern_c.carbon
+++ b/toolchain/lower/testdata/interop/cpp/extern_c.carbon
@@ -187,7 +187,7 @@ fn MyF() {
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @foo = external global i32
+// CHECK:STDOUT: @foo = external global i32, align 4
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CMyF.Main() #0 !dbg !12 {

--- a/toolchain/lower/testdata/interop/cpp/globals.carbon
+++ b/toolchain/lower/testdata/interop/cpp/globals.carbon
@@ -162,7 +162,6 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: %class.C = type { i8 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: @global = dso_local global %class.C zeroinitializer, align 1
-// CHECK:STDOUT: @global.1 = external global {}
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMyF.Main() #0 !dbg !12 {
@@ -204,7 +203,6 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: @inline_global = linkonce_odr dso_local global %struct.C zeroinitializer, comdat, align 1
 // CHECK:STDOUT: @_ZGV13inline_global = linkonce_odr dso_local global i64 0, comdat($inline_global), align 8
 // CHECK:STDOUT: @__dso_handle = external hidden global i8
-// CHECK:STDOUT: @inline_global.1 = external global {}
 // CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__cxx_global_var_init, ptr @inline_global }]
 // CHECK:STDOUT: @llvm.used = appending global [1 x ptr] [ptr @inline_global], section "llvm.metadata"
 // CHECK:STDOUT:
@@ -274,14 +272,14 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCallF.Main() #1 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_ZN1C1fEv(ptr @inline_global.1), !dbg !15
+// CHECK:STDOUT:   call void @_ZN1C1fEv(ptr @inline_global), !dbg !15
 // CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_ZN1C1fEv(ptr noundef nonnull align 1 dereferenceable(1)) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @inline_global, { 2, 3, 0, 1 }
+// CHECK:STDOUT: uselistorder ptr @inline_global, { 2, 3, 4, 0, 1 }
 // CHECK:STDOUT: uselistorder ptr @_ZGV13inline_global, { 1, 0, 2, 3 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
@@ -321,8 +319,6 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT:
 // CHECK:STDOUT: @thread_local_global = dso_local thread_local global i32 0, align 4
 // CHECK:STDOUT: @thread_local_global_with_init = dso_local thread_local global i32 0, align 4
-// CHECK:STDOUT: @thread_local_global.1 = external global i32
-// CHECK:STDOUT: @thread_local_global_with_init.2 = external global i32
 // CHECK:STDOUT: @__tls_guard = internal thread_local global i8 0, align 1
 // CHECK:STDOUT:
 // CHECK:STDOUT: @_ZTH29thread_local_global_with_init = dso_local alias void (), ptr @__tls_init
@@ -344,14 +340,14 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CThreadLocalStore.Main() #3 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   store i32 42, ptr @thread_local_global.1, align 4, !dbg !15
+// CHECK:STDOUT:   store i32 42, ptr @thread_local_global, align 4, !dbg !15
 // CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CThreadLocalTriggerInit.Main() #3 !dbg !17 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc14 = load i32, ptr @thread_local_global_with_init.2, align 4, !dbg !21
+// CHECK:STDOUT:   %.loc14 = load i32, ptr @thread_local_global_with_init, align 4, !dbg !21
 // CHECK:STDOUT:   ret i32 %.loc14, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -428,7 +424,9 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
-// CHECK:STDOUT: @_ZN1X1nE = external global i32
+// CHECK:STDOUT: $_ZN1X1nE = comdat any
+// CHECK:STDOUT:
+// CHECK:STDOUT: @_ZN1X1nE = linkonce_odr dso_local global i32 42, comdat, align 4
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CReadStatic.Main() #0 !dbg !12 {
@@ -466,10 +464,10 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
-// CHECK:STDOUT: %opaque = type opaque
+// CHECK:STDOUT: %struct.Y = type { i8 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: @_Z4tmplIiE = external global i32
-// CHECK:STDOUT: @_Z4tmplI1YE = external global %opaque
+// CHECK:STDOUT: @_Z4tmplIiE = external global i32, align 4
+// CHECK:STDOUT: @_Z4tmplI1YE = external global %struct.Y, align 1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CReadVarTemplate.Main() #0 !dbg !12 {
@@ -518,10 +516,10 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
 // CHECK:STDOUT:
-// CHECK:STDOUT: %opaque = type opaque
+// CHECK:STDOUT: %struct.Y = type { i8 }
 // CHECK:STDOUT:
-// CHECK:STDOUT: @_ZN1X11static_tmplIiEE = external global i32
-// CHECK:STDOUT: @_ZN1X11static_tmplI1YEE = external global %opaque
+// CHECK:STDOUT: @_ZN1X11static_tmplIiEE = external global i32, align 4
+// CHECK:STDOUT: @_ZN1X11static_tmplI1YEE = external global %struct.Y, align 1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CReadStaticVarTemplate.Main() #0 !dbg !12 {


### PR DESCRIPTION
Don't emit them ourselves. This was leading to our emitted variable being renamed away from the proper symbol name, leading to link errors.

Fixes #6742.