### PR TITLE
Fix backtrace symbolization.

### DIFF
--- a/toolchain/install/busybox_main.cpp
+++ b/toolchain/install/busybox_main.cpp
@@ -44,7 +44,7 @@ static auto Main(int argc, char** argv) -> ErrorOr<int> {
   // for symbolization.
   setenv(
       "LLVM_SYMBOLIZER_PATH",
-      (install_paths.llvm_install_bin().native() + "llvm-symbolizer").c_str(),
+      (install_paths.llvm_install_bin() / "llvm-symbolizer").native().c_str(),
       /*overwrite=*/0);
 
   auto fs = llvm::vfs::getRealFileSystem();


### PR DESCRIPTION
We previously set `LLVM_SYMBOLIZER_PATH` to a bogus path ending `.../binllvm-symbolizer`. Because this var was set, LLVM's symbolizer lookup would also skip looking in `$PATH`, so this was causing symbolization to never happen unless `LLVM_SYMBOLIZER_PATH` was explicitly set in the environment.
