### PR TITLE
Only treat top-level Run in Main as the entry point

### DIFF
--- a/toolchain/lower/testdata/interop/cpp/cpp_run.carbon
+++ b/toolchain/lower/testdata/interop/cpp/cpp_run.carbon
@@ -34,16 +34,10 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CMain.Main() #1 !dbg !12 {
+// CHECK:STDOUT: define void @main() #1 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !15
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #1 !dbg !16 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_ZN1N3RunEv(), !dbg !17
-// CHECK:STDOUT:   ret void, !dbg !18
+// CHECK:STDOUT:   call void @_ZN1N3RunEv(), !dbg !15
+// CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
@@ -65,10 +59,8 @@ fn Run() {
 // CHECK:STDOUT: !9 = !{!"int", !10, i64 0}
 // CHECK:STDOUT: !10 = !{!"omnipotent char", !11, i64 0}
 // CHECK:STDOUT: !11 = !{!"Simple C++ TBAA"}
-// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Main", linkageName: "_CMain.Main", scope: null, file: !7, line: 8, type: !13, spFlags: DISPFlagDefinition, unit: !6)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !7, line: 8, type: !13, spFlags: DISPFlagDefinition, unit: !6)
 // CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
 // CHECK:STDOUT: !14 = !{null}
-// CHECK:STDOUT: !15 = !DILocation(line: 8, column: 1, scope: !12)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !7, line: 10, type: !13, spFlags: DISPFlagDefinition, unit: !6)
-// CHECK:STDOUT: !17 = !DILocation(line: 11, column: 3, scope: !16)
-// CHECK:STDOUT: !18 = !DILocation(line: 10, column: 1, scope: !16)
+// CHECK:STDOUT: !15 = !DILocation(line: 9, column: 3, scope: !12)
+// CHECK:STDOUT: !16 = !DILocation(line: 8, column: 1, scope: !12)

--- a/toolchain/lower/testdata/interop/cpp/cpp_run.carbon
+++ b/toolchain/lower/testdata/interop/cpp/cpp_run.carbon
@@ -1,0 +1,74 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/interop/cpp/cpp_run.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/interop/cpp/cpp_run.carbon
+
+// --- carbon_run.carbon
+
+import Cpp inline '''
+namespace N {
+  void Run() {}
+}
+''';
+
+fn Run() {
+  Cpp.N.Run();
+}
+
+// CHECK:STDOUT: ; ModuleID = 'carbon_run.carbon'
+// CHECK:STDOUT: source_filename = "carbon_run.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: mustprogress nounwind uwtable
+// CHECK:STDOUT: define dso_local void @_ZN1N3RunEv() #0 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CMain.Main() #1 !dbg !12 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @main() #1 !dbg !16 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN1N3RunEv(), !dbg !17
+// CHECK:STDOUT:   ret void, !dbg !18
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #1 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!6}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!8}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 1, !"wchar_size", i32 4}
+// CHECK:STDOUT: !3 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !5 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !6 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !7, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !7 = !DIFile(filename: "carbon_run.carbon", directory: "")
+// CHECK:STDOUT: !8 = !{!9, !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"int", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"omnipotent char", !11, i64 0}
+// CHECK:STDOUT: !11 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Main", linkageName: "_CMain.Main", scope: null, file: !7, line: 8, type: !13, spFlags: DISPFlagDefinition, unit: !6)
+// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
+// CHECK:STDOUT: !14 = !{null}
+// CHECK:STDOUT: !15 = !DILocation(line: 8, column: 1, scope: !12)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !7, line: 10, type: !13, spFlags: DISPFlagDefinition, unit: !6)
+// CHECK:STDOUT: !17 = !DILocation(line: 11, column: 3, scope: !16)
+// CHECK:STDOUT: !18 = !DILocation(line: 10, column: 1, scope: !16)

--- a/toolchain/lower/testdata/namespace/namespace_run.carbon
+++ b/toolchain/lower/testdata/namespace/namespace_run.carbon
@@ -6,9 +6,9 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/namespace/namespaced_run.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/namespace/namespace_run.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/namespace/namespaced_run.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/namespace/namespace_run.carbon
 
 namespace Foo;
 
@@ -18,8 +18,8 @@ fn Run() {
     Foo.Run();
 }
 
-// CHECK:STDOUT: ; ModuleID = 'namespaced_run.carbon'
-// CHECK:STDOUT: source_filename = "namespaced_run.carbon"
+// CHECK:STDOUT: ; ModuleID = 'namespace_run.carbon'
+// CHECK:STDOUT: source_filename = "namespace_run.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CRun.Foo.Main() #0 !dbg !4 {
@@ -42,7 +42,7 @@ fn Run() {
 // CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !3 = !DIFile(filename: "namespaced_run.carbon", directory: "")
+// CHECK:STDOUT: !3 = !DIFile(filename: "namespace_run.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "_CRun.Foo.Main", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}

--- a/toolchain/lower/testdata/namespace/namespaced_run.carbon
+++ b/toolchain/lower/testdata/namespace/namespaced_run.carbon
@@ -1,0 +1,52 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/namespace/namespaced_run.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/namespace/namespaced_run.carbon
+
+namespace Foo;
+
+fn Foo.Run() {}
+
+fn Run() {
+    Foo.Run();
+}
+
+// CHECK:STDOUT: ; ModuleID = 'namespaced_run.carbon'
+// CHECK:STDOUT: source_filename = "namespaced_run.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CRun.Foo.Main() #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !7
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @main() #0 !dbg !8 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CRun.Foo.Main(), !dbg !9
+// CHECK:STDOUT:   ret void, !dbg !10
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "namespaced_run.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "_CRun.Foo.Main", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{null}
+// CHECK:STDOUT: !7 = !DILocation(line: 15, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !9 = !DILocation(line: 18, column: 5, scope: !8)
+// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 1, scope: !8)

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -236,6 +236,7 @@ cc_library(
     hdrs = ["entry_point.h"],
     deps = [
         ":file",
+        ":typed_insts",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/sem_ir/entry_point.cpp
+++ b/toolchain/sem_ir/entry_point.cpp
@@ -5,21 +5,18 @@
 #include "toolchain/sem_ir/entry_point.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "toolchain/sem_ir/ids.h"
 
 namespace Carbon::SemIR {
 
 static constexpr llvm::StringLiteral EntryPointFunction = "Run";
 
 auto IsEntryPoint(const File& file, FunctionId function_id) -> bool {
-  // TODO: Check if `file` is in the `Main` package.
   const auto& function = file.functions().Get(function_id);
 
-  if (function.clang_decl_id.has_value()) {
-    return false;
-  }
-
-  // TODO: Check if `function` is in a namespace.
-  return function.name_id.has_value() &&
+  return function.parent_scope_id == NameScopeId::Package &&
+         file.package_id() == PackageNameId::None &&
+         function.name_id.has_value() &&
          file.names().GetAsStringIfIdentifier(function.name_id) ==
              EntryPointFunction;
 }

--- a/toolchain/sem_ir/entry_point.cpp
+++ b/toolchain/sem_ir/entry_point.cpp
@@ -13,6 +13,11 @@ static constexpr llvm::StringLiteral EntryPointFunction = "Run";
 auto IsEntryPoint(const File& file, FunctionId function_id) -> bool {
   // TODO: Check if `file` is in the `Main` package.
   const auto& function = file.functions().Get(function_id);
+
+  if (function.clang_decl_id.has_value()) {
+    return false;
+  }
+
   // TODO: Check if `function` is in a namespace.
   return function.name_id.has_value() &&
          file.names().GetAsStringIfIdentifier(function.name_id) ==


### PR DESCRIPTION
Fix IsEntryPoint to only recognize `Run` as the program entry point when it is declared at package scope in the `Main` package, not when it appears inside a namespace or via C++ interop.

Closes #6755
