### PR TITLE
Split build information for CRT into Starlark

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -119,6 +119,7 @@ http_archive(
         "@carbon//bazel/llvm_project:0004_Introduce_basic_sources_exporting_for_libunwind.patch",
         "@carbon//bazel/llvm_project:0005_Introduce_basic_sources_exporting_for_libcxx_and_libcxxabi.patch",
         "@carbon//bazel/llvm_project:0008_Add_filegroups_for_installed_compiler-rt_headers.patch",
+        "@carbon//bazel/llvm_project:0009_Introduce_starlark_exporting_compiler-rt_build_information.patch",
     ],
     strip_prefix = "llvm-project-{0}".format(llvm_project_version),
     urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_project_version)],

--- a/bazel/llvm_project/0009_Introduce_starlark_exporting_compiler-rt_build_information.patch
+++ b/bazel/llvm_project/0009_Introduce_starlark_exporting_compiler-rt_build_information.patch
@@ -1,0 +1,35 @@
+Commit ID: 530e0f9ebec68a481e6c67e81e5ac6551a6a0bef
+Change ID: zyxuvzwmzsnorloyuupuurxkppkoplnw
+Author   : Chandler Carruth <chandlerc@gmail.com> (2026-02-16 23:17:06)
+Committer: Chandler Carruth <chandlerc@gmail.com> (2026-02-16 23:17:28)
+
+    Introduce starlark exporting compiler-rt build information
+
+diff --git a/utils/bazel/llvm-project-overlay/compiler-rt/compiler-rt.bzl b/utils/bazel/llvm-project-overlay/compiler-rt/compiler-rt.bzl
+new file mode 100644
+index 0000000000..4d0bdeeff3
+--- /dev/null
++++ b/utils/bazel/llvm-project-overlay/compiler-rt/compiler-rt.bzl
+@@ -0,0 +1,22 @@
++# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
++# See https://llvm.org/LICENSE.txt for license information.
++# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++
++"""Starlark variables and macros for building parts of compiler-rt.
++
++Variables provide base line information for how to build various parts of
++compiler-rt. These can be used to generate non-Bazel builds of the library.
++
++TODO: Add macros that provide a convenient way to construct a Bazel target for
++the Clang resource directory with builtins and crt files.
++"""
++
++crt_copts = [
++    "-DCRT_HAS_INITFINI_ARRAY",
++    "-DEH_USE_FRAME_REGISTRY",
++    "-O3",
++    "-fPIC",
++    "-ffreestanding",
++    "-fno-lto",
++    "-std=c11",
++]

--- a/bazel/llvm_project/0009_Introduce_starlark_exporting_compiler-rt_build_information.patch
+++ b/bazel/llvm_project/0009_Introduce_starlark_exporting_compiler-rt_build_information.patch
@@ -17,7 +17,7 @@ index 0000000000..4d0bdeeff3
 +
 +"""Starlark variables and macros for building parts of compiler-rt.
 +
-+Variables provide base line information for how to build various parts of
++Variables provide baseline information for how to build various parts of
 +compiler-rt. These can be used to generate non-Bazel builds of the library.
 +
 +TODO: Add macros that provide a convenient way to construct a Bazel target for

--- a/toolchain/base/runtimes_build_info.bzl
+++ b/toolchain/base/runtimes_build_info.bzl
@@ -19,6 +19,7 @@ Future runtimes we plan to add support for but not yet included:
 - Profiling runtimes
 """
 
+load("@llvm-project//compiler-rt:compiler-rt.bzl", "crt_copts")
 load("@llvm-project//libcxx:libcxx_library.bzl", "libcxx_and_abi_copts")
 load("@llvm-project//libunwind:libunwind_library.bzl", "libunwind_copts")
 load("//bazel/cc_rules:defs.bzl", "cc_library")
@@ -96,6 +97,7 @@ def _get_paths(files_attr, to_path_fn, prefix = ""):
 def _get_substitutions(ctx):
     key_attr = lambda k: getattr(ctx.attr, "_" + k)
     return {
+        "CRT_COPTS": _format_one_per_line(crt_copts),
         "LIBCXX_AND_ABI_COPTS": _format_one_per_line(libcxx_and_abi_copts),
         "LIBUNWIND_COPTS": _format_one_per_line(libunwind_copts),
     } | {

--- a/toolchain/base/runtimes_build_info.tpl.h
+++ b/toolchain/base/runtimes_build_info.tpl.h
@@ -17,6 +17,8 @@ namespace Carbon::RuntimesBuildInfo {
 constexpr inline llvm::StringLiteral CrtBegin = CRTBEGIN_SRC;
 constexpr inline llvm::StringLiteral CrtEnd = CRTEND_SRC;
 
+constexpr inline llvm::StringLiteral CrtCopts[] = {CRT_COPTS};
+
 // Prevent wrapping these lines -- the expansion of the variables will add line
 // breaks.
 //

--- a/toolchain/driver/clang_runtimes.cpp
+++ b/toolchain/driver/clang_runtimes.cpp
@@ -536,21 +536,20 @@ auto ClangResourceDirBuilder::BuildCrtFile(llvm::StringRef src_file)
       installation().runtimes_root() / std::string_view(src_file);
   CARBON_VLOG("Building `{0}' from `{1}`...\n", out_path, src_path);
 
-  CARBON_ASSIGN_OR_RETURN(bool success, clang_->RunWithNoRuntimes({
-                                            "-no-canonical-prefixes",
-                                            "-DCRT_HAS_INITFINI_ARRAY",
-                                            "-DEH_USE_FRAME_REGISTRY",
-                                            "-O3",
-                                            "-fPIC",
-                                            "-ffreestanding",
-                                            "-std=c11",
-                                            "-w",
-                                            "-c",
-                                            target_flag_,
-                                            "-o",
-                                            out_path.native(),
-                                            src_path.native(),
-                                        }));
+  llvm::SmallVector<llvm::StringRef> copts = {
+      "-no-canonical-prefixes",
+      "-w",
+      target_flag_,
+  };
+  llvm::append_range(copts, RuntimesBuildInfo::CrtCopts);
+  copts.append({
+      "-c",
+      "-o",
+      out_path.native(),
+      src_path.native(),
+  });
+
+  CARBON_ASSIGN_OR_RETURN(bool success, clang_->RunWithNoRuntimes(copts));
 
   if (success) {
     return Success();


### PR DESCRIPTION
This isn't as interesting as others, as it only involves compile options.

It also adds a missing flag of `-fno-lto` as these objects can't be LTO-ed.