### PR TITLE
Dedupe self values in identify facet type

### DIFF
--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -366,11 +366,9 @@ static auto LookupImplWitnessInSelfFacetValue(
       context.identified_facet_types().Get(identified_id).required_impls());
   auto it = llvm::find_if(facet_type_req_impls, [&](auto e) {
     auto [req_self, req_specific_interface] = e.value();
-    // The `self_facet_value_inst_id` in eval is a canonicalized facet value, so
-    // we need to do the same to `req_self` that comes from the
-    // IdentifiedFacetType in order to compare them.
-    auto canonical_req_self = GetCanonicalFacetOrTypeValue(context, req_self);
-    return canonical_req_self == self_facet_value_const_id &&
+    // The `self_facet_value_inst_id` in eval is a canonicalized facet value, as
+    // is the self in the identified facet type.
+    return req_self == self_facet_value_const_id &&
            req_specific_interface == query_specific_interface;
   });
   if (it == facet_type_req_impls.end()) {
@@ -406,7 +404,8 @@ class SubstWitnessesCallbacks : public SubstInstCallbacks {
       llvm::ArrayRef<SemIR::InstId> witness_inst_ids)
       : SubstInstCallbacks(context),
         loc_id_(loc_id),
-        query_self_const_id_(query_self_const_id),
+        canonical_query_self_const_id_(
+            GetCanonicalFacetOrTypeValue(*context, query_self_const_id)),
         req_impls_(req_impls),
         witness_inst_ids_(witness_inst_ids) {}
 
@@ -501,7 +500,7 @@ class SubstWitnessesCallbacks : public SubstInstCallbacks {
       auto [req_self, req_interface] = req_impl;
       // The `LookupImplWitness` is for `.Self`, so if the witness is for some
       // type other than the query self, we can't use it for `.Self`.
-      if (req_self != query_self_const_id_) {
+      if (req_self != canonical_query_self_const_id_) {
         continue;
       }
       // If the `LookupImplWitness` for `.Self` is not looking for the same
@@ -516,7 +515,7 @@ class SubstWitnessesCallbacks : public SubstInstCallbacks {
   }
 
   SemIR::LocId loc_id_;
-  SemIR::ConstantId query_self_const_id_;
+  SemIR::ConstantId canonical_query_self_const_id_;
   llvm::ArrayRef<SemIR::IdentifiedFacetType::RequiredImpl> req_impls_;
   llvm::ArrayRef<SemIR::InstId> witness_inst_ids_;
   int facet_type_depth_ = 0;

--- a/toolchain/check/testdata/facet/identify_self_canonicalized.carbon
+++ b/toolchain/check/testdata/facet/identify_self_canonicalized.carbon
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/convert.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/facet/identify_self_canonicalized.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/identify_self_canonicalized.carbon
+
+// --- identify_self_canonicalized.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {}
+
+constraint W {
+  extend require impls Z;
+}
+
+interface Y {}
+
+// T is a facet value (a SymbolicBinding), which is converted to `type`. The
+// identified facet type finds `(T as type) impls Z` from the top level facet
+// type. It also finds `T as Z` through `W`. It's possible for these to disagree
+// on the self and thus present as two different required interfaces in the
+// identified facet type. Instead we should only get a single interface with the
+// canonical `T` facet value as the self value.
+
+// CHECK:STDERR: identify_self_canonicalized.carbon:[[@LINE+4]]:1: error: impl as 2 interfaces, expected 1 [ImplOfNotOneInterface]
+// CHECK:STDERR: impl forall [T:! Y] T as W & Z {}
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+impl forall [T:! Y] T as W & Z {}

--- a/toolchain/check/testdata/facet/identify_self_canonicalized.carbon
+++ b/toolchain/check/testdata/facet/identify_self_canonicalized.carbon
@@ -28,8 +28,4 @@ interface Y {}
 // identified facet type. Instead we should only get a single interface with the
 // canonical `T` facet value as the self value.
 
-// CHECK:STDERR: identify_self_canonicalized.carbon:[[@LINE+4]]:1: error: impl as 2 interfaces, expected 1 [ImplOfNotOneInterface]
-// CHECK:STDERR: impl forall [T:! Y] T as W & Z {}
-// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
 impl forall [T:! Y] T as W & Z {}

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -866,15 +866,12 @@ static auto RequireCompleteNamedConstraint(
   return RequireCompleteFacetType(context, loc_id, facet_type, diagnose);
 }
 
+// Given a canonical facet value, or a type value, return a facet value.
 static auto GetSelfFacetValue(Context& context, SemIR::ConstantId self_const_id)
     -> SemIR::ConstantId {
   if (self_const_id == SemIR::ErrorInst::ConstantId) {
     return SemIR::ErrorInst::ConstantId;
   }
-
-  // Avoid wrapping a FacetAccessType(FacetValue) in another layer of
-  // FacetValue. Just unwrap the FacetValue inside.
-  self_const_id = GetCanonicalFacetOrTypeValue(context, self_const_id);
 
   auto self_inst_id = context.constant_values().GetInstId(self_const_id);
   auto type_id = context.insts().Get(self_inst_id).type_id();
@@ -932,7 +929,7 @@ auto RequireIdentifiedFacetType(Context& context, SemIR::LocId loc_id,
       break;
     }
 
-    auto self_const_id = next_impls.self;
+    auto self_const_id = GetCanonicalFacetOrTypeValue(context, next_impls.self);
     const auto& facet_type_info =
         context.facet_types().Get(next_impls.facet_type);
 

--- a/toolchain/check/type_completion.h
+++ b/toolchain/check/type_completion.h
@@ -66,11 +66,17 @@ auto RequireConcreteType(Context& context, SemIR::TypeId type_id,
     -> bool;
 
 // Requires the named constraints in the facet type to be complete, so that the
-// set of interfaces the facet type requires is known. The `self_const_id` is
-// a type or facet type expression that is the self that the FacetType is
+// set of interfaces the facet type requires is known. The `self_const_id` is a
+// type or facet type expression that is the self that the FacetType is
 // constraining. Produces a set of interfaces that must be implemented for a set
 // of types, most of them for the `self_const_id`. Diagnoses an error and
 // returns None if any error is found.
+//
+// The `self_const_id` is converted to the canonical facet value (if it's a
+// facet-value-as-type, the as-type is stripped off), and this is visible in the
+// resulting IdentifiedFacetType. Comparing the `self_const_id` against the
+// output self values requires the caller to also canonicalize the
+// `self_const_id`.
 auto RequireIdentifiedFacetType(Context& context, SemIR::LocId loc_id,
                                 SemIR::ConstantId self_const_id,
                                 const SemIR::FacetType& facet_type,

--- a/toolchain/sem_ir/facet_type_info.cpp
+++ b/toolchain/sem_ir/facet_type_info.cpp
@@ -215,16 +215,20 @@ IdentifiedFacetType::IdentifiedFacetType(
     IdentifiedFacetTypeKey key, llvm::ArrayRef<RequiredImpl> extends,
     llvm::ArrayRef<RequiredImpl> self_impls)
     : key_(key) {
-  if (extends.size() == 1) {
-    interface_id_ = extends.front().specific_interface.interface_id;
-    specific_id_ = extends.front().specific_interface.specific_id;
-  } else {
-    interface_id_ = InterfaceId::None;
-    num_interface_to_impl_ = extends.size();
-  }
-
   required_impls_.reserve(extends.size() + self_impls.size());
   llvm::append_range(required_impls_, extends);
+  SortAndDeduplicate(required_impls_, RequiredLess);
+
+  // If there's a single extended interface then we present as that interface.
+  // Otherwise, we record the number extended interfaces.
+  if (required_impls_.size() == 1) {
+    interface_id_ = required_impls_.front().specific_interface.interface_id;
+    specific_id_ = required_impls_.front().specific_interface.specific_id;
+  } else {
+    interface_id_ = InterfaceId::None;
+    num_interface_to_impl_ = required_impls_.size();
+  }
+
   llvm::append_range(required_impls_, self_impls);
   SortAndDeduplicate(required_impls_, RequiredLess);
 }


### PR DESCRIPTION
The self value can be a facet-value or a facet-value-as-type. The self value used in `require` decls is the former. The the self value used for identifying the facet type is the latter, we end up with two different required interfaces in the identified facet type: one for each self value.

Always canonicalize the self value to a facet value in identification. Then dedupe the list of extend interfaces when constructing the `IdentifiedFacetType` before counting them. And then impl lookup needs to canonicalize its query self for comparing with the result from the `IdentifiedFacetType`.