### PR TITLE
Change "FromHere" error messages to be a more direct error

### DIFF
--- a/proposals/p6806.md
+++ b/proposals/p6806.md
@@ -1,0 +1,94 @@
+# ErrorContext
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Pull request](https://github.com/carbon-language/carbon-lang/pull/6806)
+
+<!-- toc -->
+
+## Table of contents
+
+-   [Abstract](#abstract)
+-   [Problem](#problem)
+-   [Proposal](#proposal)
+-   [Rationale](#rationale)
+-   [Alternatives considered](#alternatives-considered)
+    -   [Diagnostic emitting callbacks](#diagnostic-emitting-callbacks)
+    -   [General `Context` vs `ErrorContext`](#general-context-vs-errorcontext)
+
+<!-- tocstop -->
+
+## Abstract
+
+Introduce ErrorContext as a means to modify later error diagnostics to describe
+the failure of a higher order operation. If an Error is omitted, the
+ErrorContext replaces it, and the Error becomes a Note annotation of the context
+message.
+
+## Problem
+
+There are operations in the toolchain that can fail due to an error, and we want
+to display that error as an explanation for the failure, but we also want to
+diagnose the higher level failure, which contains more context on what the user
+was trying to do, and points more directly to the user code that caused the
+error.
+
+Sometimes errors come from very distant operations, such as conversion failing
+due to an error that occurs during impl lookup. Previously we handled this by
+plumbing through a callback to call to produce an error diagnostic for the high
+level operation, and then we attach a note to that diagnostic. However that
+requires plumbing callbacks through much of the toolchain, including through
+eval in order to provide a higher level error for monomorphization failures.
+
+## Proposal
+
+Introduce `ErrorContext` messages which modify an `Error` diagnostic. The
+`ErrorContext` message becomes the primary error message, while the `Error`
+message becomes a `Note` annotation attached to it.
+
+Some scenarios want to provide an `ErrorContext` as a default, if there's not a
+better one available. Introduce `SoftErrorContext` for these, where the
+`SoftErrorContext` will be dropped if there's another (`Soft`)`ErrorContext`
+that comes first in the diagnostic.
+
+A `ContextScope` RAII object allows attaching context messages to an `Error`
+diagnostic while it is being built through a callback. This functions like
+`AnnotationScope`, but for context messages instead of annotations.
+
+`ErrorContext` only modifies `Error` diagnostics, so that the messages can be
+clearly formulated as error/failure messages. This leaves open room for a
+`WarningContext` message level in the future, which could be also added in a
+`ContextScope` callback. It would even be possible for a single `ContextScope`
+to provide both an `ErrorContext` and `WarningContext` using the same diagnostic
+kind, but with different messages.
+
+## Rationale
+
+This advances Carbon's goals of providing high quality diagnostics, by
+connecting local errors to higher level operations. And by anchoring error
+diagnostics on the user code which is the enrty-point of the failure, instead of
+in library code with a note pointing back to the user code. These advance the
+goal of
+[Code that is easy to read, understand, and write](/docs/project/goals.md#code-that-is-easy-to-read-understand-and-write).
+
+## Alternatives considered
+
+### Diagnostic emitting callbacks
+
+Previously plumbed through callbacks that would provide the higher level context
+by emitting an `Error` diagnostic. Then code could attach annotations to it with
+the more specific error. This worked for shallow call graphs but requires
+intrusive plumbing that does not work well for distant systems, or errors that
+occur during eval. Instead we end up with two separate error diagnostics for the
+same failure.
+
+### General `Context` vs `ErrorContext`
+
+We tried having a single `Context` level but it was unclear how to phase a
+context message that may become the primary message of either an `Error` or a
+`Warning`. By using `ErrorContext` as the level, and applying them only to
+`Error` diagnostics, the message phrasing can be more clear.

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -1585,7 +1585,7 @@ static auto PerformCopy(Context& context, SemIR::InstId expr_id,
   auto copy_id = BuildUnaryOperator(
       context, SemIR::LocId(expr_id), {.interface_name = CoreIdentifier::Copy},
       expr_id, target.diagnose, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(CopyOfUncopyableType, Context,
+        CARBON_DIAGNOSTIC(CopyOfUncopyableType, ErrorContext,
                           "cannot copy value of type {0}", TypeOfInstId);
         builder.Context(expr_id, CopyOfUncopyableType, expr_id);
       });
@@ -1941,10 +1941,10 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
                     !target.is_initializer(),
                     "Initialization of incomplete types is expected to be "
                     "caught elsewhere.");
-                CARBON_DIAGNOSTIC(IncompleteTypeInValueConversion, Context,
+                CARBON_DIAGNOSTIC(IncompleteTypeInValueConversion, ErrorContext,
                                   "forming value of incomplete type {0}",
                                   SemIR::TypeId);
-                CARBON_DIAGNOSTIC(IncompleteTypeInConversion, Context,
+                CARBON_DIAGNOSTIC(IncompleteTypeInConversion, ErrorContext,
                                   "invalid use of incomplete type {0}",
                                   SemIR::TypeId);
                 builder.Context(loc_id,
@@ -1954,7 +1954,7 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
                                 target.type_id);
               },
               [&](auto& builder) {
-                CARBON_DIAGNOSTIC(AbstractTypeInInit, Context,
+                CARBON_DIAGNOSTIC(AbstractTypeInInit, ErrorContext,
                                   "initialization of abstract type {0}",
                                   SemIR::TypeId);
                 builder.Context(loc_id, AbstractTypeInInit, target.type_id);
@@ -2030,7 +2030,7 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
           if (target.type_id == SemIR::TypeType::TypeId ||
               sem_ir.types().Is<SemIR::FacetType>(target.type_id)) {
             CARBON_DIAGNOSTIC(
-                ConversionFailureNonTypeToFacet, Context,
+                ConversionFailureNonTypeToFacet, ErrorContext,
                 "cannot{0:=0: implicitly|:} convert non-type value of type {1} "
                 "{2:to|into type implementing} {3}"
                 "{0:=1: with `as`|=2: with `unsafe as`|:}",
@@ -2042,7 +2042,7 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
                             target.type_id);
           } else {
             CARBON_DIAGNOSTIC(
-                ConversionFailure, Context,
+                ConversionFailure, ErrorContext,
                 "cannot{0:=0: implicitly|:} convert expression of type "
                 "{1} to {2}{0:=1: with `as`|=2: with `unsafe as`|:}",
                 Diagnostics::IntAsSelect, TypeOfInstId, SemIR::TypeId);

--- a/toolchain/check/cpp/operators.cpp
+++ b/toolchain/check/cpp/operators.cpp
@@ -478,7 +478,7 @@ auto LookupCppOperator(Context& context, SemIR::LocId loc_id, Operator op,
     SemIR::TypeId arg_type_id = context.insts().Get(arg_id).type_id();
     if (!RequireCompleteType(context, arg_type_id, loc_id, [&](auto& builder) {
           CARBON_DIAGNOSTIC(
-              IncompleteOperandTypeInCppOperatorLookup, Context,
+              IncompleteOperandTypeInCppOperatorLookup, ErrorContext,
               "looking up a C++ operator with incomplete operand type {0}",
               SemIR::TypeId);
           builder.Context(loc_id, IncompleteOperandTypeInCppOperatorLookup,

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -381,7 +381,7 @@ static auto DiagnoseQualifiedDeclInIncompleteClassScope(Context& context,
     -> void {
   Diagnostics::ContextScope diagnostic_context(
       &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(QualifiedDeclInIncompleteClassScope, Context,
+        CARBON_DIAGNOSTIC(QualifiedDeclInIncompleteClassScope, ErrorContext,
                           "cannot declare a member of incomplete class {0}",
                           SemIR::TypeId);
         builder.Context(loc_id, QualifiedDeclInIncompleteClassScope,
@@ -397,7 +397,7 @@ static auto DiagnoseQualifiedDeclInUndefinedInterfaceScope(
     SemIR::InstId interface_inst_id) -> void {
   Diagnostics::ContextScope diagnostic_context(
       &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(QualifiedDeclInUndefinedInterfaceScope, Context,
+        CARBON_DIAGNOSTIC(QualifiedDeclInUndefinedInterfaceScope, ErrorContext,
                           "cannot declare a member of undefined interface {0}",
                           InstIdAsType);
         builder.Context(loc_id, QualifiedDeclInUndefinedInterfaceScope,

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -2554,7 +2554,7 @@ auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
 
   Diagnostics::ContextScope diagnostic_context(
       &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ResolvingSpecificHere, SoftContext,
+        CARBON_DIAGNOSTIC(ResolvingSpecificHere, SoftErrorContext,
                           "unable to monomorphize specific {0}",
                           SemIR::SpecificId);
         builder.Context(loc_id, ResolvingSpecificHere, specific_id);

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -549,7 +549,7 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
   if (complete_type_id.is_concrete()) {
     Diagnostics::ContextScope diagnostic_context(
         &context.emitter(), [&](auto& builder) {
-          CARBON_DIAGNOSTIC(IncompleteTypeInMonomorphization, Context,
+          CARBON_DIAGNOSTIC(IncompleteTypeInMonomorphization, ErrorContext,
                             "{0} evaluates to incomplete type {1}",
                             InstIdAsType, InstIdAsType);
           builder.Context(inst_id, IncompleteTypeInMonomorphization,

--- a/toolchain/check/function.cpp
+++ b/toolchain/check/function.cpp
@@ -329,14 +329,14 @@ auto CheckFunctionReturnPatternType(Context& context, SemIR::LocId loc_id,
     if (!RequireConcreteType(
             context, arg_type_id, SemIR::LocId(return_pattern_id),
             [&](auto& builder) {
-              CARBON_DIAGNOSTIC(IncompleteTypeInFunctionReturnType, Context,
-                                "function returns incomplete type {0}",
-                                SemIR::TypeId);
+              CARBON_DIAGNOSTIC(
+                  IncompleteTypeInFunctionReturnType, ErrorContext,
+                  "function returns incomplete type {0}", SemIR::TypeId);
               builder.Context(loc_id, IncompleteTypeInFunctionReturnType,
                               arg_type_id);
             },
             [&](auto& builder) {
-              CARBON_DIAGNOSTIC(AbstractTypeInFunctionReturnType, Context,
+              CARBON_DIAGNOSTIC(AbstractTypeInFunctionReturnType, ErrorContext,
                                 "function returns abstract type {0}",
                                 SemIR::TypeId);
               builder.Context(loc_id, AbstractTypeInFunctionReturnType,
@@ -374,7 +374,7 @@ auto CheckFunctionDefinitionSignature(Context& context,
         context, context.insts().GetAs<SemIR::AnyParam>(param_ref_id).type_id,
         SemIR::LocId(param_ref_id), [&](auto& builder) {
           CARBON_DIAGNOSTIC(
-              IncompleteTypeInFunctionParam, Context,
+              IncompleteTypeInFunctionParam, ErrorContext,
               "parameter has incomplete type {0} in function definition",
               TypeOfInstId);
           builder.Context(param_ref_id, IncompleteTypeInFunctionParam,

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -206,7 +206,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
   };
 
   auto abstract_diagnostic_context = [&](auto& builder) {
-    CARBON_DIAGNOSTIC(AbstractTypeInVarPattern, Context,
+    CARBON_DIAGNOSTIC(AbstractTypeInVarPattern, ErrorContext,
                       "binding pattern has abstract type {0} in `var` "
                       "pattern",
                       SemIR::TypeId);
@@ -306,7 +306,7 @@ static auto HandleAnyBindingPattern(Context& context, Parse::NodeId node_id,
 
     case FullPatternStack::Kind::NameBindingDecl: {
       auto incomplete_diagnostic_context = [&](auto& builder) {
-        CARBON_DIAGNOSTIC(IncompleteTypeInBindingDecl, Context,
+        CARBON_DIAGNOSTIC(IncompleteTypeInBindingDecl, ErrorContext,
                           "binding pattern has incomplete type {0} in name "
                           "binding declaration",
                           InstIdAsType);
@@ -464,12 +464,12 @@ auto HandleParseNode(Context& context, Parse::FieldNameAndTypeId node_id)
   if (!RequireConcreteType(
           context, cast_type_id, type_node,
           [&](auto& builder) {
-            CARBON_DIAGNOSTIC(IncompleteTypeInFieldDecl, Context,
+            CARBON_DIAGNOSTIC(IncompleteTypeInFieldDecl, ErrorContext,
                               "field has incomplete type {0}", SemIR::TypeId);
             builder.Context(type_node, IncompleteTypeInFieldDecl, cast_type_id);
           },
           [&](auto& builder) {
-            CARBON_DIAGNOSTIC(AbstractTypeInFieldDecl, Context,
+            CARBON_DIAGNOSTIC(AbstractTypeInFieldDecl, ErrorContext,
                               "field has abstract type {0}", SemIR::TypeId);
             builder.Context(type_node, AbstractTypeInFieldDecl, cast_type_id);
           })) {

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -381,14 +381,14 @@ auto HandleParseNode(Context& context, Parse::AdaptDeclId node_id) -> bool {
   if (!RequireConcreteType(
           context, adapted_type_id, node_id,
           [&](auto& builder) {
-            CARBON_DIAGNOSTIC(IncompleteTypeInAdaptDecl, Context,
+            CARBON_DIAGNOSTIC(IncompleteTypeInAdaptDecl, ErrorContext,
                               "adapted type {0} is an incomplete type",
                               InstIdAsType);
             builder.Context(node_id, IncompleteTypeInAdaptDecl,
                             adapted_type_inst_id);
           },
           [&](auto& builder) {
-            CARBON_DIAGNOSTIC(AbstractTypeInAdaptDecl, Context,
+            CARBON_DIAGNOSTIC(AbstractTypeInAdaptDecl, ErrorContext,
                               "adapted type {0} is an abstract type",
                               InstIdAsType);
             builder.Context(node_id, AbstractTypeInAdaptDecl,
@@ -457,7 +457,7 @@ static auto CheckBaseType(Context& context, Parse::NodeId node_id,
     return BaseInfo::Error;
   }
   if (!RequireCompleteType(context, base_type_id, node_id, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(IncompleteTypeInBaseDecl, Context,
+        CARBON_DIAGNOSTIC(IncompleteTypeInBaseDecl, ErrorContext,
                           "base {0} is an incomplete type", InstIdAsType);
         builder.Context(node_id, IncompleteTypeInBaseDecl, base_type_inst_id);
       })) {

--- a/toolchain/check/handle_require.cpp
+++ b/toolchain/check/handle_require.cpp
@@ -213,7 +213,7 @@ static auto ValidateRequire(Context& context, SemIR::LocId loc_id,
       context, SemIR::LocId(constraint_inst_id), self_constant_value_id,
       *constraint_facet_type, [&](auto& builder) {
         CARBON_DIAGNOSTIC(
-            RequireImplsUnidentifiedFacetType, Context,
+            RequireImplsUnidentifiedFacetType, ErrorContext,
             "facet type {0} cannot be identified in `require` declaration",
             InstIdAsType);
         builder.Context(constraint_inst_id, RequireImplsUnidentifiedFacetType,
@@ -300,7 +300,7 @@ auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
     if (!RequireCompleteType(
             context, constraint_type_id, SemIR::LocId(constraint_inst_id),
             [&](auto& builder) {
-              CARBON_DIAGNOSTIC(RequireImplsIncompleteFacetType, Context,
+              CARBON_DIAGNOSTIC(RequireImplsIncompleteFacetType, ErrorContext,
                                 "`extend require` of incomplete facet type {0}",
                                 InstIdAsType);
               builder.Context(constraint_inst_id,

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -222,7 +222,7 @@ static auto ApplyExtendImplAs(Context& context, SemIR::LocId loc_id,
   if (!RequireCompleteType(
           context, context.types().GetTypeIdForTypeInstId(impl.constraint_id),
           SemIR::LocId(impl.constraint_id), [&](auto& builder) {
-            CARBON_DIAGNOSTIC(ExtendImplAsIncomplete, Context,
+            CARBON_DIAGNOSTIC(ExtendImplAsIncomplete, ErrorContext,
                               "`extend impl as` incomplete facet type {0}",
                               InstIdAsType);
             builder.Context(impl.latest_decl_id(), ExtendImplAsIncomplete,
@@ -517,7 +517,7 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
             context, context.types().GetTypeIdForTypeInstId(impl.constraint_id),
             SemIR::LocId(impl.constraint_id), [&](auto& builder) {
               CARBON_DIAGNOSTIC(
-                  ImplAsIncompleteFacetTypeDefinition, Context,
+                  ImplAsIncompleteFacetTypeDefinition, ErrorContext,
                   "definition of impl as incomplete facet type {0}",
                   InstIdAsType);
               builder.Context(SemIR::LocId(impl.latest_decl_id()),
@@ -798,7 +798,7 @@ auto CheckConstraintIsInterface(Context& context, SemIR::InstId impl_decl_id,
   auto identified_id = RequireIdentifiedFacetType(
       context, SemIR::LocId(constraint_id),
       context.constant_values().Get(self_id), *facet_type, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ImplOfUnidentifiedFacetType, Context,
+        CARBON_DIAGNOSTIC(ImplOfUnidentifiedFacetType, ErrorContext,
                           "facet type {0} cannot be identified in `impl as`",
                           InstIdAsType);
         builder.Context(impl_decl_id, ImplOfUnidentifiedFacetType,

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -221,7 +221,7 @@ static auto GetRequiredImplsFromConstraint(
   auto identified_id = RequireIdentifiedFacetType(
       context, loc_id, query_self_const_id, facet_type_inst,
       [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetType, Context,
+        CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetType, ErrorContext,
                           "facet type {0} can not be identified", InstIdAsType);
         builder.Context(loc_id, ImplLookupInUnidentifiedFacetType,
                         facet_type_inst_id);
@@ -353,9 +353,9 @@ static auto LookupImplWitnessInSelfFacetValue(
   auto identified_id = RequireIdentifiedFacetType(
       context, loc_id, self_facet_value_const_id, *facet_type,
       [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetTypeOfQuerySelf, Context,
-                          "facet type of value {0} can not be identified",
-                          InstIdAsType);
+        CARBON_DIAGNOSTIC(
+            ImplLookupInUnidentifiedFacetTypeOfQuerySelf, ErrorContext,
+            "facet type of value {0} can not be identified", InstIdAsType);
         builder.Context(loc_id, ImplLookupInUnidentifiedFacetTypeOfQuerySelf,
                         self_facet_value_inst_id);
       });

--- a/toolchain/check/literal.cpp
+++ b/toolchain/check/literal.cpp
@@ -174,7 +174,7 @@ auto MakeStringLiteral(Context& context, Parse::StringLiteralId node_id,
   auto str_type = MakeStringType(context, SemIR::LocId(node_id).AsDesugared());
   if (!RequireCompleteType(
           context, str_type.type_id, node_id, [&](auto& builder) {
-            CARBON_DIAGNOSTIC(StringLiteralTypeIncomplete, Context,
+            CARBON_DIAGNOSTIC(StringLiteralTypeIncomplete, ErrorContext,
                               "type {0} is incomplete", InstIdAsType);
             builder.Context(node_id, StringLiteralTypeIncomplete,
                             str_type.inst_id);

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -517,7 +517,7 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
       if (!RequireCompleteType(
               context, base_type_id, SemIR::LocId(base_id), [&](auto& builder) {
                 CARBON_DIAGNOSTIC(
-                    IncompleteTypeInMemberAccessOfFacet, Context,
+                    IncompleteTypeInMemberAccessOfFacet, ErrorContext,
                     "member access into facet of incomplete type {0}",
                     SemIR::TypeId);
                 builder.Context(base_id, IncompleteTypeInMemberAccessOfFacet,
@@ -560,7 +560,7 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
   if (!RequireCompleteType(
           context, base_type_id, SemIR::LocId(base_id), [&](auto& builder) {
             CARBON_DIAGNOSTIC(
-                IncompleteTypeInMemberAccess, Context,
+                IncompleteTypeInMemberAccess, ErrorContext,
                 "member access into object of incomplete type {0}",
                 TypeOfInstId);
             builder.Context(base_id, IncompleteTypeInMemberAccess, base_id);

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -363,7 +363,7 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
     RequireCompleteType(
         context, context.types().GetTypeIdForTypeConstantId(lookup_const_id),
         loc_id, [&](auto& builder) {
-          CARBON_DIAGNOSTIC(QualifiedExprInIncompleteClassScope, Context,
+          CARBON_DIAGNOSTIC(QualifiedExprInIncompleteClassScope, ErrorContext,
                             "member access into incomplete class {0}",
                             InstIdAsType);
           builder.Context(loc_id, QualifiedExprInIncompleteClassScope,
@@ -384,7 +384,7 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
             context.types().GetTypeIdForTypeConstantId(lookup_const_id), loc_id,
             [&](auto& builder) {
               CARBON_DIAGNOSTIC(
-                  QualifiedExprInIncompleteFacetTypeScope, Context,
+                  QualifiedExprInIncompleteFacetTypeScope, ErrorContext,
                   "member access into incomplete facet type {0}", InstIdAsType);
               builder.Context(loc_id, QualifiedExprInIncompleteFacetTypeScope,
                               lookup_inst_id);

--- a/toolchain/check/testdata/array/basics.carbon
+++ b/toolchain/check/testdata/array/basics.carbon
@@ -84,7 +84,7 @@ class Incomplete;
 // CHECK:STDERR: fail_incomplete_element.carbon:[[@LINE+7]]:8: error: binding pattern has incomplete type `array(Incomplete, 1)` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var a: array(Incomplete, 1);
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_incomplete_element.carbon:[[@LINE-5]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_incomplete_element.carbon:[[@LINE-5]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class Incomplete;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/builtins/cpp/std/initializer_list/make.carbon
+++ b/toolchain/check/testdata/builtins/cpp/std/initializer_list/make.carbon
@@ -61,7 +61,7 @@ class FailIncomplete;
 // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+11]]:20: error: function returns incomplete type `FailIncomplete` [IncompleteTypeInFunctionReturnType]
 // CHECK:STDERR: fn Make(n: i32) -> FailIncomplete = "cpp.std.initializer_list.make";
 // CHECK:STDERR:                    ^~~~~~~~~~~~~~
-// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-5]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_incomplete.carbon:[[@LINE-5]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class FailIncomplete;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/class/abstract/abstract.carbon
+++ b/toolchain/check/testdata/class/abstract/abstract.carbon
@@ -22,7 +22,7 @@ class Contains {
   // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE+7]]:10: error: field has abstract type `Abstract` [AbstractTypeInFieldDecl]
   // CHECK:STDERR:   var a: Abstract;
   // CHECK:STDERR:          ^~~~~~~~
-  // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE-7]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE-7]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -39,7 +39,7 @@ fn Var() {
   // CHECK:STDERR: fail_abstract_var.carbon:[[@LINE+7]]:17: error: binding pattern has abstract type `Abstract` in `var` pattern [AbstractTypeInVarPattern]
   // CHECK:STDERR:   var unused v: Abstract;
   // CHECK:STDERR:                 ^~~~~~~~
-  // CHECK:STDERR: fail_abstract_var.carbon:[[@LINE-7]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_var.carbon:[[@LINE-7]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -55,7 +55,7 @@ abstract class Abstract {
 // CHECK:STDERR: fail_abstract_var_function_param.carbon:[[@LINE+7]]:13: error: binding pattern has abstract type `Abstract` in `var` pattern [AbstractTypeInVarPattern]
 // CHECK:STDERR: fn F(var _: Abstract) {
 // CHECK:STDERR:             ^~~~~~~~
-// CHECK:STDERR: fail_abstract_var_function_param.carbon:[[@LINE-6]]:1: note: class was declared abstract here [ClassAbstractHere]
+// CHECK:STDERR: fail_abstract_var_function_param.carbon:[[@LINE-6]]:1: note: class is declared abstract [ClassAbstract]
 // CHECK:STDERR: abstract class Abstract {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -72,7 +72,7 @@ fn F(a: Abstract) {
   // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE+7]]:28: error: initialization of abstract type `Abstract` [AbstractTypeInInit]
   // CHECK:STDERR:   let unused l: Abstract = a;
   // CHECK:STDERR:                            ^
-  // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE-7]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE-7]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -90,7 +90,7 @@ class Adapter {
   // CHECK:STDERR: fail_abstract_adapter.carbon:[[@LINE+7]]:3: error: adapted type `Abstract` is an abstract type [AbstractTypeInAdaptDecl]
   // CHECK:STDERR:   adapt Abstract;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_abstract_adapter.carbon:[[@LINE-8]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_adapter.carbon:[[@LINE-8]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -109,7 +109,7 @@ fn Call(p: Abstract) {
   // CHECK:STDERR: fail_todo_define_and_call_abstract_param.carbon:[[@LINE+10]]:9: error: initialization of abstract type `Abstract` [AbstractTypeInInit]
   // CHECK:STDERR:   Param(p);
   // CHECK:STDERR:         ^
-  // CHECK:STDERR: fail_todo_define_and_call_abstract_param.carbon:[[@LINE-9]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_todo_define_and_call_abstract_param.carbon:[[@LINE-9]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_todo_define_and_call_abstract_param.carbon:[[@LINE-9]]:10: note: initializing function parameter [InCallToFunctionParam]
@@ -150,7 +150,7 @@ class Derived {
 // CHECK:STDERR: fail_return_abstract.carbon:[[@LINE+7]]:27: error: function returns abstract type `Abstract` [AbstractTypeInFunctionReturnType]
 // CHECK:STDERR: fn Return(a: Abstract) -> Abstract {
 // CHECK:STDERR:                           ^~~~~~~~
-// CHECK:STDERR: fail_return_abstract.carbon:[[@LINE-12]]:1: note: class was declared abstract here [ClassAbstractHere]
+// CHECK:STDERR: fail_return_abstract.carbon:[[@LINE-12]]:1: note: class is declared abstract [ClassAbstract]
 // CHECK:STDERR: abstract class Abstract {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -175,7 +175,7 @@ fn Access(d: Derived) -> {} {
   // CHECK:STDERR: fail_todo_access_abstract_subobject.carbon:[[@LINE+7]]:10: error: initialization of abstract type `Abstract` [AbstractTypeInInit]
   // CHECK:STDERR:   return d.base.a;
   // CHECK:STDERR:          ^~~~~~
-  // CHECK:STDERR: fail_todo_access_abstract_subobject.carbon:[[@LINE-14]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_todo_access_abstract_subobject.carbon:[[@LINE-14]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -192,7 +192,7 @@ fn F() {
   // CHECK:STDERR: fail_abstract_let_temporary_struct_literal.carbon:[[@LINE+7]]:28: error: initialization of abstract type `Abstract` [AbstractTypeInInit]
   // CHECK:STDERR:   let unused l: Abstract = {};
   // CHECK:STDERR:                            ^~
-  // CHECK:STDERR: fail_abstract_let_temporary_struct_literal.carbon:[[@LINE-7]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_let_temporary_struct_literal.carbon:[[@LINE-7]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -217,7 +217,7 @@ fn F() {
   // CHECK:STDERR: fail_todo_abstract_let_temporary.carbon:[[@LINE+7]]:28: error: initialization of abstract type `Abstract` [AbstractTypeInInit]
   // CHECK:STDERR:   let unused l: Abstract = {.base = {}} as Derived;
   // CHECK:STDERR:                            ^~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_abstract_let_temporary.carbon:[[@LINE-15]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_todo_abstract_let_temporary.carbon:[[@LINE-15]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -236,7 +236,7 @@ fn CallReturnAbstract() {
   // CHECK:STDERR: fail_call_abstract_return.carbon:[[@LINE+10]]:3: error: function returns abstract type `Abstract` [AbstractTypeInFunctionReturnType]
   // CHECK:STDERR:   ReturnAbstract();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_call_abstract_return.carbon:[[@LINE-9]]:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_call_abstract_return.carbon:[[@LINE-9]]:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_call_abstract_return.carbon:[[@LINE-9]]:24: note: return type declared here [IncompleteReturnTypeHere]

--- a/toolchain/check/testdata/class/abstract/fail_abstract_in_struct.carbon
+++ b/toolchain/check/testdata/class/abstract/fail_abstract_in_struct.carbon
@@ -21,7 +21,7 @@ class Contains {
   // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE+7]]:10: error: field has abstract type `{.m1: Abstract1}` [AbstractTypeInFieldDecl]
   // CHECK:STDERR:   var a: {.m1: Abstract1};
   // CHECK:STDERR:          ^~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE-6]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE-6]]:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract1 {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -36,7 +36,7 @@ abstract class Abstract2 {}
 // CHECK:STDERR: fail_abstract_var.carbon:[[@LINE+7]]:8: error: binding pattern has abstract type `{.m2: Abstract2}` in `var` pattern [AbstractTypeInVarPattern]
 // CHECK:STDERR: var v: {.m2: Abstract2};
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_abstract_var.carbon:[[@LINE-5]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+// CHECK:STDERR: fail_abstract_var.carbon:[[@LINE-5]]:1: note: uses class that is declared abstract [ClassAbstract]
 // CHECK:STDERR: abstract class Abstract2 {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -52,7 +52,7 @@ fn F(a: Abstract3) {
   // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE+7]]:36: error: initialization of abstract type `{.m3: Abstract3}` [AbstractTypeInInit]
   // CHECK:STDERR:   let unused l: {.m3: Abstract3} = {.m3 = a};
   // CHECK:STDERR:                                    ^~~~~~~~~
-  // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE-7]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE-7]]:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract3 {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -68,7 +68,7 @@ abstract class Abstract5 {}
 // CHECK:STDERR: fail_abstract_twice.carbon:[[@LINE+7]]:9: error: binding pattern has abstract type `{.m4: Abstract4, .m5: Abstract5}` in `var` pattern [AbstractTypeInVarPattern]
 // CHECK:STDERR: var v2: {.m4: Abstract4, .m5: Abstract5};
 // CHECK:STDERR:         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_abstract_twice.carbon:[[@LINE-6]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+// CHECK:STDERR: fail_abstract_twice.carbon:[[@LINE-6]]:1: note: uses class that is declared abstract [ClassAbstract]
 // CHECK:STDERR: abstract class Abstract4 {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -82,7 +82,7 @@ abstract class Abstract6 {}
 // CHECK:STDERR: fail_abstract_first.carbon:[[@LINE+7]]:9: error: binding pattern has abstract type `{.m6: Abstract6, .c1: ()}` in `var` pattern [AbstractTypeInVarPattern]
 // CHECK:STDERR: var v3: {.m6: Abstract6, .c1: ()};
 // CHECK:STDERR:         ^~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_abstract_first.carbon:[[@LINE-5]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+// CHECK:STDERR: fail_abstract_first.carbon:[[@LINE-5]]:1: note: uses class that is declared abstract [ClassAbstract]
 // CHECK:STDERR: abstract class Abstract6 {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -96,7 +96,7 @@ abstract class Abstract7 {}
 // CHECK:STDERR: fail_abstract_second.carbon:[[@LINE+7]]:9: error: binding pattern has abstract type `{.c2: (), .m7: Abstract7}` in `var` pattern [AbstractTypeInVarPattern]
 // CHECK:STDERR: var v4: {.c2: (), .m7: Abstract7};
 // CHECK:STDERR:         ^~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_abstract_second.carbon:[[@LINE-5]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+// CHECK:STDERR: fail_abstract_second.carbon:[[@LINE-5]]:1: note: uses class that is declared abstract [ClassAbstract]
 // CHECK:STDERR: abstract class Abstract7 {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -116,7 +116,7 @@ import library "lib";
 // CHECK:STDERR: var v5: {.m: Abstract};
 // CHECK:STDERR:         ^~~~~~~~~~~~~~
 // CHECK:STDERR: fail_import.carbon:[[@LINE-5]]:1: in import [InImport]
-// CHECK:STDERR: lib.carbon:3:1: note: uses class that was declared abstract here [ClassAbstractHere]
+// CHECK:STDERR: lib.carbon:3:1: note: uses class that is declared abstract [ClassAbstract]
 // CHECK:STDERR: abstract class Abstract {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/class/abstract/fail_abstract_in_tuple.carbon
+++ b/toolchain/check/testdata/class/abstract/fail_abstract_in_tuple.carbon
@@ -21,7 +21,7 @@ class Contains {
   // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE+7]]:10: error: field has abstract type `(Abstract1,)` [AbstractTypeInFieldDecl]
   // CHECK:STDERR:   var a: (Abstract1,);
   // CHECK:STDERR:          ^~~~~~~~~~~~
-  // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE-6]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_field.carbon:[[@LINE-6]]:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract1 {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -37,7 +37,7 @@ fn Var() {
   // CHECK:STDERR: fail_abstract_var.carbon:[[@LINE+7]]:17: error: binding pattern has abstract type `(Abstract2,)` in `var` pattern [AbstractTypeInVarPattern]
   // CHECK:STDERR:   var unused v: (Abstract2,);
   // CHECK:STDERR:                 ^~~~~~~~~~~~
-  // CHECK:STDERR: fail_abstract_var.carbon:[[@LINE-6]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_var.carbon:[[@LINE-6]]:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract2 {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -54,7 +54,7 @@ fn F(a: Abstract3) {
   // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE+7]]:32: error: initialization of abstract type `(Abstract3,)` [AbstractTypeInInit]
   // CHECK:STDERR:   let unused l: (Abstract3,) = (a,);
   // CHECK:STDERR:                                ^~~~
-  // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE-7]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_todo_abstract_let.carbon:[[@LINE-7]]:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract3 {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -71,7 +71,7 @@ fn Var2() {
   // CHECK:STDERR: fail_abstract_twice.carbon:[[@LINE+7]]:18: error: binding pattern has abstract type `(Abstract4, Abstract5)` in `var` pattern [AbstractTypeInVarPattern]
   // CHECK:STDERR:   var unused v2: (Abstract4, Abstract5);
   // CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_abstract_twice.carbon:[[@LINE-7]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_twice.carbon:[[@LINE-7]]:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract4 {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -87,7 +87,7 @@ fn Var3() {
   // CHECK:STDERR: fail_abstract_first.carbon:[[@LINE+7]]:18: error: binding pattern has abstract type `(Abstract6, {})` in `var` pattern [AbstractTypeInVarPattern]
   // CHECK:STDERR:   var unused v3: (Abstract6, {});
   // CHECK:STDERR:                  ^~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_abstract_first.carbon:[[@LINE-6]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_first.carbon:[[@LINE-6]]:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract6 {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -103,7 +103,7 @@ fn Var4() {
   // CHECK:STDERR: fail_abstract_second.carbon:[[@LINE+7]]:18: error: binding pattern has abstract type `({}, Abstract7)` in `var` pattern [AbstractTypeInVarPattern]
   // CHECK:STDERR:   var unused v4: ({}, Abstract7);
   // CHECK:STDERR:                  ^~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_abstract_second.carbon:[[@LINE-6]]:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: fail_abstract_second.carbon:[[@LINE-6]]:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract7 {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -125,7 +125,7 @@ fn Var5() {
   // CHECK:STDERR:   var unused v5: (Abstract,);
   // CHECK:STDERR:                  ^~~~~~~~~~~
   // CHECK:STDERR: fail_import.carbon:[[@LINE-6]]:1: in import [InImport]
-  // CHECK:STDERR: lib.carbon:3:1: note: uses class that was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: lib.carbon:3:1: note: uses class that is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class Abstract {}
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/class/adapter/fail_adapt_bad_type.carbon
+++ b/toolchain/check/testdata/class/adapter/fail_adapt_bad_type.carbon
@@ -20,7 +20,7 @@ class AdaptIncomplete {
   // CHECK:STDERR: fail_incomplete_type.carbon:[[@LINE+7]]:3: error: adapted type `Incomplete` is an incomplete type [IncompleteTypeInAdaptDecl]
   // CHECK:STDERR:   adapt Incomplete;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete_type.carbon:[[@LINE-6]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_type.carbon:[[@LINE-6]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Incomplete;
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/class/cross_package_import.carbon
+++ b/toolchain/check/testdata/class/cross_package_import.carbon
@@ -56,7 +56,7 @@ import Other library "other_extern";
 // CHECK:STDERR: var c: Other.C = {};
 // CHECK:STDERR:        ^~~~~~~
 // CHECK:STDERR: fail_extern.carbon:[[@LINE-5]]:1: in import [InImport]
-// CHECK:STDERR: other_extern.carbon:4:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: other_extern.carbon:4:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: extern class C;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/class/extern.carbon
+++ b/toolchain/check/testdata/class/extern.carbon
@@ -52,7 +52,7 @@ extern class C;
 // CHECK:STDERR: fail_decl_fn_in_extern.carbon:[[@LINE+7]]:4: error: cannot declare a member of incomplete class `C` [QualifiedDeclInIncompleteClassScope]
 // CHECK:STDERR: fn C.F();
 // CHECK:STDERR:    ^
-// CHECK:STDERR: fail_decl_fn_in_extern.carbon:[[@LINE-4]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_decl_fn_in_extern.carbon:[[@LINE-4]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: extern class C;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/class/fail_import_misuses.carbon
+++ b/toolchain/check/testdata/class/fail_import_misuses.carbon
@@ -40,7 +40,7 @@ class Empty {
 // CHECK:STDERR: var a: Incomplete;
 // CHECK:STDERR:        ^~~~~~~~~~
 // CHECK:STDERR: fail_b.carbon:[[@LINE-16]]:1: in import [InImport]
-// CHECK:STDERR: a.carbon:7:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: a.carbon:7:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class Incomplete;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/class/fail_incomplete.carbon
+++ b/toolchain/check/testdata/class/fail_incomplete.carbon
@@ -19,7 +19,7 @@ class Class;
 // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+7]]:4: error: cannot declare a member of incomplete class `Class` [QualifiedDeclInIncompleteClassScope]
 // CHECK:STDERR: fn Class.Function() {}
 // CHECK:STDERR:    ^~~~~
-// CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-5]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-5]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -29,7 +29,7 @@ fn CallClassFunction() {
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+7]]:3: error: member access into incomplete class `Class` [QualifiedExprInIncompleteClassScope]
   // CHECK:STDERR:   Class.Function();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-15]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-15]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR:
@@ -39,7 +39,7 @@ fn CallClassFunction() {
 // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+7]]:17: error: binding pattern has incomplete type `Class` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var global_var: Class;
 // CHECK:STDERR:                 ^~~~~
-// CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-25]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-25]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -48,7 +48,7 @@ var global_var: Class;
 // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+7]]:27: error: function returns incomplete type `Class` [IncompleteTypeInFunctionReturnType]
 // CHECK:STDERR: fn ConvertFromStruct() -> Class { return {}; }
 // CHECK:STDERR:                           ^~~~~
-// CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-34]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-34]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -58,7 +58,7 @@ fn G(p: Class*) -> () {
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+7]]:10: error: member access into object of incomplete type `Class` [IncompleteTypeInMemberAccess]
   // CHECK:STDERR:   return p->n;
   // CHECK:STDERR:          ^~~~
-  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-44]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-44]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR:
@@ -69,7 +69,7 @@ fn MemberAccess(p: Class*) -> () {
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+7]]:11: error: member access into object of incomplete type `Class` [IncompleteTypeInMemberAccess]
   // CHECK:STDERR:   return (*p).n;
   // CHECK:STDERR:           ^~
-  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-55]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-55]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR:
@@ -79,7 +79,7 @@ fn MemberAccess(p: Class*) -> () {
 // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+7]]:23: error: function returns incomplete type `Class` [IncompleteTypeInFunctionReturnType]
 // CHECK:STDERR: fn Copy(p: Class*) -> Class {
 // CHECK:STDERR:                       ^~~~~
-// CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-65]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-65]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class Class;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -91,7 +91,7 @@ fn Let(p: Class*) {
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+7]]:17: error: binding pattern has incomplete type `Class` in name binding declaration [IncompleteTypeInBindingDecl]
   // CHECK:STDERR:   let unused c: Class = *p;
   // CHECK:STDERR:                 ^~~~~
-  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-77]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-77]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR:
@@ -106,7 +106,7 @@ fn CallTakeIncomplete(p: Class*) {
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+10]]:18: error: forming value of incomplete type `Class` [IncompleteTypeInValueConversion]
   // CHECK:STDERR:   TakeIncomplete(*p);
   // CHECK:STDERR:                  ^~
-  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-92]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-92]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-11]]:19: note: initializing function parameter [InCallToFunctionParam]
@@ -118,7 +118,7 @@ fn CallTakeIncomplete(p: Class*) {
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+10]]:18: error: forming value of incomplete type `Class` [IncompleteTypeInValueConversion]
   // CHECK:STDERR:   TakeIncomplete({});
   // CHECK:STDERR:                  ^~
-  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-104]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-104]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-23]]:19: note: initializing function parameter [InCallToFunctionParam]
@@ -132,7 +132,7 @@ fn CallReturnIncomplete() {
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+10]]:3: error: function returns incomplete type `Class` [IncompleteTypeInFunctionReturnType]
   // CHECK:STDERR:   ReturnIncomplete();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-118]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-118]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-35]]:26: note: return type declared here [IncompleteReturnTypeHere]
@@ -151,7 +151,7 @@ fn CallIncompleteAddrSelf(p: Class*) {
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE+10]]:3: error: invalid use of incomplete type `Class` [IncompleteTypeInConversion]
   // CHECK:STDERR:   p->(IncompleteRefSelf.F)();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-137]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-137]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Class;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR: fail_forward_decl.carbon:[[@LINE-11]]:8: note: initializing function parameter [InCallToFunctionParam]

--- a/toolchain/check/testdata/class/inheritance/fail_base_bad_type.carbon
+++ b/toolchain/check/testdata/class/inheritance/fail_base_bad_type.carbon
@@ -136,7 +136,7 @@ class DeriveFromIncomplete {
   // CHECK:STDERR: fail_derive_from_incomplete.carbon:[[@LINE+7]]:16: error: base `Incomplete` is an incomplete type [IncompleteTypeInBaseDecl]
   // CHECK:STDERR:   extend base: Incomplete;
   // CHECK:STDERR:                ^~~~~~~~~~
-  // CHECK:STDERR: fail_derive_from_incomplete.carbon:[[@LINE-6]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_derive_from_incomplete.carbon:[[@LINE-6]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: base class Incomplete;
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/facet/fail_incomplete.carbon
+++ b/toolchain/check/testdata/facet/fail_incomplete.carbon
@@ -22,7 +22,7 @@ fn F() {
   // CHECK:STDERR: fail_impl_lookup_incomplete.carbon:[[@LINE+10]]:3: error: facet type `Z` can not be identified [ImplLookupInUnidentifiedFacetType]
   // CHECK:STDERR:   AsZ(());
   // CHECK:STDERR:   ^~~~~~~
-  // CHECK:STDERR: fail_impl_lookup_incomplete.carbon:[[@LINE-9]]:1: note: constraint was forward declared here [NamedConstraintForwardDeclaredHere]
+  // CHECK:STDERR: fail_impl_lookup_incomplete.carbon:[[@LINE-9]]:1: note: constraint is not defined [NamedConstraintIncomplete]
   // CHECK:STDERR: constraint Z;
   // CHECK:STDERR: ^~~~~~~~~~~~~
   // CHECK:STDERR: fail_impl_lookup_incomplete.carbon:[[@LINE-10]]:15: note: initializing generic parameter `T` declared here [InitializingGenericParam]

--- a/toolchain/check/testdata/function/declaration/fail_import_incomplete_return.carbon
+++ b/toolchain/check/testdata/function/declaration/fail_import_incomplete_return.carbon
@@ -28,7 +28,7 @@ fn Call() {
   // CHECK:STDERR: fail_incomplete_return.carbon:[[@LINE+10]]:3: error: function returns incomplete type `C` [IncompleteTypeInFunctionReturnType]
   // CHECK:STDERR:   ReturnCUsed();
   // CHECK:STDERR:   ^~~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete_return.carbon:[[@LINE-12]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_return.carbon:[[@LINE-12]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class C;
   // CHECK:STDERR: ^~~~~~~~
   // CHECK:STDERR: fail_incomplete_return.carbon:[[@LINE-11]]:21: note: return type declared here [IncompleteReturnTypeHere]
@@ -39,7 +39,7 @@ fn Call() {
   // CHECK:STDERR: fail_incomplete_return.carbon:[[@LINE+10]]:3: error: function returns incomplete type `D` [IncompleteTypeInFunctionReturnType]
   // CHECK:STDERR:   ReturnDUsed();
   // CHECK:STDERR:   ^~~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete_return.carbon:[[@LINE-22]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_return.carbon:[[@LINE-22]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class D;
   // CHECK:STDERR: ^~~~~~~~
   // CHECK:STDERR: fail_incomplete_return.carbon:[[@LINE-20]]:21: note: return type declared here [IncompleteReturnTypeHere]
@@ -62,7 +62,7 @@ fn CallFAndGIncomplete() {
   // CHECK:STDERR:   ReturnCUnused();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_use_imported.carbon:[[@LINE-6]]:1: in import [InImport]
-  // CHECK:STDERR: fail_incomplete_return.carbon:4:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_return.carbon:4:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class C;
   // CHECK:STDERR: ^~~~~~~~
   // CHECK:STDERR: fail_use_imported.carbon:[[@LINE-10]]:1: in import [InImport]
@@ -75,7 +75,7 @@ fn CallFAndGIncomplete() {
   // CHECK:STDERR:   ReturnCUsed();
   // CHECK:STDERR:   ^~~~~~~~~~~~~
   // CHECK:STDERR: fail_use_imported.carbon:[[@LINE-19]]:1: in import [InImport]
-  // CHECK:STDERR: fail_incomplete_return.carbon:4:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_return.carbon:4:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class C;
   // CHECK:STDERR: ^~~~~~~~
   // CHECK:STDERR: fail_use_imported.carbon:[[@LINE-23]]:1: in import [InImport]

--- a/toolchain/check/testdata/function/definition/basics.carbon
+++ b/toolchain/check/testdata/function/definition/basics.carbon
@@ -20,7 +20,7 @@ class C;
 // CHECK:STDERR: fail_incomplete_type.carbon:[[@LINE+7]]:13: error: parameter has incomplete type `C` in function definition [IncompleteTypeInFunctionParam]
 // CHECK:STDERR: fn F(unused n: C) {}
 // CHECK:STDERR:             ^~~~
-// CHECK:STDERR: fail_incomplete_type.carbon:[[@LINE-5]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_incomplete_type.carbon:[[@LINE-5]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class C;
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/generic/complete_type.carbon
+++ b/toolchain/check/testdata/generic/complete_type.carbon
@@ -28,14 +28,14 @@ class A(T:! type) {
 // CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE-6]]:10: note: `T` evaluates to incomplete type `B` [IncompleteTypeInMonomorphization]
 // CHECK:STDERR:   var v: T;
 // CHECK:STDERR:          ^
-// CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE-12]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE-12]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class B;
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
 // CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE+7]]:13: error: parameter has incomplete type `A(B)` in function definition [IncompleteTypeInFunctionParam]
 // CHECK:STDERR: fn F(unused x: A(B)) {}
 // CHECK:STDERR:             ^~~~~~~
-// CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE-19]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_incomplete_in_class.carbon:[[@LINE-19]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class B;
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
@@ -76,7 +76,7 @@ fn F(T:! type) {
 // CHECK:STDERR: fail_incomplete_in_function_at_eof.carbon:[[@LINE-6]]:3: note: `T` evaluates to incomplete type `B` [IncompleteTypeInMonomorphization]
 // CHECK:STDERR:   *v;
 // CHECK:STDERR:   ^~
-// CHECK:STDERR: fail_incomplete_in_function_at_eof.carbon:[[@LINE-13]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_incomplete_in_function_at_eof.carbon:[[@LINE-13]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class B;
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/impl/fail_extend_undefined_interface.carbon
+++ b/toolchain/check/testdata/impl/fail_extend_undefined_interface.carbon
@@ -18,7 +18,7 @@ class C {
   // CHECK:STDERR: fail_extend_undefined_interface.carbon:[[@LINE+7]]:3: error: `extend impl as` incomplete facet type `I` [ExtendImplAsIncomplete]
   // CHECK:STDERR:   extend impl as I;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_extend_undefined_interface.carbon:[[@LINE-6]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+  // CHECK:STDERR: fail_extend_undefined_interface.carbon:[[@LINE-6]]:1: note: interface is not defined [InterfaceIncomplete]
   // CHECK:STDERR: interface I;
   // CHECK:STDERR: ^~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/impl/forward_decls.carbon
+++ b/toolchain/check/testdata/impl/forward_decls.carbon
@@ -112,7 +112,7 @@ class D {}
 // CHECK:STDERR: fail_associated_const_before_interface_definition.carbon:[[@LINE+7]]:19: error: member access into facet of incomplete type `I` [IncompleteTypeInMemberAccessOfFacet]
 // CHECK:STDERR: impl D as I where .T = C;
 // CHECK:STDERR:                   ^~
-// CHECK:STDERR: fail_associated_const_before_interface_definition.carbon:[[@LINE-6]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+// CHECK:STDERR: fail_associated_const_before_interface_definition.carbon:[[@LINE-6]]:1: note: interface is not defined [InterfaceIncomplete]
 // CHECK:STDERR: interface I;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/impl/impl_thunk.carbon
+++ b/toolchain/check/testdata/impl/impl_thunk.carbon
@@ -253,7 +253,7 @@ interface I(T:! type) {
   fn F(a: T);
 }
 
-// CHECK:STDERR: fail_param_type_incomplete.carbon:[[@LINE+3]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_param_type_incomplete.carbon:[[@LINE+3]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class B;
 // CHECK:STDERR: ^~~~~~~~
 class B;

--- a/toolchain/check/testdata/impl/incomplete.carbon
+++ b/toolchain/check/testdata/impl/incomplete.carbon
@@ -23,7 +23,7 @@ impl {} as I;
 // CHECK:STDERR: fail_empty_struct.carbon:[[@LINE+7]]:1: error: definition of impl as incomplete facet type `I` [ImplAsIncompleteFacetTypeDefinition]
 // CHECK:STDERR: impl {} as I {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~
-// CHECK:STDERR: fail_empty_struct.carbon:[[@LINE-8]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+// CHECK:STDERR: fail_empty_struct.carbon:[[@LINE-8]]:1: note: interface is not defined [InterfaceIncomplete]
 // CHECK:STDERR: interface I;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -45,7 +45,7 @@ impl C as I;
 // CHECK:STDERR: fail_class.carbon:[[@LINE+7]]:1: error: definition of impl as incomplete facet type `J` [ImplAsIncompleteFacetTypeDefinition]
 // CHECK:STDERR: impl C as J {}
 // CHECK:STDERR: ^~~~~~~~~~~~~
-// CHECK:STDERR: fail_class.carbon:[[@LINE-13]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+// CHECK:STDERR: fail_class.carbon:[[@LINE-13]]:1: note: interface is not defined [InterfaceIncomplete]
 // CHECK:STDERR: interface J;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -60,7 +60,7 @@ class C {}
 // CHECK:STDERR: fail_class_no_forward_decl.carbon:[[@LINE+7]]:1: error: definition of impl as incomplete facet type `J` [ImplAsIncompleteFacetTypeDefinition]
 // CHECK:STDERR: impl C as J {}
 // CHECK:STDERR: ^~~~~~~~~~~~~
-// CHECK:STDERR: fail_class_no_forward_decl.carbon:[[@LINE-6]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+// CHECK:STDERR: fail_class_no_forward_decl.carbon:[[@LINE-6]]:1: note: interface is not defined [InterfaceIncomplete]
 // CHECK:STDERR: interface J;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -75,7 +75,7 @@ class C {}
 // CHECK:STDERR: fail_class_with_rewrite.carbon:[[@LINE+7]]:19: error: member access into facet of incomplete type `J` [IncompleteTypeInMemberAccessOfFacet]
 // CHECK:STDERR: impl C as J where .X = ();
 // CHECK:STDERR:                   ^~
-// CHECK:STDERR: fail_class_with_rewrite.carbon:[[@LINE-6]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+// CHECK:STDERR: fail_class_with_rewrite.carbon:[[@LINE-6]]:1: note: interface is not defined [InterfaceIncomplete]
 // CHECK:STDERR: interface J;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -84,7 +84,7 @@ impl C as J where .X = ();
 // CHECK:STDERR: fail_class_with_rewrite.carbon:[[@LINE+7]]:19: error: member access into facet of incomplete type `J` [IncompleteTypeInMemberAccessOfFacet]
 // CHECK:STDERR: impl C as J where .X = () {}
 // CHECK:STDERR:                   ^~
-// CHECK:STDERR: fail_class_with_rewrite.carbon:[[@LINE-15]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+// CHECK:STDERR: fail_class_with_rewrite.carbon:[[@LINE-15]]:1: note: interface is not defined [InterfaceIncomplete]
 // CHECK:STDERR: interface J;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
@@ -153,7 +153,7 @@ impl C as I where .Self impls Incomplete {
   // CHECK:STDERR: fail_declaration_lookup_into_incomplete.carbon:[[@LINE+7]]:19: error: member access into incomplete facet type `Incomplete` [QualifiedExprInIncompleteFacetTypeScope]
   // CHECK:STDERR:   fn F() -> Self.(Incomplete.T);
   // CHECK:STDERR:                   ^~~~~~~~~~~~
-  // CHECK:STDERR: fail_declaration_lookup_into_incomplete.carbon:[[@LINE-6]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+  // CHECK:STDERR: fail_declaration_lookup_into_incomplete.carbon:[[@LINE-6]]:1: note: interface is not defined [InterfaceIncomplete]
   // CHECK:STDERR: interface Incomplete;
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -170,7 +170,7 @@ class C {}
 // CHECK:STDERR: fail_unidentified_constraint.carbon:[[@LINE+7]]:1: error: facet type `X` cannot be identified in `impl as` [ImplOfUnidentifiedFacetType]
 // CHECK:STDERR: impl C as X;
 // CHECK:STDERR: ^~~~~~~~~~~~
-// CHECK:STDERR: fail_unidentified_constraint.carbon:[[@LINE-7]]:1: note: constraint was forward declared here [NamedConstraintForwardDeclaredHere]
+// CHECK:STDERR: fail_unidentified_constraint.carbon:[[@LINE-7]]:1: note: constraint is not defined [NamedConstraintIncomplete]
 // CHECK:STDERR: constraint X;
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -203,7 +203,7 @@ interface B {
   // CHECK:STDERR: fail_incomplete_constraint.carbon:[[@LINE+7]]:17: error: facet type `A` cannot be identified in `require` declaration [RequireImplsUnidentifiedFacetType]
   // CHECK:STDERR:   require impls A;
   // CHECK:STDERR:                 ^
-  // CHECK:STDERR: fail_incomplete_constraint.carbon:[[@LINE-6]]:1: note: constraint was forward declared here [NamedConstraintForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_constraint.carbon:[[@LINE-6]]:1: note: constraint is not defined [NamedConstraintIncomplete]
   // CHECK:STDERR: constraint A;
   // CHECK:STDERR: ^~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/interface/fail_lookup_undefined.carbon
+++ b/toolchain/check/testdata/interface/fail_lookup_undefined.carbon
@@ -17,7 +17,7 @@ interface Undefined;
 // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+7]]:4: error: cannot declare a member of undefined interface `Undefined` [QualifiedDeclInUndefinedInterfaceScope]
 // CHECK:STDERR: fn Undefined.F();
 // CHECK:STDERR:    ^~~~~~~~~
-// CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-5]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+// CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-5]]:1: note: interface is not defined [InterfaceIncomplete]
 // CHECK:STDERR: interface Undefined;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -27,7 +27,7 @@ fn Test() {
   // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE+7]]:3: error: member access into incomplete facet type `Undefined` [QualifiedExprInIncompleteFacetTypeScope]
   // CHECK:STDERR:   Undefined.G();
   // CHECK:STDERR:   ^~~~~~~~~~~
-  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-15]]:1: note: interface was forward declared here [InterfaceForwardDeclaredHere]
+  // CHECK:STDERR: fail_lookup_undefined.carbon:[[@LINE-15]]:1: note: interface is not defined [InterfaceIncomplete]
   // CHECK:STDERR: interface Undefined;
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/interface/incomplete.carbon
+++ b/toolchain/check/testdata/interface/incomplete.carbon
@@ -33,7 +33,7 @@ interface I {
 // CHECK:STDERR: fail_incomplete_type_impl.carbon:[[@LINE+7]]:26: error: invalid use of incomplete type `C` [IncompleteTypeInConversion]
 // CHECK:STDERR: impl {} as I where .T = ({} as C) {}
 // CHECK:STDERR:                          ^~~~~~~
-// CHECK:STDERR: fail_incomplete_type_impl.carbon:[[@LINE-9]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_incomplete_type_impl.carbon:[[@LINE-9]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class C;
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
@@ -52,7 +52,7 @@ fn F[U:! I](a: U) {
   // CHECK:STDERR: fail_incomplete_type_usage.carbon:[[@LINE+7]]:3: error: invalid use of incomplete type `C` [IncompleteTypeInConversion]
   // CHECK:STDERR:   a.T;
   // CHECK:STDERR:   ^~~
-  // CHECK:STDERR: fail_incomplete_type_usage.carbon:[[@LINE-10]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_type_usage.carbon:[[@LINE-10]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class C;
   // CHECK:STDERR: ^~~~~~~~
   // CHECK:STDERR:
@@ -68,7 +68,7 @@ interface B {
   // CHECK:STDERR: fail_incomplete_extend_constraint.carbon:[[@LINE+7]]:24: error: facet type `A` cannot be identified in `require` declaration [RequireImplsUnidentifiedFacetType]
   // CHECK:STDERR:   extend require impls A;
   // CHECK:STDERR:                        ^
-  // CHECK:STDERR: fail_incomplete_extend_constraint.carbon:[[@LINE-6]]:1: note: constraint was forward declared here [NamedConstraintForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_extend_constraint.carbon:[[@LINE-6]]:1: note: constraint is not defined [NamedConstraintIncomplete]
   // CHECK:STDERR: constraint A;
   // CHECK:STDERR: ^~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/interop/cpp/class/class.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/class.carbon
@@ -39,7 +39,7 @@ fn MyF() {
   // CHECK:STDERR:   var unused bar: Cpp.Bar;
   // CHECK:STDERR:                   ^~~~~~~
   // CHECK:STDERR: fail_use_declaration_as_definition.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./declaration.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./declaration.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Bar;
   // CHECK:STDERR:       ^
   // CHECK:STDERR:

--- a/toolchain/check/testdata/interop/cpp/class/constructor.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/constructor.carbon
@@ -248,7 +248,7 @@ fn F() {
    // CHECK:STDERR:    Cpp.C.C();
    // CHECK:STDERR:    ^~~~~~~
    // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
-   // CHECK:STDERR: ./incomplete.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+   // CHECK:STDERR: ./incomplete.h:2:7: note: class is not defined [ClassIncomplete]
    // CHECK:STDERR: class C;
    // CHECK:STDERR:       ^
    // CHECK:STDERR:

--- a/toolchain/check/testdata/interop/cpp/class/union.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/union.carbon
@@ -39,7 +39,7 @@ fn MyF() {
   // CHECK:STDERR:   var unused bar: Cpp.Bar;
   // CHECK:STDERR:                   ^~~~~~~
   // CHECK:STDERR: fail_use_declaration_as_definition.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./declaration.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./declaration.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: union Bar;
   // CHECK:STDERR:       ^
   // CHECK:STDERR:

--- a/toolchain/check/testdata/interop/cpp/enum/incomplete.carbon
+++ b/toolchain/check/testdata/interop/cpp/enum/incomplete.carbon
@@ -50,7 +50,7 @@ fn MyF() {
   // CHECK:STDERR:   var unused e: Cpp.UnsizedEnum;
   // CHECK:STDERR:                 ^~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_use_declaration_as_definition.carbon:[[@LINE-8]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./declaration.h:4:6: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./declaration.h:4:6: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: enum UnsizedEnum;
   // CHECK:STDERR:      ^
   // CHECK:STDERR:

--- a/toolchain/check/testdata/interop/cpp/function/class.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/class.carbon
@@ -57,7 +57,7 @@ fn F(p: Cpp.C*) {
   // CHECK:STDERR:   Cpp.foo1(*p);
   // CHECK:STDERR:            ^~
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-23]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_param_type.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_param_type.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class C;
   // CHECK:STDERR:       ^
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-27]]:10: in file included here [InCppInclude]
@@ -69,7 +69,7 @@ fn F(p: Cpp.C*) {
   // CHECK:STDERR:   Cpp.foo2(*p);
   // CHECK:STDERR:            ^~
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-35]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_param_type.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_param_type.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class C;
   // CHECK:STDERR:       ^
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-39]]:10: in file included here [InCppInclude]
@@ -327,7 +327,7 @@ fn F() {
   // CHECK:STDERR:   Cpp.Incomplete.foo();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./incomplete.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./incomplete.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Incomplete;
   // CHECK:STDERR:       ^
   // CHECK:STDERR:
@@ -415,7 +415,7 @@ fn F() {
   // CHECK:STDERR:   Cpp.foo();
   // CHECK:STDERR:   ^~~~~~~~~
   // CHECK:STDERR: fail_import_decl_value_return_type.carbon:[[@LINE-10]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_return_type.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_return_type.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class C;
   // CHECK:STDERR:       ^
   // CHECK:STDERR: fail_import_decl_value_return_type.carbon:[[@LINE-14]]:10: in file included here [InCppInclude]

--- a/toolchain/check/testdata/interop/cpp/function/operators.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/operators.carbon
@@ -898,7 +898,7 @@ fn F() {
   // CHECK:STDERR:   let unused result_unary: i32 = -*Cpp.CreateIncomplete();
   // CHECK:STDERR:                                  ^~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_import_incomplete_unary.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./incomplete.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./incomplete.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Incomplete;
   // CHECK:STDERR:       ^
   // CHECK:STDERR:
@@ -917,7 +917,7 @@ fn F() {
   // CHECK:STDERR:   let unused result_binary: i32 = complete + *Cpp.CreateIncomplete();
   // CHECK:STDERR:                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_import_incomplete_binary.carbon:[[@LINE-7]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./incomplete.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./incomplete.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Incomplete;
   // CHECK:STDERR:       ^
   // CHECK:STDERR:
@@ -946,7 +946,7 @@ fn F() {
   // CHECK:STDERR: fail_incomplete_operand_carbon_type.carbon:[[@LINE+7]]:28: error: looking up a C++ operator with incomplete operand type `Incomplete` [IncompleteOperandTypeInCppOperatorLookup]
   // CHECK:STDERR:   let unused result: i32 = *CreateIncomplete() + complete;
   // CHECK:STDERR:                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_incomplete_operand_carbon_type.carbon:[[@LINE-8]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_operand_carbon_type.carbon:[[@LINE-8]]:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class Incomplete;
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/interop/cpp/function/struct.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/struct.carbon
@@ -57,7 +57,7 @@ fn F(p: Cpp.S*) {
   // CHECK:STDERR:   Cpp.foo1(*p);
   // CHECK:STDERR:            ^~
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-23]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_param_type.h:2:8: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_param_type.h:2:8: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: struct S;
   // CHECK:STDERR:        ^
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-27]]:10: in file included here [InCppInclude]
@@ -69,7 +69,7 @@ fn F(p: Cpp.S*) {
   // CHECK:STDERR:   Cpp.foo2(*p);
   // CHECK:STDERR:            ^~
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-35]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_param_type.h:2:8: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_param_type.h:2:8: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: struct S;
   // CHECK:STDERR:        ^
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-39]]:10: in file included here [InCppInclude]
@@ -325,7 +325,7 @@ fn F() {
   // CHECK:STDERR:   Cpp.Incomplete.foo();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./incomplete.h:2:8: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./incomplete.h:2:8: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: struct Incomplete;
   // CHECK:STDERR:        ^
   // CHECK:STDERR:
@@ -414,7 +414,7 @@ fn F() {
   // CHECK:STDERR:   Cpp.foo();
   // CHECK:STDERR:   ^~~~~~~~~
   // CHECK:STDERR: fail_import_decl_value_return_type.carbon:[[@LINE-10]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_return_type.h:2:8: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_return_type.h:2:8: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: struct S;
   // CHECK:STDERR:        ^
   // CHECK:STDERR: fail_import_decl_value_return_type.carbon:[[@LINE-14]]:10: in file included here [InCppInclude]

--- a/toolchain/check/testdata/interop/cpp/function/union.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/union.carbon
@@ -57,7 +57,7 @@ fn F(p: Cpp.U*) {
   // CHECK:STDERR:   Cpp.foo1(*p);
   // CHECK:STDERR:            ^~
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-23]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_param_type.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_param_type.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: union U;
   // CHECK:STDERR:       ^
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-27]]:10: in file included here [InCppInclude]
@@ -69,7 +69,7 @@ fn F(p: Cpp.U*) {
   // CHECK:STDERR:   Cpp.foo2(*p);
   // CHECK:STDERR:            ^~
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-35]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_param_type.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_param_type.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: union U;
   // CHECK:STDERR:       ^
   // CHECK:STDERR: fail_import_decl_value_param_type.carbon:[[@LINE-39]]:10: in file included here [InCppInclude]
@@ -286,7 +286,7 @@ fn F() {
   // CHECK:STDERR:   Cpp.Incomplete.foo();
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_import_incomplete.carbon:[[@LINE-6]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./incomplete.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./incomplete.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: union Incomplete;
   // CHECK:STDERR:       ^
   // CHECK:STDERR:
@@ -374,7 +374,7 @@ fn F() {
   // CHECK:STDERR:   Cpp.foo();
   // CHECK:STDERR:   ^~~~~~~~~
   // CHECK:STDERR: fail_import_decl_value_return_type.carbon:[[@LINE-10]]:10: in file included here [InCppInclude]
-  // CHECK:STDERR: ./decl_value_return_type.h:2:7: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: ./decl_value_return_type.h:2:7: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: union U;
   // CHECK:STDERR:       ^
   // CHECK:STDERR: fail_import_decl_value_return_type.carbon:[[@LINE-14]]:10: in file included here [InCppInclude]

--- a/toolchain/check/testdata/interop/cpp/void.carbon
+++ b/toolchain/check/testdata/interop/cpp/void.carbon
@@ -30,7 +30,7 @@ fn G() {
   // CHECK:STDERR: fail_void_abstract.carbon:[[@LINE+7]]:17: error: binding pattern has abstract type `Cpp.void` in `var` pattern [AbstractTypeInVarPattern]
   // CHECK:STDERR:   var unused x: Cpp.void;
   // CHECK:STDERR:                 ^~~~~~~~
-  // CHECK:STDERR: {{.*}}/prelude/types/cpp/void.carbon:24:1: note: class was declared abstract here [ClassAbstractHere]
+  // CHECK:STDERR: {{.*}}/prelude/types/cpp/void.carbon:24:1: note: class is declared abstract [ClassAbstract]
   // CHECK:STDERR: abstract class CppCompat.VoidBase {
   // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
+++ b/toolchain/check/testdata/named_constraint/import_constraint_decl.carbon
@@ -43,7 +43,7 @@ class C {}
 // CHECK:STDERR: impl C as A;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR: fail_import_not_identified.carbon:[[@LINE-6]]:1: in import [InImport]
-// CHECK:STDERR: a.carbon:3:1: note: constraint was forward declared here [NamedConstraintForwardDeclaredHere]
+// CHECK:STDERR: a.carbon:3:1: note: constraint is not defined [NamedConstraintIncomplete]
 // CHECK:STDERR: constraint A;
 // CHECK:STDERR: ^~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/named_constraint/incomplete.carbon
+++ b/toolchain/check/testdata/named_constraint/incomplete.carbon
@@ -24,7 +24,7 @@ fn F(T:! N) {
   // CHECK:STDERR: fail_incomplete_constraint_in_impl_lookup.carbon:[[@LINE+11]]:3: error: facet type of value `T` can not be identified [ImplLookupInUnidentifiedFacetTypeOfQuerySelf]
   // CHECK:STDERR:   T as Z;
   // CHECK:STDERR:   ^~~~~~
-  // CHECK:STDERR: fail_incomplete_constraint_in_impl_lookup.carbon:[[@LINE-9]]:1: note: constraint was forward declared here [NamedConstraintForwardDeclaredHere]
+  // CHECK:STDERR: fail_incomplete_constraint_in_impl_lookup.carbon:[[@LINE-9]]:1: note: constraint is not defined [NamedConstraintIncomplete]
   // CHECK:STDERR: constraint N;
   // CHECK:STDERR: ^~~~~~~~~~~~~
   // CHECK:STDERR:
@@ -55,7 +55,7 @@ fn F() {
   // CHECK:STDERR: fail_todo_does_not_diagnose_identify_failure_in_deduce.carbon:[[@LINE+11]]:3: error: facet type `N` can not be identified [ImplLookupInUnidentifiedFacetType]
   // CHECK:STDERR:   C as Z;
   // CHECK:STDERR:   ^~~~~~
-  // CHECK:STDERR: fail_todo_does_not_diagnose_identify_failure_in_deduce.carbon:[[@LINE-17]]:1: note: constraint was forward declared here [NamedConstraintForwardDeclaredHere]
+  // CHECK:STDERR: fail_todo_does_not_diagnose_identify_failure_in_deduce.carbon:[[@LINE-17]]:1: note: constraint is not defined [NamedConstraintIncomplete]
   // CHECK:STDERR: constraint N;
   // CHECK:STDERR: ^~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/named_constraint/require.carbon
+++ b/toolchain/check/testdata/named_constraint/require.carbon
@@ -164,7 +164,7 @@ constraint Z {
   // CHECK:STDERR: fail_require_impls_incomplete_constraint.carbon:[[@LINE+7]]:17: error: facet type `Y` cannot be identified in `require` declaration [RequireImplsUnidentifiedFacetType]
   // CHECK:STDERR:   require impls Y;
   // CHECK:STDERR:                 ^
-  // CHECK:STDERR: fail_require_impls_incomplete_constraint.carbon:[[@LINE-7]]:1: note: constraint was forward declared here [NamedConstraintForwardDeclaredHere]
+  // CHECK:STDERR: fail_require_impls_incomplete_constraint.carbon:[[@LINE-7]]:1: note: constraint is not defined [NamedConstraintIncomplete]
   // CHECK:STDERR: constraint Y;
   // CHECK:STDERR: ^~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/namespace/imported_indirect.carbon
+++ b/toolchain/check/testdata/namespace/imported_indirect.carbon
@@ -61,7 +61,7 @@ import library "b";
 // CHECK:STDERR:          ^~~
 // CHECK:STDERR: fail_named_indirectly_same_package.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: b.carbon:3:1: in import [InImport]
-// CHECK:STDERR: a.carbon:6:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: a.carbon:6:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class A.C;
 // CHECK:STDERR: ^~~~~~~~~~
 // CHECK:STDERR: fail_named_indirectly_same_package.carbon:[[@LINE-10]]:1: in import [InImport]
@@ -82,7 +82,7 @@ import Same library "b";
 // CHECK:STDERR:          ^~~~~~~~
 // CHECK:STDERR: fail_named_indirectly_different_package.carbon:[[@LINE-5]]:1: in import [InImport]
 // CHECK:STDERR: b.carbon:3:1: in import [InImport]
-// CHECK:STDERR: a.carbon:6:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: a.carbon:6:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class A.C;
 // CHECK:STDERR: ^~~~~~~~~~
 // CHECK:STDERR: fail_named_indirectly_different_package.carbon:[[@LINE-10]]:1: in import [InImport]

--- a/toolchain/check/testdata/primitives/string_literals.carbon
+++ b/toolchain/check/testdata/primitives/string_literals.carbon
@@ -59,7 +59,7 @@ fn F() {
   // CHECK:STDERR: fail_use_incomplete_string.carbon:[[@LINE+7]]:3: error: type `Core.String` is incomplete [StringLiteralTypeIncomplete]
   // CHECK:STDERR:   "hello";
   // CHECK:STDERR:   ^~~~~~~
-  // CHECK:STDERR: incomplete_string.carbon:4:1: note: class was forward declared here [ClassForwardDeclaredHere]
+  // CHECK:STDERR: incomplete_string.carbon:4:1: note: class is not defined [ClassIncomplete]
   // CHECK:STDERR: class String;
   // CHECK:STDERR: ^~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
+++ b/toolchain/check/testdata/struct/fail_nested_incomplete.carbon
@@ -17,7 +17,7 @@ class Incomplete;
 // CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE+7]]:8: error: binding pattern has incomplete type `{.a: Incomplete}` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var s: {.a: Incomplete};
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE-5]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE-5]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class Incomplete;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/testdata/tuple/class_tuples.carbon
+++ b/toolchain/check/testdata/tuple/class_tuples.carbon
@@ -39,7 +39,7 @@ class Incomplete;
 // CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE+7]]:8: error: binding pattern has incomplete type `(Complete, Incomplete)` in name binding declaration [IncompleteTypeInBindingDecl]
 // CHECK:STDERR: var t: (Complete, Incomplete);
 // CHECK:STDERR:        ^~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE-5]]:1: note: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: fail_nested_incomplete.carbon:[[@LINE-5]]:1: note: class is not defined [ClassIncomplete]
 // CHECK:STDERR: class Incomplete;
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -39,10 +39,8 @@ auto DiagnoseIncompleteClass(Context& context, SemIR::ClassId class_id)
     context.emitter().Emit(class_info.definition_id,
                            ClassIncompleteWithinDefinition);
   } else {
-    CARBON_DIAGNOSTIC(ClassForwardDeclaredHere, Error,
-                      "class was forward declared here");
-    context.emitter().Emit(class_info.latest_decl_id(),
-                           ClassForwardDeclaredHere);
+    CARBON_DIAGNOSTIC(ClassIncomplete, Error, "class is not defined");
+    context.emitter().Emit(class_info.latest_decl_id(), ClassIncomplete);
   }
 }
 
@@ -59,10 +57,9 @@ auto DiagnoseIncompleteInterface(Context& context,
     context.emitter().Emit(interface_info.definition_id,
                            InterfaceIncompleteWithinDefinition);
   } else {
-    CARBON_DIAGNOSTIC(InterfaceForwardDeclaredHere, Error,
-                      "interface was forward declared here");
+    CARBON_DIAGNOSTIC(InterfaceIncomplete, Error, "interface is not defined");
     context.emitter().Emit(interface_info.latest_decl_id(),
-                           InterfaceForwardDeclaredHere);
+                           InterfaceIncomplete);
   }
 }
 
@@ -75,11 +72,10 @@ auto DiagnoseAbstractClass(Context& context, SemIR::ClassId class_id,
   CARBON_CHECK(
       class_info.inheritance_kind == SemIR::Class::InheritanceKind::Abstract,
       "Class is not abstract");
-  CARBON_DIAGNOSTIC(
-      ClassAbstractHere, Error,
-      "{0:=0:uses class that|=1:class} was declared abstract here",
-      Diagnostics::IntAsSelect);
-  context.emitter().Emit(class_info.definition_id, ClassAbstractHere,
+  CARBON_DIAGNOSTIC(ClassAbstract, Error,
+                    "{0:=0:uses class that|=1:class} is declared abstract",
+                    Diagnostics::IntAsSelect);
+  context.emitter().Emit(class_info.definition_id, ClassAbstract,
                          static_cast<int>(direct_use));
 }
 
@@ -96,10 +92,10 @@ static auto DiagnoseIncompleteNamedConstraint(
     context.emitter().Emit(constraint.definition_id,
                            NamedConstraintIncompleteWithinDefinition);
   } else {
-    CARBON_DIAGNOSTIC(NamedConstraintForwardDeclaredHere, Error,
-                      "constraint was forward declared here");
+    CARBON_DIAGNOSTIC(NamedConstraintIncomplete, Error,
+                      "constraint is not defined");
     context.emitter().Emit(constraint.latest_decl_id(),
-                           NamedConstraintForwardDeclaredHere);
+                           NamedConstraintIncomplete);
   }
 }
 

--- a/toolchain/diagnostics/consumer.cpp
+++ b/toolchain/diagnostics/consumer.cpp
@@ -17,7 +17,7 @@ auto StreamConsumer::HandleDiagnostic(Diagnostic diagnostic) -> void {
   }
 
   auto message_level = [&, first = true](const Message& m) mutable {
-    if (m.level >= Level::SoftContext && std::exchange(first, false)) {
+    if (m.level >= Level::SoftErrorContext && std::exchange(first, false)) {
       return diagnostic.level;
     }
     return std::min(Level::Note, m.level);
@@ -36,8 +36,8 @@ auto StreamConsumer::HandleDiagnostic(Diagnostic diagnostic) -> void {
         break;
       case Level::LocationInfo:
         break;
-      case Level::SoftContext:
-      case Level::Context:
+      case Level::SoftErrorContext:
+      case Level::ErrorContext:
         CARBON_FATAL("Context messages are presented as a different level");
     }
     *stream_ << message.Format();

--- a/toolchain/diagnostics/diagnostic.h
+++ b/toolchain/diagnostics/diagnostic.h
@@ -25,16 +25,17 @@ enum class Level : int8_t {
   // A note, not indicating an error on its own, but possibly providing
   // additional information for an error or warning.
   Note,
-  // A Context that will be discarded if another Context precedes it in the
-  // diagnostic, as the Context is assumed to provide better information. Used
-  // as a fallback for when no better Context is provided.
-  SoftContext,
-  // Describes the high level operation being performed. If a diagnostic is
-  // issued, the first Context message will steal its level and be displayed as
-  // if it is the top-level diagnostic, and the rest are treated as Note
-  // messages. The diagnostic message also becomes a Note of the first Context
-  // message.
-  Context,
+  // An ErrorContext that will be discarded if another ErrorContext precedes it
+  // in the diagnostic, as the ErrorContext is assumed to provide better
+  // information. Used as a fallback for when no better ErrorContext is
+  // provided.
+  SoftErrorContext,
+  // Describes the high level operation being performed. If an Error diagnostic
+  // is issued, the first ErrorContext message will steal its level and be
+  // displayed as if it is the top-level diagnostic, and the rest are treated as
+  // Note messages. The original Error diagnostic message also becomes a Note of
+  // the first ErrorContext message.
+  ErrorContext,
   // A warning diagnostic, indicating a likely problem with the program.
   Warning,
   // An error diagnostic, indicating that the program is not valid.

--- a/toolchain/diagnostics/emitter.h
+++ b/toolchain/diagnostics/emitter.h
@@ -133,19 +133,22 @@ class Emitter {
     static auto FormatFn(const Message& message,
                          std::index_sequence<N...> /*indices*/) -> std::string;
 
-    // Whether a Context or SoftContext message has been added to the Builder.
-    auto has_context_message() const -> bool { return has_context_message_; }
+    // Whether an ErrorContext or ErrorSoftContext message has been added to the
+    // Builder.
+    auto has_error_context_message() const -> bool {
+      return has_error_context_message_;
+    }
 
     Emitter<LocT>* emitter_;
     Diagnostic diagnostic_;
-    bool has_context_message_ = false;
+    bool has_error_context_message_ = false;
   };
 
   class ContextBuilder {
    public:
-    // Adds a Context describing a higher level operation that failed due to the
-    // diagnostic being built. The API mirrors the main emission API:
-    // `Emitter::Emit`. For the expected usage see the builder API:
+    // Adds a context message describing a higher level operation that has
+    // encountered the diagnostic being built. The API mirrors the main emission
+    // API: `Emitter::Emit`. For the expected usage see the builder API:
     // `Emitter::Build`.
     template <typename... Args>
     auto Context(LocT loc, const DiagnosticBase<Args...>& diagnostic_base,
@@ -457,9 +460,9 @@ auto Emitter<LocT>::Builder::AddMessageWithLoc(
       diagnostic_base.Level <= diagnostic_.level,
       "message with level {0} is higher than the diagnostic's level {1}",
       diagnostic_base.Level, diagnostic_.level);
-  if (diagnostic_base.Level == Level::SoftContext ||
-      diagnostic_base.Level == Level::Context) {
-    has_context_message_ = true;
+  if (diagnostic_base.Level == Level::SoftErrorContext ||
+      diagnostic_base.Level == Level::ErrorContext) {
+    has_error_context_message_ = true;
   }
   diagnostic_.messages.push_back(
       Message{.kind = diagnostic_base.Kind,
@@ -503,11 +506,15 @@ template <typename... Args>
 auto Emitter<LocT>::ContextBuilder::Context(
     LocT loc, const DiagnosticBase<Args...>& diagnostic_base,
     Internal::NoTypeDeduction<Args>... args) -> ContextBuilder& {
-  CARBON_CHECK(diagnostic_base.Level == Level::SoftContext ||
-                   diagnostic_base.Level == Level::Context,
+  CARBON_CHECK(diagnostic_base.Level == Level::SoftErrorContext ||
+                   diagnostic_base.Level == Level::ErrorContext,
                "{0}", static_cast<int>(diagnostic_base.Level));
-  if (builder_->has_context_message() &&
-      diagnostic_base.Level == Level::SoftContext) {
+  if (builder_->diagnostic_.level != Level::Error) {
+    // ErrorContext and SoftErrorContext messages are only for errors.
+    return *this;
+  }
+  if (builder_->has_error_context_message() &&
+      diagnostic_base.Level == Level::SoftErrorContext) {
     return *this;
   }
   builder_->AddMessage(LocT(loc), diagnostic_base,

--- a/toolchain/diagnostics/emitter_test.cpp
+++ b/toolchain/diagnostics/emitter_test.cpp
@@ -80,64 +80,64 @@ TEST_F(EmitterTest, EmitNote) {
   emitter_.Build(1, TestDiagnostic).Note(2, TestDiagnosticNote).Emit();
 }
 
-TEST_F(EmitterTest, EmitContext) {
+TEST_F(EmitterTest, EmitErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::Context, 1, 2, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 2, "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(2, TestDiagnosticContext);
   });
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitSoftContext) {
+TEST_F(EmitterTest, EmitSoftErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
                     "soft context");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticSoftContext,
-                                  Diagnostics::Level::SoftContext, 1, 2,
+                                  Diagnostics::Level::SoftErrorContext, 1, 2,
                                   "soft context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope soft_scope(&emitter_, [&](auto& builder) {
     builder.Context(2, TestDiagnosticSoftContext);
   });
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitSoftContextAndContext) {
+TEST_F(EmitterTest, EmitSoftErrorContextAndErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
                     "soft context");
   CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticSoftContext,
-                                  Diagnostics::Level::SoftContext, 1, 3,
+                                  Diagnostics::Level::SoftErrorContext, 1, 3,
                                   "soft context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::Context, 1, 2, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 2, "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope soft_scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticSoftContext);
   });
@@ -147,21 +147,21 @@ TEST_F(EmitterTest, EmitSoftContextAndContext) {
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitContextAndSoftContext) {
+TEST_F(EmitterTest, EmitErrorContextAndSoftErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
                     "soft context");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::Context, 1, 3, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 3, "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticContext);
   });
@@ -173,23 +173,23 @@ TEST_F(EmitterTest, EmitContextAndSoftContext) {
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitTwoContext) {
+TEST_F(EmitterTest, EmitTwoErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
   CARBON_DIAGNOSTIC(TestDiagnosticContext2, ErrorContext, "context 2");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::Context, 1, 3, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 3, "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext2,
-                                  Diagnostics::Level::Context, 1, 2,
+                                  Diagnostics::Level::ErrorContext, 1, 2,
                                   "context 2"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticContext);
   });
@@ -199,23 +199,23 @@ TEST_F(EmitterTest, EmitTwoContext) {
   emitter_.Emit(1, TestDiagnostic);
 }
 
-TEST_F(EmitterTest, EmitTwoSoftContext) {
+TEST_F(EmitterTest, EmitTwoSoftErrorContext) {
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
                     "soft context");
   CARBON_DIAGNOSTIC(TestDiagnosticSoftContext2, SoftErrorContext,
                     "soft context 2");
-  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Error, "simple error");
   EXPECT_CALL(
       consumer_,
       HandleDiagnostic(IsDiagnostic(
-          Diagnostics::Level::Warning,
+          Diagnostics::Level::Error,
           ElementsAre(
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticSoftContext,
-                                  Diagnostics::Level::SoftContext, 1, 3,
+                                  Diagnostics::Level::SoftErrorContext, 1, 3,
                                   "soft context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Warning, 1, 1,
-                                  "simple warning")))));
+                                  Diagnostics::Level::Error, 1, 1,
+                                  "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticSoftContext);
   });

--- a/toolchain/diagnostics/emitter_test.cpp
+++ b/toolchain/diagnostics/emitter_test.cpp
@@ -81,7 +81,7 @@ TEST_F(EmitterTest, EmitNote) {
 }
 
 TEST_F(EmitterTest, EmitContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticContext, Context, "context");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -100,7 +100,8 @@ TEST_F(EmitterTest, EmitContext) {
 }
 
 TEST_F(EmitterTest, EmitSoftContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftContext, "soft context");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
+                    "soft context");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -120,8 +121,9 @@ TEST_F(EmitterTest, EmitSoftContext) {
 }
 
 TEST_F(EmitterTest, EmitSoftContextAndContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftContext, "soft context");
-  CARBON_DIAGNOSTIC(TestDiagnosticContext, Context, "context");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
+                    "soft context");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -146,8 +148,9 @@ TEST_F(EmitterTest, EmitSoftContextAndContext) {
 }
 
 TEST_F(EmitterTest, EmitContextAndSoftContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticContext, Context, "context");
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftContext, "soft context");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
+                    "soft context");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -171,8 +174,8 @@ TEST_F(EmitterTest, EmitContextAndSoftContext) {
 }
 
 TEST_F(EmitterTest, EmitTwoContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticContext, Context, "context");
-  CARBON_DIAGNOSTIC(TestDiagnosticContext2, Context, "context 2");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
+  CARBON_DIAGNOSTIC(TestDiagnosticContext2, ErrorContext, "context 2");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,
@@ -197,8 +200,10 @@ TEST_F(EmitterTest, EmitTwoContext) {
 }
 
 TEST_F(EmitterTest, EmitTwoSoftContext) {
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftContext, "soft context");
-  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext2, SoftContext, "soft context 2");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext, SoftErrorContext,
+                    "soft context");
+  CARBON_DIAGNOSTIC(TestDiagnosticSoftContext2, SoftErrorContext,
+                    "soft context 2");
   CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
   EXPECT_CALL(
       consumer_,

--- a/toolchain/diagnostics/emitter_test.cpp
+++ b/toolchain/diagnostics/emitter_test.cpp
@@ -87,12 +87,12 @@ TEST_F(EmitterTest, EmitErrorContext) {
       consumer_,
       HandleDiagnostic(IsDiagnostic(
           Diagnostics::Level::Error,
-          ElementsAre(
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::ErrorContext, 1, 2, "context"),
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Error, 1, 1,
-                                  "simple error")))));
+          ElementsAre(IsDiagnosticMessage(
+                          Diagnostics::Kind::TestDiagnosticContext,
+                          Diagnostics::Level::ErrorContext, 1, 2, "context"),
+                      IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
+                                          Diagnostics::Level::Error, 1, 1,
+                                          "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(2, TestDiagnosticContext);
   });
@@ -134,7 +134,8 @@ TEST_F(EmitterTest, EmitSoftErrorContextAndErrorContext) {
                                   Diagnostics::Level::SoftErrorContext, 1, 3,
                                   "soft context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::ErrorContext, 1, 2, "context"),
+                                  Diagnostics::Level::ErrorContext, 1, 2,
+                                  "context"),
               IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
                                   Diagnostics::Level::Error, 1, 1,
                                   "simple error")))));
@@ -156,12 +157,12 @@ TEST_F(EmitterTest, EmitErrorContextAndSoftErrorContext) {
       consumer_,
       HandleDiagnostic(IsDiagnostic(
           Diagnostics::Level::Error,
-          ElementsAre(
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::ErrorContext, 1, 3, "context"),
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Error, 1, 1,
-                                  "simple error")))));
+          ElementsAre(IsDiagnosticMessage(
+                          Diagnostics::Kind::TestDiagnosticContext,
+                          Diagnostics::Level::ErrorContext, 1, 3, "context"),
+                      IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
+                                          Diagnostics::Level::Error, 1, 1,
+                                          "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticContext);
   });
@@ -181,15 +182,15 @@ TEST_F(EmitterTest, EmitTwoErrorContext) {
       consumer_,
       HandleDiagnostic(IsDiagnostic(
           Diagnostics::Level::Error,
-          ElementsAre(
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext,
-                                  Diagnostics::Level::ErrorContext, 1, 3, "context"),
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnosticContext2,
-                                  Diagnostics::Level::ErrorContext, 1, 2,
-                                  "context 2"),
-              IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
-                                  Diagnostics::Level::Error, 1, 1,
-                                  "simple error")))));
+          ElementsAre(IsDiagnosticMessage(
+                          Diagnostics::Kind::TestDiagnosticContext,
+                          Diagnostics::Level::ErrorContext, 1, 3, "context"),
+                      IsDiagnosticMessage(
+                          Diagnostics::Kind::TestDiagnosticContext2,
+                          Diagnostics::Level::ErrorContext, 1, 2, "context 2"),
+                      IsDiagnosticMessage(Diagnostics::Kind::TestDiagnostic,
+                                          Diagnostics::Level::Error, 1, 1,
+                                          "simple error")))));
   Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
     builder.Context(3, TestDiagnosticContext);
   });
@@ -223,6 +224,21 @@ TEST_F(EmitterTest, EmitTwoSoftErrorContext) {
   // supersedes it.
   Diagnostics::ContextScope soft_scope(&emitter_, [&](auto& builder) {
     builder.Context(2, TestDiagnosticSoftContext2);
+  });
+  emitter_.Emit(1, TestDiagnostic);
+}
+
+TEST_F(EmitterTest, EmitErrorContextWithWarning) {
+  CARBON_DIAGNOSTIC(TestDiagnosticContext, ErrorContext, "context");
+  CARBON_DIAGNOSTIC(TestDiagnostic, Warning, "simple warning");
+  EXPECT_CALL(consumer_,
+              HandleDiagnostic(IsDiagnostic(
+                  Diagnostics::Level::Warning,
+                  ElementsAre(IsDiagnosticMessage(
+                      Diagnostics::Kind::TestDiagnostic,
+                      Diagnostics::Level::Warning, 1, 1, "simple warning")))));
+  Diagnostics::ContextScope scope(&emitter_, [&](auto& builder) {
+    builder.Context(2, TestDiagnosticContext);
   });
   emitter_.Emit(1, TestDiagnostic);
 }

--- a/toolchain/diagnostics/kind.def
+++ b/toolchain/diagnostics/kind.def
@@ -298,10 +298,10 @@ CARBON_DIAGNOSTIC_KIND(BaseDeclRepeated)
 CARBON_DIAGNOSTIC_KIND(BaseIsFinal)
 CARBON_DIAGNOSTIC_KIND(BaseMissingExtend)
 CARBON_DIAGNOSTIC_KIND(BaseDeclAfterFieldDecl)
-CARBON_DIAGNOSTIC_KIND(ClassAbstractHere)
+CARBON_DIAGNOSTIC_KIND(ClassAbstract)
 CARBON_DIAGNOSTIC_KIND(ClassSpecificDeclOutsideClass)
 CARBON_DIAGNOSTIC_KIND(ClassSpecificDeclPrevious)
-CARBON_DIAGNOSTIC_KIND(ClassForwardDeclaredHere)
+CARBON_DIAGNOSTIC_KIND(ClassIncomplete)
 CARBON_DIAGNOSTIC_KIND(ClassIncompleteWithinDefinition)
 CARBON_DIAGNOSTIC_KIND(GenericVirtual)
 CARBON_DIAGNOSTIC_KIND(OverrideWithoutBase)
@@ -323,11 +323,11 @@ CARBON_DIAGNOSTIC_KIND(ExportRedundant)
 CARBON_DIAGNOSTIC_KIND(ExportPrevious)
 
 // Interface checking.
-CARBON_DIAGNOSTIC_KIND(InterfaceForwardDeclaredHere)
+CARBON_DIAGNOSTIC_KIND(InterfaceIncomplete)
 CARBON_DIAGNOSTIC_KIND(InterfaceIncompleteWithinDefinition)
 
 // Named constraint checking.
-CARBON_DIAGNOSTIC_KIND(NamedConstraintForwardDeclaredHere)
+CARBON_DIAGNOSTIC_KIND(NamedConstraintIncomplete)
 CARBON_DIAGNOSTIC_KIND(NamedConstraintIncompleteWithinDefinition)
 
 // Impl checking.

--- a/toolchain/diagnostics/mocks.cpp
+++ b/toolchain/diagnostics/mocks.cpp
@@ -27,11 +27,11 @@ auto PrintTo(Level level, std::ostream* os) -> void {
     case Level::Note:
       *os << "Note";
       break;
-    case Level::SoftContext:
-      *os << "SoftContext";
+    case Level::SoftErrorContext:
+      *os << "SoftErrorContext";
       break;
-    case Level::Context:
-      *os << "Context";
+    case Level::ErrorContext:
+      *os << "ErrorContext";
       break;
     case Level::Warning:
       *os << "Warning";

--- a/toolchain/docs/diagnostics.md
+++ b/toolchain/docs/diagnostics.md
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -   [Diagnostic context](#diagnostic-context)
 -   [Diagnostic parameter types](#diagnostic-parameter-types)
 -   [Diagnostic message style guide](#diagnostic-message-style-guide)
+-   [ErrorContext](#errorcontext)
 -   [Alternatives considered](#alternatives-considered)
 -   [References](#references)
 
@@ -317,6 +318,29 @@ Carbon's diagnostic style aims to balance these concerns. Our style is:
     only allowed for types?
 
 -   TODO: Lots more things to decide, give examples.
+
+## ErrorContext
+
+Some operations in the toolchain can fail due to errors in a smaller operation.
+For example, requiring an identified facet type can fail in which a diagnostic
+is emitted saying what was wrong, such as
+`"error: named constraint is not defined"`.
+
+When this happens, the higher level operation can provide a more contextual
+error that supersedes the specific one. This is done with a `ContextScope` that
+takes a lambda that is called if a diagnostic is emitted. The callback can
+introduce an `ErrorContext` that modifies a `Error` diagnostic. The
+`ErrorContext` message becomes the main diagnostic message, and the `Error`
+diagnostic message becomes a `Note` annotation. Given our example above, this
+can convert `"error: named constraint is not defined"` into
+`"error: failed to identify facet type for impl definition" / "note: named constraint is not defined"`.
+
+If multiple `ErrorContext` are introduced, the first one becomes the diagnostic
+message, and the others are converted to `Note` annotations that come before the
+`Error` diagnostic message.
+
+The message in an `ErrorContext` should be formulated as an error, in the same
+way as an `Error` message, as that is what it becomes.
 
 ## Alternatives considered
 


### PR DESCRIPTION
These messages used to be annotation notes. Now they are error messages. However they are in a position where they require some `ErrorContext` to exist (type completion internals require `CheckHasContext` to be true), so we do know they will end up being transformed into notes. Regardless, as they are errors, phrase them in terms of a failure instead of as an annotation.

Depends on #6806