### PR TITLE
Mark mangled enclosed entities

### DIFF
--- a/toolchain/lower/mangler.cpp
+++ b/toolchain/lower/mangler.cpp
@@ -44,14 +44,15 @@ auto Mangler::MangleInverseQualifiedNameScope(llvm::raw_ostream& os,
                              .prefix = '.'});
   while (!names_to_render.empty()) {
     auto [name_scope_id, specific_id, prefix] = names_to_render.pop_back_val();
-    if (prefix) {
-      os << prefix;
-    }
     if (!name_scope_id.has_value()) {
       // TODO: Include something in the mangling to identify the scope for a
       // function-local class, function, or similar. We may need to number
       // these within the enclosing function, as their name need not be unique.
+      os << ":enclosed";
       continue;
+    }
+    if (prefix) {
+      os << prefix;
     }
     if (name_scope_id == SemIR::NameScopeId::Package) {
       auto package_id = sem_ir().package_id();

--- a/toolchain/lower/testdata/function/generic/local_function.carbon
+++ b/toolchain/lower/testdata/function/generic/local_function.carbon
@@ -36,12 +36,12 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr i32 @_CF.Main.64ccbb8e5d9a0b8e(i32 %y) #0 !dbg !10 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call = call i32 @_CG..64ccbb8e5d9a0b8e(i32 %y), !dbg !15
+// CHECK:STDOUT:   %G.call = call i32 @"_CG:enclosed.64ccbb8e5d9a0b8e"(i32 %y), !dbg !15
 // CHECK:STDOUT:   ret i32 %G.call, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CG..64ccbb8e5d9a0b8e(i32 %x) #0 !dbg !17 {
+// CHECK:STDOUT: define linkonce_odr i32 @"_CG:enclosed.64ccbb8e5d9a0b8e"(i32 %x) #0 !dbg !17 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret i32 %x, !dbg !20
 // CHECK:STDOUT: }
@@ -68,7 +68,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !14 = !DILocalVariable(arg: 1, scope: !10, type: !7)
 // CHECK:STDOUT: !15 = !DILocation(line: 19, column: 10, scope: !10)
 // CHECK:STDOUT: !16 = !DILocation(line: 19, column: 3, scope: !10)
-// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "G", linkageName: "_CG..64ccbb8e5d9a0b8e", scope: null, file: !3, line: 18, type: !11, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !18)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "G", linkageName: "_CG:enclosed.64ccbb8e5d9a0b8e", scope: null, file: !3, line: 18, type: !11, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !18)
 // CHECK:STDOUT: !18 = !{!19}
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !20 = !DILocation(line: 18, column: 21, scope: !17)


### PR DESCRIPTION
This overlapped a little with `Destroy` work; adding the `:enclosed` identifier (similar to `:thunk`) just to make it easier to identify. I believe the TODO still applies.

Assisted-by: Google Antigravity with Gemini 3 Flash