### PR TITLE
Fix issues from #6745

### DIFF
--- a/core/prelude/types/form.carbon
+++ b/core/prelude/types/form.carbon
@@ -5,4 +5,4 @@
 package Core library "prelude/types/form";
 
 // TODO: this should be a concrete constant, not a function.
-fn Form() -> type = "bool.make_type";
+fn Form() -> type = "form.make_type";

--- a/toolchain/check/testdata/builtins/form/make_type.carbon
+++ b/toolchain/check/testdata/builtins/form/make_type.carbon
@@ -22,10 +22,8 @@ library "[[@TEST_NAME]]";
 
 import library "types";
 
-// TODO: test more more realistic usages once they're supported.
-
 //@dump-sem-ir-begin
-var f: Form();
+let f: Form() = form(var ());
 //@dump-sem-ir-end
 
 // CHECK:STDOUT: --- use_types.carbon
@@ -34,6 +32,9 @@ var f: Form();
 // CHECK:STDOUT:   %Form.type: type = fn_type @Form [concrete]
 // CHECK:STDOUT:   %Form: %Form.type = struct_value () [concrete]
 // CHECK:STDOUT:   %pattern_type.13f: type = pattern_type Core.Form [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
+// CHECK:STDOUT:   %.e36: Core.Form = init_form %empty_tuple.type, call_param<none> [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -42,16 +43,22 @@ var f: Form();
 // CHECK:STDOUT:
 // CHECK:STDOUT: file {
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %f.patt: %pattern_type.13f = ref_binding_pattern f [concrete]
-// CHECK:STDOUT:     %f.var_patt: %pattern_type.13f = var_pattern %f.patt [concrete]
+// CHECK:STDOUT:     %f.patt: %pattern_type.13f = value_binding_pattern f [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %f.var: ref Core.Form = var %f.var_patt [concrete]
-// CHECK:STDOUT:   %.loc9_13.1: type = splice_block %.loc9_13.3 [concrete = Core.Form] {
+// CHECK:STDOUT:   %.loc7_13.1: type = splice_block %.loc7_13.3 [concrete = Core.Form] {
 // CHECK:STDOUT:     %Form.ref: %Form.type = name_ref Form, imports.%Main.Form [concrete = constants.%Form]
 // CHECK:STDOUT:     %Form.call: init type = call %Form.ref() [concrete = Core.Form]
-// CHECK:STDOUT:     %.loc9_13.2: type = value_of_initializer %Form.call [concrete = Core.Form]
-// CHECK:STDOUT:     %.loc9_13.3: type = converted %Form.call, %.loc9_13.2 [concrete = Core.Form]
+// CHECK:STDOUT:     %.loc7_13.2: type = value_of_initializer %Form.call [concrete = Core.Form]
+// CHECK:STDOUT:     %.loc7_13.3: type = converted %Form.call, %.loc7_13.2 [concrete = Core.Form]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %f: ref Core.Form = ref_binding f, %f.var [concrete = %f.var]
+// CHECK:STDOUT:   %f: Core.Form = value_binding f, @__global_init.%.loc7_22
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @__global_init() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %.loc7_27.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
+// CHECK:STDOUT:   %.loc7_27.2: type = converted %.loc7_27.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
+// CHECK:STDOUT:   %.loc7_22: Core.Form = init_form %.loc7_27.2, call_param<none> [concrete = constants.%.e36]
+// CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/handle_call.cpp
+++ b/toolchain/lower/handle_call.cpp
@@ -409,11 +409,11 @@ static auto HandleBuiltinCall(FunctionContext& context, SemIR::InstId inst_id,
     case SemIR::BuiltinFunctionKind::CharLiteralMakeType:
     case SemIR::BuiltinFunctionKind::FloatLiteralMakeType:
     case SemIR::BuiltinFunctionKind::FloatMakeType:
+    case SemIR::BuiltinFunctionKind::FormMakeType:
     case SemIR::BuiltinFunctionKind::IntLiteralMakeType:
     case SemIR::BuiltinFunctionKind::IntMakeTypeSigned:
     case SemIR::BuiltinFunctionKind::IntMakeTypeUnsigned:
     case SemIR::BuiltinFunctionKind::MaybeUnformedMakeType:
-    case SemIR::BuiltinFunctionKind::FormMakeType:
       context.SetLocal(inst_id, context.GetTypeAsValue());
       return;
 


### PR DESCRIPTION
- Typo in the definition of `Core.Form`
- Resolved TODO to add test coverage
- Restored lexicographic order in a switch

