### PR TITLE
Return non-final for destroying symbolic queries earlier

### DIFF
--- a/toolchain/check/custom_witness.cpp
+++ b/toolchain/check/custom_witness.cpp
@@ -47,10 +47,10 @@ static auto GetFacetAsType(Context& context,
 // TODO: This mirrors `TypeCanDestroy` below, think about ways to share what's
 // handled.
 static auto MakeDestroyOpBody(Context& context, SemIR::LocId loc_id,
-                              SemIR::TypeId self_type_id)
+                              SemIR::TypeInstId self_type_inst_id)
     -> SemIR::InstBlockId {
   context.inst_block_stack().Push();
-  auto inst = context.types().GetAsInst(self_type_id);
+  auto inst = context.insts().Get(self_type_inst_id);
 
   while (auto class_type = inst.TryAs<SemIR::ClassType>()) {
     // Switch to looking at the object representation.
@@ -95,20 +95,21 @@ static auto MakeDestroyOpBody(Context& context, SemIR::LocId loc_id,
 // Returns a manufactured `Destroy.Op` function with the `self` parameter typed
 // to `self_type_id`.
 static auto MakeDestroyOpFunction(Context& context, SemIR::LocId loc_id,
-                                  SemIR::TypeId self_type_id,
+                                  SemIR::TypeInstId self_type_inst_id,
                                   SemIR::NameScopeId parent_scope_id)
     -> SemIR::InstId {
   auto name_id = context.core_identifiers().AddNameId(CoreIdentifier::Op);
 
-  auto [decl_id, function_id] =
-      MakeGeneratedFunctionDecl(context, loc_id,
-                                {.parent_scope_id = parent_scope_id,
-                                 .name_id = name_id,
-                                 .self_type_id = self_type_id});
+  auto [decl_id, function_id] = MakeGeneratedFunctionDecl(
+      context, loc_id,
+      {.parent_scope_id = parent_scope_id,
+       .name_id = name_id,
+       .self_type_id =
+           context.types().GetTypeIdForTypeInstId(self_type_inst_id)});
 
   auto& function = context.functions().Get(function_id);
 
-  auto body_id = MakeDestroyOpBody(context, loc_id, self_type_id);
+  auto body_id = MakeDestroyOpBody(context, loc_id, self_type_inst_id);
   if (body_id.has_value()) {
     function.SetCoreWitness();
     function.body_block_ids.push_back(body_id);
@@ -291,21 +292,8 @@ auto GetCoreInterface(Context& context, SemIR::InterfaceId interface_id)
 
 // Returns true if the `Self` should impl `Destroy`.
 static auto TypeCanDestroy(Context& context,
-                           SemIR::ConstantId query_self_const_id,
-                           SemIR::InterfaceId destroy_interface_id) -> bool {
-  auto inst = context.insts().Get(context.constant_values().GetInstId(
-      GetCanonicalFacetOrTypeValue(context, query_self_const_id)));
-
-  // For facet values, look if the FacetType provides the same.
-  if (auto facet_type =
-          context.types().TryGetAs<SemIR::FacetType>(inst.type_id())) {
-    const auto& info = context.facet_types().Get(facet_type->facet_type_id);
-    for (auto interface : info.extend_constraints) {
-      if (interface.interface_id == destroy_interface_id) {
-        return true;
-      }
-    }
-  }
+                           SemIR::TypeInstId self_type_inst_id) -> bool {
+  auto inst = context.insts().Get(self_type_inst_id);
 
   CARBON_KIND_SWITCH(inst) {
     case CARBON_KIND(SemIR::ClassType class_type): {
@@ -355,27 +343,27 @@ auto LookupCustomWitness(Context& context, SemIR::LocId loc_id,
     return std::nullopt;
   }
 
-  auto query_specific_interface =
-      context.specific_interfaces().Get(query_specific_interface_id);
-
-  if (!TypeCanDestroy(context, query_self_const_id,
-                      query_specific_interface.interface_id)) {
-    return std::nullopt;
-  }
-
+  // Give a non-final answer for destroying symbolic types.
   if (query_self_const_id.is_symbolic()) {
     return SemIR::InstId::None;
   }
 
+  auto self_type_inst_id = context.types().GetAsTypeInstId(
+      context.constant_values().GetInstId(query_self_const_id));
+  if (!TypeCanDestroy(context, self_type_inst_id)) {
+    return std::nullopt;
+  }
+
   // Mark functions with the interface's scope as a hint to mangling. This does
   // not add them to the scope.
+  auto query_specific_interface =
+      context.specific_interfaces().Get(query_specific_interface_id);
   auto parent_scope_id = context.interfaces()
                              .Get(query_specific_interface.interface_id)
                              .scope_without_self_id;
 
-  auto self_type_id = GetFacetAsType(context, query_self_const_id);
-  auto op_id =
-      MakeDestroyOpFunction(context, loc_id, self_type_id, parent_scope_id);
+  auto op_id = MakeDestroyOpFunction(context, loc_id, self_type_inst_id,
+                                     parent_scope_id);
   return BuildCustomWitness(context, loc_id, query_self_const_id,
                             query_specific_interface_id, {op_id});
 }

--- a/toolchain/check/testdata/eval/call.carbon
+++ b/toolchain/check/testdata/eval/call.carbon
@@ -91,15 +91,11 @@ eval fn F(_: i32) -> type {
 }
 
 fn UseFGenerically(X:! i32) {
-  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE+12]]:3: error: member name of type `<dependent type>` in compound member access is not an instance member or an interface member [CompoundMemberAccessDoesNotUseBase]
+  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE+8]]:3: error: member name of type `<dependent type>` in compound member access is not an instance member or an interface member [CompoundMemberAccessDoesNotUseBase]
   // CHECK:STDERR:   var unused v: F(X) = {};
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE+8]]:3: error: value of type `<dependent type>` is not callable [CallToNonCallable]
-  // CHECK:STDERR:   var unused v: F(X) = {};
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.Destroy` in type `<cannot stringify inst7800018B: {kind: Call, arg0: inst7800003E, arg1: inst_block78000091, type: type(TypeType)}>` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE+4]]:3: error: value of type `<dependent type>` is not callable [CallToNonCallable]
   // CHECK:STDERR:   var unused v: F(X) = {};
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:

--- a/toolchain/check/testdata/facet/period_self.carbon
+++ b/toolchain/check/testdata/facet/period_self.carbon
@@ -313,21 +313,11 @@ interface I(T:! Core.Destroy) {}
 // The `.Self` can see the LHS of the `where` to know `U` impls Core.Destroy.
 fn F(unused U:! Core.Destroy where .Self impls I(.Self)) {}
 
-// --- fail_todo_period_self_parameter_constraint_satisfied_with_type_and.carbon
+// --- period_self_parameter_constraint_satisfied_with_type_and.carbon
 library "[[@TEST_NAME]]";
 
 interface I(T:! Core.Destroy) {}
 
-// TODO: Implied constraints that `.Self` impls `Core.Destroy` are satisfied by
-// the `&` expression.
-//
-// CHECK:STDERR: fail_todo_period_self_parameter_constraint_satisfied_with_type_and.carbon:[[@LINE+7]]:32: error: cannot convert type `.Self` that implements `type` into type implementing `Core.Destroy` [ConversionFailureFacetToFacet]
-// CHECK:STDERR: fn F(unused U:! Core.Destroy & I(.Self)) {}
-// CHECK:STDERR:                                ^~~~~~~~
-// CHECK:STDERR: fail_todo_period_self_parameter_constraint_satisfied_with_type_and.carbon:[[@LINE-8]]:13: note: initializing generic parameter `T` declared here [InitializingGenericParam]
-// CHECK:STDERR: interface I(T:! Core.Destroy) {}
-// CHECK:STDERR:             ^
-// CHECK:STDERR:
 fn F(unused U:! Core.Destroy & I(.Self)) {}
 
 // --- fail_todo_compound_lookup_on_returned_period_self_parameter.carbon


### PR DESCRIPTION
This removes the need for `TypeCanDestroy` to check if `Destroy` was supported, which wasn't working correctly anyways. Checking symbolic values is kind of moot when it's not going to generate `Destroy` anyways.

Assisted-by: Google Antigravity with Gemini 3 Flash