### PR TITLE
Rewrite the FormatterChunks API 

### DIFF
--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -216,7 +216,6 @@ cc_library(
     hdrs = ["formatter_chunks.h"],
     deps = [
         "//common:check",
-        "//toolchain/base:value_store",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -216,6 +216,7 @@ cc_library(
     hdrs = ["formatter_chunks.h"],
     deps = [
         "//common:check",
+        "//toolchain/base:value_store",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -55,24 +55,25 @@ Formatter::Formatter(
       get_tree_and_subtrees_(get_tree_and_subtrees),
       include_ir_in_dumps_(include_ir_in_dumps),
       use_dump_sem_ir_ranges_(use_dump_sem_ir_ranges),
-      // Create a placeholder visible chunk and assign it to all instructions
-      // that don't have a chunk of their own.
       tentative_inst_chunks_(sem_ir_->insts(), FormatterChunks::None) {
   if (use_dump_sem_ir_ranges_) {
     ComputeNodeParents();
   }
 
+  // Reserve space for parents. There will be more content, but we don't try to
+  // guess how much.
   size_t reserve_chunks = scope_label_chunks_.size();
   for (auto [_, insts] : GetTentativeScopes(*sem_ir_)) {
     reserve_chunks += insts.size();
   }
   chunks_.Reserve(reserve_chunks);
 
+  // Create parent chunks for scopes.
   for (auto& chunk : scope_label_chunks_) {
     chunk = chunks_.AddParent();
   }
 
-  // Create empty parent chunks for instructions that we output lazily.
+  // Create parent chunks for the tentative instructions.
   for (auto [scope_id, insts] : GetTentativeScopes(*sem_ir_)) {
     auto scope_chunk = scope_label_chunks_[static_cast<size_t>(scope_id)];
     for (auto inst_id : insts) {
@@ -84,7 +85,7 @@ Formatter::Formatter(
 
   CARBON_CHECK(chunks_.size() == reserve_chunks);
 
-  // Create a content chunk for the start of the output.
+  // Prepare to add content.
   chunks_.StartContent();
 }
 

--- a/toolchain/sem_ir/formatter.cpp
+++ b/toolchain/sem_ir/formatter.cpp
@@ -57,28 +57,35 @@ Formatter::Formatter(
       use_dump_sem_ir_ranges_(use_dump_sem_ir_ranges),
       // Create a placeholder visible chunk and assign it to all instructions
       // that don't have a chunk of their own.
-      tentative_inst_chunks_(
-          sem_ir_->insts(),
-          chunks_.AddChunkNoFlush(/*include_in_output=*/true)) {
+      tentative_inst_chunks_(sem_ir_->insts(), FormatterChunks::None) {
   if (use_dump_sem_ir_ranges_) {
     ComputeNodeParents();
   }
 
+  size_t reserve_chunks = scope_label_chunks_.size();
+  for (auto [_, insts] : GetTentativeScopes(*sem_ir_)) {
+    reserve_chunks += insts.size();
+  }
+  chunks_.Reserve(reserve_chunks);
+
   for (auto& chunk : scope_label_chunks_) {
-    chunk = chunks_.AddChunkNoFlush(/*include_in_output=*/false);
+    chunk = chunks_.AddParent();
   }
 
-  // Create empty placeholder chunks for instructions that we output lazily.
+  // Create empty parent chunks for instructions that we output lazily.
   for (auto [scope_id, insts] : GetTentativeScopes(*sem_ir_)) {
     auto scope_chunk = scope_label_chunks_[static_cast<size_t>(scope_id)];
     for (auto inst_id : insts) {
-      tentative_inst_chunks_.Set(
-          inst_id, chunks_.AddTentativeChunkWithChild(scope_chunk));
+      // Instructions are "parents" of their scopes because if any instruction
+      // is printed, the label is also printed.
+      tentative_inst_chunks_.Set(inst_id, chunks_.AddParent(scope_chunk));
     }
   }
 
-  // Create a real chunk for the start of the output.
-  chunks_.AddChunkNoFlush(/*include_in_output=*/true);
+  CARBON_CHECK(chunks_.size() == reserve_chunks);
+
+  // Create a content chunk for the start of the output.
+  chunks_.StartContent();
 }
 
 auto Formatter::Format() -> void {
@@ -276,7 +283,7 @@ auto Formatter::FormatTopLevelScope(InstNamer::ScopeId scope_id,
   llvm::SaveAndRestore scope(scope_, scope_id);
   auto scope_chunk = scope_label_chunks_[static_cast<size_t>(scope_id)];
 
-  chunks_.FormatTentativeChunkWithParent(scope_chunk, [&] {
+  chunks_.FormatChildContent(scope_chunk, [&] {
     // Note, we don't use OpenBrace() / CloseBrace() here because we always want
     // a newline to avoid misformatting if the first instruction is omitted.
     out() << "\n" << inst_namer_.GetScopeName(scope_id) << " {\n";
@@ -295,17 +302,17 @@ auto Formatter::FormatTopLevelScope(InstNamer::ScopeId scope_id,
 
       FormatInst(inst_id);
       // Include the `file` scope label directly here.
-      chunks_.IncludeChunkInOutput(scope_chunk);
+      chunks_.AppendChildToCurrentParent(scope_chunk);
     } else {
       // Other scopes format each instruction in its own chunk, to support
       // tentative formatting.
-      chunks_.FormatTentativeChunkWithParent(
-          tentative_inst_chunks_.Get(inst_id), [&] { FormatInst(inst_id); });
+      chunks_.FormatChildContent(tentative_inst_chunks_.Get(inst_id),
+                                 [&] { FormatInst(inst_id); });
     }
   }
   indent_ -= 2;
 
-  chunks_.FormatTentativeChunkWithParent(scope_chunk, [&] { out() << "}\n"; });
+  chunks_.FormatChildContent(scope_chunk, [&] { out() << "}\n"; });
 }
 
 auto Formatter::FormatClass(ClassId id, const Class& class_info) -> void {
@@ -1556,7 +1563,10 @@ auto Formatter::FormatName(NameId id) -> void {
 
 auto Formatter::FormatName(InstId id) -> void {
   if (id.has_value()) {
-    chunks_.IncludeChunkInOutput(tentative_inst_chunks_.Get(id));
+    if (auto chunk = tentative_inst_chunks_.Get(id);
+        chunk != FormatterChunks::None) {
+      chunks_.AppendChildToCurrentParent(chunk);
+    }
   }
   out() << inst_namer_.GetNameFor(scope_, id);
 }

--- a/toolchain/sem_ir/formatter_chunks.cpp
+++ b/toolchain/sem_ir/formatter_chunks.cpp
@@ -11,7 +11,6 @@ namespace Carbon::SemIR {
 auto FormatterChunks::StartContent() -> void {
   CARBON_CHECK(content_start_id_ == None);
   content_start_id_ = ChunkId{.index = chunks_.size()};
-  AddContent(/*include_in_output=*/true);
 }
 
 auto FormatterChunks::AddContent(bool include_in_output) -> ChunkId {

--- a/toolchain/sem_ir/formatter_chunks.cpp
+++ b/toolchain/sem_ir/formatter_chunks.cpp
@@ -15,7 +15,7 @@ auto FormatterChunks::StartContent() -> void {
 }
 
 auto FormatterChunks::AddContent(bool include_in_output) -> ChunkId {
-  CARBON_CHECK(content_start_id_ != None);
+  CARBON_CHECK(content_start_id_ != None, "Must call StartContent first");
   auto chunk_id = ChunkId{.index = chunks_.size()};
   chunks_.push_back(
       {.include_in_output = include_in_output, .data = std::string()});
@@ -25,7 +25,7 @@ auto FormatterChunks::AddContent(bool include_in_output) -> ChunkId {
 }
 
 auto FormatterChunks::AddParent(ChunkId child_chunk_id) -> ChunkId {
-  CARBON_CHECK(content_start_id_ == None, "Parents are added before content");
+  CARBON_CHECK(content_start_id_ == None, "Already called StartContent");
   llvm::SmallVector<ChunkId> children;
   if (child_chunk_id != None) {
     children.push_back(child_chunk_id);
@@ -37,8 +37,9 @@ auto FormatterChunks::AddParent(ChunkId child_chunk_id) -> ChunkId {
 
 auto FormatterChunks::FormatChildContent(
     ChunkId parent_chunk_id, llvm::function_ref<auto()->void> format) -> void {
-  CARBON_CHECK(content_start_id_ != None, "Parents are added before content");
-  CARBON_CHECK(current_parent_id_ == None, "Nested FormatChildChunk");
+  CARBON_CHECK(content_start_id_ != None, "Must call StartContent first");
+  CARBON_CHECK(current_parent_id_ == None, "Cannot nest FormatChildContent");
+
   // If the parent is already included, we don't need to make a chunk.
   if (Get(parent_chunk_id).include_in_output) {
     format();
@@ -47,8 +48,7 @@ auto FormatterChunks::FormatChildContent(
 
   // Otherwise, create a new chunk and include it only if the parent is later
   // found to be used.
-  auto chunk = AddContent(/*include_in_output=*/false);
-  AppendChildToParent(chunk, parent_chunk_id);
+  AppendChildToParent(AddContent(/*include_in_output=*/false), parent_chunk_id);
 
   current_parent_id_ = parent_chunk_id;
   format();

--- a/toolchain/sem_ir/formatter_chunks.cpp
+++ b/toolchain/sem_ir/formatter_chunks.cpp
@@ -8,77 +8,99 @@
 
 namespace Carbon::SemIR {
 
-auto FormatterChunks::FlushChunk() -> void {
-  CARBON_CHECK(output_chunks_.back().chunk.empty());
-  output_chunks_.back().chunk = std::move(buffer_);
-  buffer_.clear();
+auto FormatterChunks::StartContent() -> void {
+  CARBON_CHECK(content_start_id_ == None);
+  content_start_id_ = ChunkId{.index = chunks_.size()};
+  AddContent(/*include_in_output=*/true);
 }
 
-auto FormatterChunks::AddChunkNoFlush(bool include_in_output) -> ChunkId {
-  CARBON_CHECK(buffer_.empty());
-  output_chunks_.push_back({.include_in_output = include_in_output});
-  return ChunkId{.index = output_chunks_.size() - 1};
+auto FormatterChunks::AddContent(bool include_in_output) -> ChunkId {
+  CARBON_CHECK(content_start_id_ != None);
+  auto chunk_id = ChunkId{.index = chunks_.size()};
+  chunks_.push_back(
+      {.include_in_output = include_in_output, .data = std::string()});
+  out_ = std::make_unique<llvm::raw_string_ostream>(
+      std::get<std::string>(Get(chunk_id).data));
+  return chunk_id;
 }
 
-auto FormatterChunks::AddChunk(bool include_in_output) -> ChunkId {
-  FlushChunk();
-  return AddChunkNoFlush(include_in_output);
+auto FormatterChunks::AddParent(ChunkId child_chunk_id) -> ChunkId {
+  CARBON_CHECK(content_start_id_ == None, "Parents are added before content");
+  llvm::SmallVector<ChunkId> children;
+  if (child_chunk_id != None) {
+    children.push_back(child_chunk_id);
+  }
+  auto chunk_id = ChunkId{.index = chunks_.size()};
+  chunks_.push_back({.include_in_output = false, .data = std::move(children)});
+  return chunk_id;
 }
 
-auto FormatterChunks::AddTentativeChunkWithChild(ChunkId child_chunk)
-    -> ChunkId {
-  auto chunk = AddChunkNoFlush(/*include_in_output=*/false);
-  output_chunks_[chunk.index].dependencies.push_back(child_chunk);
-  return chunk;
-}
-
-auto FormatterChunks::FormatTentativeChunkWithParent(
-    ChunkId parent_chunk, llvm::function_ref<auto()->void> format) -> void {
-  CARBON_CHECK(output_chunks_.back().include_in_output,
-               "All non-included chunks must be added first.");
-
+auto FormatterChunks::FormatChildContent(
+    ChunkId parent_chunk_id, llvm::function_ref<auto()->void> format) -> void {
+  CARBON_CHECK(content_start_id_ != None, "Parents are added before content");
+  CARBON_CHECK(current_parent_id_ == None, "Nested FormatChildChunk");
   // If the parent is already included, we don't need to make a chunk.
-  if (output_chunks_[parent_chunk.index].include_in_output) {
+  if (Get(parent_chunk_id).include_in_output) {
     format();
     return;
   }
 
   // Otherwise, create a new chunk and include it only if the parent is later
   // found to be used.
-  auto chunk = AddChunk(false);
-  output_chunks_[parent_chunk.index].dependencies.push_back(chunk);
+  auto chunk = AddContent(/*include_in_output=*/false);
+  AppendChildToParent(chunk, parent_chunk_id);
+
+  current_parent_id_ = parent_chunk_id;
   format();
-  auto next_chunk = AddChunk(true);
-  CARBON_CHECK(next_chunk.index == chunk.index + 1, "Nested FormatChildChunk");
+  current_parent_id_ = None;
+
+  // Reset the output stream so that the next call to `out()` creates a new
+  // chunk.
+  out_.reset();
 }
 
-auto FormatterChunks::IncludeChunkInOutput(ChunkId chunk) -> void {
-  CARBON_CHECK(chunk.index != output_chunks_.size() - 1,
-               "Should only be called on earlier chunks");
+auto FormatterChunks::AppendChildToParent(ChunkId child_chunk_id,
+                                          ChunkId parent_chunk_id) -> void {
+  CARBON_CHECK(!Get(parent_chunk_id).include_in_output);
+  auto* children =
+      std::get_if<llvm::SmallVector<ChunkId>>(&Get(parent_chunk_id).data);
+  CARBON_CHECK(children);
+  children->push_back(child_chunk_id);
+}
 
-  if (auto& current_chunk = output_chunks_.back();
-      !current_chunk.include_in_output) {
-    current_chunk.dependencies.push_back(chunk);
-    return;
+auto FormatterChunks::AppendChildToCurrentParent(ChunkId chunk_id) -> void {
+  if (current_parent_id_ != None) {
+    // If the parent is not included, add the `chunk` to the parent's children
+    // for conditional inclusion.
+    if (!Get(current_parent_id_).include_in_output) {
+      AppendChildToParent(chunk_id, current_parent_id_);
+      return;
+    }
   }
 
-  llvm::SmallVector<ChunkId> to_add = {chunk};
-  while (!to_add.empty()) {
-    auto& chunk_ref = output_chunks_[to_add.pop_back_val().index];
+  // If the parent is already included, or there is no parent (this is not
+  // currently a tentative chunk), include the chunk and all of its children.
+  llvm::SmallVector<ChunkId> to_include = {chunk_id};
+  while (!to_include.empty()) {
+    auto& chunk_ref = Get(to_include.pop_back_val());
     if (chunk_ref.include_in_output) {
       continue;
     }
     chunk_ref.include_in_output = true;
-    to_add.append(chunk_ref.dependencies);
-    chunk_ref.dependencies.clear();
+    if (auto* children =
+            std::get_if<llvm::SmallVector<ChunkId>>(&chunk_ref.data)) {
+      to_include.append(*children);
+      children->clear();
+    }
   }
 }
 
 auto FormatterChunks::Write(llvm::raw_ostream& stream) -> void {
-  FlushChunk();
-  for (const auto& chunk : output_chunks_) {
+  CARBON_CHECK(content_start_id_ != None);
+  for (const auto& chunk :
+       llvm::ArrayRef(chunks_).drop_front(content_start_id_.index)) {
     if (chunk.include_in_output) {
-      stream << chunk.chunk;
+      stream << std::get<std::string>(chunk.data);
     }
   }
 }

--- a/toolchain/sem_ir/formatter_chunks.cpp
+++ b/toolchain/sem_ir/formatter_chunks.cpp
@@ -39,14 +39,15 @@ auto FormatterChunks::FormatChildContent(
   CARBON_CHECK(content_start_id_ != None, "Must call StartContent first");
   CARBON_CHECK(current_parent_id_ == None, "Cannot nest FormatChildContent");
 
-  // If the parent is already included, we don't need to make a chunk.
+  // We only need to call `AddContent` for non-included content because `out()`
+  // is included by default.
   if (Get(parent_chunk_id).include_in_output) {
     format();
     return;
   }
 
-  // Otherwise, create a new chunk and include it only if the parent is later
-  // found to be used.
+  // Otherwise, create a content `Chunk` and include it only if the parent is
+  // later found to be used.
   AppendChildToParent(AddContent(/*include_in_output=*/false), parent_chunk_id);
 
   current_parent_id_ = parent_chunk_id;
@@ -67,19 +68,20 @@ auto FormatterChunks::AppendChildToParent(ChunkId child_chunk_id,
   children->push_back(child_chunk_id);
 }
 
-auto FormatterChunks::AppendChildToCurrentParent(ChunkId chunk_id) -> void {
+auto FormatterChunks::AppendChildToCurrentParent(ChunkId child_chunk_id)
+    -> void {
   if (current_parent_id_ != None) {
     // If the parent is not included, add the `chunk` to the parent's children
     // for conditional inclusion.
     if (!Get(current_parent_id_).include_in_output) {
-      AppendChildToParent(chunk_id, current_parent_id_);
+      AppendChildToParent(child_chunk_id, current_parent_id_);
       return;
     }
   }
 
   // If the parent is already included, or there is no parent (this is not
   // currently a tentative chunk), include the chunk and all of its children.
-  llvm::SmallVector<ChunkId> to_include = {chunk_id};
+  llvm::SmallVector<ChunkId> to_include = {child_chunk_id};
   while (!to_include.empty()) {
     auto& chunk_ref = Get(to_include.pop_back_val());
     if (chunk_ref.include_in_output) {

--- a/toolchain/sem_ir/formatter_chunks.h
+++ b/toolchain/sem_ir/formatter_chunks.h
@@ -7,81 +7,117 @@
 
 #include <string>
 
+#include "common/check.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
+#include "toolchain/base/value_store.h"
 
 namespace Carbon::SemIR {
 
 // Manages the chunks created by the formatter.
 //
-// All output of the formatter is stored as `OutputChunk`s. Tentative scopes,
-// such as constants, may have output for instructions made optional; these are
-// stored as `include_in_output=false`, but have dependencies in case they're
-// later referenced. Unreferenced tentative chunks are omitted from the output.
+// There are two kinds of `Chunk`s:
+// - Parent `Chunk`s, with children in a vector.
+// - Content `Chunk`s, with content in a string.
 //
-// Output of the main file scope is always included in output, and causes
-// referenced tentative instructions to be included in output, including
-// indirect dependencies. During this, `Formatter::FormatName` will mark
-// referenced instructions for inclusion.
+// Initially, `AddParent` is called one or more times. Then `StartContent` is
+// called once to switch modes, and creates an initial content `Chunk`. After
+// that, either content may be written to `out()` immediately (going to the
+// current content `Chunk`), or `FormatChildContent` may be used to create a
+// content `Chunk` which is a child of a parent.
+//
+// Content `Chunk`s that are created implicitly (not through
+// `FormatChildContent`) are automatically included in output. Other `Chunk`s
+// are included only when marked as a child of a `Chunk` that is included, using
+// `AppendChildToCurrentParent`.
 class FormatterChunks {
  public:
+  // A type-safe index into `chunks_`.
   struct ChunkId {
+    auto operator==(const ChunkId& other) const -> bool = default;
+
     size_t index;
   };
 
-  // A chunk of the buffered output.
-  struct OutputChunk {
+  // Either a parent or content.
+  struct Chunk {
     // Whether this chunk is known to be included in the output.
     bool include_in_output;
-    // The textual contents of this chunk.
-    std::string chunk = std::string();
-    // Indices in `ouput_chunks_` that should be included in the output if this
-    // one is.
-    llvm::SmallVector<ChunkId> dependencies = {};
+
+    // Either children or content.
+    std::variant<llvm::SmallVector<ChunkId>, std::string> data;
   };
 
-  // Flushes the buffered output to the current chunk.
-  auto FlushChunk() -> void;
+  // An empty `ChunkId`.
+  static constexpr ChunkId None = ChunkId(-1);
 
-  // Adds a new chunk with `include_in_output`. Does not flush existing output,
-  // so should only be called if there is no buffered output.
-  auto AddChunkNoFlush(bool include_in_output) -> ChunkId;
+  // Reserves space for at least `count` chunks.
+  auto Reserve(size_t count) -> void { chunks_.reserve(count); }
 
-  // Flushes the current chunk and add a new chunk with `include_in_output`.
-  auto AddChunk(bool include_in_output) -> ChunkId;
+  // Adds a `Chunk` that can have `children`. It can optionally start with one
+  // `child_chunk`.
+  auto AddParent(ChunkId child_chunk_id = None) -> ChunkId;
 
-  // Adds a new tentative `OutputChunk`. If the new chunk is included in
-  // output, it'll also include `child_chunk`.
-  auto AddTentativeChunkWithChild(ChunkId child_chunk) -> ChunkId;
+  // Switches from adding parents to adding content. This immediately makes
+  // `out()` valid.
+  auto StartContent() -> void;
 
-  // Adds a new tentative `OutputChunk`. If the `parent_chunk` is included in
+  // Adds a new content `Chunk`. If the `parent_chunk` is included in
   // output, it'll also include the new chunk. Calls `format` to support adding
   // content to the new chunk.
-  auto FormatTentativeChunkWithParent(ChunkId parent_chunk,
-                                      llvm::function_ref<auto()->void> format)
-      -> void;
+  auto FormatChildContent(ChunkId parent_chunk_id,
+                          llvm::function_ref<auto()->void> format) -> void;
 
   // Marks the given chunk as being included in the output if the current chunk
-  // is.
-  auto IncludeChunkInOutput(ChunkId chunk) -> void;
+  // is. When `FormatChildContent` is currently active, there's a parent that
+  // will determine `include_in_output for the child; otherwise, the child is
+  // always included.
+  //
+  // For example, instructions in the file scope are added to implicitly-created
+  // `Chunks` (`FormatChildContent` is not used). When
+  // `AppendChildToCurrentParent` is called in that context, there's no parent
+  // to limit visibility, so the child is also included.
+  auto AppendChildToCurrentParent(ChunkId child_chunk_id) -> void;
 
   // Writes included chunks to the given stream.
   auto Write(llvm::raw_ostream& stream) -> void;
 
-  // Returns stream representing the buffer for the current chunk.
-  auto out() -> llvm::raw_ostream& { return out_; }
+  // Returns a stream to write to the current chunk. Only valid to use after
+  // `StartContent`, and may add a new chunk if one hasn't been started.
+  auto out() -> llvm::raw_ostream& {
+    CARBON_CHECK(content_start_id_ != None);
+    if (!out_) {
+      AddContent(/*include_in_output=*/true);
+    }
+    return *out_;
+  }
+
+  auto size() -> size_t { return chunks_.size(); }
 
  private:
-  friend struct TentativeOutputScope;
+  // Adds a `Chunk` that will have `content`.
+  auto AddContent(bool include_in_output) -> ChunkId;
 
-  // The output stream buffer.
-  std::string buffer_;
+  // Adds `child_chunk_id` to the children of `parent_chunk_id`.
+  auto AppendChildToParent(ChunkId child_chunk_id, ChunkId parent_chunk_id)
+      -> void;
 
-  // The output stream.
-  llvm::raw_string_ostream out_{buffer_};
+  // Indexes into `chunks_`.
+  auto Get(ChunkId chunk_id) -> Chunk& { return chunks_[chunk_id.index]; }
 
-  // Chunks of output text that we have created so far.
-  llvm::SmallVector<OutputChunk> output_chunks_;
+  // An output stream pointing at the current content `Chunk`.
+  std::unique_ptr<llvm::raw_string_ostream> out_;
+
+  // The location where content started. Set by `StartContent`.
+  ChunkId content_start_id_ = None;
+
+  // The current parent `Chunk`. This is only set during calls to
+  // `FormatChildContent`.
+  ChunkId current_parent_id_ = None;
+
+  // A sequential ordering of `Chunk`s. This will have all parent `Chunk`s
+  // first, followed by content `Chunk`s at `content_start_`.
+  llvm::SmallVector<Chunk> chunks_;
 };
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/formatter_chunks.h
+++ b/toolchain/sem_ir/formatter_chunks.h
@@ -20,10 +20,9 @@ namespace Carbon::SemIR {
 // - Content `Chunk`s, with content in a string.
 //
 // Initially, `AddParent` is called one or more times. Then `StartContent` is
-// called once to switch modes, and creates an initial content `Chunk`. After
-// that, either content may be written to `out()` immediately (going to the
-// current content `Chunk`), or `FormatChildContent` may be used to create a
-// content `Chunk` which is a child of a parent.
+// called once to switch modes. Once content is started, `out()` adds text to
+// content `Chunk`s. `FormatChildContent` may be used to create a content
+// `Chunk` which is a child of a parent.
 //
 // Content `Chunk`s that are created implicitly (not through
 // `FormatChildContent`) are automatically included in output. Other `Chunk`s
@@ -38,51 +37,38 @@ class FormatterChunks {
     size_t index;
   };
 
-  // Either a parent or content.
-  struct Chunk {
-    // Whether this chunk is known to be included in the output.
-    bool include_in_output;
-
-    // Either children or content.
-    std::variant<llvm::SmallVector<ChunkId>, std::string> data;
-  };
-
   // An empty `ChunkId`.
   static constexpr ChunkId None = ChunkId(-1);
 
   // Reserves space for at least `count` chunks.
   auto Reserve(size_t count) -> void { chunks_.reserve(count); }
 
-  // Adds a `Chunk` that can have `children`. It can optionally start with one
-  // `child_chunk`.
+  // Adds a parent `Chunk` and returns its `ChunkId`. If `child_chunk_id` isn't
+  // `None`, it's added as a child. Must be called before `StartContent`.
   auto AddParent(ChunkId child_chunk_id = None) -> ChunkId;
 
-  // Switches from adding parents to adding content. This immediately makes
-  // `out()` valid.
+  // Switches from adding parents to adding content.
   auto StartContent() -> void;
 
-  // Adds a new content `Chunk`. If the `parent_chunk` is included in
+  // Adds a new content `Chunk`. If `parent_chunk_id` is included in
   // output, it'll also include the new chunk. Calls `format` to support adding
-  // content to the new chunk.
+  // content to the new chunk. Must be called after `StartContent`.
   auto FormatChildContent(ChunkId parent_chunk_id,
                           llvm::function_ref<auto()->void> format) -> void;
 
-  // Marks the given chunk as being included in the output if the current chunk
-  // is. When `FormatChildContent` is currently active, there's a parent that
-  // will determine `include_in_output for the child; otherwise, the child is
-  // always included.
-  //
-  // For example, instructions in the file scope are added to implicitly-created
-  // `Chunks` (`FormatChildContent` is not used). When
-  // `AppendChildToCurrentParent` is called in that context, there's no parent
-  // to limit visibility, so the child is also included.
+  // Adds `child_chunk_id` to the children of a `FormatChildContent`'s
+  // `parent_chunk_id` if called during `format`, or otherwise includes the
+  // chunk in output.
   auto AppendChildToCurrentParent(ChunkId child_chunk_id) -> void;
 
   // Writes included chunks to the given stream.
   auto Write(llvm::raw_ostream& stream) -> void;
 
-  // Returns a stream to write to the current chunk. Only valid to use after
-  // `StartContent`, and may add a new chunk if one hasn't been started.
+  // Returns a stream to write to a content `Chunk`. The returned reference is only valid
+  // until the next `Chunk` starts. Must be called after `StartContent`.
+  //
+  // This adds a new, parentless content `Chunk` if there's not a ready content
+  // `Chunk` to write to.
   auto out() -> llvm::raw_ostream& {
     CARBON_CHECK(content_start_id_ != None);
     if (!out_) {
@@ -94,7 +80,16 @@ class FormatterChunks {
   auto size() -> size_t { return chunks_.size(); }
 
  private:
-  // Adds a `Chunk` that will have `content`.
+  // Either a parent or content.
+  struct Chunk {
+    // Whether this chunk is known to be included in the output.
+    bool include_in_output;
+
+    // Either children or content.
+    std::variant<llvm::SmallVector<ChunkId>, std::string> data;
+  };
+
+  // Adds a `Chunk` that will have `content`, and directs `out_` to it.
   auto AddContent(bool include_in_output) -> ChunkId;
 
   // Adds `child_chunk_id` to the children of `parent_chunk_id`.

--- a/toolchain/sem_ir/formatter_chunks.h
+++ b/toolchain/sem_ir/formatter_chunks.h
@@ -19,15 +19,11 @@ namespace Carbon::SemIR {
 // - Parent `Chunk`s, with children in a vector.
 // - Content `Chunk`s, with content in a string.
 //
-// Initially, `AddParent` is called one or more times. Then `StartContent` is
-// called once to switch modes. Once content is started, `out()` adds text to
-// content `Chunk`s. `FormatChildContent` may be used to create a content
-// `Chunk` which is a child of a parent.
-//
-// Content `Chunk`s that are created implicitly (not through
-// `FormatChildContent`) are automatically included in output. Other `Chunk`s
-// are included only when marked as a child of a `Chunk` that is included, using
-// `AppendChildToCurrentParent`.
+// The high level usage is:
+// 1. Calls to `AddParent` to prepare parent `Chunk`s.
+// 2. One call to `StartContent` to switch modes.
+// 3. Calls to `FormatChildContent`, `AppendChildToCurrentParent`, and `out`.
+// 4. Calls to `Write`.
 class FormatterChunks {
  public:
   // A type-safe index into `chunks_`.
@@ -45,14 +41,22 @@ class FormatterChunks {
 
   // Adds a parent `Chunk` and returns its `ChunkId`. If `child_chunk_id` isn't
   // `None`, it's added as a child. Must be called before `StartContent`.
+  //
+  // By default the parent `Chunk` will not be included in the output, and
+  // `AppendChildToCurrentParent` must be called to include it.
   auto AddParent(ChunkId child_chunk_id = None) -> ChunkId;
 
   // Switches from adding parents to adding content.
   auto StartContent() -> void;
 
-  // Adds a new content `Chunk`. If `parent_chunk_id` is included in
-  // output, it'll also include the new chunk. Calls `format` to support adding
-  // content to the new chunk. Must be called after `StartContent`.
+  // Calls `format` to add content conditionally included when `parent_chunk_id`
+  // is included. Must be called after `StartContent`.
+  //
+  // During a `FormatChildContent` call where the `parent_chunk_id` is not
+  // already included in output, a new content `Chunk` is created, marked as a
+  // child of `parent_chunk_id`, and `out` is temporarily directed to it during
+  // the duration of `format. Otherwise, `out` lazily creates a content `Chunk`
+  // which is always included in output.
   auto FormatChildContent(ChunkId parent_chunk_id,
                           llvm::function_ref<auto()->void> format) -> void;
 
@@ -64,11 +68,11 @@ class FormatterChunks {
   // Writes included chunks to the given stream.
   auto Write(llvm::raw_ostream& stream) -> void;
 
-  // Returns a stream to write to a content `Chunk`. The returned reference is only valid
-  // until the next `Chunk` starts. Must be called after `StartContent`.
+  // Returns a stream to write to a content `Chunk`. The returned reference is
+  // only valid until the next `Chunk` starts. Must be called after
+  // `StartContent`.
   //
-  // This adds a new, parentless content `Chunk` if there's not a ready content
-  // `Chunk` to write to.
+  // See `FormatChildContent` for details of the target content `Chunk`.
   auto out() -> llvm::raw_ostream& {
     CARBON_CHECK(content_start_id_ != None);
     if (!out_) {

--- a/toolchain/sem_ir/formatter_chunks.h
+++ b/toolchain/sem_ir/formatter_chunks.h
@@ -10,7 +10,6 @@
 #include "common/check.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
-#include "toolchain/base/value_store.h"
 
 namespace Carbon::SemIR {
 


### PR DESCRIPTION
This is a refactoring change with no output changes.

The chunk logic already separates the concepts of "nodes with children" and "nodes with content" in practice, but it's not obvious in the API. This rewrites the logic to make the separation clearer.

This also subtly takes advantage of the API to avoid creating lots of empty chunks... Right now, there's always an empty chunk between two tentative chunks. With this change, it lazily creates a chunk only when `out()` is used (which it often isn't), which should substantially reduce the number of chunks created.