### PR TITLE
Provide an optional diagnoser to eval when resolving a specific

### DIFF
--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -505,7 +505,7 @@ auto CheckUnit::CheckRequiredDefinitions() -> void {
        GrowingRange(context_.definitions_required_by_use())) {
     // This is using the location for the use. We could track the
     // list of enclosing locations if this was used from a generic.
-    if (!ResolveSpecificDefinition(context_, loc, specific_id)) {
+    if (!ResolveSpecificDefinition(context_, loc, specific_id, nullptr)) {
       CARBON_DIAGNOSTIC(MissingGenericFunctionDefinition, Error,
                         "use of undefined generic function");
       CARBON_DIAGNOSTIC(MissingGenericFunctionDefinitionHere, Note,

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -123,7 +123,7 @@ auto DeclNameStack::Restore(SuspendedName&& sus) -> void {
     // have been defined after we suspended this scope.
     if (suspended_scope.entry.specific_id.has_value()) {
       ResolveSpecificDefinition(*context_, sus.name_context.loc_id,
-                                suspended_scope.entry.specific_id);
+                                suspended_scope.entry.specific_id, nullptr);
     }
 
     context_->scope_stack().Restore(std::move(suspended_scope));
@@ -221,7 +221,7 @@ static auto PushNameQualifierScope(Context& context, SemIR::LocId loc_id,
   if (generic_id.has_value()) {
     self_specific_id = context.generics().GetSelfSpecific(generic_id);
     // When declaring a member of a generic, resolve the self specific.
-    ResolveSpecificDefinition(context, loc_id, self_specific_id);
+    ResolveSpecificDefinition(context, loc_id, self_specific_id, nullptr);
   }
 
   // Close the generic stack scope and open a new one for whatever comes after

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -573,7 +573,17 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
 auto DeductionContext::MakeSpecific() -> SemIR::SpecificId {
   // TODO: Convert the deduced values to the types of the bindings.
 
-  return Check::MakeSpecific(context(), loc_id_, generic_id_, result_arg_ids_);
+  return Check::MakeSpecific(
+      context(), loc_id_, generic_id_, result_arg_ids_, [&] {
+        if (diagnose_) {
+          CARBON_DIAGNOSTIC(MonomorphizationErrorInDeduce, Error,
+                            "cannot deduce with invalid specific");
+          return context().emitter().Build(loc_id_,
+                                           MonomorphizationErrorInDeduce);
+        } else {
+          return context().emitter().BuildSuppressed();
+        }
+      });
 }
 
 auto DeduceGenericCallArguments(

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -70,11 +70,13 @@ class EvalContext {
   explicit EvalContext(
       Context* context, SemIR::LocId fallback_loc_id,
       SemIR::SpecificId specific_id = SemIR::SpecificId::None,
-      std::optional<SpecificEvalInfo> specific_eval_info = std::nullopt)
+      std::optional<SpecificEvalInfo> specific_eval_info = std::nullopt,
+      MakeDiagnosticBuilderFn specific_diagnoser = nullptr)
       : context_(context),
         fallback_loc_id_(fallback_loc_id),
         specific_id_(specific_id),
-        specific_eval_info_(specific_eval_info) {}
+        specific_eval_info_(specific_eval_info),
+        specific_diagnoser_(specific_diagnoser) {}
 
   EvalContext(const EvalContext&) = delete;
   auto operator=(const EvalContext&) -> EvalContext& = delete;
@@ -240,7 +242,13 @@ class EvalContext {
 
   auto sem_ir() -> SemIR::File& { return context().sem_ir(); }
 
+  // Diagnostics inside eval should all prefer to use the `diagnoser()` if it is
+  // present. This can be done bu constructing the diagnostic, and passing it to
+  // Diagnostics::Emitter::BuildDiagnosticOrNote, which will either use the
+  // diagnostics as-is, or convert it to a note of the diagnostic that comes
+  // from the `diagnoser()`.
   auto emitter() -> DiagnosticEmitterBase& { return context().emitter(); }
+  auto diagnoser() -> MakeDiagnosticBuilderFn { return specific_diagnoser_; }
 
  protected:
   explicit EvalContext(Context* context, SemIR::LocId fallback_loc_id,
@@ -266,6 +274,11 @@ class EvalContext {
   // If we are currently evaluating an eval block for `specific_id_`,
   // information about that evaluation.
   std::optional<SpecificEvalInfo> specific_eval_info_;
+  // When instantiating a specific this can contain a diagnoser to construct
+  // the error diagnostic to report when encountering a monomorphization error.
+  // In that case, the error in eval becomes a note on the returned builder
+  // instead of an error diagnostic of its own.
+  MakeDiagnosticBuilderFn specific_diagnoser_;
   // If we are currently evaluating within a local scope, values of local
   // instructions that have already been evaluated. This is here rather than in
   // `FunctionEvalContext` so we can reference it from `GetConstantValue`.
@@ -443,8 +456,10 @@ static auto DiagnoseNonConstantValue(EvalContext& eval_context,
   if (inst_id != SemIR::ErrorInst::InstId) {
     CARBON_DIAGNOSTIC(EvalRequiresConstantValue, Error,
                       "expression is runtime; expected constant");
-    eval_context.emitter().Emit(eval_context.GetDiagnosticLoc({inst_id}),
-                                EvalRequiresConstantValue);
+    auto builder = eval_context.emitter().BuildDiagnosticOrNote(
+        eval_context.diagnoser(), eval_context.GetDiagnosticLoc({inst_id}),
+        EvalRequiresConstantValue);
+    builder.Emit();
   }
 }
 
@@ -928,7 +943,7 @@ static auto ResolveSpecificDeclForSpecificId(EvalContext& eval_context,
     return;
   }
   ResolveSpecificDecl(eval_context.context(), eval_context.fallback_loc_id(),
-                      specific_id);
+                      specific_id, eval_context.diagnoser());
 }
 
 // Resolves the specific declarations for a specific id in any field of the
@@ -1043,9 +1058,11 @@ static auto PerformArrayIndex(EvalContext& eval_context, SemIR::ArrayIndex inst)
         CARBON_DIAGNOSTIC(ArrayIndexOutOfBounds, Error,
                           "array index `{0}` is past the end of type {1}",
                           TypedInt, SemIR::TypeId);
-        eval_context.emitter().Emit(
+        auto builder = eval_context.emitter().BuildDiagnosticOrNote(
+            eval_context.diagnoser(),
             eval_context.GetDiagnosticLoc(inst.index_id), ArrayIndexOutOfBounds,
             {.type = index->type_id, .value = index_val}, aggregate_type_id);
+        builder.Emit();
         return SemIR::ErrorInst::ConstantId;
       }
     }
@@ -1069,8 +1086,9 @@ static auto PerformArrayIndex(EvalContext& eval_context, SemIR::ArrayIndex inst)
 
 // Performs a conversion between character types, diagnosing if the value
 // doesn't fit in the destination type.
-static auto PerformCheckedCharConvert(Context& context, SemIR::LocId loc_id,
-                                      SemIR::InstId arg_id,
+static auto PerformCheckedCharConvert(Context& context,
+                                      MakeDiagnosticBuilderFn diagnoser,
+                                      SemIR::LocId loc_id, SemIR::InstId arg_id,
                                       SemIR::TypeId dest_type_id)
     -> SemIR::ConstantId {
   auto arg = context.insts().GetAs<SemIR::CharLiteralValue>(arg_id);
@@ -1080,8 +1098,9 @@ static auto PerformCheckedCharConvert(Context& context, SemIR::LocId loc_id,
     CARBON_DIAGNOSTIC(CharTooLargeForType, Error,
                       "character value {0} too large for type {1}",
                       SemIR::CharId, SemIR::TypeId);
-    context.emitter().Emit(loc_id, CharTooLargeForType, arg.value,
-                           dest_type_id);
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, loc_id, CharTooLargeForType, arg.value, dest_type_id);
+    builder.Emit();
     return SemIR::ErrorInst::ConstantId;
   }
 
@@ -1091,13 +1110,21 @@ static auto PerformCheckedCharConvert(Context& context, SemIR::LocId loc_id,
 
 // Forms a constant int type as an evaluation result. Requires that width_id is
 // constant.
-static auto MakeIntTypeResult(Context& context, SemIR::LocId loc_id,
-                              SemIR::IntKind int_kind, SemIR::InstId width_id,
-                              Phase phase) -> SemIR::ConstantId {
+static auto MakeIntTypeResult(Context& context,
+                              MakeDiagnosticBuilderFn diagnoser,
+                              SemIR::LocId loc_id, SemIR::IntKind int_kind,
+                              SemIR::InstId width_id, Phase phase)
+    -> SemIR::ConstantId {
+  if (!diagnoser) {
+    diagnoser = [&] {
+      CARBON_DIAGNOSTIC(IntTypeInvalid, Error, "invalid int type");
+      return context.emitter().Build(loc_id, IntTypeInvalid);
+    };
+  }
   auto result = SemIR::IntType{.type_id = SemIR::TypeType::TypeId,
                                .int_kind = int_kind,
                                .bit_width_id = width_id};
-  if (!ValidateIntType(context, loc_id, result)) {
+  if (!ValidateIntType(context, loc_id, diagnoser, result)) {
     return SemIR::ErrorInst::ConstantId;
   }
   return MakeConstantResult(context, result, phase);
@@ -1105,13 +1132,20 @@ static auto MakeIntTypeResult(Context& context, SemIR::LocId loc_id,
 
 // Forms a constant float type as an evaluation result. Requires that width_id
 // is constant.
-static auto MakeFloatTypeResult(Context& context, SemIR::LocId loc_id,
-                                SemIR::InstId width_id, Phase phase)
-    -> SemIR::ConstantId {
+static auto MakeFloatTypeResult(Context& context,
+                                MakeDiagnosticBuilderFn diagnoser,
+                                SemIR::LocId loc_id, SemIR::InstId width_id,
+                                Phase phase) -> SemIR::ConstantId {
+  if (!diagnoser) {
+    diagnoser = [&] {
+      CARBON_DIAGNOSTIC(FloatTypeInvalid, Error, "invalid float type");
+      return context.emitter().Build(loc_id, FloatTypeInvalid);
+    };
+  }
   auto result = SemIR::FloatType{.type_id = SemIR::TypeType::TypeId,
                                  .bit_width_id = width_id,
                                  .float_kind = SemIR::FloatKind::None};
-  if (!ValidateFloatTypeAndSetKind(context, loc_id, result)) {
+  if (!ValidateFloatTypeAndSetKind(context, loc_id, diagnoser, result)) {
     return SemIR::ErrorInst::ConstantId;
   }
   return MakeConstantResult(context, result, phase);
@@ -1139,8 +1173,9 @@ static auto PerformIntConvert(Context& context, SemIR::InstId arg_id,
 
 // Performs a conversion between integer types, diagnosing if the value doesn't
 // fit in the destination type.
-static auto PerformCheckedIntConvert(Context& context, SemIR::LocId loc_id,
-                                     SemIR::InstId arg_id,
+static auto PerformCheckedIntConvert(Context& context,
+                                     MakeDiagnosticBuilderFn diagnoser,
+                                     SemIR::LocId loc_id, SemIR::InstId arg_id,
                                      SemIR::TypeId dest_type_id)
     -> SemIR::ConstantId {
   auto arg = context.insts().GetAs<SemIR::IntValue>(arg_id);
@@ -1157,9 +1192,10 @@ static auto PerformCheckedIntConvert(Context& context, SemIR::LocId loc_id,
         NegativeIntInUnsignedType, Error,
         "negative integer value {0} converted to unsigned type {1}", TypedInt,
         SemIR::TypeId);
-    context.emitter().Emit(loc_id, NegativeIntInUnsignedType,
-                           {.type = arg.type_id, .value = arg_val},
-                           dest_type_id);
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, loc_id, NegativeIntInUnsignedType,
+        {.type = arg.type_id, .value = arg_val}, dest_type_id);
+    builder.Emit();
   }
 
   unsigned arg_non_sign_bits = arg_val.getSignificantBits() - 1;
@@ -1167,9 +1203,10 @@ static auto PerformCheckedIntConvert(Context& context, SemIR::LocId loc_id,
     CARBON_DIAGNOSTIC(IntTooLargeForType, Error,
                       "integer value {0} too large for type {1}", TypedInt,
                       SemIR::TypeId);
-    context.emitter().Emit(loc_id, IntTooLargeForType,
-                           {.type = arg.type_id, .value = arg_val},
-                           dest_type_id);
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, loc_id, IntTooLargeForType,
+        {.type = arg.type_id, .value = arg_val}, dest_type_id);
+    builder.Emit();
   }
 
   return MakeConstantResult(
@@ -1179,10 +1216,9 @@ static auto PerformCheckedIntConvert(Context& context, SemIR::LocId loc_id,
 
 // Performs a conversion between floating-point types, diagnosing if the value
 // doesn't fit in the destination type.
-static auto PerformCheckedFloatConvert(Context& context, SemIR::LocId loc_id,
-                                       SemIR::InstId arg_id,
-                                       SemIR::TypeId dest_type_id)
-    -> SemIR::ConstantId {
+static auto PerformCheckedFloatConvert(
+    Context& context, MakeDiagnosticBuilderFn diagnoser, SemIR::LocId loc_id,
+    SemIR::InstId arg_id, SemIR::TypeId dest_type_id) -> SemIR::ConstantId {
   auto dest_type_object_rep_id = context.types().GetObjectRepr(dest_type_id);
   CARBON_CHECK(dest_type_object_rep_id.has_value(),
                "Conversion to incomplete type");
@@ -1234,8 +1270,10 @@ static auto PerformCheckedFloatConvert(Context& context, SemIR::LocId loc_id,
       CARBON_DIAGNOSTIC(FloatLiteralTooLargeForType, Error,
                         "value {0} too large for floating-point type {1}",
                         RealId, SemIR::TypeId);
-      context.emitter().Emit(loc_id, FloatLiteralTooLargeForType,
-                             literal->real_id, dest_type_id);
+      auto builder = context.emitter().BuildDiagnosticOrNote(
+          diagnoser, loc_id, FloatLiteralTooLargeForType, literal->real_id,
+          dest_type_id);
+      builder.Emit();
       return SemIR::ErrorInst::ConstantId;
     }
     return MakeFloatResult(context, dest_type_id, std::move(result));
@@ -1256,8 +1294,10 @@ static auto PerformCheckedFloatConvert(Context& context, SemIR::LocId loc_id,
     CARBON_DIAGNOSTIC(FloatTooLargeForType, Error,
                       "value {0} too large for floating-point type {1}",
                       llvm::APFloat, SemIR::TypeId);
-    context.emitter().Emit(loc_id, FloatTooLargeForType,
-                           context.floats().Get(arg.float_id), dest_type_id);
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, loc_id, FloatTooLargeForType,
+        context.floats().Get(arg.float_id), dest_type_id);
+    builder.Emit();
     return SemIR::ErrorInst::ConstantId;
   }
 
@@ -1265,10 +1305,13 @@ static auto PerformCheckedFloatConvert(Context& context, SemIR::LocId loc_id,
 }
 
 // Issues a diagnostic for a compile-time division by zero.
-static auto DiagnoseDivisionByZero(Context& context, SemIR::LocId loc_id)
-    -> void {
+static auto DiagnoseDivisionByZero(Context& context,
+                                   MakeDiagnosticBuilderFn diagnoser,
+                                   SemIR::LocId loc_id) -> void {
   CARBON_DIAGNOSTIC(CompileTimeDivisionByZero, Error, "division by zero");
-  context.emitter().Emit(loc_id, CompileTimeDivisionByZero);
+  auto builder = context.emitter().BuildDiagnosticOrNote(
+      diagnoser, loc_id, CompileTimeDivisionByZero);
+  builder.Emit();
 }
 
 // Get an integer at a suitable bit-width: either `bit_width_id` if it has a
@@ -1281,7 +1324,9 @@ static auto GetIntAtSuitableWidth(Context& context, IntId int_id,
 }
 
 // Performs a builtin unary integer -> integer operation.
-static auto PerformBuiltinUnaryIntOp(Context& context, SemIR::LocId loc_id,
+static auto PerformBuiltinUnaryIntOp(Context& context,
+                                     MakeDiagnosticBuilderFn diagnoser,
+                                     SemIR::LocId loc_id,
                                      SemIR::BuiltinFunctionKind builtin_kind,
                                      SemIR::InstId arg_id)
     -> SemIR::ConstantId {
@@ -1296,8 +1341,10 @@ static auto PerformBuiltinUnaryIntOp(Context& context, SemIR::LocId loc_id,
         if (bit_width_id.has_value()) {
           CARBON_DIAGNOSTIC(CompileTimeIntegerNegateOverflow, Error,
                             "integer overflow in negation of {0}", TypedInt);
-          context.emitter().Emit(loc_id, CompileTimeIntegerNegateOverflow,
-                                 {.type = op.type_id, .value = op_val});
+          auto builder = context.emitter().BuildDiagnosticOrNote(
+              diagnoser, loc_id, CompileTimeIntegerNegateOverflow,
+              {.type = op.type_id, .value = op_val});
+          builder.Emit();
         } else {
           // Widen the integer so we don't overflow into the sign bit.
           op_val = op_val.sext(op_val.getBitWidth() +
@@ -1448,7 +1495,9 @@ static auto ComputeBinaryIntOpResult(SemIR::BuiltinFunctionKind builtin_kind,
 }
 
 // Performs a builtin integer bit shift operation.
-static auto PerformBuiltinIntShiftOp(Context& context, SemIR::LocId loc_id,
+static auto PerformBuiltinIntShiftOp(Context& context,
+                                     MakeDiagnosticBuilderFn diagnoser,
+                                     SemIR::LocId loc_id,
                                      SemIR::BuiltinFunctionKind builtin_kind,
                                      SemIR::InstId lhs_id, SemIR::InstId rhs_id)
     -> SemIR::ConstantId {
@@ -1466,11 +1515,12 @@ static auto PerformBuiltinIntShiftOp(Context& context, SemIR::LocId loc_id,
         CompileTimeShiftOutOfRange, Error,
         "shift distance >= type width of {0} in `{1} {2:<<|>>} {3}`", unsigned,
         TypedInt, Diagnostics::BoolAsSelect, TypedInt);
-    context.emitter().Emit(
-        loc_id, CompileTimeShiftOutOfRange, lhs_val.getBitWidth(),
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, loc_id, CompileTimeShiftOutOfRange, lhs_val.getBitWidth(),
         {.type = lhs.type_id, .value = lhs_val},
         builtin_kind == SemIR::BuiltinFunctionKind::IntLeftShift,
         {.type = rhs.type_id, .value = rhs_orig_val});
+    builder.Emit();
     // TODO: Is it useful to recover by returning 0 or -1?
     return SemIR::ErrorInst::ConstantId;
   }
@@ -1480,11 +1530,12 @@ static auto PerformBuiltinIntShiftOp(Context& context, SemIR::LocId loc_id,
     CARBON_DIAGNOSTIC(CompileTimeShiftNegative, Error,
                       "shift distance negative in `{0} {1:<<|>>} {2}`",
                       TypedInt, Diagnostics::BoolAsSelect, TypedInt);
-    context.emitter().Emit(
-        loc_id, CompileTimeShiftNegative,
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, loc_id, CompileTimeShiftNegative,
         {.type = lhs.type_id, .value = lhs_val},
         builtin_kind == SemIR::BuiltinFunctionKind::IntLeftShift,
         {.type = rhs.type_id, .value = rhs_orig_val});
+    builder.Emit();
     // TODO: Is it useful to recover by returning 0 or -1?
     return SemIR::ErrorInst::ConstantId;
   }
@@ -1502,9 +1553,11 @@ static auto PerformBuiltinIntShiftOp(Context& context, SemIR::LocId loc_id,
                           "integer whose width is greater than the "
                           "maximum supported width of {1}",
                           TypedInt, int);
-        context.emitter().Emit(loc_id, CompileTimeUnsizedShiftOutOfRange,
-                               {.type = rhs.type_id, .value = rhs_orig_val},
-                               IntStore::MaxIntWidth);
+        auto builder = context.emitter().BuildDiagnosticOrNote(
+            diagnoser, loc_id, CompileTimeUnsizedShiftOutOfRange,
+            {.type = rhs.type_id, .value = rhs_orig_val},
+            IntStore::MaxIntWidth);
+        builder.Emit();
         return SemIR::ErrorInst::ConstantId;
       }
       lhs_val = lhs_val.sext(
@@ -1526,11 +1579,10 @@ static auto PerformBuiltinIntShiftOp(Context& context, SemIR::LocId loc_id,
 }
 
 // Performs a homogeneous builtin binary integer -> integer operation.
-static auto PerformBuiltinBinaryIntOp(Context& context, SemIR::LocId loc_id,
-                                      SemIR::BuiltinFunctionKind builtin_kind,
-                                      SemIR::InstId lhs_id,
-                                      SemIR::InstId rhs_id)
-    -> SemIR::ConstantId {
+static auto PerformBuiltinBinaryIntOp(
+    Context& context, MakeDiagnosticBuilderFn diagnoser, SemIR::LocId loc_id,
+    SemIR::BuiltinFunctionKind builtin_kind, SemIR::InstId lhs_id,
+    SemIR::InstId rhs_id) -> SemIR::ConstantId {
   auto lhs = context.insts().GetAs<SemIR::IntValue>(lhs_id);
   auto rhs = context.insts().GetAs<SemIR::IntValue>(rhs_id);
 
@@ -1548,7 +1600,7 @@ static auto PerformBuiltinBinaryIntOp(Context& context, SemIR::LocId loc_id,
     case SemIR::BuiltinFunctionKind::IntUDiv:
     case SemIR::BuiltinFunctionKind::IntUMod:
       if (rhs_val.isZero()) {
-        DiagnoseDivisionByZero(context, loc_id);
+        DiagnoseDivisionByZero(context, diagnoser, loc_id);
         return SemIR::ErrorInst::ConstantId;
       }
       break;
@@ -1590,9 +1642,11 @@ static auto PerformBuiltinBinaryIntOp(Context& context, SemIR::LocId loc_id,
     CARBON_DIAGNOSTIC(CompileTimeIntegerOverflow, Error,
                       "integer overflow in calculation `{0} {1} {2}`", TypedInt,
                       Lex::TokenKind, TypedInt);
-    context.emitter().Emit(loc_id, CompileTimeIntegerOverflow,
-                           {.type = type_id, .value = lhs_val}, result.op_token,
-                           {.type = type_id, .value = rhs_val});
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, loc_id, CompileTimeIntegerOverflow,
+        {.type = type_id, .value = lhs_val}, result.op_token,
+        {.type = type_id, .value = rhs_val});
+    builder.Emit();
   }
 
   return MakeIntResult(context, type_id, is_signed,
@@ -1740,8 +1794,10 @@ static auto PerformBuiltinBoolComparison(
 }
 
 // Converts a call argument to a FacetTypeId.
-static auto ArgToFacetTypeId(Context& context, SemIR::LocId loc_id,
-                             SemIR::InstId arg_id) -> SemIR::FacetTypeId {
+static auto ArgToFacetTypeId(Context& context,
+                             MakeDiagnosticBuilderFn diagnoser,
+                             SemIR::LocId loc_id, SemIR::InstId arg_id)
+    -> SemIR::FacetTypeId {
   auto type_arg_id = context.types().GetAsTypeInstId(arg_id);
   if (auto facet_type =
           context.insts().TryGetAs<SemIR::FacetType>(type_arg_id)) {
@@ -1754,8 +1810,10 @@ static auto ArgToFacetTypeId(Context& context, SemIR::LocId loc_id,
   // the whole thing. If that's not possible we can change the text to
   // say if it's referring to the left or the right side for the error.
   // The `arg_id` instruction has no location in it for some reason.
-  context.emitter().Emit(loc_id, FacetTypeRequiredForTypeAndOperator,
-                         context.types().GetTypeIdForTypeInstId(type_arg_id));
+  auto builder = context.emitter().BuildDiagnosticOrNote(
+      diagnoser, loc_id, FacetTypeRequiredForTypeAndOperator,
+      context.types().GetTypeIdForTypeInstId(type_arg_id));
+  builder.Emit();
   return SemIR::FacetTypeId::None;
 }
 
@@ -1806,10 +1864,11 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
       if (index_val.isNegative()) {
         CARBON_DIAGNOSTIC(StringAtIndexNegative, Error,
                           "index `{0}` is negative.", TypedInt);
-        context.emitter().Emit(
-            loc_id, StringAtIndexNegative,
+        auto builder = context.emitter().BuildDiagnosticOrNote(
+            eval_context.diagnoser(), loc_id, StringAtIndexNegative,
             {.type = eval_context.insts().Get(index_id).type_id(),
              .value = index_val});
+        builder.Emit();
         return SemIR::ConstantId::NotConstant;
       }
 
@@ -1818,11 +1877,12 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
             StringAtIndexOutOfBounds, Error,
             "string index `{0}` is out of bounds; string has length {1}.",
             TypedInt, size_t);
-        context.emitter().Emit(
-            loc_id, StringAtIndexOutOfBounds,
+        auto builder = context.emitter().BuildDiagnosticOrNote(
+            eval_context.diagnoser(), loc_id, StringAtIndexOutOfBounds,
             {.type = eval_context.insts().Get(index_id).type_id(),
              .value = index_val},
             string_value.size());
+        builder.Emit();
         return SemIR::ConstantId::NotConstant;
       }
 
@@ -1869,8 +1929,10 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
 
     case SemIR::BuiltinFunctionKind::TypeAnd: {
       CARBON_CHECK(arg_ids.size() == 2);
-      auto lhs_facet_type_id = ArgToFacetTypeId(context, loc_id, arg_ids[0]);
-      auto rhs_facet_type_id = ArgToFacetTypeId(context, loc_id, arg_ids[1]);
+      auto lhs_facet_type_id = ArgToFacetTypeId(
+          context, eval_context.diagnoser(), loc_id, arg_ids[0]);
+      auto rhs_facet_type_id = ArgToFacetTypeId(
+          context, eval_context.diagnoser(), loc_id, arg_ids[1]);
 
       // Allow errors to be diagnosed for both sides of the operator before
       // returning here if any error occurred on either side.
@@ -1907,17 +1969,18 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
     }
 
     case SemIR::BuiltinFunctionKind::IntMakeTypeSigned: {
-      return MakeIntTypeResult(context, loc_id, SemIR::IntKind::Signed,
-                               arg_ids[0], phase);
+      return MakeIntTypeResult(context, eval_context.diagnoser(), loc_id,
+                               SemIR::IntKind::Signed, arg_ids[0], phase);
     }
 
     case SemIR::BuiltinFunctionKind::IntMakeTypeUnsigned: {
-      return MakeIntTypeResult(context, loc_id, SemIR::IntKind::Unsigned,
-                               arg_ids[0], phase);
+      return MakeIntTypeResult(context, eval_context.diagnoser(), loc_id,
+                               SemIR::IntKind::Unsigned, arg_ids[0], phase);
     }
 
     case SemIR::BuiltinFunctionKind::FloatMakeType: {
-      return MakeFloatTypeResult(context, loc_id, arg_ids[0], phase);
+      return MakeFloatTypeResult(context, eval_context.diagnoser(), loc_id,
+                                 arg_ids[0], phase);
     }
 
     case SemIR::BuiltinFunctionKind::BoolMakeType: {
@@ -1938,8 +2001,8 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
       if (phase != Phase::Concrete) {
         return MakeConstantResult(context, call, phase);
       }
-      return PerformCheckedCharConvert(context, loc_id, arg_ids[0],
-                                       call.type_id);
+      return PerformCheckedCharConvert(context, eval_context.diagnoser(),
+                                       loc_id, arg_ids[0], call.type_id);
     }
 
     // Integer conversions.
@@ -1959,8 +2022,8 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
       if (phase != Phase::Concrete) {
         return MakeConstantResult(context, call, phase);
       }
-      return PerformCheckedIntConvert(context, loc_id, arg_ids[0],
-                                      call.type_id);
+      return PerformCheckedIntConvert(context, eval_context.diagnoser(), loc_id,
+                                      arg_ids[0], call.type_id);
     }
 
     // Unary integer -> integer operations.
@@ -1970,8 +2033,8 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
       if (phase != Phase::Concrete) {
         break;
       }
-      return PerformBuiltinUnaryIntOp(context, loc_id, builtin_kind,
-                                      arg_ids[0]);
+      return PerformBuiltinUnaryIntOp(context, eval_context.diagnoser(), loc_id,
+                                      builtin_kind, arg_ids[0]);
     }
 
     // Homogeneous binary integer -> integer operations.
@@ -1991,8 +2054,9 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
       if (phase != Phase::Concrete) {
         break;
       }
-      return PerformBuiltinBinaryIntOp(context, loc_id, builtin_kind,
-                                       arg_ids[0], arg_ids[1]);
+      return PerformBuiltinBinaryIntOp(context, eval_context.diagnoser(),
+                                       loc_id, builtin_kind, arg_ids[0],
+                                       arg_ids[1]);
     }
 
     // Bit shift operations.
@@ -2001,8 +2065,8 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
       if (phase != Phase::Concrete) {
         break;
       }
-      return PerformBuiltinIntShiftOp(context, loc_id, builtin_kind, arg_ids[0],
-                                      arg_ids[1]);
+      return PerformBuiltinIntShiftOp(context, eval_context.diagnoser(), loc_id,
+                                      builtin_kind, arg_ids[0], arg_ids[1]);
     }
 
     // Integer comparisons.
@@ -2024,8 +2088,8 @@ static auto MakeConstantForBuiltinCall(EvalContext& eval_context,
       if (phase != Phase::Concrete) {
         return MakeConstantResult(context, call, phase);
       }
-      return PerformCheckedFloatConvert(context, loc_id, arg_ids[0],
-                                        call.type_id);
+      return PerformCheckedFloatConvert(context, eval_context.diagnoser(),
+                                        loc_id, arg_ids[0], call.type_id);
     }
 
     // Unary float -> float operations.
@@ -2279,14 +2343,30 @@ static auto TryEvalTypedInst(EvalContext& eval_context, SemIR::InstId inst_id,
     } else if constexpr (InstT::Kind.constant_needs_inst_id() !=
                          SemIR::InstConstantNeedsInstIdKind::No) {
       CARBON_CHECK(inst_id.has_value());
-      return ConvertEvalResultToConstantId(
-          eval_context.context(),
-          EvalConstantInst(eval_context.context(), inst_id, inst.As<InstT>()),
-          phase);
+      if constexpr (InstT::Kind.constant_needs_diagnoser()) {
+        return ConvertEvalResultToConstantId(
+            eval_context.context(),
+            EvalConstantInst(eval_context.context(), eval_context.diagnoser(),
+                             inst_id, inst.As<InstT>()),
+            phase);
+      } else {
+        return ConvertEvalResultToConstantId(
+            eval_context.context(),
+            EvalConstantInst(eval_context.context(), inst_id, inst.As<InstT>()),
+            phase);
+      }
     } else {
-      return ConvertEvalResultToConstantId(
-          eval_context.context(),
-          EvalConstantInst(eval_context.context(), inst.As<InstT>()), phase);
+      if constexpr (InstT::Kind.constant_needs_diagnoser()) {
+        return ConvertEvalResultToConstantId(
+            eval_context.context(),
+            EvalConstantInst(eval_context.context(), eval_context.diagnoser(),
+                             inst.As<InstT>()),
+            phase);
+      } else {
+        return ConvertEvalResultToConstantId(
+            eval_context.context(),
+            EvalConstantInst(eval_context.context(), inst.As<InstT>()), phase);
+      }
     }
   }
 }
@@ -2533,7 +2613,8 @@ auto TryEvalInstUnsafe(Context& context, SemIR::InstId inst_id,
 
 auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
                              SemIR::SpecificId specific_id,
-                             SemIR::GenericInstIndex::Region region)
+                             SemIR::GenericInstIndex::Region region,
+                             MakeDiagnosticBuilderFn diagnoser)
     -> SemIR::InstBlockId {
   auto generic_id = context.specifics().Get(specific_id).generic_id;
   auto eval_block_id = context.generics().Get(generic_id).GetEvalBlock(region);
@@ -2546,13 +2627,20 @@ auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
                            SpecificEvalInfo{
                                .region = region,
                                .values = result,
-                           });
+                           },
+                           diagnoser);
 
+  // FIXME: If diagnoser is null, should we construct one here? How about in the
+  // other eval paths?
   Diagnostics::AnnotationScope annotate_diagnostics(
       &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ResolvingSpecificHere, Note, "in {0} used here",
-                          SemIR::SpecificId);
-        builder.Note(loc_id, ResolvingSpecificHere, specific_id);
+        // TODO: Require callers to provide a diagnoser instead of the nullptr
+        // default, then remove this note entirely.
+        if (!diagnoser) {
+          CARBON_DIAGNOSTIC(ResolvingSpecificHere, Note, "in {0} used here",
+                            SemIR::SpecificId);
+          builder.Note(loc_id, ResolvingSpecificHere, specific_id);
+        }
       });
 
   for (auto [i, inst_id] : llvm::enumerate(eval_block)) {

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -243,7 +243,7 @@ class EvalContext {
   auto sem_ir() -> SemIR::File& { return context().sem_ir(); }
 
   // Diagnostics inside eval should all prefer to use the `diagnoser()` if it is
-  // present. This can be done bu constructing the diagnostic, and passing it to
+  // present. This can be done by constructing the diagnostic, and passing it to
   // Diagnostics::Emitter::BuildDiagnosticOrNote, which will either use the
   // diagnostics as-is, or convert it to a note of the diagnostic that comes
   // from the `diagnoser()`.
@@ -2630,12 +2630,12 @@ auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
                            },
                            diagnoser);
 
-  // FIXME: If diagnoser is null, should we construct one here? How about in the
-  // other eval paths?
   Diagnostics::AnnotationScope annotate_diagnostics(
       &context.emitter(), [&](auto& builder) {
         // TODO: Require callers to provide a diagnoser instead of the nullptr
-        // default, then remove this note entirely.
+        // default? Then remove this note entirely. Or make `diagonser` a
+        // tri-state of "none provided, do not diagnose", "none provided,
+        // produce diagnostics", "daignoser provided, attach notes".
         if (!diagnoser) {
           CARBON_DIAGNOSTIC(ResolvingSpecificHere, Note, "in {0} used here",
                             SemIR::SpecificId);

--- a/toolchain/check/eval.h
+++ b/toolchain/check/eval.h
@@ -54,7 +54,8 @@ auto TryEvalInst(Context& context, InstT inst) -> SemIR::ConstantId {
 // block.
 auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
                              SemIR::SpecificId specific_id,
-                             SemIR::GenericInstIndex::Region region)
+                             SemIR::GenericInstIndex::Region region,
+                             MakeDiagnosticBuilderFn diagnoser = nullptr)
     -> SemIR::InstBlockId;
 
 }  // namespace Carbon::Check

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -53,8 +53,9 @@ auto EvalConstantInst(Context& /*context*/, SemIR::ArrayInit inst)
       SemIR::TupleValue{.type_id = inst.type_id, .elements_id = inst.inits_id});
 }
 
-auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
-                      SemIR::ArrayType inst) -> ConstantEvalResult {
+auto EvalConstantInst(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                      SemIR::InstId inst_id, SemIR::ArrayType inst)
+    -> ConstantEvalResult {
   auto bound_inst = context.insts().Get(inst.bound_id);
   auto int_bound = bound_inst.TryAs<SemIR::IntValue>();
   if (!int_bound) {
@@ -70,17 +71,19 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
       bound_val.isNegative()) {
     CARBON_DIAGNOSTIC(ArrayBoundNegative, Error,
                       "array bound of {0} is negative", TypedInt);
-    context.emitter().Emit(
-        context.insts().GetAs<SemIR::ArrayType>(inst_id).bound_id,
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, context.insts().GetAs<SemIR::ArrayType>(inst_id).bound_id,
         ArrayBoundNegative, {.type = int_bound->type_id, .value = bound_val});
+    builder.Emit();
     return ConstantEvalResult::Error;
   }
   if (bound_val.getActiveBits() > 64) {
     CARBON_DIAGNOSTIC(ArrayBoundTooLarge, Error,
                       "array bound of {0} is too large", TypedInt);
-    context.emitter().Emit(
-        context.insts().GetAs<SemIR::ArrayType>(inst_id).bound_id,
+    auto builder = context.emitter().BuildDiagnosticOrNote(
+        diagnoser, context.insts().GetAs<SemIR::ArrayType>(inst_id).bound_id,
         ArrayBoundTooLarge, {.type = int_bound->type_id, .value = bound_val});
+    builder.Emit();
     return ConstantEvalResult::Error;
   }
   return ConstantEvalResult::NewSamePhase(inst);
@@ -252,9 +255,17 @@ auto EvalConstantInst(Context& context, SemIR::FacetValue inst)
   return ConstantEvalResult::NewSamePhase(inst);
 }
 
-auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
-                      SemIR::FloatType inst) -> ConstantEvalResult {
-  return ValidateFloatTypeAndSetKind(context, SemIR::LocId(inst_id), inst)
+auto EvalConstantInst(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                      SemIR::InstId inst_id, SemIR::FloatType inst)
+    -> ConstantEvalResult {
+  if (!diagnoser) {
+    diagnoser = [&] {
+      CARBON_DIAGNOSTIC(FloatTypeInvalid, Error, "invalid float type");
+      return context.emitter().Build(SemIR::LocId(inst_id), FloatTypeInvalid);
+    };
+  }
+  return ValidateFloatTypeAndSetKind(context, SemIR::LocId(inst_id), diagnoser,
+                                     inst)
              ? ConstantEvalResult::NewSamePhase(inst)
              : ConstantEvalResult::Error;
 }
@@ -315,8 +326,9 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
   return ConstantEvalResult::NewSamePhase(inst);
 }
 
-auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
-                      SemIR::ImplWitnessAccess inst) -> ConstantEvalResult {
+auto EvalConstantInst(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                      SemIR::InstId inst_id, SemIR::ImplWitnessAccess inst)
+    -> ConstantEvalResult {
   CARBON_DIAGNOSTIC(ImplAccessMemberBeforeSet, Error,
                     "accessing member from impl before it has a defined value");
   CARBON_KIND_SWITCH(context.insts().Get(inst.witness_id)) {
@@ -340,7 +352,9 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
       // If we get here, this impl witness table entry has not been populated
       // yet, because the impl was referenced within its own definition.
       // TODO: Add note pointing to the impl declaration.
-      context.emitter().Emit(inst_id, ImplAccessMemberBeforeSet);
+      auto builder = context.emitter().BuildDiagnosticOrNote(
+          diagnoser, inst_id, ImplAccessMemberBeforeSet);
+      builder.Emit();
       return ConstantEvalResult::Error;
     }
     case CARBON_KIND(SemIR::CustomWitness custom_witness): {
@@ -355,7 +369,9 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
       // If we get here, this synthesized witness table entry has not been
       // populated yet.
       // TODO: Is this reachable? We have no test coverage for this diagnostic.
-      context.emitter().Emit(inst_id, ImplAccessMemberBeforeSet);
+      auto builder = context.emitter().BuildDiagnosticOrNote(
+          diagnoser, inst_id, ImplAccessMemberBeforeSet);
+      builder.Emit();
       return ConstantEvalResult::Error;
     }
     case CARBON_KIND(SemIR::LookupImplWitness witness): {
@@ -450,9 +466,16 @@ auto EvalConstantInst(Context& context, SemIR::InPlaceInit inst)
       context.constant_values().Get(inst.src_id));
 }
 
-auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
-                      SemIR::IntType inst) -> ConstantEvalResult {
-  return ValidateIntType(context, SemIR::LocId(inst_id), inst)
+auto EvalConstantInst(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                      SemIR::InstId inst_id, SemIR::IntType inst)
+    -> ConstantEvalResult {
+  if (!diagnoser) {
+    diagnoser = [&] {
+      CARBON_DIAGNOSTIC(IntTypeInvalid, Error, "invalid int type");
+      return context.emitter().Build(SemIR::LocId(inst_id), IntTypeInvalid);
+    };
+  }
+  return ValidateIntType(context, SemIR::LocId(inst_id), diagnoser, inst)
              ? ConstantEvalResult::NewSamePhase(inst)
              : ConstantEvalResult::Error;
 }
@@ -502,8 +525,9 @@ auto EvalConstantInst(Context& context, SemIR::NameRef inst)
       context.constant_values().Get(inst.value_id));
 }
 
-auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
-                      SemIR::RequireCompleteType inst) -> ConstantEvalResult {
+auto EvalConstantInst(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                      SemIR::InstId inst_id, SemIR::RequireCompleteType inst)
+    -> ConstantEvalResult {
   auto witness_type_id =
       GetSingletonType(context, SemIR::WitnessType::TypeInstId);
 
@@ -516,8 +540,8 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
               CARBON_DIAGNOSTIC(IncompleteTypeInMonomorphization, Error,
                                 "{0} evaluates to incomplete type {1}",
                                 InstIdAsType, InstIdAsType);
-              return context.emitter().Build(
-                  inst_id, IncompleteTypeInMonomorphization,
+              return context.emitter().BuildDiagnosticOrNote(
+                  diagnoser, inst_id, IncompleteTypeInMonomorphization,
                   context.insts()
                       .GetAs<SemIR::RequireCompleteType>(inst_id)
                       .complete_type_inst_id,
@@ -536,10 +560,12 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
   return ConstantEvalResult::NewSamePhase(inst);
 }
 
-auto EvalConstantInst(Context& context, SemIR::RequireSpecificDefinition inst)
+auto EvalConstantInst(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                      SemIR::RequireSpecificDefinition inst)
     -> ConstantEvalResult {
   // This can return false, we just need to try it.
-  ResolveSpecificDefinition(context, SemIR::LocId::None, inst.specific_id);
+  ResolveSpecificDefinition(context, SemIR::LocId::None, inst.specific_id,
+                            diagnoser);
   return ConstantEvalResult::NewSamePhase(inst);
 }
 
@@ -550,8 +576,9 @@ auto EvalConstantInst(Context& context, SemIR::SpecificConstant inst)
       context.sem_ir(), inst.specific_id, inst.inst_id));
 }
 
-auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
-                      SemIR::SpecificImplFunction inst) -> ConstantEvalResult {
+auto EvalConstantInst(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                      SemIR::InstId inst_id, SemIR::SpecificImplFunction inst)
+    -> ConstantEvalResult {
   auto callee_inst = context.insts().Get(inst.callee_id);
   // If the callee is not a function value, we're not ready to evaluate this
   // yet. Build a symbolic `SpecificImplFunction` constant.
@@ -597,7 +624,7 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
   args.append(interface_fn_args.end() - remaining_params,
               interface_fn_args.end());
   auto specific_id =
-      MakeSpecific(context, SemIR::LocId(inst_id), generic_id, args);
+      MakeSpecific(context, SemIR::LocId(inst_id), generic_id, args, diagnoser);
   context.definitions_required_by_use().push_back(
       {SemIR::LocId(inst_id), specific_id});
 

--- a/toolchain/check/eval_inst.h
+++ b/toolchain/check/eval_inst.h
@@ -5,6 +5,7 @@
 #ifndef CARBON_TOOLCHAIN_CHECK_EVAL_INST_H_
 #define CARBON_TOOLCHAIN_CHECK_EVAL_INST_H_
 
+#include "toolchain/check/diagnostic_helpers.h"
 #include "toolchain/check/eval.h"
 #include "toolchain/sem_ir/inst_kind.h"
 
@@ -121,29 +122,42 @@ constexpr auto ConstantKindHasEvalConstantInst(SemIR::InstConstantKind kind)
 
 // Given an instruction kind, determines the type that should be used to declare
 // `EvalConstantInst` for that instruction.
-template <typename InstT, bool HasFn, bool HasInstId>
+template <typename InstT, bool HasFn, bool HasInstId, bool HasDiagnoser>
 struct FunctionTypeForEvalConstantInstImpl {
   // By default, we want no `EvalConstantInst` function at all. But we can't
   // express that, so use the type `auto () -> voic` as a placaeholder.
   using Type = auto() -> void;
 };
 template <typename InstT>
-struct FunctionTypeForEvalConstantInstImpl<InstT, true, false> {
+struct FunctionTypeForEvalConstantInstImpl<InstT, true, false, false> {
   // Can be evaluated, evaluation doesn't need InstId.
   using Type = auto(Context& context, InstT inst) -> ConstantEvalResult;
 };
 template <typename InstT>
-struct FunctionTypeForEvalConstantInstImpl<InstT, true, true> {
+struct FunctionTypeForEvalConstantInstImpl<InstT, true, true, false> {
   // Can be evaluated, evaluation needs InstId.
   using Type = auto(Context& context, SemIR::InstId inst_id, InstT inst)
       -> ConstantEvalResult;
+};
+template <typename InstT>
+struct FunctionTypeForEvalConstantInstImpl<InstT, true, false, true> {
+  // Can be evaluated, evaluation doesn't need InstId.
+  using Type = auto(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                    InstT inst) -> ConstantEvalResult;
+};
+template <typename InstT>
+struct FunctionTypeForEvalConstantInstImpl<InstT, true, true, true> {
+  // Can be evaluated, evaluation needs InstId.
+  using Type = auto(Context& context, MakeDiagnosticBuilderFn diagnoser,
+                    SemIR::InstId inst_id, InstT inst) -> ConstantEvalResult;
 };
 template <typename InstT>
 using FunctionTypeForEvalConstantInst =
     typename FunctionTypeForEvalConstantInstImpl<
         InstT, ConstantKindHasEvalConstantInst(InstT::Kind.constant_kind()),
         InstT::Kind.constant_needs_inst_id() !=
-            SemIR::InstConstantNeedsInstIdKind::No>::Type;
+            SemIR::InstConstantNeedsInstIdKind::No,
+        InstT::Kind.constant_needs_diagnoser()>::Type;
 
 }  // namespace Internal
 

--- a/toolchain/check/generic.cpp
+++ b/toolchain/check/generic.cpp
@@ -477,7 +477,7 @@ auto FinishGenericDecl(Context& context, SemIR::LocId loc_id,
   context.generics().Get(generic_id).decl_block_id = decl_block_id;
 
   ResolveSpecificDecl(context, loc_id,
-                      context.generics().GetSelfSpecific(generic_id));
+                      context.generics().GetSelfSpecific(generic_id), nullptr);
 }
 
 auto BuildGenericDecl(Context& context, SemIR::InstId decl_id)
@@ -645,7 +645,8 @@ auto FinishGenericDefinition(Context& context, SemIR::GenericId generic_id)
 }
 
 auto ResolveSpecificDecl(Context& context, SemIR::LocId loc_id,
-                         SemIR::SpecificId specific_id) -> void {
+                         SemIR::SpecificId specific_id,
+                         MakeDiagnosticBuilderFn diagnoser) -> void {
   // If this is the first time we've formed this specific, evaluate its decl
   // block to form information about the specific.
   auto& specific = context.specifics().Get(specific_id);
@@ -654,25 +655,26 @@ auto ResolveSpecificDecl(Context& context, SemIR::LocId loc_id,
     // recursively resolve the same specific.
     specific.decl_block_id = SemIR::InstBlockId::Empty;
 
-    specific.decl_block_id =
-        TryEvalBlockForSpecific(context, loc_id, specific_id,
-                                SemIR::GenericInstIndex::Region::Declaration);
+    specific.decl_block_id = TryEvalBlockForSpecific(
+        context, loc_id, specific_id,
+        SemIR::GenericInstIndex::Region::Declaration, diagnoser);
   }
 }
 
 auto MakeSpecific(Context& context, SemIR::LocId loc_id,
-                  SemIR::GenericId generic_id, SemIR::InstBlockId args_id)
-    -> SemIR::SpecificId {
+                  SemIR::GenericId generic_id, SemIR::InstBlockId args_id,
+                  MakeDiagnosticBuilderFn diagnoser) -> SemIR::SpecificId {
   auto specific_id = context.specifics().GetOrAdd(generic_id, args_id);
-  ResolveSpecificDecl(context, loc_id, specific_id);
+  ResolveSpecificDecl(context, loc_id, specific_id, diagnoser);
   return specific_id;
 }
 
 auto MakeSpecific(Context& context, SemIR::LocId loc_id,
                   SemIR::GenericId generic_id,
-                  llvm::ArrayRef<SemIR::InstId> args) -> SemIR::SpecificId {
+                  llvm::ArrayRef<SemIR::InstId> args,
+                  MakeDiagnosticBuilderFn diagnoser) -> SemIR::SpecificId {
   auto args_id = context.inst_blocks().AddCanonical(args);
-  return MakeSpecific(context, loc_id, generic_id, args_id);
+  return MakeSpecific(context, loc_id, generic_id, args_id, diagnoser);
 }
 
 static auto MakeSelfSpecificId(Context& context, SemIR::GenericId generic_id)
@@ -701,12 +703,13 @@ auto MakeSelfSpecific(Context& context, SemIR::LocId loc_id,
   // TODO: This could be made more efficient. We don't need to perform
   // substitution here; we know we want identity mappings for all constants and
   // types. We could also consider not storing the mapping at all in this case.
-  ResolveSpecificDecl(context, loc_id, specific_id);
+  ResolveSpecificDecl(context, loc_id, specific_id, nullptr);
   return specific_id;
 }
 
 auto ResolveSpecificDefinition(Context& context, SemIR::LocId loc_id,
-                               SemIR::SpecificId specific_id) -> bool {
+                               SemIR::SpecificId specific_id,
+                               MakeDiagnosticBuilderFn diagnoser) -> bool {
   // TODO: Handle recursive resolution of the same generic definition.
   auto& specific = context.specifics().Get(specific_id);
   auto generic_id = specific.generic_id;
@@ -720,8 +723,9 @@ auto ResolveSpecificDefinition(Context& context, SemIR::LocId loc_id,
       // The generic is not defined yet.
       return false;
     }
-    specific.definition_block_id = TryEvalBlockForSpecific(
-        context, loc_id, specific_id, SemIR::GenericInstIndex::Definition);
+    specific.definition_block_id =
+        TryEvalBlockForSpecific(context, loc_id, specific_id,
+                                SemIR::GenericInstIndex::Definition, diagnoser);
   }
   return true;
 }

--- a/toolchain/check/generic.h
+++ b/toolchain/check/generic.h
@@ -7,6 +7,7 @@
 
 #include "common/enum_mask_base.h"
 #include "toolchain/check/context.h"
+#include "toolchain/check/diagnostic_helpers.h"
 #include "toolchain/sem_ir/entity_with_params_base.h"
 #include "toolchain/sem_ir/ids.h"
 
@@ -93,14 +94,15 @@ auto RebuildGenericEvalBlock(Context& context, SemIR::GenericId generic_id,
 // substitution into the declaration, but not the definition, of the generic.
 auto MakeSpecific(Context& context, SemIR::LocId loc_id,
                   SemIR::GenericId generic_id,
-                  llvm::ArrayRef<SemIR::InstId> args) -> SemIR::SpecificId;
+                  llvm::ArrayRef<SemIR::InstId> args,
+                  MakeDiagnosticBuilderFn diagnoser) -> SemIR::SpecificId;
 
 // Builds a new specific or finds an existing one in the case where the argument
 // list has already been converted into an instruction block. `args_id` should
 // be a canonical instruction block referring to constants.
 auto MakeSpecific(Context& context, SemIR::LocId loc_id,
-                  SemIR::GenericId generic_id, SemIR::InstBlockId args_id)
-    -> SemIR::SpecificId;
+                  SemIR::GenericId generic_id, SemIR::InstBlockId args_id,
+                  MakeDiagnosticBuilderFn diagnoser) -> SemIR::SpecificId;
 
 // Builds the specific that describes how the generic should refer to itself.
 // For example, for a generic `G(T:! type)`, this is the specific `G(T)`. If
@@ -112,13 +114,15 @@ auto MakeSelfSpecific(Context& context, SemIR::LocId loc_id,
 // of the corresponding generic and storing a corresponding value block in the
 // specific.
 auto ResolveSpecificDecl(Context& context, SemIR::LocId loc_id,
-                         SemIR::SpecificId specific_id) -> void;
+                         SemIR::SpecificId specific_id,
+                         MakeDiagnosticBuilderFn diagnoser) -> void;
 
 // Attempts to resolve the definition of the given specific, by evaluating the
 // eval block of the corresponding generic and storing a corresponding value
 // block in the specific. Returns false if a definition is not available.
 auto ResolveSpecificDefinition(Context& context, SemIR::LocId loc_id,
-                               SemIR::SpecificId specific_id) -> bool;
+                               SemIR::SpecificId specific_id,
+                               MakeDiagnosticBuilderFn diagnoser) -> bool;
 
 // Diagnoses if an entity has implicit parameters, indicating it's generic, but
 // is missing explicit parameters.

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -697,7 +697,8 @@ auto CheckRequireDeclsSatisfied(Context& context, SemIR::LocId loc_id,
 
     auto require_specific =
         GetRequireImplsSpecificFromEnclosingSpecificWithSelfFacetValue(
-            context, require, impl.interface.specific_id, self_facet_value);
+            context, require, impl.interface.specific_id, self_facet_value,
+            nullptr);
     auto self_const_id = GetConstantValueInRequireImplsSpecific(
         context, require_specific, require.self_id);
     auto facet_type_const_id = GetConstantValueInRequireImplsSpecific(

--- a/toolchain/check/interface.cpp
+++ b/toolchain/check/interface.cpp
@@ -186,7 +186,8 @@ auto GetSelfSpecificForInterfaceMemberWithSelfType(
     arg_ids.push_back(new_arg_id);
   }
 
-  return MakeSpecific(context, loc_id, generic_id, arg_ids);
+  // TODO: Receive a diagnoser from the caller?
+  return MakeSpecific(context, loc_id, generic_id, arg_ids, nullptr);
 }
 
 auto GetTypeForSpecificAssociatedEntity(Context& context, SemIR::LocId loc_id,
@@ -211,7 +212,9 @@ auto GetTypeForSpecificAssociatedEntity(Context& context, SemIR::LocId loc_id,
     auto arg_ids =
         GetGenericArgsWithSelfType(context, interface_specific_id, generic_id,
                                    self_type_id, self_witness_id);
-    auto const_specific_id = MakeSpecific(context, loc_id, generic_id, arg_ids);
+    // TODO: Receive a diagnoser from the caller?
+    auto const_specific_id =
+        MakeSpecific(context, loc_id, generic_id, arg_ids, nullptr);
     return SemIR::GetTypeOfInstInSpecific(context.sem_ir(), const_specific_id,
                                           decl_id);
   }

--- a/toolchain/check/require_impls.cpp
+++ b/toolchain/check/require_impls.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/require_impls.h"
 
+#include "toolchain/check/diagnostic_helpers.h"
 #include "toolchain/check/generic.h"
 #include "toolchain/check/inst.h"
 #include "toolchain/check/interface.h"
@@ -36,7 +37,8 @@ static auto GetSpecificArgsFromEnclosingSpecific(
 
 auto GetRequireImplsSpecificFromEnclosingSpecific(
     Context& context, const SemIR::RequireImpls& require,
-    SemIR::SpecificId enclosing_specific_id) -> RequireImplsSpecific {
+    SemIR::SpecificId enclosing_specific_id, MakeDiagnosticBuilderFn diagnoser)
+    -> RequireImplsSpecific {
   if (enclosing_specific_id.has_value()) {
     auto enclosing_generic_decl =
         GetEnclosingDeclFromEnclosingSpecificId(context, enclosing_specific_id);
@@ -65,7 +67,7 @@ auto GetRequireImplsSpecificFromEnclosingSpecific(
   arg_ids.push_back(self_inst_id);
 
   auto specific_id = MakeSpecific(context, SemIR::LocId(require.decl_id),
-                                  require.generic_id, arg_ids);
+                                  require.generic_id, arg_ids, diagnoser);
   // TODO: Cache the specific on Context.
   return {.specific_id = specific_id};
 }
@@ -73,7 +75,8 @@ auto GetRequireImplsSpecificFromEnclosingSpecific(
 auto GetRequireImplsSpecificFromEnclosingSpecificWithSelfFacetValue(
     Context& context, const SemIR::RequireImpls& require,
     SemIR::SpecificId enclosing_specific_id,
-    SemIR::ConstantId self_facet_value_id) -> RequireImplsSpecific {
+    SemIR::ConstantId self_facet_value_id, MakeDiagnosticBuilderFn diagnoser)
+    -> RequireImplsSpecific {
   auto self_facet_value_inst_id =
       context.constant_values().GetInstId(self_facet_value_id);
   auto self_facet_value = context.insts().Get(self_facet_value_inst_id);
@@ -85,7 +88,7 @@ auto GetRequireImplsSpecificFromEnclosingSpecificWithSelfFacetValue(
   arg_ids.push_back(self_facet_value_inst_id);
 
   auto specific_id = MakeSpecific(context, SemIR::LocId(require.decl_id),
-                                  require.generic_id, arg_ids);
+                                  require.generic_id, arg_ids, diagnoser);
   // TODO: Cache the specific on Context.
   return {.specific_id = specific_id};
 }

--- a/toolchain/check/require_impls.h
+++ b/toolchain/check/require_impls.h
@@ -23,14 +23,16 @@ struct RequireImplsSpecific {
 // constructed from the enclosing one.
 auto GetRequireImplsSpecificFromEnclosingSpecific(
     Context& context, const SemIR::RequireImpls& require,
-    SemIR::SpecificId enclosing_specific_id) -> RequireImplsSpecific;
+    SemIR::SpecificId enclosing_specific_id, MakeDiagnosticBuilderFn diagnoser)
+    -> RequireImplsSpecific;
 
 // Like GetRequireImplsSpecificFromEnclosingSpecific but the `Self` value in the
 // specific is replaced by a given facet value.
 auto GetRequireImplsSpecificFromEnclosingSpecificWithSelfFacetValue(
     Context& context, const SemIR::RequireImpls& require,
     SemIR::SpecificId enclosing_specific_id,
-    SemIR::ConstantId self_facet_value_id) -> RequireImplsSpecific;
+    SemIR::ConstantId self_facet_value_id, MakeDiagnosticBuilderFn diagnoser)
+    -> RequireImplsSpecific;
 
 // Returns the constant value of `inst_id` from inside a RequireImpls
 // declaration, mapped into `enclosing_specific_id`. If an error results, it

--- a/toolchain/check/testdata/builtins/float/make_type.carbon
+++ b/toolchain/check/testdata/builtins/float/make_type.carbon
@@ -39,7 +39,10 @@ library "[[@TEST_NAME]]";
 
 import library "types";
 
-// CHECK:STDERR: fail_invalid_size.carbon:[[@LINE+4]]:20: error: unsupported floating-point bit width 931 [CompileTimeFloatBitWidth]
+// CHECK:STDERR: fail_invalid_size.carbon:[[@LINE+7]]:20: error: invalid float type [FloatTypeInvalid]
+// CHECK:STDERR: var invalid_float: Float(931);
+// CHECK:STDERR:                    ^~~~~~~~~~
+// CHECK:STDERR: fail_invalid_size.carbon:[[@LINE+4]]:20: note: unsupported floating-point bit width 931 [CompileTimeFloatBitWidth]
 // CHECK:STDERR: var invalid_float: Float(931);
 // CHECK:STDERR:                    ^~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/builtins/int/make_type_signed.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_signed.carbon
@@ -70,7 +70,10 @@ library "[[@TEST_NAME]]";
 
 import library "types";
 
-// CHECK:STDERR: fail_zero_size.carbon:[[@LINE+4]]:8: error: integer type width of 0 is not positive [IntWidthNotPositive]
+// CHECK:STDERR: fail_zero_size.carbon:[[@LINE+7]]:8: error: invalid int type [IntTypeInvalid]
+// CHECK:STDERR: var n: Int(0);
+// CHECK:STDERR:        ^~~~~~
+// CHECK:STDERR: fail_zero_size.carbon:[[@LINE+4]]:8: note: integer type width of 0 is not positive [IntWidthNotPositive]
 // CHECK:STDERR: var n: Int(0);
 // CHECK:STDERR:        ^~~~~~
 // CHECK:STDERR:
@@ -84,7 +87,10 @@ import library "types";
 
 fn Negate(a: IntLiteral()) -> IntLiteral() = "int.snegate";
 
-// CHECK:STDERR: fail_negative_size.carbon:[[@LINE+4]]:8: error: integer type width of -1 is not positive [IntWidthNotPositive]
+// CHECK:STDERR: fail_negative_size.carbon:[[@LINE+7]]:8: error: invalid int type [IntTypeInvalid]
+// CHECK:STDERR: var n: Int(Negate(1));
+// CHECK:STDERR:        ^~~~~~~~~~~~~~
+// CHECK:STDERR: fail_negative_size.carbon:[[@LINE+4]]:8: note: integer type width of -1 is not positive [IntWidthNotPositive]
 // CHECK:STDERR: var n: Int(Negate(1));
 // CHECK:STDERR:        ^~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -96,7 +102,10 @@ library "[[@TEST_NAME]]";
 
 import library "types";
 
-// CHECK:STDERR: fail_oversized.carbon:[[@LINE+4]]:8: error: integer type width of 1000000000 is greater than the maximum supported width of 8388608 [IntWidthTooLarge]
+// CHECK:STDERR: fail_oversized.carbon:[[@LINE+7]]:8: error: invalid int type [IntTypeInvalid]
+// CHECK:STDERR: var m: Int(1000000000);
+// CHECK:STDERR:        ^~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_oversized.carbon:[[@LINE+4]]:8: note: integer type width of 1000000000 is greater than the maximum supported width of 8388608 [IntWidthTooLarge]
 // CHECK:STDERR: var m: Int(1000000000);
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
+++ b/toolchain/check/testdata/builtins/int/make_type_unsigned.carbon
@@ -52,7 +52,10 @@ library "[[@TEST_NAME]]";
 
 import library "types";
 
-// CHECK:STDERR: fail_zero_size.carbon:[[@LINE+4]]:8: error: integer type width of 0 is not positive [IntWidthNotPositive]
+// CHECK:STDERR: fail_zero_size.carbon:[[@LINE+7]]:8: error: invalid int type [IntTypeInvalid]
+// CHECK:STDERR: var n: UInt(0);
+// CHECK:STDERR:        ^~~~~~~
+// CHECK:STDERR: fail_zero_size.carbon:[[@LINE+4]]:8: note: integer type width of 0 is not positive [IntWidthNotPositive]
 // CHECK:STDERR: var n: UInt(0);
 // CHECK:STDERR:        ^~~~~~~
 // CHECK:STDERR:
@@ -66,7 +69,10 @@ import library "types";
 
 fn Negate(n: i32) -> i32 = "int.snegate";
 
-// CHECK:STDERR: fail_negative_size.carbon:[[@LINE+4]]:8: error: integer type width of -1 is not positive [IntWidthNotPositive]
+// CHECK:STDERR: fail_negative_size.carbon:[[@LINE+7]]:8: error: invalid int type [IntTypeInvalid]
+// CHECK:STDERR: var n: UInt(Negate(1));
+// CHECK:STDERR:        ^~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_negative_size.carbon:[[@LINE+4]]:8: note: integer type width of -1 is not positive [IntWidthNotPositive]
 // CHECK:STDERR: var n: UInt(Negate(1));
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -78,7 +84,10 @@ library "[[@TEST_NAME]]";
 
 import library "types";
 
-// CHECK:STDERR: fail_oversized.carbon:[[@LINE+4]]:8: error: integer type width of 1000000000 is greater than the maximum supported width of 8388608 [IntWidthTooLarge]
+// CHECK:STDERR: fail_oversized.carbon:[[@LINE+7]]:8: error: invalid int type [IntTypeInvalid]
+// CHECK:STDERR: var m: UInt(1000000000);
+// CHECK:STDERR:        ^~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_oversized.carbon:[[@LINE+4]]:8: note: integer type width of 1000000000 is greater than the maximum supported width of 8388608 [IntWidthTooLarge]
 // CHECK:STDERR: var m: UInt(1000000000);
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/class/generic/complete_in_conversion.carbon
+++ b/toolchain/check/testdata/class/generic/complete_in_conversion.carbon
@@ -21,7 +21,10 @@ base class B {}
 class A(N:! i32) {
   extend base: B;
 
-  // CHECK:STDERR: fail_derived_to_base.carbon:[[@LINE+3]]:10: error: integer type width of 0 is not positive [IntWidthNotPositive]
+  // CHECK:STDERR: fail_derived_to_base.carbon:[[@LINE+6]]:10: error: invalid int type [IntTypeInvalid]
+  // CHECK:STDERR:   var n: Int(N);
+  // CHECK:STDERR:          ^~~~~~
+  // CHECK:STDERR: fail_derived_to_base.carbon:[[@LINE+3]]:10: note: integer type width of 0 is not positive [IntWidthNotPositive]
   // CHECK:STDERR:   var n: Int(N);
   // CHECK:STDERR:          ^~~~~~
   var n: Int(N);
@@ -169,18 +172,18 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:     %a.param_patt: %pattern_type.f32 = value_param_pattern %a.patt, call_param0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %a.param: %ptr.0e2 = value_param call_param0
-// CHECK:STDOUT:     %.loc15_13: type = splice_block %ptr.loc15 [concrete = constants.%ptr.0e2] {
+// CHECK:STDOUT:     %.loc18_13: type = splice_block %ptr.loc18 [concrete = constants.%ptr.0e2] {
 // CHECK:STDOUT:       %A.ref: %A.type = name_ref A, file.%A.decl [concrete = constants.%A.generic]
 // CHECK:STDOUT:       %int_0: Core.IntLiteral = int_value 0 [concrete = constants.%int_0.5c6]
 // CHECK:STDOUT:       %impl.elem0: %.863 = impl_witness_access constants.%ImplicitAs.impl_witness.6bc, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.0b5]
-// CHECK:STDOUT:       %bound_method.loc15_12.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
+// CHECK:STDOUT:       %bound_method.loc18_12.1: <bound method> = bound_method %int_0, %impl.elem0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]
 // CHECK:STDOUT:       %specific_fn: <specific function> = specific_function %impl.elem0, @Core.IntLiteral.as.ImplicitAs.impl.Convert(constants.%int_32) [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.specific_fn]
-// CHECK:STDOUT:       %bound_method.loc15_12.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method.d2e]
-// CHECK:STDOUT:       %Core.IntLiteral.as.ImplicitAs.impl.Convert.call: init %i32 = call %bound_method.loc15_12.2(%int_0) [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:       %.loc15_12.1: %i32 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call [concrete = constants.%int_0.6a9]
-// CHECK:STDOUT:       %.loc15_12.2: %i32 = converted %int_0, %.loc15_12.1 [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:       %bound_method.loc18_12.2: <bound method> = bound_method %int_0, %specific_fn [concrete = constants.%bound_method.d2e]
+// CHECK:STDOUT:       %Core.IntLiteral.as.ImplicitAs.impl.Convert.call: init %i32 = call %bound_method.loc18_12.2(%int_0) [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:       %.loc18_12.1: %i32 = value_of_initializer %Core.IntLiteral.as.ImplicitAs.impl.Convert.call [concrete = constants.%int_0.6a9]
+// CHECK:STDOUT:       %.loc18_12.2: %i32 = converted %int_0, %.loc18_12.1 [concrete = constants.%int_0.6a9]
 // CHECK:STDOUT:       %A: type = class_type @A, @A(constants.%int_0.6a9) [concrete = constants.%A.dc6]
-// CHECK:STDOUT:       %ptr.loc15: type = ptr_type %A [concrete = constants.%ptr.0e2]
+// CHECK:STDOUT:       %ptr.loc18: type = ptr_type %A [concrete = constants.%ptr.0e2]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %a: %ptr.0e2 = value_binding a, %a.param
 // CHECK:STDOUT:   }
@@ -203,13 +206,13 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:   %A: type = class_type @A, @A(%N.loc6_9.1) [symbolic = %A (constants.%A.54d)]
 // CHECK:STDOUT:   %A.elem.loc7: type = unbound_element_type %A, constants.%B [symbolic = %A.elem.loc7 (constants.%A.elem.ade)]
 // CHECK:STDOUT:   %Int.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %N.loc6_9.1, constants.%Int.as.ImplicitAs.impl.Convert.dd4 [symbolic = %Int.as.ImplicitAs.impl.Convert.bound (constants.%Int.as.ImplicitAs.impl.Convert.bound.d32)]
-// CHECK:STDOUT:   %bound_method.loc12_14.3: <bound method> = bound_method %N.loc6_9.1, constants.%Int.as.ImplicitAs.impl.Convert.specific_fn [symbolic = %bound_method.loc12_14.3 (constants.%bound_method.d76)]
-// CHECK:STDOUT:   %Int.as.ImplicitAs.impl.Convert.call.loc12_14.2: init Core.IntLiteral = call %bound_method.loc12_14.3(%N.loc6_9.1) [symbolic = %Int.as.ImplicitAs.impl.Convert.call.loc12_14.2 (constants.%Int.as.ImplicitAs.impl.Convert.call)]
-// CHECK:STDOUT:   %iN.builtin: type = int_type signed, %Int.as.ImplicitAs.impl.Convert.call.loc12_14.2 [symbolic = %iN.builtin (constants.%iN.builtin.f1b)]
+// CHECK:STDOUT:   %bound_method.loc15_14.3: <bound method> = bound_method %N.loc6_9.1, constants.%Int.as.ImplicitAs.impl.Convert.specific_fn [symbolic = %bound_method.loc15_14.3 (constants.%bound_method.d76)]
+// CHECK:STDOUT:   %Int.as.ImplicitAs.impl.Convert.call.loc15_14.2: init Core.IntLiteral = call %bound_method.loc15_14.3(%N.loc6_9.1) [symbolic = %Int.as.ImplicitAs.impl.Convert.call.loc15_14.2 (constants.%Int.as.ImplicitAs.impl.Convert.call)]
+// CHECK:STDOUT:   %iN.builtin: type = int_type signed, %Int.as.ImplicitAs.impl.Convert.call.loc15_14.2 [symbolic = %iN.builtin (constants.%iN.builtin.f1b)]
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %iN.builtin [symbolic = %require_complete (constants.%require_complete.c9d)]
-// CHECK:STDOUT:   %A.elem.loc12: type = unbound_element_type %A, %iN.builtin [symbolic = %A.elem.loc12 (constants.%A.elem.a53)]
+// CHECK:STDOUT:   %A.elem.loc15: type = unbound_element_type %A, %iN.builtin [symbolic = %A.elem.loc15 (constants.%A.elem.a53)]
 // CHECK:STDOUT:   %struct_type.base.n: type = struct_type {.base: %B, .n: @A.%iN.builtin (%iN.builtin.f1b)} [symbolic = %struct_type.base.n (constants.%struct_type.base.n)]
-// CHECK:STDOUT:   %complete_type.loc13_1.2: <witness> = complete_type_witness %struct_type.base.n [symbolic = %complete_type.loc13_1.2 (constants.%complete_type.8c7)]
+// CHECK:STDOUT:   %complete_type.loc16_1.2: <witness> = complete_type_witness %struct_type.base.n [symbolic = %complete_type.loc16_1.2 (constants.%complete_type.8c7)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
@@ -217,18 +220,18 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:     %Int.ref: %Int.type.b3e = name_ref Int, file.%Int.decl [concrete = constants.%Int.d6d]
 // CHECK:STDOUT:     %N.ref: %i32 = name_ref N, %N.loc6_9.2 [symbolic = %N.loc6_9.1 (constants.%N.5de)]
 // CHECK:STDOUT:     %impl.elem0: %.71e = impl_witness_access constants.%ImplicitAs.impl_witness.640, element0 [concrete = constants.%Int.as.ImplicitAs.impl.Convert.dd4]
-// CHECK:STDOUT:     %bound_method.loc12_14.1: <bound method> = bound_method %N.ref, %impl.elem0 [symbolic = %Int.as.ImplicitAs.impl.Convert.bound (constants.%Int.as.ImplicitAs.impl.Convert.bound.d32)]
+// CHECK:STDOUT:     %bound_method.loc15_14.1: <bound method> = bound_method %N.ref, %impl.elem0 [symbolic = %Int.as.ImplicitAs.impl.Convert.bound (constants.%Int.as.ImplicitAs.impl.Convert.bound.d32)]
 // CHECK:STDOUT:     %specific_fn: <specific function> = specific_function %impl.elem0, @Int.as.ImplicitAs.impl.Convert(constants.%int_32) [concrete = constants.%Int.as.ImplicitAs.impl.Convert.specific_fn]
-// CHECK:STDOUT:     %bound_method.loc12_14.2: <bound method> = bound_method %N.ref, %specific_fn [symbolic = %bound_method.loc12_14.3 (constants.%bound_method.d76)]
-// CHECK:STDOUT:     %Int.as.ImplicitAs.impl.Convert.call.loc12_14.1: init Core.IntLiteral = call %bound_method.loc12_14.2(%N.ref) [symbolic = %Int.as.ImplicitAs.impl.Convert.call.loc12_14.2 (constants.%Int.as.ImplicitAs.impl.Convert.call)]
-// CHECK:STDOUT:     %.loc12_14.1: Core.IntLiteral = value_of_initializer %Int.as.ImplicitAs.impl.Convert.call.loc12_14.1 [symbolic = %Int.as.ImplicitAs.impl.Convert.call.loc12_14.2 (constants.%Int.as.ImplicitAs.impl.Convert.call)]
-// CHECK:STDOUT:     %.loc12_14.2: Core.IntLiteral = converted %N.ref, %.loc12_14.1 [symbolic = %Int.as.ImplicitAs.impl.Convert.call.loc12_14.2 (constants.%Int.as.ImplicitAs.impl.Convert.call)]
-// CHECK:STDOUT:     %Int.call: init type = call %Int.ref(%.loc12_14.2) [symbolic = %iN.builtin (constants.%iN.builtin.f1b)]
-// CHECK:STDOUT:     %.loc12_15.1: type = value_of_initializer %Int.call [symbolic = %iN.builtin (constants.%iN.builtin.f1b)]
-// CHECK:STDOUT:     %.loc12_15.2: type = converted %Int.call, %.loc12_15.1 [symbolic = %iN.builtin (constants.%iN.builtin.f1b)]
-// CHECK:STDOUT:     %.loc12_8: @A.%A.elem.loc12 (%A.elem.a53) = field_decl n, element1 [concrete]
-// CHECK:STDOUT:     %complete_type.loc13_1.1: <witness> = complete_type_witness constants.%struct_type.base.n [symbolic = %complete_type.loc13_1.2 (constants.%complete_type.8c7)]
-// CHECK:STDOUT:     complete_type_witness = %complete_type.loc13_1.1
+// CHECK:STDOUT:     %bound_method.loc15_14.2: <bound method> = bound_method %N.ref, %specific_fn [symbolic = %bound_method.loc15_14.3 (constants.%bound_method.d76)]
+// CHECK:STDOUT:     %Int.as.ImplicitAs.impl.Convert.call.loc15_14.1: init Core.IntLiteral = call %bound_method.loc15_14.2(%N.ref) [symbolic = %Int.as.ImplicitAs.impl.Convert.call.loc15_14.2 (constants.%Int.as.ImplicitAs.impl.Convert.call)]
+// CHECK:STDOUT:     %.loc15_14.1: Core.IntLiteral = value_of_initializer %Int.as.ImplicitAs.impl.Convert.call.loc15_14.1 [symbolic = %Int.as.ImplicitAs.impl.Convert.call.loc15_14.2 (constants.%Int.as.ImplicitAs.impl.Convert.call)]
+// CHECK:STDOUT:     %.loc15_14.2: Core.IntLiteral = converted %N.ref, %.loc15_14.1 [symbolic = %Int.as.ImplicitAs.impl.Convert.call.loc15_14.2 (constants.%Int.as.ImplicitAs.impl.Convert.call)]
+// CHECK:STDOUT:     %Int.call: init type = call %Int.ref(%.loc15_14.2) [symbolic = %iN.builtin (constants.%iN.builtin.f1b)]
+// CHECK:STDOUT:     %.loc15_15.1: type = value_of_initializer %Int.call [symbolic = %iN.builtin (constants.%iN.builtin.f1b)]
+// CHECK:STDOUT:     %.loc15_15.2: type = converted %Int.call, %.loc15_15.1 [symbolic = %iN.builtin (constants.%iN.builtin.f1b)]
+// CHECK:STDOUT:     %.loc15_8: @A.%A.elem.loc15 (%A.elem.a53) = field_decl n, element1 [concrete]
+// CHECK:STDOUT:     %complete_type.loc16_1.1: <witness> = complete_type_witness constants.%struct_type.base.n [symbolic = %complete_type.loc16_1.2 (constants.%complete_type.8c7)]
+// CHECK:STDOUT:     complete_type_witness = %complete_type.loc16_1.1
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = constants.%A.54d
@@ -236,7 +239,7 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:     .base = %.loc7
 // CHECK:STDOUT:     .Int = <poisoned>
 // CHECK:STDOUT:     .N = <poisoned>
-// CHECK:STDOUT:     .n = %.loc12_8
+// CHECK:STDOUT:     .n = %.loc15_8
 // CHECK:STDOUT:     extend %B.ref
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -249,15 +252,15 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:     %b.patt: %pattern_type.191 = value_binding_pattern b [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.ref: %ptr.0e2 = name_ref a, %a
-// CHECK:STDOUT:   %.loc20_11: type = splice_block %ptr.loc20 [concrete = constants.%ptr.27c] {
+// CHECK:STDOUT:   %.loc23_11: type = splice_block %ptr.loc23 [concrete = constants.%ptr.27c] {
 // CHECK:STDOUT:     %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B]
-// CHECK:STDOUT:     %ptr.loc20: type = ptr_type %B.ref [concrete = constants.%ptr.27c]
+// CHECK:STDOUT:     %ptr.loc23: type = ptr_type %B.ref [concrete = constants.%ptr.27c]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc20_15.1: ref %A.dc6 = deref %a.ref
-// CHECK:STDOUT:   %.loc20_15.2: ref %B = class_element_access %.loc20_15.1, element0
-// CHECK:STDOUT:   %addr: %ptr.27c = addr_of %.loc20_15.2
-// CHECK:STDOUT:   %.loc20_15.3: %ptr.27c = converted %a.ref, %addr
-// CHECK:STDOUT:   %b: %ptr.27c = value_binding b, %.loc20_15.3
+// CHECK:STDOUT:   %.loc23_15.1: ref %A.dc6 = deref %a.ref
+// CHECK:STDOUT:   %.loc23_15.2: ref %B = class_element_access %.loc23_15.1, element0
+// CHECK:STDOUT:   %addr: %ptr.27c = addr_of %.loc23_15.2
+// CHECK:STDOUT:   %.loc23_15.3: %ptr.27c = converted %a.ref, %addr
+// CHECK:STDOUT:   %b: %ptr.27c = value_binding b, %.loc23_15.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -272,12 +275,12 @@ fn F(a: A(0)*) {
 // CHECK:STDOUT:   %A => constants.%A.dc6
 // CHECK:STDOUT:   %A.elem.loc7 => constants.%A.elem.665
 // CHECK:STDOUT:   %Int.as.ImplicitAs.impl.Convert.bound => constants.%Int.as.ImplicitAs.impl.Convert.bound.564
-// CHECK:STDOUT:   %bound_method.loc12_14.3 => constants.%bound_method.77d
-// CHECK:STDOUT:   %Int.as.ImplicitAs.impl.Convert.call.loc12_14.2 => constants.%int_0.5c6
+// CHECK:STDOUT:   %bound_method.loc15_14.3 => constants.%bound_method.77d
+// CHECK:STDOUT:   %Int.as.ImplicitAs.impl.Convert.call.loc15_14.2 => constants.%int_0.5c6
 // CHECK:STDOUT:   %iN.builtin => <error>
 // CHECK:STDOUT:   %require_complete => <error>
-// CHECK:STDOUT:   %A.elem.loc12 => <error>
+// CHECK:STDOUT:   %A.elem.loc15 => <error>
 // CHECK:STDOUT:   %struct_type.base.n => <error>
-// CHECK:STDOUT:   %complete_type.loc13_1.2 => <error>
+// CHECK:STDOUT:   %complete_type.loc16_1.2 => <error>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/require_satisified.carbon
+++ b/toolchain/check/testdata/facet/require_satisified.carbon
@@ -223,9 +223,6 @@ class W(T:! type) {
 }
 
 interface A(N:! Core.IntLiteral()) {
-  // CHECK:STDERR: fail_impl_requires_itself_cycle_with_monomorphization_error.carbon:[[@LINE+3]]:26: error: array bound of -1 is negative [ArrayBoundNegative]
-  // CHECK:STDERR:   fn AA() -> W(array((), N));
-  // CHECK:STDERR:                          ^
   fn AA() -> W(array((), N));
 }
 interface B(N:! Core.IntLiteral()) {
@@ -250,9 +247,12 @@ impl forall [N:! Core.IntLiteral(), T:! C(N)] T as B(N) {
 }
 
 fn F(T:! C(-1)) {
-  // CHECK:STDERR: fail_impl_requires_itself_cycle_with_monomorphization_error.carbon:[[@LINE+4]]:3: note: in `AA()` used here [ResolvingSpecificHere]
+  // CHECK:STDERR: fail_impl_requires_itself_cycle_with_monomorphization_error.carbon:[[@LINE+7]]:3: error: cannot deduce with invalid specific [MonomorphizationErrorInDeduce]
   // CHECK:STDERR:   T.(A(-1).AA)();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_impl_requires_itself_cycle_with_monomorphization_error.carbon:[[@LINE-27]]:26: note: array bound of -1 is negative [ArrayBoundNegative]
+  // CHECK:STDERR:   fn AA() -> W(array((), N));
+  // CHECK:STDERR:                          ^
   // CHECK:STDERR:
   T.(A(-1).AA)();
 }

--- a/toolchain/check/testdata/function/generic/resolve_used.carbon
+++ b/toolchain/check/testdata/function/generic/resolve_used.carbon
@@ -21,12 +21,12 @@ fn ErrorIfNIsZero(N:! Core.IntLiteral()) {
   // ensuring we produce an error when doing so. Notionally this error is
   // produced as a result of instantiating the `Core.Int` template, although
   // that's not how we currently model `Core.Int`.
-  // CHECK:STDERR: min_prelude/parts/int.carbon:11:9: error: integer type width of 0 is not positive [IntWidthNotPositive]
-  // CHECK:STDERR:   adapt MakeInt(N);
-  // CHECK:STDERR:         ^~~~~~~~~~
-  // CHECK:STDERR: fail_todo_call_monomorphization_error.carbon:[[@LINE+3]]:10: note: in `i0` used here [ResolvingSpecificHere]
+  // CHECK:STDERR: fail_todo_call_monomorphization_error.carbon:[[@LINE+6]]:10: error: `Core.Int(N)` evaluates to incomplete type `i0` [IncompleteTypeInMonomorphization]
   // CHECK:STDERR:   var v: Core.Int(N);
   // CHECK:STDERR:          ^~~~~~~~~~~
+  // CHECK:STDERR: min_prelude/parts/int.carbon:11:9: note: integer type width of 0 is not positive [IntWidthNotPositive]
+  // CHECK:STDERR:   adapt MakeInt(N);
+  // CHECK:STDERR:         ^~~~~~~~~~
   var v: Core.Int(N);
 }
 

--- a/toolchain/check/testdata/generic/complete_type.carbon
+++ b/toolchain/check/testdata/generic/complete_type.carbon
@@ -19,18 +19,18 @@ library "[[@TEST_NAME]]";
 class B;
 
 class A(T:! type) {
-  // CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE+6]]:10: error: `T` evaluates to incomplete type `B` [IncompleteTypeInMonomorphization]
-  // CHECK:STDERR:   var v: T;
-  // CHECK:STDERR:          ^
-  // CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE-6]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
-  // CHECK:STDERR: class B;
-  // CHECK:STDERR: ^~~~~~~~
   var v: T;
 }
 
-// CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE+11]]:6: note: in `A(B)` used here [ResolvingSpecificHere]
+// CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE+17]]:6: error: parameter has incomplete type `A(B)` in function definition [IncompleteTypeInFunctionParam]
 // CHECK:STDERR: fn F(x: A(B)) {}
 // CHECK:STDERR:      ^~~~~~~
+// CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE-6]]:10: note: `T` evaluates to incomplete type `B` [IncompleteTypeInMonomorphization]
+// CHECK:STDERR:   var v: T;
+// CHECK:STDERR:          ^
+// CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE-12]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: class B;
+// CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
 // CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE+7]]:6: error: parameter has incomplete type `A(B)` in function definition [IncompleteTypeInFunctionParam]
 // CHECK:STDERR: fn F(x: A(B)) {}
@@ -161,18 +161,18 @@ fn G() { F(B); }
 // CHECK:STDOUT:   %A: type = class_type @A, @A(%T.loc6_9.1) [symbolic = %A (constants.%A.95c)]
 // CHECK:STDOUT:   %A.elem: type = unbound_element_type %A, %T.loc6_9.1 [symbolic = %A.elem (constants.%A.elem.8a2)]
 // CHECK:STDOUT:   %struct_type.v: type = struct_type {.v: @A.%T.loc6_9.1 (%T)} [symbolic = %struct_type.v (constants.%struct_type.v.a4d)]
-// CHECK:STDOUT:   %complete_type.loc14_1.2: <witness> = complete_type_witness %struct_type.v [symbolic = %complete_type.loc14_1.2 (constants.%complete_type.136)]
+// CHECK:STDOUT:   %complete_type.loc8_1.2: <witness> = complete_type_witness %struct_type.v [symbolic = %complete_type.loc8_1.2 (constants.%complete_type.136)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   class {
 // CHECK:STDOUT:     %T.ref: type = name_ref T, %T.loc6_9.2 [symbolic = %T.loc6_9.1 (constants.%T)]
-// CHECK:STDOUT:     %.loc13: @A.%A.elem (%A.elem.8a2) = field_decl v, element0 [concrete]
-// CHECK:STDOUT:     %complete_type.loc14_1.1: <witness> = complete_type_witness constants.%struct_type.v.a4d [symbolic = %complete_type.loc14_1.2 (constants.%complete_type.136)]
-// CHECK:STDOUT:     complete_type_witness = %complete_type.loc14_1.1
+// CHECK:STDOUT:     %.loc7: @A.%A.elem (%A.elem.8a2) = field_decl v, element0 [concrete]
+// CHECK:STDOUT:     %complete_type.loc8_1.1: <witness> = complete_type_witness constants.%struct_type.v.a4d [symbolic = %complete_type.loc8_1.2 (constants.%complete_type.136)]
+// CHECK:STDOUT:     complete_type_witness = %complete_type.loc8_1.1
 // CHECK:STDOUT:
 // CHECK:STDOUT:   !members:
 // CHECK:STDOUT:     .Self = constants.%A.95c
 // CHECK:STDOUT:     .T = <poisoned>
-// CHECK:STDOUT:     .v = %.loc13
+// CHECK:STDOUT:     .v = %.loc7
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -193,7 +193,7 @@ fn G() { F(B); }
 // CHECK:STDOUT:   %A => constants.%A.764
 // CHECK:STDOUT:   %A.elem => constants.%A.elem.46a
 // CHECK:STDOUT:   %struct_type.v => constants.%struct_type.v.b74
-// CHECK:STDOUT:   %complete_type.loc14_1.2 => constants.%complete_type.aac
+// CHECK:STDOUT:   %complete_type.loc8_1.2 => constants.%complete_type.aac
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- incomplete_in_function.carbon

--- a/toolchain/check/testdata/generic/extend_type_completion.carbon
+++ b/toolchain/check/testdata/generic/extend_type_completion.carbon
@@ -28,16 +28,16 @@ library "[[@TEST_NAME]]";
 interface K(T:! type) {}
 
 class C(N:! i32) {
-  // CHECK:STDERR: fail_class_extend_impl_does_need_complete_interface.carbon:[[@LINE+3]]:18: error: array bound of -1 is negative [ArrayBoundNegative]
-  // CHECK:STDERR:   extend impl as K(array(i32, N)) {}
-  // CHECK:STDERR:                  ^~~~~~~~~~~~~~~~
   extend impl as K(array(i32, N)) {}
 }
 
 // C extends K so the type of K is completed, but is invalid.
-// CHECK:STDERR: fail_class_extend_impl_does_need_complete_interface.carbon:[[@LINE+4]]:8: note: in `C(-1)` used here [ResolvingSpecificHere]
+// CHECK:STDERR: fail_class_extend_impl_does_need_complete_interface.carbon:[[@LINE+7]]:8: error: binding pattern has incomplete type `C(-1)` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var v: C(-1);
 // CHECK:STDERR:        ^~~~~
+// CHECK:STDERR: fail_class_extend_impl_does_need_complete_interface.carbon:[[@LINE-7]]:18: note: array bound of -1 is negative [ArrayBoundNegative]
+// CHECK:STDERR:   extend impl as K(array(i32, N)) {}
+// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 var v: C(-1);
 
@@ -57,15 +57,15 @@ library "[[@TEST_NAME]]";
 
 interface K(T:! type) {}
 interface J(N:! i32) {
-  // CHECK:STDERR: fail_interface_extend_require_impls_does_need_complete_interface.carbon:[[@LINE+3]]:24: error: array bound of -1 is negative [ArrayBoundNegative]
-  // CHECK:STDERR:   extend require impls K(array(i32, N));
-  // CHECK:STDERR:                        ^~~~~~~~~~~~~~~~
   extend require impls K(array(i32, N));
 }
 interface I(N:! i32) {
-  // CHECK:STDERR: fail_interface_extend_require_impls_does_need_complete_interface.carbon:[[@LINE+3]]:24: note: in `J(-1)` used here [ResolvingSpecificHere]
+  // CHECK:STDERR: fail_interface_extend_require_impls_does_need_complete_interface.carbon:[[@LINE+6]]:24: error: `J(N)` evaluates to incomplete type `J(-1)` [IncompleteTypeInMonomorphization]
   // CHECK:STDERR:   extend require impls J(N);
   // CHECK:STDERR:                        ^~~~
+  // CHECK:STDERR: fail_interface_extend_require_impls_does_need_complete_interface.carbon:[[@LINE-6]]:24: note: array bound of -1 is negative [ArrayBoundNegative]
+  // CHECK:STDERR:   extend require impls K(array(i32, N));
+  // CHECK:STDERR:                        ^~~~~~~~~~~~~~~~
   extend require impls J(N);
 }
 
@@ -97,15 +97,15 @@ library "[[@TEST_NAME]]";
 
 interface K(T:! type) {}
 constraint J(N:! i32) {
-  // CHECK:STDERR: fail_constraint_extend_require_impls_does_need_complete_interface.carbon:[[@LINE+3]]:24: error: array bound of -1 is negative [ArrayBoundNegative]
-  // CHECK:STDERR:   extend require impls K(array(i32, N));
-  // CHECK:STDERR:                        ^~~~~~~~~~~~~~~~
   extend require impls K(array(i32, N));
 }
 constraint I(N:! i32) {
-  // CHECK:STDERR: fail_constraint_extend_require_impls_does_need_complete_interface.carbon:[[@LINE+3]]:24: note: in `J(-1)` used here [ResolvingSpecificHere]
+  // CHECK:STDERR: fail_constraint_extend_require_impls_does_need_complete_interface.carbon:[[@LINE+6]]:24: error: `J(N)` evaluates to incomplete type `J(-1)` [IncompleteTypeInMonomorphization]
   // CHECK:STDERR:   extend require impls J(N);
   // CHECK:STDERR:                        ^~~~
+  // CHECK:STDERR: fail_constraint_extend_require_impls_does_need_complete_interface.carbon:[[@LINE-6]]:24: note: array bound of -1 is negative [ArrayBoundNegative]
+  // CHECK:STDERR:   extend require impls K(array(i32, N));
+  // CHECK:STDERR:                        ^~~~~~~~~~~~~~~~
   extend require impls J(N);
 }
 

--- a/toolchain/check/testdata/generic/identify_specific_facet_type.carbon
+++ b/toolchain/check/testdata/generic/identify_specific_facet_type.carbon
@@ -18,15 +18,15 @@ library "[[@TEST_NAME]]";
 
 interface K(T:! type) {}
 constraint J(N:! i32) {
-  // CHECK:STDERR: fail_error_in_identifying_require_facet_type.carbon:[[@LINE+6]]:30: error: array bound of -1 is negative [ArrayBoundNegative]
-  // CHECK:STDERR:   require impls K(array(i32, N));
-  // CHECK:STDERR:                              ^
-  // CHECK:STDERR: fail_error_in_identifying_require_facet_type.carbon:[[@LINE+3]]:3: note: in `require` used here [ResolvingSpecificHere]
-  // CHECK:STDERR:   require impls K(array(i32, N));
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   require impls K(array(i32, N));
 }
 
+// CHECK:STDERR: fail_error_in_identifying_require_facet_type.carbon:[[@LINE+10]]:1: error: facet type `J(-1)` cannot be identified in `impl as` [ImplOfUnidentifiedFacetType]
+// CHECK:STDERR: impl {} as J(-1) {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_error_in_identifying_require_facet_type.carbon:[[@LINE-6]]:30: note: array bound of -1 is negative [ArrayBoundNegative]
+// CHECK:STDERR:   require impls K(array(i32, N));
+// CHECK:STDERR:                              ^
 // CHECK:STDERR: fail_error_in_identifying_require_facet_type.carbon:[[@LINE+4]]:12: note: identifying facet type `J(-1)` here [IdentifyingFacetTypeHere]
 // CHECK:STDERR: impl {} as J(-1) {}
 // CHECK:STDERR:            ^~~~~
@@ -43,15 +43,15 @@ library "[[@TEST_NAME]]";
 
 interface K(T:! type) {}
 constraint J(N:! i32) {
-  // CHECK:STDERR: fail_error_in_identifying_extend_require_facet_type.carbon:[[@LINE+6]]:37: error: array bound of -1 is negative [ArrayBoundNegative]
-  // CHECK:STDERR:   extend require impls K(array(i32, N));
-  // CHECK:STDERR:                                     ^
-  // CHECK:STDERR: fail_error_in_identifying_extend_require_facet_type.carbon:[[@LINE+3]]:3: note: in `require` used here [ResolvingSpecificHere]
-  // CHECK:STDERR:   extend require impls K(array(i32, N));
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   extend require impls K(array(i32, N));
 }
 
+// CHECK:STDERR: fail_error_in_identifying_extend_require_facet_type.carbon:[[@LINE+10]]:1: error: facet type `J(-1)` cannot be identified in `impl as` [ImplOfUnidentifiedFacetType]
+// CHECK:STDERR: impl {} as J(-1) {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_error_in_identifying_extend_require_facet_type.carbon:[[@LINE-6]]:37: note: array bound of -1 is negative [ArrayBoundNegative]
+// CHECK:STDERR:   extend require impls K(array(i32, N));
+// CHECK:STDERR:                                     ^
 // CHECK:STDERR: fail_error_in_identifying_extend_require_facet_type.carbon:[[@LINE+4]]:12: note: identifying facet type `J(-1)` here [IdentifyingFacetTypeHere]
 // CHECK:STDERR: impl {} as J(-1) {}
 // CHECK:STDERR:            ^~~~~

--- a/toolchain/check/testdata/primitives/type_literals.carbon
+++ b/toolchain/check/testdata/primitives/type_literals.carbon
@@ -82,12 +82,12 @@ var test_i1: i1;
 // CHECK:STDERR:               ^~~
 // CHECK:STDERR:
 var test_i15: i15;
-// CHECK:STDERR: min_prelude/parts/int.carbon:11:9: error: integer type width of 1000000000 is greater than the maximum supported width of 8388608 [IntWidthTooLarge]
-// CHECK:STDERR:   adapt MakeInt(N);
-// CHECK:STDERR:         ^~~~~~~~~~
-// CHECK:STDERR: fail_iN_bad_width.carbon:[[@LINE+4]]:23: note: in `i1000000000` used here [ResolvingSpecificHere]
+// CHECK:STDERR: fail_iN_bad_width.carbon:[[@LINE+7]]:23: error: binding pattern has incomplete type `i1000000000` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var test_i1000000000: i1000000000;
 // CHECK:STDERR:                       ^~~~~~~~~~~
+// CHECK:STDERR: min_prelude/parts/int.carbon:11:9: note: integer type width of 1000000000 is greater than the maximum supported width of 8388608 [IntWidthTooLarge]
+// CHECK:STDERR:   adapt MakeInt(N);
+// CHECK:STDERR:         ^~~~~~~~~~
 // CHECK:STDERR:
 var test_i1000000000: i1000000000;
 // TODO: This diagnostic is not very good.
@@ -119,12 +119,12 @@ var test_u1: u1;
 // CHECK:STDERR:               ^~~
 // CHECK:STDERR:
 var test_u15: u15;
-// CHECK:STDERR: min_prelude/parts/uint.carbon:11:9: error: integer type width of 1000000000 is greater than the maximum supported width of 8388608 [IntWidthTooLarge]
-// CHECK:STDERR:   adapt MakeUInt(N);
-// CHECK:STDERR:         ^~~~~~~~~~~
-// CHECK:STDERR: fail_uN_bad_width.carbon:[[@LINE+4]]:23: note: in `u1000000000` used here [ResolvingSpecificHere]
+// CHECK:STDERR: fail_uN_bad_width.carbon:[[@LINE+7]]:23: error: binding pattern has incomplete type `u1000000000` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var test_u1000000000: u1000000000;
 // CHECK:STDERR:                       ^~~~~~~~~~~
+// CHECK:STDERR: min_prelude/parts/uint.carbon:11:9: note: integer type width of 1000000000 is greater than the maximum supported width of 8388608 [IntWidthTooLarge]
+// CHECK:STDERR:   adapt MakeUInt(N);
+// CHECK:STDERR:         ^~~~~~~~~~~
 // CHECK:STDERR:
 var test_u1000000000: u1000000000;
 // TODO: This diagnostic is not very good.
@@ -146,53 +146,53 @@ library "[[@TEST_NAME]]";
 // CHECK:STDERR:              ^~
 // CHECK:STDERR:
 var test_f0: f0;
-// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: error: unsupported floating-point bit width 1 [CompileTimeFloatBitWidth]
-// CHECK:STDERR:   adapt MakeFloat(N);
-// CHECK:STDERR:         ^~~~~~~~~~~~
-// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+4]]:14: note: in `f1` used here [ResolvingSpecificHere]
+// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+7]]:14: error: binding pattern has incomplete type `f1` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var test_f1: f1;
 // CHECK:STDERR:              ^~
-// CHECK:STDERR:
-var test_f1: f1;
-// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: error: unsupported floating-point bit width 15 [CompileTimeFloatBitWidth]
+// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: note: unsupported floating-point bit width 1 [CompileTimeFloatBitWidth]
 // CHECK:STDERR:   adapt MakeFloat(N);
 // CHECK:STDERR:         ^~~~~~~~~~~~
-// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+4]]:15: note: in `f15` used here [ResolvingSpecificHere]
+// CHECK:STDERR:
+var test_f1: f1;
+// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+7]]:15: error: binding pattern has incomplete type `f15` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var test_f15: f15;
 // CHECK:STDERR:               ^~~
+// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: note: unsupported floating-point bit width 15 [CompileTimeFloatBitWidth]
+// CHECK:STDERR:   adapt MakeFloat(N);
+// CHECK:STDERR:         ^~~~~~~~~~~~
 // CHECK:STDERR:
 var test_f15: f15;
 // TODO: Decide if we want to expose the x87 80-bit floating point type this way.
-// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: error: unsupported floating-point bit width 80 [CompileTimeFloatBitWidth]
-// CHECK:STDERR:   adapt MakeFloat(N);
-// CHECK:STDERR:         ^~~~~~~~~~~~
-// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+4]]:15: note: in `f80` used here [ResolvingSpecificHere]
+// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+7]]:15: error: binding pattern has incomplete type `f80` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var test_f80: f80;
 // CHECK:STDERR:               ^~~
+// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: note: unsupported floating-point bit width 80 [CompileTimeFloatBitWidth]
+// CHECK:STDERR:   adapt MakeFloat(N);
+// CHECK:STDERR:         ^~~~~~~~~~~~
 // CHECK:STDERR:
 var test_f80: f80;
-// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: error: unsupported floating-point bit width 100 [CompileTimeFloatBitWidth]
-// CHECK:STDERR:   adapt MakeFloat(N);
-// CHECK:STDERR:         ^~~~~~~~~~~~
-// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+4]]:16: note: in `f100` used here [ResolvingSpecificHere]
+// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+7]]:16: error: binding pattern has incomplete type `f100` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var test_f100: f100;
 // CHECK:STDERR:                ^~~~
+// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: note: unsupported floating-point bit width 100 [CompileTimeFloatBitWidth]
+// CHECK:STDERR:   adapt MakeFloat(N);
+// CHECK:STDERR:         ^~~~~~~~~~~~
 // CHECK:STDERR:
 var test_f100: f100;
-// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: error: unsupported floating-point bit width 1000000000 [CompileTimeFloatBitWidth]
-// CHECK:STDERR:   adapt MakeFloat(N);
-// CHECK:STDERR:         ^~~~~~~~~~~~
-// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+4]]:23: note: in `f1000000000` used here [ResolvingSpecificHere]
+// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+7]]:23: error: binding pattern has incomplete type `f1000000000` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var test_f1000000000: f1000000000;
 // CHECK:STDERR:                       ^~~~~~~~~~~
-// CHECK:STDERR:
-var test_f1000000000: f1000000000;
-// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: error: unsupported floating-point bit width 1000000000000 [CompileTimeFloatBitWidth]
+// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: note: unsupported floating-point bit width 1000000000 [CompileTimeFloatBitWidth]
 // CHECK:STDERR:   adapt MakeFloat(N);
 // CHECK:STDERR:         ^~~~~~~~~~~~
-// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+4]]:26: note: in `f1000000000000` used here [ResolvingSpecificHere]
+// CHECK:STDERR:
+var test_f1000000000: f1000000000;
+// CHECK:STDERR: fail_fN_bad_width.carbon:[[@LINE+7]]:26: error: binding pattern has incomplete type `f1000000000000` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var test_f1000000000000: f1000000000000;
 // CHECK:STDERR:                          ^~~~~~~~~~~~~~
+// CHECK:STDERR: min_prelude/parts/float.carbon:12:9: note: unsupported floating-point bit width 1000000000000 [CompileTimeFloatBitWidth]
+// CHECK:STDERR:   adapt MakeFloat(N);
+// CHECK:STDERR:         ^~~~~~~~~~~~
 // CHECK:STDERR:
 var test_f1000000000000: f1000000000000;
 

--- a/toolchain/check/type.cpp
+++ b/toolchain/check/type.cpp
@@ -4,6 +4,7 @@
 
 #include "toolchain/check/type.h"
 
+#include "toolchain/check/diagnostic_helpers.h"
 #include "toolchain/check/eval.h"
 #include "toolchain/check/facet_type.h"
 #include "toolchain/check/type_completion.h"
@@ -14,7 +15,8 @@
 namespace Carbon::Check {
 
 auto ValidateIntType(Context& context, SemIR::LocId loc_id,
-                     SemIR::IntType result) -> bool {
+                     MakeDiagnosticBuilderFn diagnoser, SemIR::IntType result)
+    -> bool {
   auto bit_width =
       context.insts().TryGetAs<SemIR::IntValue>(result.bit_width_id);
   if (!bit_width) {
@@ -25,27 +27,35 @@ auto ValidateIntType(Context& context, SemIR::LocId loc_id,
   if (bit_width_val.isZero() ||
       (context.types().IsSignedInt(bit_width->type_id) &&
        bit_width_val.isNegative())) {
-    CARBON_DIAGNOSTIC(IntWidthNotPositive, Error,
-                      "integer type width of {0} is not positive", TypedInt);
-    context.emitter().Emit(
-        loc_id, IntWidthNotPositive,
-        {.type = bit_width->type_id, .value = bit_width_val});
+    if (diagnoser) {
+      auto builder = diagnoser();
+      CARBON_DIAGNOSTIC(IntWidthNotPositive, Note,
+                        "integer type width of {0} is not positive", TypedInt);
+      builder.Note(loc_id, IntWidthNotPositive,
+                   {.type = bit_width->type_id, .value = bit_width_val});
+      builder.Emit();
+    }
     return false;
   }
   if (bit_width_val.ugt(IntStore::MaxIntWidth)) {
-    CARBON_DIAGNOSTIC(IntWidthTooLarge, Error,
-                      "integer type width of {0} is greater than the "
-                      "maximum supported width of {1}",
-                      TypedInt, int);
-    context.emitter().Emit(loc_id, IntWidthTooLarge,
-                           {.type = bit_width->type_id, .value = bit_width_val},
-                           IntStore::MaxIntWidth);
+    if (diagnoser) {
+      auto builder = diagnoser();
+      CARBON_DIAGNOSTIC(IntWidthTooLarge, Note,
+                        "integer type width of {0} is greater than the "
+                        "maximum supported width of {1}",
+                        TypedInt, int);
+      builder.Note(loc_id, IntWidthTooLarge,
+                   {.type = bit_width->type_id, .value = bit_width_val},
+                   IntStore::MaxIntWidth);
+      builder.Emit();
+    }
     return false;
   }
   return true;
 }
 
 auto ValidateFloatTypeAndSetKind(Context& context, SemIR::LocId loc_id,
+                                 MakeDiagnosticBuilderFn diagnoser,
                                  SemIR::FloatType& result) -> bool {
   // Get the bit width value.
   auto bit_width_inst =
@@ -72,10 +82,15 @@ auto ValidateFloatTypeAndSetKind(Context& context, SemIR::LocId loc_id,
         result.float_kind = SemIR::FloatKind::Binary128;
         break;
       default:
-        CARBON_DIAGNOSTIC(CompileTimeFloatBitWidth, Error,
-                          "unsupported floating-point bit width {0}", TypedInt);
-        context.emitter().Emit(loc_id, CompileTimeFloatBitWidth,
-                               TypedInt(bit_width_inst->type_id, bit_width));
+        if (diagnoser) {
+          auto builder = diagnoser();
+          CARBON_DIAGNOSTIC(CompileTimeFloatBitWidth, Note,
+                            "unsupported floating-point bit width {0}",
+                            TypedInt);
+          builder.Note(loc_id, CompileTimeFloatBitWidth,
+                       TypedInt(bit_width_inst->type_id, bit_width));
+          builder.Emit();
+        }
         return false;
     }
   }

--- a/toolchain/check/type.h
+++ b/toolchain/check/type.h
@@ -13,11 +13,13 @@ namespace Carbon::Check {
 
 // Enforces that an integer type has a valid bit width.
 auto ValidateIntType(Context& context, SemIR::LocId loc_id,
-                     SemIR::IntType result) -> bool;
+                     MakeDiagnosticBuilderFn diagnoser, SemIR::IntType result)
+    -> bool;
 
 // Enforces that a float type has a valid bit width. If the `float_kind` field
 // is `None`, sets it to a suitable kind for the bit width.
 auto ValidateFloatTypeAndSetKind(Context& context, SemIR::LocId loc_id,
+                                 MakeDiagnosticBuilderFn diagnoser,
                                  SemIR::FloatType& result) -> bool;
 
 // Gets the type to use for an unbound associated entity declared in this

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -108,7 +108,8 @@ static auto RequireCompleteFacetType(Context& context, SemIR::LocId loc_id,
       return false;
     }
     if (interface.generic_id.has_value()) {
-      ResolveSpecificDefinition(context, loc_id, extends.specific_id);
+      ResolveSpecificDefinition(context, loc_id, extends.specific_id,
+                                diagnoser);
     }
   }
 
@@ -125,7 +126,8 @@ static auto RequireCompleteFacetType(Context& context, SemIR::LocId loc_id,
       return false;
     }
     if (constraint.generic_id.has_value()) {
-      ResolveSpecificDefinition(context, loc_id, extends.specific_id);
+      ResolveSpecificDefinition(context, loc_id, extends.specific_id,
+                                diagnoser);
     }
   }
 
@@ -417,7 +419,8 @@ auto TypeCompleter::AddNestedIncompleteTypes(SemIR::Inst type_inst) -> bool {
         return false;
       }
       if (inst.specific_id.has_value()) {
-        ResolveSpecificDefinition(*context_, loc_id_, inst.specific_id);
+        ResolveSpecificDefinition(*context_, loc_id_, inst.specific_id,
+                                  diagnoser_);
       }
       if (auto adapted_type_id =
               class_info.GetAdaptedType(context_->sem_ir(), inst.specific_id);
@@ -926,7 +929,8 @@ auto RequireIdentifiedFacetType(Context& context, SemIR::LocId loc_id,
         const auto& require = context.require_impls().Get(require_impls_id);
         auto require_specific =
             GetRequireImplsSpecificFromEnclosingSpecificWithSelfFacetValue(
-                context, require, extends.specific_id, self_facet_value);
+                context, require, extends.specific_id, self_facet_value,
+                diagnoser);
         auto require_self = GetConstantValueInRequireImplsSpecific(
             context, require_specific, require.self_id);
         auto require_facet_type = GetConstantValueInRequireImplsSpecific(
@@ -958,7 +962,8 @@ auto RequireIdentifiedFacetType(Context& context, SemIR::LocId loc_id,
         const auto& require = context.require_impls().Get(require_impls_id);
         auto require_specific =
             GetRequireImplsSpecificFromEnclosingSpecificWithSelfFacetValue(
-                context, require, impls.specific_id, self_facet_value);
+                context, require, impls.specific_id, self_facet_value,
+                diagnoser);
         auto require_self = GetConstantValueInRequireImplsSpecific(
             context, require_specific, require.self_id);
         auto require_facet_type = GetConstantValueInRequireImplsSpecific(

--- a/toolchain/diagnostics/emitter.h
+++ b/toolchain/diagnostics/emitter.h
@@ -193,6 +193,25 @@ class Emitter {
     }
   }
 
+  // For functions that produce diagnostics, either makes a new diagnostic, or
+  // uses the diagnoser, if present to make one and adds the new diagnostic as a
+  // note.
+  template <typename... Args>
+  auto BuildDiagnosticOrNote(
+      llvm::function_ref<auto()->Builder> diagnoser, LocT loc,
+      const Diagnostics::DiagnosticBase<Args...>& diagnostic_base,
+      Internal::NoTypeDeduction<Args>... args) -> Builder {
+    if (diagnoser) {
+      auto note = diagnostic_base;
+      note.Level = Diagnostics::Level::Note;
+      auto builder = diagnoser();
+      builder.Note(loc, note, std::forward<Args>(args)...);
+      return builder;
+    } else {
+      return Build(loc, diagnostic_base, std::forward<Args>(args)...);
+    }
+  }
+
  protected:
   // Callback type used to report context messages from ConvertLoc.
   // Note that the first parameter type is Loc rather than

--- a/toolchain/diagnostics/kind.def
+++ b/toolchain/diagnostics/kind.def
@@ -312,6 +312,7 @@ CARBON_DIAGNOSTIC_KIND(DeductionGenericHere)
 CARBON_DIAGNOSTIC_KIND(InitializingGenericParam)
 CARBON_DIAGNOSTIC_KIND(CompTimeArgumentNotConstant)
 CARBON_DIAGNOSTIC_KIND(RuntimeConversionDuringCompTimeDeduction)
+CARBON_DIAGNOSTIC_KIND(MonomorphizationErrorInDeduce)
 
 // Export checking.
 CARBON_DIAGNOSTIC_KIND(ExportNotImportedEntity)
@@ -368,6 +369,10 @@ CARBON_DIAGNOSTIC_KIND(MissingImplInMemberAccessNote)
 CARBON_DIAGNOSTIC_KIND(ImplLookupCycle)
 CARBON_DIAGNOSTIC_KIND(ImplLookupCycleNote)
 CARBON_DIAGNOSTIC_KIND(ImplLookupInUnidentifiedFacetType)
+
+// Int and Float types
+CARBON_DIAGNOSTIC_KIND(FloatTypeInvalid)
+CARBON_DIAGNOSTIC_KIND(IntTypeInvalid)
 
 // Require checking.
 CARBON_DIAGNOSTIC_KIND(RequireImplsExtendWithExplicitSelf)

--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -284,6 +284,7 @@ class InstKind : public CARBON_ENUM_BASE(InstKind) {
         constant_kind == InstConstantKind::AlwaysUnique
             ? InstConstantNeedsInstIdKind::Permanent
             : InstConstantNeedsInstIdKind::No;
+    bool constant_needs_diagnoser = false;
     TerminatorKind terminator_kind = TerminatorKind::NotTerminator;
     bool is_lowered = true;
     bool deduce_through = false;
@@ -423,6 +424,16 @@ class InstKind::Definition : public InstKind {
   // Returns whether constant evaluation of this instruction needs an InstId.
   constexpr auto constant_needs_inst_id() const -> InstConstantNeedsInstIdKind {
     return info_.constant_needs_inst_id;
+  }
+
+  // Whether evaluation of the instruction can produce an error. Any instruction
+  // whose evaluation can produce a diagnostic should use `true`.
+  //
+  // Errors during eval lead to monomorphization errors when evaluating a
+  // specific. Emitting an error needs a diagnoser to properly attribute that
+  // error back to the specific instantiation when possible.
+  constexpr auto constant_needs_diagnoser() const -> bool {
+    return info_.constant_needs_diagnoser;
   }
 
   // Returns whether this instruction kind is a code block terminator. See

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -181,6 +181,7 @@ struct ArrayType {
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Conditional,
        .constant_needs_inst_id = InstConstantNeedsInstIdKind::DuringEvaluation,
+       .constant_needs_diagnoser = true,
        .deduce_through = true});
 
   TypeId type_id;
@@ -723,6 +724,7 @@ struct FloatType {
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Conditional,
        .constant_needs_inst_id = InstConstantNeedsInstIdKind::DuringEvaluation,
+       .constant_needs_diagnoser = true,
        .deduce_through = true});
 
   TypeId type_id;
@@ -887,6 +889,7 @@ struct ImplWitnessAccess {
            .constant_kind = InstConstantKind::SymbolicOnly,
            .constant_needs_inst_id =
                InstConstantNeedsInstIdKind::DuringEvaluation,
+           .constant_needs_diagnoser = true,
            .is_lowered = false});
 
   TypeId type_id;
@@ -1109,6 +1112,7 @@ struct IntType {
        .is_type = InstIsType::Always,
        .constant_kind = InstConstantKind::Conditional,
        .constant_needs_inst_id = InstConstantNeedsInstIdKind::DuringEvaluation,
+       .constant_needs_diagnoser = true,
        .deduce_through = true});
 
   TypeId type_id;
@@ -1440,6 +1444,7 @@ struct RequireCompleteType {
            .constant_kind = InstConstantKind::SymbolicOnly,
            .constant_needs_inst_id =
                InstConstantNeedsInstIdKind::DuringEvaluation,
+           .constant_needs_diagnoser = true,
            .is_lowered = false});
   // Always the builtin `WitnessType` type.
   TypeId type_id;
@@ -1466,6 +1471,7 @@ struct RequireSpecificDefinition {
       InstKind::RequireSpecificDefinition.Define<Parse::NodeId>(
           {.ir_name = "require_specific_def",
            .constant_kind = InstConstantKind::Conditional,
+           .constant_needs_diagnoser = true,
            .is_lowered = false});
   // Always the builtin `RequireSpecificDefinitionType` type.
   TypeId type_id;
@@ -1668,7 +1674,8 @@ struct SpecificImplFunction {
           {.ir_name = "specific_impl_function",
            .constant_kind = InstConstantKind::SymbolicOnly,
            // InstId is added to definitions_required_by_use.
-           .constant_needs_inst_id = InstConstantNeedsInstIdKind::Permanent});
+           .constant_needs_inst_id = InstConstantNeedsInstIdKind::Permanent,
+           .constant_needs_diagnoser = true});
 
   // Always the builtin SpecificFunctionType.
   TypeId type_id;


### PR DESCRIPTION
Eval should use the diagnoser when provided, to produce a diagnostic that explains the failing operation, and attach its own failures as notes to it. But if no diagnoser is provided, then it needs to still produce a top-level diagnostic of its own.

There are some questions to be resolved in this PR still:
- Should eval have both: "squelch diagnostics", and "produce your own diagnostics", in addition to "here's a diagnoser, attach notes"? Or should it not have the "ignore diagnostics" option?
  - This relates to things that it then calls outside of eval which now need to accept a diagnoser. Usually (elsewhere) a null diagnoser means "squelch diagnostics". But atm null in eval means "produce your own diagnostics".
- Should we _require_ all callers that evaluate a specific to provide a diagnoser?