### PR TITLE
Refactor `TryEvaluateMacroToConstant` to simplify and dedup code

### DIFF
--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -9,7 +9,6 @@
 
 namespace Carbon::Check {
 
-// TODO: dedup with code in `MapConstant` and `TryEvaluateMacroToConstant`.
 auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
                           const clang::APValue& ap_value, clang::QualType type)
     -> SemIR::ConstantId {

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -2079,11 +2079,10 @@ static auto IsIncompleteClass(Context& context, SemIR::NameScopeId scope_id)
              context.classes().Get(class_decl->class_id).self_type_id);
 }
 
-// Maps a Clang literal expression to a Carbon constant.
 // TODO: Add support for all constant types for which a C++ to Carbon type
 // mapping exists.
-static auto MapConstant(Context& context, SemIR::LocId loc_id,
-                        clang::Expr* expr) -> SemIR::InstId {
+auto MapConstant(Context& context, SemIR::LocId loc_id, clang::Expr* expr)
+    -> SemIR::InstId {
   CARBON_CHECK(expr, "empty expression");
 
   if (auto* string_literal = dyn_cast<clang::StringLiteral>(expr)) {

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -2103,54 +2103,10 @@ auto MapConstant(Context& context, SemIR::LocId loc_id, clang::Expr* expr)
                                                    {.type_id = type_id});
   }
 
-  SemIR::TypeId type_id = MapType(context, loc_id, expr->getType()).type_id;
-  if (!type_id.has_value()) {
-    context.TODO(loc_id, llvm::formatv("Unsupported: C++ literal's type `{0}` "
-                                       "could not be mapped to a Carbon type",
-                                       expr->getType().getAsString()));
-    return SemIR::ErrorInst::InstId;
-  }
-
-  SemIR::InstId inst_id = SemIR::InstId::None;
-  SemIR::ImportIRInstId imported_loc_id =
-      AddImportIRInst(context.sem_ir(), expr->getExprLoc());
-
-  if (auto* integer_literal = dyn_cast<clang::IntegerLiteral>(expr)) {
-    IntId int_id =
-        context.ints().Add(integer_literal->getValue().getSExtValue());
-    inst_id = AddInstInNoBlock(
-        context,
-        MakeImportedLocIdAndInst<SemIR::IntValue>(
-            context, imported_loc_id, {.type_id = type_id, .int_id = int_id}));
-  } else if (auto* bool_literal = dyn_cast<clang::CXXBoolLiteralExpr>(expr)) {
-    inst_id = AddInstInNoBlock(
-        context,
-        MakeImportedLocIdAndInst<SemIR::BoolLiteral>(
-            context, imported_loc_id,
-            {.type_id = type_id,
-             .value = SemIR::BoolValue::From(bool_literal->getValue())}));
-  } else if (auto* float_literal = dyn_cast<clang::FloatingLiteral>(expr)) {
-    FloatId float_id = context.floats().Add(float_literal->getValue());
-    inst_id = AddInstInNoBlock(context,
-                               MakeImportedLocIdAndInst<SemIR::FloatValue>(
-                                   context, imported_loc_id,
-                                   {.type_id = type_id, .float_id = float_id}));
-  } else if (auto* character_literal =
-                 dyn_cast<clang::CharacterLiteral>(expr)) {
-    inst_id = AddInstInNoBlock(
-        context, MakeImportedLocIdAndInst<SemIR::CharLiteralValue>(
-                     context, imported_loc_id,
-                     {.type_id = type_id,
-                      .value = SemIR::CharId(character_literal->getValue())}));
-  } else {
-    context.TODO(loc_id, llvm::formatv(
-                             "Unsupported: C++ constant expression type: '{0}'",
+  context.TODO(loc_id,
+               llvm::formatv("Unsupported: C++ constant expression type: '{0}'",
                              expr->getType().getAsString()));
-    return SemIR::ErrorInst::InstId;
-  }
-
-  context.imports().push_back(inst_id);
-  return inst_id;
+  return SemIR::ErrorInst::InstId;
 }
 
 // Imports a macro definition into the scope. Currently supports only simple

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -2160,14 +2160,8 @@ static auto ImportMacro(Context& context, SemIR::LocId loc_id,
                         SemIR::NameScopeId scope_id, SemIR::NameId name_id,
                         clang::MacroInfo* macro_info)
     -> SemIR::ScopeLookupResult {
-  clang::Expr* macro_expr =
+  auto inst_id =
       TryEvaluateMacroToConstant(context, loc_id, name_id, macro_info);
-
-  if (!macro_expr) {
-    return SemIR::ScopeLookupResult::MakeNotFound();
-  }
-
-  auto inst_id = MapConstant(context, loc_id, macro_expr);
   if (inst_id == SemIR::ErrorInst::InstId) {
     return SemIR::ScopeLookupResult::MakeNotFound();
   }

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -2079,36 +2079,6 @@ static auto IsIncompleteClass(Context& context, SemIR::NameScopeId scope_id)
              context.classes().Get(class_decl->class_id).self_type_id);
 }
 
-// TODO: Add support for all constant types for which a C++ to Carbon type
-// mapping exists.
-auto MapConstant(Context& context, SemIR::LocId loc_id, clang::Expr* expr)
-    -> SemIR::InstId {
-  CARBON_CHECK(expr, "empty expression");
-
-  if (auto* string_literal = dyn_cast<clang::StringLiteral>(expr)) {
-    if (!string_literal->isOrdinary() && !string_literal->isUTF8()) {
-      context.TODO(loc_id,
-                   llvm::formatv("Unsupported: string literal type: {0}",
-                                 expr->getType()));
-      return SemIR::ErrorInst::InstId;
-    }
-    StringLiteralValueId string_id =
-        context.string_literal_values().Add(string_literal->getString());
-    auto inst_id =
-        MakeStringLiteral(context, Parse::StringLiteralId::None, string_id);
-    return inst_id;
-  } else if (isa<clang::CXXNullPtrLiteralExpr>(expr)) {
-    auto type_id = MapNullptrType(context, loc_id).type_id;
-    return GetOrAddInst<SemIR::UninitializedValue>(context, SemIR::LocId::None,
-                                                   {.type_id = type_id});
-  }
-
-  context.TODO(loc_id,
-               llvm::formatv("Unsupported: C++ constant expression type: '{0}'",
-                             expr->getType().getAsString()));
-  return SemIR::ErrorInst::InstId;
-}
-
 // Imports a macro definition into the scope. Currently supports only simple
 // object-like macros that expand to a constant integer value.
 // TODO: Add support for other macro types and non-integer literal values.

--- a/toolchain/check/cpp/import.h
+++ b/toolchain/check/cpp/import.h
@@ -87,10 +87,6 @@ auto GetClangIdentifierInfo(Context& context, SemIR::NameId name_id)
 auto GetAsClangVarDecl(Context& context, SemIR::InstId inst_id)
     -> clang::VarDecl*;
 
-// Maps a Clang literal expression to a Carbon constant.
-auto MapConstant(Context& context, SemIR::LocId loc_id, clang::Expr* expr)
-    -> SemIR::InstId;
-
 }  // namespace Carbon::Check
 
 #endif  // CARBON_TOOLCHAIN_CHECK_CPP_IMPORT_H_

--- a/toolchain/check/cpp/import.h
+++ b/toolchain/check/cpp/import.h
@@ -87,6 +87,10 @@ auto GetClangIdentifierInfo(Context& context, SemIR::NameId name_id)
 auto GetAsClangVarDecl(Context& context, SemIR::InstId inst_id)
     -> clang::VarDecl*;
 
+// Maps a Clang literal expression to a Carbon constant.
+auto MapConstant(Context& context, SemIR::LocId loc_id, clang::Expr* expr)
+    -> SemIR::InstId;
+
 }  // namespace Carbon::Check
 
 #endif  // CARBON_TOOLCHAIN_CHECK_CPP_IMPORT_H_

--- a/toolchain/check/cpp/macros.cpp
+++ b/toolchain/check/cpp/macros.cpp
@@ -9,18 +9,19 @@
 #include "clang/Parse/Parser.h"
 #include "clang/Sema/Sema.h"
 #include "common/check.h"
+#include "toolchain/check/cpp/import.h"
 
 namespace Carbon::Check {
 
 auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
                                 SemIR::NameId name_id,
-                                clang::MacroInfo* macro_info) -> clang::Expr* {
+                                clang::MacroInfo* macro_info) -> SemIR::InstId {
   auto name_str_opt = context.names().GetAsStringIfIdentifier(name_id);
   CARBON_CHECK(macro_info, "macro info missing");
 
   if (macro_info->getNumTokens() == 0) {
     context.TODO(loc_id, "Unsupported: macro with 0 replacement tokens");
-    return nullptr;
+    return SemIR::ErrorInst::InstId;
   }
 
   clang::Sema& sema = context.clang_sema();
@@ -59,7 +60,7 @@ auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
         "failed to parse macro Cpp.{0} to a valid constant expression",
         std::string);
     context.emitter().Emit(loc_id, InCppMacroEvaluation, (*name_str_opt).str());
-    return nullptr;
+    return SemIR::ErrorInst::InstId;
   }
 
   result_expr = result_expr->IgnoreParenImpCasts();
@@ -67,7 +68,7 @@ auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
   if (isa<clang::StringLiteral>(result_expr) ||
       isa<clang::CharacterLiteral>(result_expr) ||
       isa<clang::CXXNullPtrLiteralExpr>(result_expr)) {
-    return result_expr;
+    return MapConstant(context, loc_id, result_expr);
   }
 
   clang::Expr::EvalResult evaluated_result;
@@ -80,7 +81,7 @@ auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
     if (!result_expr->EvaluateAsInt(evaluated_result, sema.getASTContext())) {
       context.TODO(loc_id,
                    "Unsupported: macro evaluated to a non-integer LValue");
-      return nullptr;
+      return SemIR::ErrorInst::InstId;
     }
     ap_value = evaluated_result.Val;
   }
@@ -88,22 +89,28 @@ auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
   switch (ap_value.getKind()) {
     case clang::APValue::Int:
       if (result_expr->getType()->isBooleanType()) {
-        return clang::CXXBoolLiteralExpr::Create(
-            sema.getASTContext(), ap_value.getInt().getBoolValue(),
-            result_expr->getType(), result_expr->getExprLoc());
+        return MapConstant(
+            context, loc_id,
+            clang::CXXBoolLiteralExpr::Create(
+                sema.getASTContext(), ap_value.getInt().getBoolValue(),
+                result_expr->getType(), result_expr->getExprLoc()));
       }
-      return clang::IntegerLiteral::Create(
-          sema.getASTContext(), ap_value.getInt(), result_expr->getType(),
-          result_expr->getExprLoc());
+      return MapConstant(
+          context, loc_id,
+          clang::IntegerLiteral::Create(sema.getASTContext(), ap_value.getInt(),
+                                        result_expr->getType(),
+                                        result_expr->getExprLoc()));
     case clang::APValue::Float:
-      return clang::FloatingLiteral::Create(
-          sema.getASTContext(), ap_value.getFloat(),
-          /*isExact=*/true, result_expr->getType(), result_expr->getExprLoc());
+      return MapConstant(context, loc_id,
+                         clang::FloatingLiteral::Create(
+                             sema.getASTContext(), ap_value.getFloat(),
+                             /*isExact=*/true, result_expr->getType(),
+                             result_expr->getExprLoc()));
     default:
       context.TODO(loc_id,
                    "Unsupported: macro evaluated to a constant of type: " +
                        result_expr->getType().getAsString());
-      return nullptr;
+      return SemIR::ErrorInst::InstId;
   }
 }
 

--- a/toolchain/check/cpp/macros.cpp
+++ b/toolchain/check/cpp/macros.cpp
@@ -9,6 +9,7 @@
 #include "clang/Parse/Parser.h"
 #include "clang/Sema/Sema.h"
 #include "common/check.h"
+#include "toolchain/check/cpp/constant.h"
 #include "toolchain/check/cpp/import.h"
 
 namespace Carbon::Check {
@@ -86,32 +87,16 @@ auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
     ap_value = evaluated_result.Val;
   }
 
-  switch (ap_value.getKind()) {
-    case clang::APValue::Int:
-      if (result_expr->getType()->isBooleanType()) {
-        return MapConstant(
-            context, loc_id,
-            clang::CXXBoolLiteralExpr::Create(
-                sema.getASTContext(), ap_value.getInt().getBoolValue(),
-                result_expr->getType(), result_expr->getExprLoc()));
-      }
-      return MapConstant(
-          context, loc_id,
-          clang::IntegerLiteral::Create(sema.getASTContext(), ap_value.getInt(),
-                                        result_expr->getType(),
-                                        result_expr->getExprLoc()));
-    case clang::APValue::Float:
-      return MapConstant(context, loc_id,
-                         clang::FloatingLiteral::Create(
-                             sema.getASTContext(), ap_value.getFloat(),
-                             /*isExact=*/true, result_expr->getType(),
-                             result_expr->getExprLoc()));
-    default:
-      context.TODO(loc_id,
-                   "Unsupported: macro evaluated to a constant of type: " +
-                       result_expr->getType().getAsString());
-      return SemIR::ErrorInst::InstId;
+  auto const_id =
+      MapAPValueToConstant(context, loc_id, ap_value, result_expr->getType());
+  if (const_id == SemIR::ConstantId::NotConstant) {
+    context.TODO(loc_id,
+                 "Unsupported: macro evaluated to a constant of type: " +
+                     result_expr->getType().getAsString());
+    return SemIR::ErrorInst::InstId;
   }
+
+  return context.constant_values().GetInstId(const_id);
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/cpp/macros.cpp
+++ b/toolchain/check/cpp/macros.cpp
@@ -67,7 +67,6 @@ auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
   result_expr = result_expr->IgnoreParenImpCasts();
 
   if (isa<clang::StringLiteral>(result_expr) ||
-      isa<clang::CharacterLiteral>(result_expr) ||
       isa<clang::CXXNullPtrLiteralExpr>(result_expr)) {
     return MapConstant(context, loc_id, result_expr);
   }

--- a/toolchain/check/cpp/macros.cpp
+++ b/toolchain/check/cpp/macros.cpp
@@ -11,8 +11,38 @@
 #include "common/check.h"
 #include "toolchain/check/cpp/constant.h"
 #include "toolchain/check/cpp/import.h"
+#include "toolchain/check/literal.h"
 
 namespace Carbon::Check {
+
+// Maps a Clang literal expression to a Carbon constant.
+static auto MapConstant(Context& context, SemIR::LocId loc_id,
+                        clang::Expr* expr) -> SemIR::InstId {
+  CARBON_CHECK(expr, "empty expression");
+
+  if (auto* string_literal = dyn_cast<clang::StringLiteral>(expr)) {
+    if (!string_literal->isOrdinary() && !string_literal->isUTF8()) {
+      context.TODO(loc_id,
+                   llvm::formatv("Unsupported: string literal type: {0}",
+                                 expr->getType()));
+      return SemIR::ErrorInst::InstId;
+    }
+    StringLiteralValueId string_id =
+        context.string_literal_values().Add(string_literal->getString());
+    auto inst_id =
+        MakeStringLiteral(context, Parse::StringLiteralId::None, string_id);
+    return inst_id;
+  } else if (isa<clang::CXXNullPtrLiteralExpr>(expr)) {
+    auto type_id = ImportCppType(context, loc_id, expr->getType()).type_id;
+    return GetOrAddInst<SemIR::UninitializedValue>(context, SemIR::LocId::None,
+                                                   {.type_id = type_id});
+  }
+
+  context.TODO(loc_id,
+               llvm::formatv("Unsupported: C++ constant expression type: '{0}'",
+                             expr->getType().getAsString()));
+  return SemIR::ErrorInst::InstId;
+}
 
 auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
                                 SemIR::NameId name_id,

--- a/toolchain/check/cpp/macros.h
+++ b/toolchain/check/cpp/macros.h
@@ -14,7 +14,7 @@ namespace Carbon::Check {
 // TODO: Add support for all literal types.
 auto TryEvaluateMacroToConstant(Context& context, SemIR::LocId loc_id,
                                 SemIR::NameId name_id,
-                                clang::MacroInfo* macro_info) -> clang::Expr*;
+                                clang::MacroInfo* macro_info) -> SemIR::InstId;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -377,7 +377,7 @@ library "[[@TEST_NAME]]";
 import Cpp library "unsupported_floating_point_literal_macro.h";
 
 fn F() {
-  // CHECK:STDERR: fail_import_unsupported_floating_point_literal_macro.carbon:[[@LINE+11]]:3: error: semantics TODO: `Unsupported: C++ literal's type `long double` could not be mapped to a Carbon type` [SemanticsTodo]
+  // CHECK:STDERR: fail_import_unsupported_floating_point_literal_macro.carbon:[[@LINE+11]]:3: error: semantics TODO: `Unsupported: macro evaluated to a constant of type: long double` [SemanticsTodo]
   // CHECK:STDERR:   Cpp.MyLongDouble;
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~
   // CHECK:STDERR: fail_import_unsupported_floating_point_literal_macro.carbon:[[@LINE+8]]:3: note: in `Cpp` name lookup for `MyLongDouble` [InCppNameLookup]
@@ -873,20 +873,14 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .CONFIG_VALUE = %int_42.c68
-// CHECK:STDOUT:     .CONFIG_VALUE_LONG = %int_42.434
-// CHECK:STDOUT:     .CONFIG_VALUE_UNSIGNED = %int_42.58b
-// CHECK:STDOUT:     .CONFIG_VALUE_HEXA = %int_255
-// CHECK:STDOUT:     .CONFIG_VALUE_OCTAL = %int_8
-// CHECK:STDOUT:     .CONFIG_VALUE_BINARY = %int_5
+// CHECK:STDOUT:     .CONFIG_VALUE = constants.%int_42.c68
+// CHECK:STDOUT:     .CONFIG_VALUE_LONG = constants.%int_42.434
+// CHECK:STDOUT:     .CONFIG_VALUE_UNSIGNED = constants.%int_42.58b
+// CHECK:STDOUT:     .CONFIG_VALUE_HEXA = constants.%int_255
+// CHECK:STDOUT:     .CONFIG_VALUE_OCTAL = constants.%int_8
+// CHECK:STDOUT:     .CONFIG_VALUE_BINARY = constants.%int_5
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_42.c68: %i32 = int_value 42 [concrete = constants.%int_42.c68]
-// CHECK:STDOUT:   %int_42.434: %i64 = int_value 42 [concrete = constants.%int_42.434]
-// CHECK:STDOUT:   %int_42.58b: %u32 = int_value 42 [concrete = constants.%int_42.58b]
-// CHECK:STDOUT:   %int_255: %i32 = int_value 255 [concrete = constants.%int_255]
-// CHECK:STDOUT:   %int_8: %i32 = int_value 8 [concrete = constants.%int_8]
-// CHECK:STDOUT:   %int_5: %i32 = int_value 5 [concrete = constants.%int_5]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -896,7 +890,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc8: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CONFIG_VALUE.ref: %i32 = name_ref CONFIG_VALUE, imports.%int_42.c68 [concrete = constants.%int_42.c68]
+// CHECK:STDOUT:   %CONFIG_VALUE.ref: %i32 = name_ref CONFIG_VALUE, constants.%int_42.c68 [concrete = constants.%int_42.c68]
 // CHECK:STDOUT:   %i32.loc8: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %a: %i32 = value_binding a, %CONFIG_VALUE.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -904,7 +898,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CONFIG_VALUE_LONG.ref: %i64 = name_ref CONFIG_VALUE_LONG, imports.%int_42.434 [concrete = constants.%int_42.434]
+// CHECK:STDOUT:   %CONFIG_VALUE_LONG.ref: %i64 = name_ref CONFIG_VALUE_LONG, constants.%int_42.434 [concrete = constants.%int_42.434]
 // CHECK:STDOUT:   %i64.loc9: type = type_literal constants.%i64 [concrete = constants.%i64]
 // CHECK:STDOUT:   %b: %i64 = value_binding b, %CONFIG_VALUE_LONG.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -912,7 +906,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CONFIG_VALUE_UNSIGNED.ref: %u32 = name_ref CONFIG_VALUE_UNSIGNED, imports.%int_42.58b [concrete = constants.%int_42.58b]
+// CHECK:STDOUT:   %CONFIG_VALUE_UNSIGNED.ref: %u32 = name_ref CONFIG_VALUE_UNSIGNED, constants.%int_42.58b [concrete = constants.%int_42.58b]
 // CHECK:STDOUT:   %u32.loc10: type = type_literal constants.%u32 [concrete = constants.%u32]
 // CHECK:STDOUT:   %c: %u32 = value_binding c, %CONFIG_VALUE_UNSIGNED.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -920,7 +914,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CONFIG_VALUE_HEXA.ref: %i32 = name_ref CONFIG_VALUE_HEXA, imports.%int_255 [concrete = constants.%int_255]
+// CHECK:STDOUT:   %CONFIG_VALUE_HEXA.ref: %i32 = name_ref CONFIG_VALUE_HEXA, constants.%int_255 [concrete = constants.%int_255]
 // CHECK:STDOUT:   %i32.loc11: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %d: %i32 = value_binding d, %CONFIG_VALUE_HEXA.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -928,7 +922,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc12: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CONFIG_VALUE_OCTAL.ref: %i32 = name_ref CONFIG_VALUE_OCTAL, imports.%int_8 [concrete = constants.%int_8]
+// CHECK:STDOUT:   %CONFIG_VALUE_OCTAL.ref: %i32 = name_ref CONFIG_VALUE_OCTAL, constants.%int_8 [concrete = constants.%int_8]
 // CHECK:STDOUT:   %i32.loc12: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %e: %i32 = value_binding e, %CONFIG_VALUE_OCTAL.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -936,7 +930,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc13: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CONFIG_VALUE_BINARY.ref: %i32 = name_ref CONFIG_VALUE_BINARY, imports.%int_5 [concrete = constants.%int_5]
+// CHECK:STDOUT:   %CONFIG_VALUE_BINARY.ref: %i32 = name_ref CONFIG_VALUE_BINARY, constants.%int_5 [concrete = constants.%int_5]
 // CHECK:STDOUT:   %i32.loc13: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %f: %i32 = value_binding f, %CONFIG_VALUE_BINARY.ref
 // CHECK:STDOUT:   <elided>
@@ -992,11 +986,10 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .n = %int_1
+// CHECK:STDOUT:     .n = constants.%int_1.5d2
 // CHECK:STDOUT:     .X = %X
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_1: %i32 = int_value 1 [concrete = constants.%int_1.5d2]
 // CHECK:STDOUT:   %Core.import_ref.0bc: @Int.as.ImplicitAs.impl.%Int.as.ImplicitAs.impl.Convert.type (%Int.as.ImplicitAs.impl.Convert.type.2ed) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.ImplicitAs.impl.%Int.as.ImplicitAs.impl.Convert (constants.%Int.as.ImplicitAs.impl.Convert.d29)]
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.ea2 = impl_witness_table (%Core.import_ref.0bc), @Int.as.ImplicitAs.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.38a: @Core.FloatLiteral.as.ImplicitAs.impl.%Core.FloatLiteral.as.ImplicitAs.impl.Convert.type (%Core.FloatLiteral.as.ImplicitAs.impl.Convert.type.02f) = import_ref Core//prelude/types/float, loc{{\d+_\d+}}, loaded [symbolic = @Core.FloatLiteral.as.ImplicitAs.impl.%Core.FloatLiteral.as.ImplicitAs.impl.Convert (constants.%Core.FloatLiteral.as.ImplicitAs.impl.Convert.1f0)]
@@ -1035,7 +1028,7 @@ fn F() {
 // CHECK:STDOUT:     %f32.loc10: type = type_literal constants.%f32.97e [concrete = constants.%f32.97e]
 // CHECK:STDOUT:     %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %n.ref.loc10: %i32 = name_ref n, imports.%int_1 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:     %n.ref.loc10: %i32 = name_ref n, constants.%int_1.5d2 [concrete = constants.%int_1.5d2]
 // CHECK:STDOUT:     %impl.elem0.loc10_31: %.0a7 = impl_witness_access constants.%ImplicitAs.impl_witness.640, element0 [concrete = constants.%Int.as.ImplicitAs.impl.Convert.dd4]
 // CHECK:STDOUT:     %bound_method.loc10_31.1: <bound method> = bound_method %n.ref.loc10, %impl.elem0.loc10_31 [concrete = constants.%Int.as.ImplicitAs.impl.Convert.bound]
 // CHECK:STDOUT:     %specific_fn.loc10_31: <specific function> = specific_function %impl.elem0.loc10_31, @Int.as.ImplicitAs.impl.Convert(constants.%int_32) [concrete = constants.%Int.as.ImplicitAs.impl.Convert.specific_fn]
@@ -1074,10 +1067,9 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .NEGATIVE = %int_-1
+// CHECK:STDOUT:     .NEGATIVE = constants.%int_-1
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_-1: %i32 = int_value -1 [concrete = constants.%int_-1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1087,7 +1079,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %NEGATIVE.ref: %i32 = name_ref NEGATIVE, imports.%int_-1 [concrete = constants.%int_-1]
+// CHECK:STDOUT:   %NEGATIVE.ref: %i32 = name_ref NEGATIVE, constants.%int_-1 [concrete = constants.%int_-1]
 // CHECK:STDOUT:   %i32.loc8: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %a: %i32 = value_binding a, %NEGATIVE.ref
 // CHECK:STDOUT:   <elided>
@@ -1104,10 +1096,9 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .ADDITION = %int_3
+// CHECK:STDOUT:     .ADDITION = constants.%int_3
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_3: %i32 = int_value 3 [concrete = constants.%int_3]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1117,7 +1108,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %ADDITION.ref: %i32 = name_ref ADDITION, imports.%int_3 [concrete = constants.%int_3]
+// CHECK:STDOUT:   %ADDITION.ref: %i32 = name_ref ADDITION, constants.%int_3 [concrete = constants.%int_3]
 // CHECK:STDOUT:   %i32.loc8: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %a: %i32 = value_binding a, %ADDITION.ref
 // CHECK:STDOUT:   <elided>
@@ -1139,16 +1130,12 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .CAST_UNSIGNED = %int_1.c1d
-// CHECK:STDOUT:     .CAST_STATIC = %int_100
-// CHECK:STDOUT:     .CAST_FUNCTIONAL = %int_99
-// CHECK:STDOUT:     .CAST_BOOL_TO_INT = %int_1.5d2
+// CHECK:STDOUT:     .CAST_UNSIGNED = constants.%int_1.c1d
+// CHECK:STDOUT:     .CAST_STATIC = constants.%int_100
+// CHECK:STDOUT:     .CAST_FUNCTIONAL = constants.%int_99
+// CHECK:STDOUT:     .CAST_BOOL_TO_INT = constants.%int_1.5d2
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_1.c1d: %u32 = int_value 1 [concrete = constants.%int_1.c1d]
-// CHECK:STDOUT:   %int_100: %i32 = int_value 100 [concrete = constants.%int_100]
-// CHECK:STDOUT:   %int_99: %i32 = int_value 99 [concrete = constants.%int_99]
-// CHECK:STDOUT:   %int_1.5d2: %i32 = int_value 1 [concrete = constants.%int_1.5d2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1158,7 +1145,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc8: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CAST_UNSIGNED.ref: %u32 = name_ref CAST_UNSIGNED, imports.%int_1.c1d [concrete = constants.%int_1.c1d]
+// CHECK:STDOUT:   %CAST_UNSIGNED.ref: %u32 = name_ref CAST_UNSIGNED, constants.%int_1.c1d [concrete = constants.%int_1.c1d]
 // CHECK:STDOUT:   %u32.loc8: type = type_literal constants.%u32 [concrete = constants.%u32]
 // CHECK:STDOUT:   %a: %u32 = value_binding a, %CAST_UNSIGNED.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1166,7 +1153,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CAST_STATIC.ref: %i32 = name_ref CAST_STATIC, imports.%int_100 [concrete = constants.%int_100]
+// CHECK:STDOUT:   %CAST_STATIC.ref: %i32 = name_ref CAST_STATIC, constants.%int_100 [concrete = constants.%int_100]
 // CHECK:STDOUT:   %i32.loc9: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %b: %i32 = value_binding b, %CAST_STATIC.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1174,7 +1161,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CAST_FUNCTIONAL.ref: %i32 = name_ref CAST_FUNCTIONAL, imports.%int_99 [concrete = constants.%int_99]
+// CHECK:STDOUT:   %CAST_FUNCTIONAL.ref: %i32 = name_ref CAST_FUNCTIONAL, constants.%int_99 [concrete = constants.%int_99]
 // CHECK:STDOUT:   %i32.loc10: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %c: %i32 = value_binding c, %CAST_FUNCTIONAL.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1182,7 +1169,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %CAST_BOOL_TO_INT.ref: %i32 = name_ref CAST_BOOL_TO_INT, imports.%int_1.5d2 [concrete = constants.%int_1.5d2]
+// CHECK:STDOUT:   %CAST_BOOL_TO_INT.ref: %i32 = name_ref CAST_BOOL_TO_INT, constants.%int_1.5d2 [concrete = constants.%int_1.5d2]
 // CHECK:STDOUT:   %i32.loc11: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %d: %i32 = value_binding d, %CAST_BOOL_TO_INT.ref
 // CHECK:STDOUT:   <elided>
@@ -1199,10 +1186,9 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .INDIRECT_ONE = %int_1
+// CHECK:STDOUT:     .INDIRECT_ONE = constants.%int_1
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_1: %i32 = int_value 1 [concrete = constants.%int_1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1212,7 +1198,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %INDIRECT_ONE.ref: %i32 = name_ref INDIRECT_ONE, imports.%int_1 [concrete = constants.%int_1]
+// CHECK:STDOUT:   %INDIRECT_ONE.ref: %i32 = name_ref INDIRECT_ONE, constants.%int_1 [concrete = constants.%int_1]
 // CHECK:STDOUT:   %i32.loc8: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %a: %i32 = value_binding a, %INDIRECT_ONE.ref
 // CHECK:STDOUT:   <elided>
@@ -1338,14 +1324,11 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .MyDouble = %float.d20
-// CHECK:STDOUT:     .MyDoubleE = %float.e0c
-// CHECK:STDOUT:     .MyFloat = %float.e3b
+// CHECK:STDOUT:     .MyDouble = constants.%float.d20
+// CHECK:STDOUT:     .MyDoubleE = constants.%float.e0c
+// CHECK:STDOUT:     .MyFloat = constants.%float.e3b
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %float.d20: %f64.d77 = float_value 1 [concrete = constants.%float.d20]
-// CHECK:STDOUT:   %float.e0c: %f64.d77 = float_value 100 [concrete = constants.%float.e0c]
-// CHECK:STDOUT:   %float.e3b: %f32.97e = float_value 1 [concrete = constants.%float.e3b]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1355,7 +1338,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc8: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %MyDouble.ref: %f64.d77 = name_ref MyDouble, imports.%float.d20 [concrete = constants.%float.d20]
+// CHECK:STDOUT:   %MyDouble.ref: %f64.d77 = name_ref MyDouble, constants.%float.d20 [concrete = constants.%float.d20]
 // CHECK:STDOUT:   %f64.loc8: type = type_literal constants.%f64.d77 [concrete = constants.%f64.d77]
 // CHECK:STDOUT:   %a: %f64.d77 = value_binding a, %MyDouble.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1363,7 +1346,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %MyDoubleE.ref: %f64.d77 = name_ref MyDoubleE, imports.%float.e0c [concrete = constants.%float.e0c]
+// CHECK:STDOUT:   %MyDoubleE.ref: %f64.d77 = name_ref MyDoubleE, constants.%float.e0c [concrete = constants.%float.e0c]
 // CHECK:STDOUT:   %f64.loc9: type = type_literal constants.%f64.d77 [concrete = constants.%f64.d77]
 // CHECK:STDOUT:   %b: %f64.d77 = value_binding b, %MyDoubleE.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1371,7 +1354,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %MyFloat.ref: %f32.97e = name_ref MyFloat, imports.%float.e3b [concrete = constants.%float.e3b]
+// CHECK:STDOUT:   %MyFloat.ref: %f32.97e = name_ref MyFloat, constants.%float.e3b [concrete = constants.%float.e3b]
 // CHECK:STDOUT:   %f32.loc10: type = type_literal constants.%f32.97e [concrete = constants.%f32.97e]
 // CHECK:STDOUT:   %c: %f32.97e = value_binding c, %MyFloat.ref
 // CHECK:STDOUT:   <elided>
@@ -1477,14 +1460,11 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .M_CONDITIONAL = %int_97
-// CHECK:STDOUT:     .M_A_PLUS_ONE = %int_98
-// CHECK:STDOUT:     .M_A_EQUAL = %true
+// CHECK:STDOUT:     .M_CONDITIONAL = constants.%int_97
+// CHECK:STDOUT:     .M_A_PLUS_ONE = constants.%int_98
+// CHECK:STDOUT:     .M_A_EQUAL = constants.%true
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_97: %char = int_value 97 [concrete = constants.%int_97]
-// CHECK:STDOUT:   %int_98: %i32 = int_value 98 [concrete = constants.%int_98]
-// CHECK:STDOUT:   %true: bool = bool_literal true [concrete = constants.%true]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1494,7 +1474,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc8: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_CONDITIONAL.ref: %char = name_ref M_CONDITIONAL, imports.%int_97 [concrete = constants.%int_97]
+// CHECK:STDOUT:   %M_CONDITIONAL.ref: %char = name_ref M_CONDITIONAL, constants.%int_97 [concrete = constants.%int_97]
 // CHECK:STDOUT:   %char.loc8: type = type_literal constants.%char [concrete = constants.%char]
 // CHECK:STDOUT:   %a: %char = value_binding a, %M_CONDITIONAL.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1502,14 +1482,14 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_A_PLUS_ONE.ref: %i32 = name_ref M_A_PLUS_ONE, imports.%int_98 [concrete = constants.%int_98]
+// CHECK:STDOUT:   %M_A_PLUS_ONE.ref: %i32 = name_ref M_A_PLUS_ONE, constants.%int_98 [concrete = constants.%int_98]
 // CHECK:STDOUT:   %i32.loc9: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %b: %i32 = value_binding b, %M_A_PLUS_ONE.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %pattern_type.831 = value_binding_pattern c [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_A_EQUAL.ref: bool = name_ref M_A_EQUAL, imports.%true [concrete = constants.%true]
+// CHECK:STDOUT:   %M_A_EQUAL.ref: bool = name_ref M_A_EQUAL, constants.%true [concrete = constants.%true]
 // CHECK:STDOUT:   %.loc10: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %c: bool = value_binding c, %M_A_EQUAL.ref
 // CHECK:STDOUT:   <elided>
@@ -1530,30 +1510,19 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .M_TRUE = %true.d1048d.1
-// CHECK:STDOUT:     .M_FALSE = %false.505718.1
-// CHECK:STDOUT:     .M_NOT_TRUE = %false.505718.2
-// CHECK:STDOUT:     .M_NOT_ZERO = %true.d1048d.2
-// CHECK:STDOUT:     .M_ONE_EQ_ONE = %true.d1048d.3
-// CHECK:STDOUT:     .M_ONE_NEQ_ONE = %false.505718.3
-// CHECK:STDOUT:     .M_AND = %true.d1048d.4
-// CHECK:STDOUT:     .M_OR = %true.d1048d.5
-// CHECK:STDOUT:     .M_COMPLEX = %true.d1048d.6
-// CHECK:STDOUT:     .M_ONE = %int_1
-// CHECK:STDOUT:     .M_ZERO = %int_0
+// CHECK:STDOUT:     .M_TRUE = constants.%true
+// CHECK:STDOUT:     .M_FALSE = constants.%false
+// CHECK:STDOUT:     .M_NOT_TRUE = constants.%false
+// CHECK:STDOUT:     .M_NOT_ZERO = constants.%true
+// CHECK:STDOUT:     .M_ONE_EQ_ONE = constants.%true
+// CHECK:STDOUT:     .M_ONE_NEQ_ONE = constants.%false
+// CHECK:STDOUT:     .M_AND = constants.%true
+// CHECK:STDOUT:     .M_OR = constants.%true
+// CHECK:STDOUT:     .M_COMPLEX = constants.%true
+// CHECK:STDOUT:     .M_ONE = constants.%int_1
+// CHECK:STDOUT:     .M_ZERO = constants.%int_0
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %true.d1048d.1: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %false.505718.1: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %false.505718.2: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %true.d1048d.2: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %true.d1048d.3: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %false.505718.3: bool = bool_literal false [concrete = constants.%false]
-// CHECK:STDOUT:   %true.d1048d.4: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %true.d1048d.5: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %true.d1048d.6: bool = bool_literal true [concrete = constants.%true]
-// CHECK:STDOUT:   %int_1: %i32 = int_value 1 [concrete = constants.%int_1]
-// CHECK:STDOUT:   %int_0: %i32 = int_value 0 [concrete = constants.%int_0]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1562,63 +1531,63 @@ fn F() {
 // CHECK:STDOUT:     %a.patt: %pattern_type.831 = value_binding_pattern a [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc8: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_TRUE.ref: bool = name_ref M_TRUE, imports.%true.d1048d.1 [concrete = constants.%true]
+// CHECK:STDOUT:   %M_TRUE.ref: bool = name_ref M_TRUE, constants.%true [concrete = constants.%true]
 // CHECK:STDOUT:   %.loc8: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %a: bool = value_binding a, %M_TRUE.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %b.patt: %pattern_type.831 = value_binding_pattern b [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_FALSE.ref: bool = name_ref M_FALSE, imports.%false.505718.1 [concrete = constants.%false]
+// CHECK:STDOUT:   %M_FALSE.ref: bool = name_ref M_FALSE, constants.%false [concrete = constants.%false]
 // CHECK:STDOUT:   %.loc9: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %b: bool = value_binding b, %M_FALSE.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %c.patt: %pattern_type.831 = value_binding_pattern c [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_NOT_TRUE.ref: bool = name_ref M_NOT_TRUE, imports.%false.505718.2 [concrete = constants.%false]
+// CHECK:STDOUT:   %M_NOT_TRUE.ref: bool = name_ref M_NOT_TRUE, constants.%false [concrete = constants.%false]
 // CHECK:STDOUT:   %.loc10: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %c: bool = value_binding c, %M_NOT_TRUE.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %d.patt: %pattern_type.831 = value_binding_pattern d [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_NOT_ZERO.ref: bool = name_ref M_NOT_ZERO, imports.%true.d1048d.2 [concrete = constants.%true]
+// CHECK:STDOUT:   %M_NOT_ZERO.ref: bool = name_ref M_NOT_ZERO, constants.%true [concrete = constants.%true]
 // CHECK:STDOUT:   %.loc11: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %d: bool = value_binding d, %M_NOT_ZERO.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %e.patt: %pattern_type.831 = value_binding_pattern e [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc12: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_ONE_EQ_ONE.ref: bool = name_ref M_ONE_EQ_ONE, imports.%true.d1048d.3 [concrete = constants.%true]
+// CHECK:STDOUT:   %M_ONE_EQ_ONE.ref: bool = name_ref M_ONE_EQ_ONE, constants.%true [concrete = constants.%true]
 // CHECK:STDOUT:   %.loc12: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %e: bool = value_binding e, %M_ONE_EQ_ONE.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %f.patt: %pattern_type.831 = value_binding_pattern f [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc13: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_ONE_NEQ_ONE.ref: bool = name_ref M_ONE_NEQ_ONE, imports.%false.505718.3 [concrete = constants.%false]
+// CHECK:STDOUT:   %M_ONE_NEQ_ONE.ref: bool = name_ref M_ONE_NEQ_ONE, constants.%false [concrete = constants.%false]
 // CHECK:STDOUT:   %.loc13: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %f: bool = value_binding f, %M_ONE_NEQ_ONE.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %g.patt: %pattern_type.831 = value_binding_pattern g [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc14: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_AND.ref: bool = name_ref M_AND, imports.%true.d1048d.4 [concrete = constants.%true]
+// CHECK:STDOUT:   %M_AND.ref: bool = name_ref M_AND, constants.%true [concrete = constants.%true]
 // CHECK:STDOUT:   %.loc14: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %g: bool = value_binding g, %M_AND.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %h.patt: %pattern_type.831 = value_binding_pattern h [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc15: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_OR.ref: bool = name_ref M_OR, imports.%true.d1048d.5 [concrete = constants.%true]
+// CHECK:STDOUT:   %M_OR.ref: bool = name_ref M_OR, constants.%true [concrete = constants.%true]
 // CHECK:STDOUT:   %.loc15: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %h: bool = value_binding h, %M_OR.ref
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %i.patt: %pattern_type.831 = value_binding_pattern i [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc16: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_COMPLEX.ref: bool = name_ref M_COMPLEX, imports.%true.d1048d.6 [concrete = constants.%true]
+// CHECK:STDOUT:   %M_COMPLEX.ref: bool = name_ref M_COMPLEX, constants.%true [concrete = constants.%true]
 // CHECK:STDOUT:   %.loc16: type = type_literal bool [concrete = bool]
 // CHECK:STDOUT:   %i: bool = value_binding i, %M_COMPLEX.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1626,7 +1595,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc18: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_ONE.ref: %i32 = name_ref M_ONE, imports.%int_1 [concrete = constants.%int_1]
+// CHECK:STDOUT:   %M_ONE.ref: %i32 = name_ref M_ONE, constants.%int_1 [concrete = constants.%int_1]
 // CHECK:STDOUT:   %i32.loc18: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %j: %i32 = value_binding j, %M_ONE.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1634,7 +1603,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc19: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_ZERO.ref: %i32 = name_ref M_ZERO, imports.%int_0 [concrete = constants.%int_0]
+// CHECK:STDOUT:   %M_ZERO.ref: %i32 = name_ref M_ZERO, constants.%int_0 [concrete = constants.%int_0]
 // CHECK:STDOUT:   %i32.loc19: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %k: %i32 = value_binding k, %M_ZERO.ref
 // CHECK:STDOUT:   <elided>
@@ -1745,11 +1714,10 @@ fn F() {
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
 // CHECK:STDOUT:     .A = %A.decl
-// CHECK:STDOUT:     .M_A = %int_1
+// CHECK:STDOUT:     .M_A = constants.%int_1
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %A.decl: type = class_decl @A [concrete = constants.%A] {} {}
-// CHECK:STDOUT:   %int_1: %A = int_value 1 [concrete = constants.%int_1]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1758,7 +1726,7 @@ fn F() {
 // CHECK:STDOUT:     %a.patt: %pattern_type = value_binding_pattern a [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc11_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %M_A.ref: %A = name_ref M_A, imports.%int_1 [concrete = constants.%int_1]
+// CHECK:STDOUT:   %M_A.ref: %A = name_ref M_A, constants.%int_1 [concrete = constants.%int_1]
 // CHECK:STDOUT:   %.loc11: type = splice_block %A.ref [concrete = constants.%A] {
 // CHECK:STDOUT:     %Cpp.ref.loc11_17: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %A.ref: type = name_ref A, imports.%A.decl [concrete = constants.%A]
@@ -1780,10 +1748,9 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .M_CONSTEXPR_INT = %int_1
+// CHECK:STDOUT:     .M_CONSTEXPR_INT = constants.%int_1.22e
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_1: %const = int_value 1 [concrete = constants.%int_1.22e]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1793,7 +1760,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_CONSTEXPR_INT.ref: %const = name_ref M_CONSTEXPR_INT, imports.%int_1 [concrete = constants.%int_1.22e]
+// CHECK:STDOUT:   %M_CONSTEXPR_INT.ref: %const = name_ref M_CONSTEXPR_INT, constants.%int_1.22e [concrete = constants.%int_1.22e]
 // CHECK:STDOUT:   %i32.loc11: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %.loc11_26.1: %i32 = as_compatible %M_CONSTEXPR_INT.ref [concrete = constants.%int_1.5d2]
 // CHECK:STDOUT:   %.loc11_26.2: %i32 = converted %M_CONSTEXPR_INT.ref, %.loc11_26.1 [concrete = constants.%int_1.5d2]
@@ -1812,10 +1779,9 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .MyIntLambda = %int_7
+// CHECK:STDOUT:     .MyIntLambda = constants.%int_7
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_7: %i32 = int_value 7 [concrete = constants.%int_7]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1825,7 +1791,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %MyIntLambda.ref: %i32 = name_ref MyIntLambda, imports.%int_7 [concrete = constants.%int_7]
+// CHECK:STDOUT:   %MyIntLambda.ref: %i32 = name_ref MyIntLambda, constants.%int_7 [concrete = constants.%int_7]
 // CHECK:STDOUT:   %i32.loc10: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %i: %i32 = value_binding i, %MyIntLambda.ref
 // CHECK:STDOUT:   <elided>
@@ -1842,10 +1808,9 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .REDEF_NAME = %int_2
+// CHECK:STDOUT:     .REDEF_NAME = constants.%int_2
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_2: %i32 = int_value 2 [concrete = constants.%int_2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1855,7 +1820,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %REDEF_NAME.ref: %i32 = name_ref REDEF_NAME, imports.%int_2 [concrete = constants.%int_2]
+// CHECK:STDOUT:   %REDEF_NAME.ref: %i32 = name_ref REDEF_NAME, constants.%int_2 [concrete = constants.%int_2]
 // CHECK:STDOUT:   %i32.loc8: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %a: %i32 = value_binding a, %REDEF_NAME.ref
 // CHECK:STDOUT:   <elided>
@@ -1872,10 +1837,9 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .TWICE_DEF = %int_2
+// CHECK:STDOUT:     .TWICE_DEF = constants.%int_2
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %int_2: %i32 = int_value 2 [concrete = constants.%int_2]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1885,7 +1849,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %TWICE_DEF.ref: %i32 = name_ref TWICE_DEF, imports.%int_2 [concrete = constants.%int_2]
+// CHECK:STDOUT:   %TWICE_DEF.ref: %i32 = name_ref TWICE_DEF, constants.%int_2 [concrete = constants.%int_2]
 // CHECK:STDOUT:   %i32.loc17: type = type_literal constants.%i32 [concrete = constants.%i32]
 // CHECK:STDOUT:   %a: %i32 = value_binding a, %TWICE_DEF.ref
 // CHECK:STDOUT:   <elided>

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -486,7 +486,7 @@ library "[[@TEST_NAME]]";
 import Cpp library "unsupported_character_literal_types.h";
 
 fn F() {
- // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+11]]:23: error: semantics TODO: `Unsupported: C++ literal's type `char16_t` could not be mapped to a Carbon type` [SemanticsTodo]
+ // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+11]]:23: error: semantics TODO: `Unsupported: macro evaluated to a constant of type: char16_t` [SemanticsTodo]
  // CHECK:STDERR:  let unused a: char = Cpp.M_UTF16_CHAR;
  // CHECK:STDERR:                       ^~~~~~~~~~~~~~~~
  // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+8]]:23: note: in `Cpp` name lookup for `M_UTF16_CHAR` [InCppNameLookup]
@@ -498,7 +498,7 @@ fn F() {
  // CHECK:STDERR:                       ^~~~~~~~~~~~~~~~
  // CHECK:STDERR:
  let unused a: char = Cpp.M_UTF16_CHAR;
- // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+11]]:23: error: semantics TODO: `Unsupported: C++ literal's type `char32_t` could not be mapped to a Carbon type` [SemanticsTodo]
+ // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+11]]:23: error: semantics TODO: `Unsupported: macro evaluated to a constant of type: char32_t` [SemanticsTodo]
  // CHECK:STDERR:  let unused b: char = Cpp.M_UTF32_CHAR;
  // CHECK:STDERR:                       ^~~~~~~~~~~~~~~~
  // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+8]]:23: note: in `Cpp` name lookup for `M_UTF32_CHAR` [InCppNameLookup]
@@ -510,7 +510,7 @@ fn F() {
  // CHECK:STDERR:                       ^~~~~~~~~~~~~~~~
  // CHECK:STDERR:
  let unused b: char = Cpp.M_UTF32_CHAR;
- // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+11]]:23: error: semantics TODO: `Unsupported: C++ literal's type `wchar_t` could not be mapped to a Carbon type` [SemanticsTodo]
+ // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+11]]:23: error: semantics TODO: `Unsupported: macro evaluated to a constant of type: wchar_t` [SemanticsTodo]
  // CHECK:STDERR:  let unused c: char = Cpp.M_WIDE_CHAR;
  // CHECK:STDERR:                       ^~~~~~~~~~~~~~~
  // CHECK:STDERR: fail_unsupported_character_literal_types.carbon:[[@LINE+8]]:23: note: in `Cpp` name lookup for `M_WIDE_CHAR` [InCppNameLookup]
@@ -1365,30 +1365,24 @@ fn F() {
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %char: type = class_type @Char [concrete]
 // CHECK:STDOUT:   %pattern_type.b09: type = pattern_type %char [concrete]
-// CHECK:STDOUT:   %.b69: %char = char_value U+0061 [concrete]
-// CHECK:STDOUT:   %.13f: %char = char_value U+0041 [concrete]
-// CHECK:STDOUT:   %.c50: %char = char_value U+0031 [concrete]
-// CHECK:STDOUT:   %.e74: %char = char_value U+0020 [concrete]
-// CHECK:STDOUT:   %.a7f: %char = char_value U+0009 [concrete]
-// CHECK:STDOUT:   %.133: %char = char_value U+0058 [concrete]
+// CHECK:STDOUT:   %int_97: %char = int_value 97 [concrete]
+// CHECK:STDOUT:   %int_65: %char = int_value 65 [concrete]
+// CHECK:STDOUT:   %int_49: %char = int_value 49 [concrete]
+// CHECK:STDOUT:   %int_32: %char = int_value 32 [concrete]
+// CHECK:STDOUT:   %int_9: %char = int_value 9 [concrete]
+// CHECK:STDOUT:   %int_88: %char = int_value 88 [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .M_LOWERCASE = %.b69
-// CHECK:STDOUT:     .M_UPPERCASE = %.13f
-// CHECK:STDOUT:     .M_DIGIT = %.c50
-// CHECK:STDOUT:     .M_SPACE = %.e74
-// CHECK:STDOUT:     .M_TAB = %.a7f
-// CHECK:STDOUT:     .M_UTF8_CHAR = %.133
+// CHECK:STDOUT:     .M_LOWERCASE = constants.%int_97
+// CHECK:STDOUT:     .M_UPPERCASE = constants.%int_65
+// CHECK:STDOUT:     .M_DIGIT = constants.%int_49
+// CHECK:STDOUT:     .M_SPACE = constants.%int_32
+// CHECK:STDOUT:     .M_TAB = constants.%int_9
+// CHECK:STDOUT:     .M_UTF8_CHAR = constants.%int_88
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.b69: %char = char_value U+0061 [concrete = constants.%.b69]
-// CHECK:STDOUT:   %.13f: %char = char_value U+0041 [concrete = constants.%.13f]
-// CHECK:STDOUT:   %.c50: %char = char_value U+0031 [concrete = constants.%.c50]
-// CHECK:STDOUT:   %.e74: %char = char_value U+0020 [concrete = constants.%.e74]
-// CHECK:STDOUT:   %.a7f: %char = char_value U+0009 [concrete = constants.%.a7f]
-// CHECK:STDOUT:   %.133: %char = char_value U+0058 [concrete = constants.%.133]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1398,7 +1392,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc8: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_LOWERCASE.ref: %char = name_ref M_LOWERCASE, imports.%.b69 [concrete = constants.%.b69]
+// CHECK:STDOUT:   %M_LOWERCASE.ref: %char = name_ref M_LOWERCASE, constants.%int_97 [concrete = constants.%int_97]
 // CHECK:STDOUT:   %char.loc8: type = type_literal constants.%char [concrete = constants.%char]
 // CHECK:STDOUT:   %a: %char = value_binding a, %M_LOWERCASE.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1406,7 +1400,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc9: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_UPPERCASE.ref: %char = name_ref M_UPPERCASE, imports.%.13f [concrete = constants.%.13f]
+// CHECK:STDOUT:   %M_UPPERCASE.ref: %char = name_ref M_UPPERCASE, constants.%int_65 [concrete = constants.%int_65]
 // CHECK:STDOUT:   %char.loc9: type = type_literal constants.%char [concrete = constants.%char]
 // CHECK:STDOUT:   %b: %char = value_binding b, %M_UPPERCASE.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1414,7 +1408,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_DIGIT.ref: %char = name_ref M_DIGIT, imports.%.c50 [concrete = constants.%.c50]
+// CHECK:STDOUT:   %M_DIGIT.ref: %char = name_ref M_DIGIT, constants.%int_49 [concrete = constants.%int_49]
 // CHECK:STDOUT:   %char.loc10: type = type_literal constants.%char [concrete = constants.%char]
 // CHECK:STDOUT:   %c: %char = value_binding c, %M_DIGIT.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1422,7 +1416,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_SPACE.ref: %char = name_ref M_SPACE, imports.%.e74 [concrete = constants.%.e74]
+// CHECK:STDOUT:   %M_SPACE.ref: %char = name_ref M_SPACE, constants.%int_32 [concrete = constants.%int_32]
 // CHECK:STDOUT:   %char.loc11: type = type_literal constants.%char [concrete = constants.%char]
 // CHECK:STDOUT:   %d: %char = value_binding d, %M_SPACE.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1430,7 +1424,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc12: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_TAB.ref: %char = name_ref M_TAB, imports.%.a7f [concrete = constants.%.a7f]
+// CHECK:STDOUT:   %M_TAB.ref: %char = name_ref M_TAB, constants.%int_9 [concrete = constants.%int_9]
 // CHECK:STDOUT:   %char.loc12: type = type_literal constants.%char [concrete = constants.%char]
 // CHECK:STDOUT:   %e: %char = value_binding e, %M_TAB.ref
 // CHECK:STDOUT:   name_binding_decl {
@@ -1438,7 +1432,7 @@ fn F() {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc13: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %M_UTF8_CHAR.ref: %char = name_ref M_UTF8_CHAR, imports.%.133 [concrete = constants.%.133]
+// CHECK:STDOUT:   %M_UTF8_CHAR.ref: %char = name_ref M_UTF8_CHAR, constants.%int_88 [concrete = constants.%int_88]
 // CHECK:STDOUT:   %char.loc13: type = type_literal constants.%char [concrete = constants.%char]
 // CHECK:STDOUT:   %f: %char = value_binding f, %M_UTF8_CHAR.ref
 // CHECK:STDOUT:   <elided>


### PR DESCRIPTION
For integral and float types, `TryEvaluateMacroToConstant` now calls `MapAPValueToConstant` to directly convert from an APValue, rather than converting the `APValue` to an expression and importing it with `MapConstant`.

`MapConstant` is still used, but only for string literals and nullptrs. Since it's only used by `TryEvaluateMacroToConstant`, moved it to `macros.cpp` and removed the code for other types of expressions.
