### PR TITLE
Add Open VSX publishing for VSCode extension

### DIFF
--- a/.github/workflows/publish_vscode_extension.yaml
+++ b/.github/workflows/publish_vscode_extension.yaml
@@ -1,0 +1,72 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Publishes the Carbon Language VSCode extension to both the VS Code
+# Marketplace and Open VSX Registry (open-vsx.org).
+
+name: Publish VSCode Extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_targets:
+        description: 'Where to publish'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - marketplace-only
+          - open-vsx-only
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: utils/vscode
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: block
+          # prettier-ignore
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+            marketplace.visualstudio.com:443
+            open-vsx.org:443
+
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build VSIX package
+        run: npx vsce package -o carbon.vsix
+
+      - name: Publish to VS Code Marketplace
+        if: >-
+          inputs.publish_targets == 'both' ||
+          inputs.publish_targets == 'marketplace-only'
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx vsce publish --pat "$VSCE_PAT"
+
+      - name: Publish to Open VSX
+        if: >-
+          inputs.publish_targets == 'both' ||
+          inputs.publish_targets == 'open-vsx-only'
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: npx ovsx publish carbon.vsix --pat "$OVSX_PAT"

--- a/utils/vscode/development.md
+++ b/utils/vscode/development.md
@@ -50,6 +50,24 @@ in your `$PATH` environment variable to use it.
     3. Next to the extension name, click the "..." and select "Update".
     4. Select the `carbon.vsix` file.
 
+-   Build and publish to Open VSX manually:
+
+    1. `npm install && vsce package -o carbon.vsix`
+    2. `npx ovsx publish carbon.vsix --pat <your-open-vsx-token>`
+
+    Note: The `carbon-lang` namespace must exist on open-vsx.org. Create it
+    with: `npx ovsx create-namespace carbon-lang --pat <your-token>`
+
+-   Publish via CI (recommended):
+
+    1. Go to the
+       [Publish VSCode Extension](https://github.com/carbon-language/carbon-lang/actions/workflows/publish_vscode_extension.yaml)
+       workflow in GitHub Actions.
+    2. Click "Run workflow" and select the publish target (both, marketplace
+       only, or Open VSX only).
+    3. The workflow requires two repository secrets: `VSCE_PAT` (VS Code
+       Marketplace token) and `OVSX_PAT` (Open VSX token).
+
 ## Development
 
 1.  `bazel build //toolchain` in project root.

--- a/utils/vscode/package.json
+++ b/utils/vscode/package.json
@@ -83,6 +83,7 @@
     "@vscode/vsce": "^2.27.0",
     "esbuild": "^0.25.0",
     "eslint": "^9.13.0",
+    "ovsx": "^0.10.0",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.16.0"
   },


### PR DESCRIPTION
## Summary

Adds support for publishing the Carbon Language VSCode extension to [open-vsx.org](https://open-vsx.org), addressing **#6766**.

This enables users of VSCodium, Cursor, Antigravity, and other VS Code-compatible IDEs to install the Carbon Language extension from the Open VSX Registry.

## Changes

### New: `.github/workflows/publish_vscode_extension.yaml`
GitHub Actions workflow that:
- Triggers via **`workflow_dispatch`** with a selectable publish target (`both`, `marketplace-only`, `open-vsx-only`)
- Builds the VSIX package
- Publishes to **VS Code Marketplace** via `vsce`
- Publishes to **Open VSX** via `ovsx`
- Follows existing CI patterns: pinned action versions, `step-security/harden-runner` with egress policy

### Modified: `utils/vscode/package.json`
- Added `ovsx` (`^0.10.0`) as a devDependency

### Modified: `utils/vscode/development.md`
- Added documentation for manual Open VSX publishing
- Added documentation for CI-based publishing workflow
- Documented required repository secrets

## Setup Required (by maintainer)

Before the first publish, the following one-time setup is needed:

1. **Create the `carbon-lang` namespace on open-vsx.org:**
   ```
   npx ovsx create-namespace carbon-lang --pat <token>
   ```
2. **Add repository secrets:**
   - `VSCE_PAT` — Personal Access Token for VS Code Marketplace
   - `OVSX_PAT` — Access Token from open-vsx.org

## Testing

- Workflow can be tested by running it manually from the Actions tab after secrets are configured
- Dry-run is possible locally: `npx ovsx publish carbon.vsix --dry-run`

Closes #6766