### PR TITLE
ErrorContext modifies Error diagnostics to replace the primary error message

### DIFF
--- a/proposals/p6806.md
+++ b/proposals/p6806.md
@@ -1,0 +1,94 @@
+# ErrorContext
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/6806)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Proposal](#proposal)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+    -   [Diagnostic emitting callbacks](#diagnostic-emitting-callbacks)
+    -   [General `Context` vs `ErrorContext`](#general-context-vs-errorcontext)
+
+<!-- tocstop -->
+
+## Abstract
+
+Introduce ErrorContext as a means to modify later error diagnostics to describe
+the failure of a higher order operation. If an Error is omitted, the
+ErrorContext replaces it, and the Error becomes a Note annotation of the context
+message.
+
+## Problem
+
+There are operations in the toolchain that can fail due to an error, and we want
+to display that error as an explanation for the failure, but we also want to
+diagnose the higher level failure, which contains more context on what the user
+was trying to do, and points more directly to the user code that caused the
+error.
+
+Sometimes errors come from very distant operations, such as conversion failing
+due to an error that occurs during impl lookup. Previously we handled this by
+plumbing through a callback to call to produce an error diagnostic for the high
+level operation, and then we attach a note to that diagnostic. However that
+requires plumbing callbacks through much of the toolchain, including through
+eval in order to provide a higher level error for monomorphization failures.
+
+## Proposal
+
+Introduce `ErrorContext` messages which modify an `Error` diagnostic. The
+`ErrorContext` message becomes the primary error message, while the `Error`
+message becomes a `Note` annotation attached to it.
+
+Some scenarios want to provide an `ErrorContext` as a default, if there's not a
+better one available. Introduce `SoftErrorContext` for these, where the
+`SoftErrorContext` will be dropped if there's another (`Soft`)`ErrorContext`
+that comes first in the diagnostic.
+
+A `ContextScope` RAII object allows attaching context messages to an `Error`
+diagnostic while it is being built through a callback. This functions like
+`AnnotationScope`, but for context messages instead of annotations.
+
+`ErrorContext` only modifies `Error` diagnostics, so that the messages can be
+clearly formulated as error/failure messages. This leaves open room for a
+`WarningContext` message level in the future, which could be also added in a
+`ContextScope` callback. It would even be possible for a single `ContextScope`
+to provide both an `ErrorContext` and `WarningContext` using the same diagnostic
+kind, but with different messages.
+
+## Rationale
+
+This advances Carbon's goals of providing high quality diagnostics, by
+connecting local errors to higher level operations. And by anchoring error
+diagnostics on the user code which is the enrty-point of the failure, instead of
+in library code with a note pointing back to the user code. These advance the
+goal of
+[Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
+
+## Alternatives considered
+
+### Diagnostic emitting callbacks
+
+Previously plumbed through callbacks that would provide the higher level context
+by emitting an `Error` diagnostic. Then code could attach annotations to it with
+the more specific error. This worked for shallow call graphs but requires
+intrusive plumbing that does not work well for distant systems, or errors that
+occur during eval. Instead we end up with two separate error diagnostics for the
+same failure.
+
+### General `Context` vs `ErrorContext`
+
+We tried having a single `Context` level but it was unclear how to phase a
+context message that may become the primary message of either an `Error` or a
+`Warning`. By using `ErrorContext` as the level, and applying them only to
+`Error` diagnostics, the message phrasing can be more clear.

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -1585,7 +1585,7 @@ static auto PerformCopy(Context& context, SemIR::InstId expr_id,
   auto copy_id = BuildUnaryOperator(
       context, SemIR::LocId(expr_id), {.interface_name = CoreIdentifier::Copy},
       expr_id, target.diagnose, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(CopyOfUncopyableType, Context,
+        CARBON_DIAGNOSTIC(CopyOfUncopyableType, ErrorContext,
                           "cannot copy value of type {0}", TypeOfInstId);
         builder.Context(expr_id, CopyOfUncopyableType, expr_id);
       });
@@ -1941,10 +1941,10 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
                     !target.is_initializer(),
                     "Initialization of incomplete types is expected to be "
                     "caught elsewhere.");
-                CARBON_DIAGNOSTIC(IncompleteTypeInValueConversion, Context,
+                CARBON_DIAGNOSTIC(IncompleteTypeInValueConversion, ErrorContext,
                                   "forming value of incomplete type {0}",
                                   SemIR::TypeId);
-                CARBON_DIAGNOSTIC(IncompleteTypeInConversion, Context,
+                CARBON_DIAGNOSTIC(IncompleteTypeInConversion, ErrorContext,
                                   "invalid use of incomplete type {0}",
                                   SemIR::TypeId);
                 builder.Context(loc_id,
@@ -1954,7 +1954,7 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
                                 target.type_id);
               },
               [&](auto& builder) {
-                CARBON_DIAGNOSTIC(AbstractTypeInInit, Context,
+                CARBON_DIAGNOSTIC(AbstractTypeInInit, ErrorContext,
                                   "initialization of abstract type {0}",
                                   SemIR::TypeId);
                 builder.Context(loc_id, AbstractTypeInInit, target.type_id);
@@ -2030,7 +2030,7 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
           if (target.type_id == SemIR::TypeType::TypeId ||
               sem_ir.types().Is<SemIR::FacetType>(target.type_id)) {
             CARBON_DIAGNOSTIC(
-                ConversionFailureNonTypeToFacet, Context,
+                ConversionFailureNonTypeToFacet, ErrorContext,
                 "cannot{0:=0: implicitly|:} convert non-type value of type {1} "
                 "{2:to|into type implementing} {3}"
                 "{0:=1: with `as`|=2: with `unsafe as`|:}",
@@ -2042,7 +2042,7 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
                             target.type_id);
           } else {
             CARBON_DIAGNOSTIC(
-                ConversionFailure, Context,
+                ConversionFailure, ErrorContext,
                 "cannot{0:=0: implicitly|:} convert expression of type "
                 "{1} to {2}{0:=1: with `as`|=2: with `unsafe as`|:}",
                 Diagnostics::IntAsSelect, TypeOfInstId, SemIR::TypeId);

--- a/toolchain/check/cpp/operators.cpp
+++ b/toolchain/check/cpp/operators.cpp
@@ -478,7 +478,7 @@ auto LookupCppOperator(Context& context, SemIR::LocId loc_id, Operator op,
     SemIR::TypeId arg_type_id = context.insts().Get(arg_id).type_id();
     if (!RequireCompleteType(context, arg_type_id, loc_id, [&](auto& builder) {
           CARBON_DIAGNOSTIC(
-              IncompleteOperandTypeInCppOperatorLookup, Context,
+              IncompleteOperandTypeInCppOperatorLookup, ErrorContext,
               "looking up a C++ operator with incomplete operand type {0}",
               SemIR::TypeId);
           builder.Context(loc_id, IncompleteOperandTypeInCppOperatorLookup,

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -381,7 +381,7 @@ static auto DiagnoseQualifiedDeclInIncompleteClassScope(Context& context,
     -> void {
   Diagnostics::ContextScope diagnostic_context(
       &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(QualifiedDeclInIncompleteClassScope, Context,
+        CARBON_DIAGNOSTIC(QualifiedDeclInIncompleteClassScope, ErrorContext,
                           "cannot declare a member of incomplete class {0}",
                           SemIR::TypeId);
         builder.Context(loc_id, QualifiedDeclInIncompleteClassScope,
@@ -397,7 +397,7 @@ static auto DiagnoseQualifiedDeclInUndefinedInterfaceScope(
     SemIR::InstId interface_inst_id) -> void {
   Diagnostics::ContextScope diagnostic_context(
       &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(QualifiedDeclInUndefinedInterfaceScope, Context,
+        CARBON_DIAGNOSTIC(QualifiedDeclInUndefinedInterfaceScope, ErrorContext,
                           "cannot declare a member of undefined interface {0}",
                           InstIdAsType);
         builder.Context(loc_id, QualifiedDeclInUndefinedInterfaceScope,

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -2554,7 +2554,7 @@ auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
 
   Diagnostics::ContextScope diagnostic_context(
       &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ResolvingSpecificHere, SoftContext,
+        CARBON_DIAGNOSTIC(ResolvingSpecificHere, SoftErrorContext,
                           "unable to monomorphize specific {0}",
                           SemIR::SpecificId);
         builder.Context(loc_id, ResolvingSpecificHere, specific_id);

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -549,7 +549,7 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
   if (complete_type_id.is_concrete()) {
     Diagnostics::ContextScope diagnostic_context(
         &context.emitter(), [&](auto& builder) {
-          CARBON_DIAGNOSTIC(IncompleteTypeInMonomorphization, Context,
+          CARBON_DIAGNOSTIC(IncompleteTypeInMonomorphization, ErrorContext,
                             "{0} evaluates to incomplete type {1}",
                             InstIdAsType, InstIdAsType);
           builder.Context(inst_id, IncompleteTypeInMonomorphization,

--- a/toolchain/check/function.cpp
+++ b/toolchain/check/function.cpp
@@ -329,14 +329,14 @@ auto CheckFunctionReturnPatternType(Context& context, SemIR::LocId loc_id,
     if (!RequireConcreteType(
             context, arg_type_id, SemIR::LocId(return_pattern_id),
             [&](auto& builder) {
-              CARBON_DIAGNOSTIC(IncompleteTypeInFunctionReturnType, Context,
-                                "function returns incomplete type {0}",
-                                SemIR::TypeId);
+              CARBON_DIAGNOSTIC(
+                  IncompleteTypeInFunctionReturnType, ErrorContext,
+                  "function returns incomplete type {0}", SemIR::TypeId);
               builder.Context(loc_id, IncompleteTypeInFunctionReturnType,
                               arg_type_id);
             },
             [&](auto& builder) {
-              CARBON_DIAGNOSTIC(AbstractTypeInFunctionReturnType, Context,
+              CARBON_DIAGNOSTIC(AbstractTypeInFunctionReturnType, ErrorContext,
                                 "function returns abstract type {0}",
                                 SemIR::TypeId);
               builder.Context(loc_id, AbstractTypeInFunctionReturnType,
@@ -374,7 +374,7 @@ auto CheckFunctionDefinitionSignature(Context& context,
         context, context.insts().GetAs<SemIR::AnyParam>(param_ref_id).type_id,
         SemIR::LocId(param_ref_id), [&](auto& builder) {
           CARBON_DIAGNOSTIC(
-              IncompleteTypeInFunctionParam, Context,
+              IncompleteTypeInFunctionParam, ErrorContext,
               "parameter has incomplete type {0} in function definition",
               TypeOfInstId);
           builder.Context(param_ref_id, IncompleteTypeInFunctionParam,

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -206,7 +206,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
   };
 
   auto abstract_diagnostic_context = [&](auto& builder) {
-    CARBON_DIAGNOSTIC(AbstractTypeInVarPattern, Context,
+    CARBON_DIAGNOSTIC(AbstractTypeInVarPattern, ErrorContext,
                       "binding pattern has abstract type {0} in `var` "
                       "pattern",
                       SemIR::TypeId);
@@ -306,7 +306,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
 
     case FullPatternStack::Kind::NameBindingDecl: {
       auto incomplete_diagnostic_context = [&](auto& builder) {
-        CARBON_DIAGNOSTIC(IncompleteTypeInBindingDecl, Context,
+        CARBON_DIAGNOSTIC(IncompleteTypeInBindingDecl, ErrorContext,
                           "binding pattern has incomplete type {0} in name "
                           "binding declaration",
                           InstIdAsType);
@@ -464,12 +464,12 @@ auto HandleParseNode(Context& context, Parse::FieldNameAndTypeId node_id)
   if (!RequireConcreteType(
           context, cast_type_id, type_node,
           [&](auto& builder) {
-            CARBON_DIAGNOSTIC(IncompleteTypeInFieldDecl, Context,
+            CARBON_DIAGNOSTIC(IncompleteTypeInFieldDecl, ErrorContext,
                               "field has incomplete type {0}", SemIR::TypeId);
             builder.Context(type_node, IncompleteTypeInFieldDecl, cast_type_id);
           },
           [&](auto& builder) {
-            CARBON_DIAGNOSTIC(AbstractTypeInFieldDecl, Context,
+            CARBON_DIAGNOSTIC(AbstractTypeInFieldDecl, ErrorContext,
                               "field has abstract type {0}", SemIR::TypeId);
             builder.Context(type_node, AbstractTypeInFieldDecl, cast_type_id);
           })) {

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -381,14 +381,14 @@ auto HandleParseNode(Context& context, Parse::AdaptDeclId node_id) -> bool {
   if (!RequireConcreteType(
           context, adapted_type_id, node_id,
           [&](auto& builder) {
-            CARBON_DIAGNOSTIC(IncompleteTypeInAdaptDecl, Context,
+            CARBON_DIAGNOSTIC(IncompleteTypeInAdaptDecl, ErrorContext,
                               "adapted type {0} is an incomplete type",
                               InstIdAsType);
             builder.Context(node_id, IncompleteTypeInAdaptDecl,
                             adapted_type_inst_id);
           },
           [&](auto& builder) {
-            CARBON_DIAGNOSTIC(AbstractTypeInAdaptDecl, Context,
+            CARBON_DIAGNOSTIC(AbstractTypeInAdaptDecl, ErrorContext,
                               "adapted type {0} is an abstract type",
                               InstIdAsType);
             builder.Context(node_id, AbstractTypeInAdaptDecl,
@@ -457,7 +457,7 @@ static auto CheckBaseType(Context& context, Parse::NodeId node_id,
     return BaseInfo::Error;
   }
   if (!RequireCompleteType(context, base_type_id, node_id, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(IncompleteTypeInBaseDecl, Context,
+        CARBON_DIAGNOSTIC(IncompleteTypeInBaseDecl, ErrorContext,
                           "base {0} is an incomplete type", InstIdAsType);
         builder.Context(node_id, IncompleteTypeInBaseDecl, base_type_inst_id);
       })) {

--- a/toolchain/check/handle_require.cpp
+++ b/toolchain/check/handle_require.cpp
@@ -213,7 +213,7 @@ static auto ValidateRequire(Context& context, SemIR::LocId loc_id,
       context, SemIR::LocId(constraint_inst_id), self_constant_value_id,
       *constraint_facet_type, [&](auto& builder) {
         CARBON_DIAGNOSTIC(
-            RequireImplsUnidentifiedFacetType, Context,
+            RequireImplsUnidentifiedFacetType, ErrorContext,
             "facet type {0} cannot be identified in `require` declaration",
             InstIdAsType);
         builder.Context(constraint_inst_id, RequireImplsUnidentifiedFacetType,
@@ -300,7 +300,7 @@ auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
     if (!RequireCompleteType(
             context, constraint_type_id, SemIR::LocId(constraint_inst_id),
             [&](auto& builder) {
-              CARBON_DIAGNOSTIC(RequireImplsIncompleteFacetType, Context,
+              CARBON_DIAGNOSTIC(RequireImplsIncompleteFacetType, ErrorContext,
                                 "`extend require` of incomplete facet type {0}",
                                 InstIdAsType);
               builder.Context(constraint_inst_id,

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -222,7 +222,7 @@ static auto ApplyExtendImplAs(Context& context, SemIR::LocId loc_id,
   if (!RequireCompleteType(
           context, context.types().GetTypeIdForTypeInstId(impl.constraint_id),
           SemIR::LocId(impl.constraint_id), [&](auto& builder) {
-            CARBON_DIAGNOSTIC(ExtendImplAsIncomplete, Context,
+            CARBON_DIAGNOSTIC(ExtendImplAsIncomplete, ErrorContext,
                               "`extend impl as` incomplete facet type {0}",
                               InstIdAsType);
             builder.Context(impl.latest_decl_id(), ExtendImplAsIncomplete,
@@ -517,7 +517,7 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
             context, context.types().GetTypeIdForTypeInstId(impl.constraint_id),
             SemIR::LocId(impl.constraint_id), [&](auto& builder) {
               CARBON_DIAGNOSTIC(
-                  ImplAsIncompleteFacetTypeDefinition, Context,
+                  ImplAsIncompleteFacetTypeDefinition, ErrorContext,
                   "definition of impl as incomplete facet type {0}",
                   InstIdAsType);
               builder.Context(SemIR::LocId(impl.latest_decl_id()),
@@ -798,7 +798,7 @@ auto CheckConstraintIsInterface(Context& context, SemIR::InstId impl_decl_id,
   auto identified_id = RequireIdentifiedFacetType(
       context, SemIR::LocId(constraint_id),
       context.constant_values().Get(self_id), *facet_type, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ImplOfUnidentifiedFacetType, Context,
+        CARBON_DIAGNOSTIC(ImplOfUnidentifiedFacetType, ErrorContext,
                           "facet type {0} cannot be identified in `impl as`",
                           InstIdAsType);
         builder.Context(impl_decl_id, ImplOfUnidentifiedFacetType,

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -221,7 +221,7 @@ static auto GetRequiredImplsFromConstraint(
   auto identified_id = RequireIdentifiedFacetType(
       context, loc_id, query_self_const_id, facet_type_inst,
       [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetType, Context,
+        CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetType, ErrorContext,
                           "facet type {0} can not be identified", InstIdAsType);
         builder.Context(loc_id, ImplLookupInUnidentifiedFacetType,
                         facet_type_inst_id);
@@ -353,9 +353,9 @@ static auto LookupImplWitnessInSelfFacetValue(
   auto identified_id = RequireIdentifiedFacetType(
       context, loc_id, self_facet_value_const_id, *facet_type,
       [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetTypeOfQuerySelf, Context,
-                          "facet type of value {0} can not be identified",
-                          InstIdAsType);
+        CARBON_DIAGNOSTIC(
+            ImplLookupInUnidentifiedFacetTypeOfQuerySelf, ErrorContext,
+            "facet type of value {0} can not be identified", InstIdAsType);
         builder.Context(loc_id, ImplLookupInUnidentifiedFacetTypeOfQuerySelf,
                         self_facet_value_inst_id);
       });

--- a/toolchain/check/literal.cpp
+++ b/toolchain/check/literal.cpp
@@ -174,7 +174,7 @@ auto MakeStringLiteral(Context& context, Parse::StringLiteralId node_id,
   auto str_type = MakeStringType(context, SemIR::LocId(node_id).AsDesugared());
   if (!RequireCompleteType(
           context, str_type.type_id, node_id, [&](auto& builder) {
-            CARBON_DIAGNOSTIC(StringLiteralTypeIncomplete, Context,
+            CARBON_DIAGNOSTIC(StringLiteralTypeIncomplete, ErrorContext,
                               "type {0} is incomplete", InstIdAsType);
             builder.Context(node_id, StringLiteralTypeIncomplete,
                             str_type.inst_id);

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -517,7 +517,7 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
       if (!RequireCompleteType(
               context, base_type_id, SemIR::LocId(base_id), [&](auto& builder) {
                 CARBON_DIAGNOSTIC(
-                    IncompleteTypeInMemberAccessOfFacet, Context,
+                    IncompleteTypeInMemberAccessOfFacet, ErrorContext,
                     "member access into facet of incomplete type {0}",
                     SemIR::TypeId);
                 builder.Context(base_id, IncompleteTypeInMemberAccessOfFacet,
@@ -560,7 +560,7 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
   if (!RequireCompleteType(
           context, base_type_id, SemIR::LocId(base_id), [&](auto& builder) {
             CARBON_DIAGNOSTIC(
-                IncompleteTypeInMemberAccess, Context,
+                IncompleteTypeInMemberAccess, ErrorContext,
                 "member access into object of incomplete type {0}",
                 TypeOfInstId);
             builder.Context(base_id, IncompleteTypeInMemberAccess, base_id);

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -363,7 +363,7 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
     RequireCompleteType(
         context, context.types().GetTypeIdForTypeConstantId(lookup_const_id),
         loc_id, [&](auto& builder) {
-          CARBON_DIAGNOSTIC(QualifiedExprInIncompleteClassScope, Context,
+          CARBON_DIAGNOSTIC(QualifiedExprInIncompleteClassScope, ErrorContext,
                             "member access into incomplete class {0}",
                             InstIdAsType);
           builder.Context(loc_id, QualifiedExprInIncompleteClassScope,
@@ -384,7 +384,7 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
             context.types().GetTypeIdForTypeConstantId(lookup_const_id), loc_id,
             [&](auto& builder) {
               CARBON_DIAGNOSTIC(
-                  QualifiedExprInIncompleteFacetTypeScope, Context,
+                  QualifiedExprInIncompleteFacetTypeScope, ErrorContext,
                   "member access into incomplete facet type {0}", InstIdAsType);
               builder.Context(loc_id, QualifiedExprInIncompleteFacetTypeScope,
                               lookup_inst_id);

--- a/toolchain/diagnostics/consumer.cpp
+++ b/toolchain/diagnostics/consumer.cpp
@@ -17,7 +17,7 @@ auto StreamConsumer::HandleDiagnostic(Diagnostic diagnostic) -> void {
   }
 
   auto message_level = [&, first = true](const Message& m) mutable {
-    if (m.level >= Level::SoftContext && std::exchange(first, false)) {
+    if (m.level >= Level::SoftErrorContext && std::exchange(first, false)) {
       return diagnostic.level;
     }
     return std::min(Level::Note, m.level);
@@ -36,8 +36,8 @@ auto StreamConsumer::HandleDiagnostic(Diagnostic diagnostic) -> void {
         break;
       case Level::LocationInfo:
         break;
-      case Level::SoftContext:
-      case Level::Context:
+      case Level::SoftErrorContext:
+      case Level::ErrorContext:
         CARBON_FATAL("Context messages are presented as a different level");
     }
     *stream_ << message.Format();

--- a/toolchain/diagnostics/diagnostic.h
+++ b/toolchain/diagnostics/diagnostic.h
@@ -25,16 +25,17 @@ enum class Level : int8_t {
   // A note, not indicating an error on its own, but possibly providing
   // additional information for an error or warning.
   Note,
-  // A Context that will be discarded if another Context precedes it in the
-  // diagnostic, as the Context is assumed to provide better information. Used
-  // as a fallback for when no better Context is provided.
-  SoftContext,
-  // Describes the high level operation being performed. If a diagnostic is
-  // issued, the first Context message will steal its level and be displayed as
-  // if it is the top-level diagnostic, and the rest are treated as Note
-  // messages. The diagnostic message also becomes a Note of the first Context
-  // message.
-  Context,
+  // An ErrorContext that will be discarded if another ErrorContext precedes it
+  // in the diagnostic, as the ErrorContext is assumed to provide better
+  // information. Used as a fallback for when no better ErrorContext is
+  // provided.
+  SoftErrorContext,
+  // Describes the high level operation being performed. If an Error diagnostic
+  // is issued, the first ErrorContext message will steal its level and be
+  // displayed as if it is the top-level diagnostic, and the rest are treated as
+  // Note messages. The original Error diagnostic message also becomes a Note of
+  // the first ErrorContext message.
+  ErrorContext,
   // A warning diagnostic, indicating a likely problem with the program.
   Warning,
   // An error diagnostic, indicating that the program is not valid.

--- a/toolchain/diagnostics/emitter.h
+++ b/toolchain/diagnostics/emitter.h
@@ -133,19 +133,22 @@ class Emitter {
     static auto FormatFn(const Message& message,
                          std::index_sequence<N...> /*indices*/) -> std::string;
 
-    // Whether a Context or SoftContext message has been added to the Builder.
-    auto has_context_message() const -> bool { return has_context_message_; }
+    // Whether an ErrorContext or ErrorSoftContext message has been added to the
+    // Builder.
+    auto has_error_context_message() const -> bool {
+      return has_error_context_message_;
+    }
 
     Emitter<LocT>* emitter_;
     Diagnostic diagnostic_;
-    bool has_context_message_ = false;
+    bool has_error_context_message_ = false;
   };
 
   class ContextBuilder {
    public:
-    // Adds a Context describing a higher level operation that failed due to the
-    // diagnostic being built. The API mirrors the main emission API:
-    // `Emitter::Emit`. For the expected usage see the builder API:
+    // Adds a context message describing a higher level operation that has
+    // encountered the diagnostic being built. The API mirrors the main emission
+    // API: `Emitter::Emit`. For the expected usage see the builder API:
     // `Emitter::Build`.
     template <typename... Args>
     auto Context(LocT loc, const DiagnosticBase<Args...>& diagnostic_base,
@@ -457,9 +460,9 @@ auto Emitter<LocT>::Builder::AddMessageWithLoc(
       diagnostic_base.Level <= diagnostic_.level,
       "message with level {0} is higher than the diagnostic's level {1}",
       diagnostic_base.Level, diagnostic_.level);
-  if (diagnostic_base.Level == Level::SoftContext ||
-      diagnostic_base.Level == Level::Context) {
-    has_context_message_ = true;
+  if (diagnostic_base.Level == Level::SoftErrorContext ||
+      diagnostic_base.Level == Level::ErrorContext) {
+    has_error_context_message_ = true;
   }
   diagnostic_.messages.push_back(
       Message{.kind = diagnostic_base.Kind,
@@ -503,11 +506,15 @@ template <typename... Args>
 auto Emitter<LocT>::ContextBuilder::Context(
     LocT loc, const DiagnosticBase<Args...>& diagnostic_base,
     Internal::NoTypeDeduction<Args>... args) -> ContextBuilder& {
-  CARBON_CHECK(diagnostic_base.Level == Level::SoftContext ||
-                   diagnostic_base.Level == Level::Context,
+  CARBON_CHECK(diagnostic_base.Level == Level::SoftErrorContext ||
+                   diagnostic_base.Level == Level::ErrorContext,
                "{0}", static_cast<int>(diagnostic_base.Level));
-  if (builder_->has_context_message() &&
-      diagnostic_base.Level == Level::SoftContext) {
+  if (builder_->diagnostic_.level != Level::Error) {
+    // ErrorContext and SoftErrorContext messages are only for errors.
+    return *this;
+  }
+  if (builder_->has_error_context_message() &&
+      diagnostic_base.Level == Level::SoftErrorContext) {
     return *this;
   }
   builder_->AddMessage(LocT(loc), diagnostic_base,

--- a/toolchain/diagnostics/emitter_test.cpp
+++ b/toolchain/diagnostics/emitter_test.cpp
@@ -80,64 +80,64 @@ TEST_F(EmitterTest, EmitNote) {
   emitter_.Build(1, TestDiagnostic).Note(2, TestDiagnosticNote).Emit();
 }
 
-TEST_F(EmitterTest, EmitContext) {
+TEST_F(EmitterTest, EmitErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::Context, 1, 2, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 2, "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(2, TestDiagnosticContext);
   });
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitSoftContext) {
+TEST_F(EmitterTest, EmitSoftErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
                     "soft context");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticSoftContext,
-                                  Diagnostics::Level::SoftContext, 1, 2,
+                                  Diagnostics::Level::SoftErrorContext, 1, 2,
                                   "soft context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope soft_scope(&emitter_, [&](auto& builder) {
     builder.Context(2, TestDiagnosticSoftContext);
   });
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitSoftContextAndContext) {
+TEST_F(EmitterTest, EmitSoftErrorContextAndErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
                     "soft context");
   CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticSoftContext,
-                                  Diagnostics::Level::SoftContext, 1, 3,
+                                  Diagnostics::Level::SoftErrorContext, 1, 3,
                                   "soft context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::Context, 1, 2, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 2, "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope soft_scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticSoftContext);
   });
@@ -147,21 +147,21 @@ TEST_F(EmitterTest, EmitSoftContextAndContext) {
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitContextAndSoftContext) {
+TEST_F(EmitterTest, EmitErrorContextAndSoftErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
                     "soft context");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::Context, 1, 3, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 3, "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticContext);
   });
@@ -173,23 +173,23 @@ TEST_F(EmitterTest, EmitContextAndSoftContext) {
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitTwoContext) {
+TEST_F(EmitterTest, EmitTwoErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
   CARBON_DIAGNOSTIC(TestDiagnosticContext2, ErrorContext, "context 2");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::Context, 1, 3, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 3, "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext2,
-                                  Diagnostics::Level::Context, 1, 2,
+                                  Diagnostics::Level::ErrorContext, 1, 2,
                                   "context 2"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticContext);
   });
@@ -199,23 +199,23 @@ TEST_F(EmitterTest, EmitTwoContext) {
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitTwoSoftContext) {
+TEST_F(EmitterTest, EmitTwoSoftErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
                     "soft context");
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext2, SoftErrorContext,
                     "soft context 2");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticSoftContext,
-                                  Diagnostics::Level::SoftContext, 1, 3,
+                                  Diagnostics::Level::SoftErrorContext, 1, 3,
                                   "soft context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticSoftContext);
   });

--- a/toolchain/diagnostics/emitter_test.cpp
+++ b/toolchain/diagnostics/emitter_test.cpp
@@ -81,7 +81,7 @@ TEST_F(EmitterTest, EmitNote) {
 }
 
 TEST_F(EmitterTest, EmitContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticContext, Context, "context");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -100,7 +100,8 @@ TEST_F(EmitterTest, EmitContext) {
 }
 
 TEST_F(EmitterTest, EmitSoftContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftContext, "soft context");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
+                    "soft context");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -120,8 +121,9 @@ TEST_F(EmitterTest, EmitSoftContext) {
 }
 
 TEST_F(EmitterTest, EmitSoftContextAndContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftContext, "soft context");
-  CARBON_DIAGNOSTIC(TestDiagnosticContext, Context, "context");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
+                    "soft context");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -146,8 +148,9 @@ TEST_F(EmitterTest, EmitSoftContextAndContext) {
 }
 
 TEST_F(EmitterTest, EmitContextAndSoftContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticContext, Context, "context");
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftContext, "soft context");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
+                    "soft context");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -171,8 +174,8 @@ TEST_F(EmitterTest, EmitContextAndSoftContext) {
 }
 
 TEST_F(EmitterTest, EmitTwoContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticContext, Context, "context");
-  CARBON_DIAGNOSTIC(TestDiagnosticContext2, Context, "context 2");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext2, ErrorContext, "context 2");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -197,8 +200,10 @@ TEST_F(EmitterTest, EmitTwoContext) {
 }
 
 TEST_F(EmitterTest, EmitTwoSoftContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftContext, "soft context");
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext2, SoftContext, "soft context 2");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
+                    "soft context");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext2, SoftErrorContext,
+                    "soft context 2");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,

--- a/toolchain/diagnostics/emitter_test.cpp
+++ b/toolchain/diagnostics/emitter_test.cpp
@@ -87,12 +87,12 @@ TEST_F(EmitterTest, EmitErrorContext) {
       consumer_,
       HandleDiagnostic(IsDiagnostic(
           Diagnostics::Level::Error,
-          ElementsAre(
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::ErrorContext, 1, 2, "context"),
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Error, 1, 1,
-                                  "simple error")))));
+          ElementsAre(IsDiagnosticMessage(
+                          Diagnostics::Kind::TestDiagnosticContext,
+                          Diagnostics::Level::ErrorContext, 1, 2, "context"),
+                      IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
+                                          Diagnostics::Level::Error, 1, 1,
+                                          "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(2, TestDiagnosticContext);
   });
@@ -134,7 +134,8 @@ TEST_F(EmitterTest, EmitSoftErrorContextAndErrorContext) {
                                   Diagnostics::Level::SoftErrorContext, 1, 3,
                                   "soft context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::ErrorContext, 1, 2, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 2,
+                                  "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
                                   Diagnostics::Level::Error, 1, 1,
                                   "simple error")))));
@@ -156,12 +157,12 @@ TEST_F(EmitterTest, EmitErrorContextAndSoftErrorContext) {
       consumer_,
       HandleDiagnostic(IsDiagnostic(
           Diagnostics::Level::Error,
-          ElementsAre(
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::ErrorContext, 1, 3, "context"),
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Error, 1, 1,
-                                  "simple error")))));
+          ElementsAre(IsDiagnosticMessage(
+                          Diagnostics::Kind::TestDiagnosticContext,
+                          Diagnostics::Level::ErrorContext, 1, 3, "context"),
+                      IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
+                                          Diagnostics::Level::Error, 1, 1,
+                                          "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticContext);
   });
@@ -181,15 +182,15 @@ TEST_F(EmitterTest, EmitTwoErrorContext) {
       consumer_,
       HandleDiagnostic(IsDiagnostic(
           Diagnostics::Level::Error,
-          ElementsAre(
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::ErrorContext, 1, 3, "context"),
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext2,
-                                  Diagnostics::Level::ErrorContext, 1, 2,
-                                  "context 2"),
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Error, 1, 1,
-                                  "simple error")))));
+          ElementsAre(IsDiagnosticMessage(
+                          Diagnostics::Kind::TestDiagnosticContext,
+                          Diagnostics::Level::ErrorContext, 1, 3, "context"),
+                      IsDiagnosticMessage(
+                          Diagnostics::Kind::TestDiagnosticContext2,
+                          Diagnostics::Level::ErrorContext, 1, 2, "context 2"),
+                      IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
+                                          Diagnostics::Level::Error, 1, 1,
+                                          "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticContext);
   });
@@ -223,6 +224,21 @@ TEST_F(EmitterTest, EmitTwoSoftErrorContext) {
   // supersedes it.
   Diagnostics::ContextScope soft_scope(&emitter_, [&](auto& builder) {
     builder.Context(2, TestDiagnosticSoftContext2);
+  });
+  emitter_.Emit(1, TestDiagnostic);
+}
+
+TEST_F(EmitterTest, EmitErrorContextWithWarning) {
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  EXPECT_CALL(consumer_,
+              HandleDiagnostic(IsDiagnostic(
+                  Diagnostics::Level::Warning,
+                  ElementsAre(IsDiagnosticMessage(
+                      Diagnostics::Kind::TestDiagnostic,
+                      Diagnostics::Level::Warning, 1, 1, "simple warning")))));
+  Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
+    builder.Context(2, TestDiagnosticContext);
   });
   emitter_.Emit(1, TestDiagnostic);
 }

--- a/toolchain/diagnostics/mocks.cpp
+++ b/toolchain/diagnostics/mocks.cpp
@@ -27,11 +27,11 @@ auto PrintTo(Level level, std::ostream* os) -> void {
     case Level::Note:
       *os << "Note";
       break;
-    case Level::SoftContext:
-      *os << "SoftContext";
+    case Level::SoftErrorContext:
+      *os << "SoftErrorContext";
       break;
-    case Level::Context:
-      *os << "Context";
+    case Level::ErrorContext:
+      *os << "ErrorContext";
       break;
     case Level::Warning:
       *os << "Warning";

--- a/toolchain/docs/diagnostics.md
+++ b/toolchain/docs/diagnostics.md
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Diagnostic context](#diagnostic-context)
 -   [Diagnostic parameter types](#diagnostic-parameter-types)
 -   [Diagnostic message style guide](#diagnostic-message-style-guide)
+-   [ErrorContext](#errorcontext)
 -   [Alternatives considered](#alternatives-considered)
 -   [References](#references)
 
@@ -317,6 +318,29 @@ Carbon's diagnostic style aims to balance these concerns. Our style is:
     only allowed for types?
 
 -   TODO: Lots more things to decide, give examples.
+
+## ErrorContext
+
+Some operations in the toolchain can fail due to errors in a smaller operation.
+For example, requiring an identified facet type can fail in which a diagnostic
+is emitted saying what was wrong, such as
+`"error: named constraint is not defined"`.
+
+When this happens, the higher level operation can provide a more contextual
+error that supersedes the specific one. This is done with a `ContextScope` that
+takes a lambda that is called if a diagnostic is emitted. The callback can
+introduce an `ErrorContext` that modifies a `Error` diagnostic. The
+`ErrorContext` message becomes the main diagnostic message, and the `Error`
+diagnostic message becomes a `Note` annotation. Given our example above, this
+can convert `"error: named constraint is not defined"` into
+`"error: failed to identify facet type for impl definition" / "note: named constraint is not defined"`.
+
+If multiple `ErrorContext` are introduced, the first one becomes the diagnostic
+message, and the others are converted to `Note` annotations that come before the
+`Error` diagnostic message.
+
+The message in an `ErrorContext` should be formulated as an error, in the same
+way as an `Error` message, as that is what it becomes.
 
 ## Alternatives considered
 


### PR DESCRIPTION
Rename the `Context` levels to `ErrorContext` and limit them to only modifying `Error` diagnostics.

Add documentation and a proposal.