### PR TITLE
Support floats in MapAPValueToConstant

### DIFF
--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -30,6 +30,10 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
       return TryEvalInst(context,
                          SemIR::IntValue{.type_id = type_id, .int_id = int_id});
     }
+  } else if (ap_value.isFloat()) {
+    FloatId float_id = context.floats().Add(ap_value.getFloat());
+    return TryEvalInst(
+        context, SemIR::FloatValue{.type_id = type_id, .float_id = float_id});
   } else {
     // TODO: support other types.
     return SemIR::ConstantId::NotConstant;

--- a/toolchain/check/testdata/interop/cpp/constexpr.carbon
+++ b/toolchain/check/testdata/interop/cpp/constexpr.carbon
@@ -33,3 +33,22 @@ constexpr int i = 123;
 class C(I:! i32) {}
 fn F() -> C(Cpp.i);
 let x: C(123) = F();
+
+// --- float.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp inline '''
+constexpr float flt = 123.5;
+''';
+
+class C(V:! f32) {}
+// CHECK:STDERR: float.carbon:[[@LINE+7]]:11: error: argument for generic parameter is not a compile-time constant [CompTimeArgumentNotConstant]
+// CHECK:STDERR: fn F() -> C(Cpp.flt);
+// CHECK:STDERR:           ^~~~~~~~~~
+// CHECK:STDERR: float.carbon:[[@LINE-4]]:9: note: initializing generic parameter `V` declared here [InitializingGenericParam]
+// CHECK:STDERR: class C(V:! f32) {}
+// CHECK:STDERR:         ^
+// CHECK:STDERR:
+fn F() -> C(Cpp.flt);
+let x: C(123.5) = F();

--- a/toolchain/check/testdata/interop/cpp/constexpr.carbon
+++ b/toolchain/check/testdata/interop/cpp/constexpr.carbon
@@ -43,12 +43,5 @@ constexpr float flt = 123.5;
 ''';
 
 class C(V:! f32) {}
-// CHECK:STDERR: float.carbon:[[@LINE+7]]:11: error: argument for generic parameter is not a compile-time constant [CompTimeArgumentNotConstant]
-// CHECK:STDERR: fn F() -> C(Cpp.flt);
-// CHECK:STDERR:           ^~~~~~~~~~
-// CHECK:STDERR: float.carbon:[[@LINE-4]]:9: note: initializing generic parameter `V` declared here [InitializingGenericParam]
-// CHECK:STDERR: class C(V:! f32) {}
-// CHECK:STDERR:         ^
-// CHECK:STDERR:
 fn F() -> C(Cpp.flt);
 let x: C(123.5) = F();


### PR DESCRIPTION
This allows `constexpr float` to be properly imported as a constant.