### PR TITLE
refactors `PerformCppOverloadResolution` to take `CppOverloadSet`

### DIFF
--- a/toolchain/check/cpp/call.cpp
+++ b/toolchain/check/cpp/call.cpp
@@ -57,9 +57,9 @@ auto PerformCallToCppFunction(Context& context, SemIR::LocId loc_id,
                               bool is_operator_syntax) -> SemIR::InstId {
   auto [template_arg_ids, function_arg_ids] =
       SplitCallArgumentList(context, arg_ids);
-  auto callee_id =
-      PerformCppOverloadResolution(context, loc_id, overload_set_id,
-                                   template_arg_ids, self_id, function_arg_ids);
+  auto callee_id = PerformCppOverloadResolution(
+      context, loc_id, context.cpp_overload_sets().Get(overload_set_id),
+      template_arg_ids, self_id, function_arg_ids);
   SemIR::Callee callee = GetCallee(context.sem_ir(), callee_id);
   CARBON_KIND_SWITCH(callee) {
     case CARBON_KIND(SemIR::CalleeError _): {

--- a/toolchain/check/cpp/overload_resolution.cpp
+++ b/toolchain/check/cpp/overload_resolution.cpp
@@ -132,7 +132,7 @@ auto CheckCppOverloadAccess(
 
 auto PerformCppOverloadResolution(
     Context& context, SemIR::LocId loc_id,
-    SemIR::CppOverloadSetId overload_set_id,
+    const SemIR::CppOverloadSet& overload_set,
     llvm::ArrayRef<SemIR::InstId> template_arg_ids, SemIR::InstId self_id,
     llvm::ArrayRef<SemIR::InstId> arg_ids) -> SemIR::InstId {
   // Register an annotation scope to flush any Clang diagnostics when we return.
@@ -154,9 +154,6 @@ auto PerformCppOverloadResolution(
     return SemIR::ErrorInst::InstId;
   }
   auto& arg_exprs = *maybe_arg_exprs;
-
-  const SemIR::CppOverloadSet& overload_set =
-      context.cpp_overload_sets().Get(overload_set_id);
 
   clang::SourceLocation loc = GetCppLocation(context, loc_id);
 

--- a/toolchain/check/cpp/overload_resolution.h
+++ b/toolchain/check/cpp/overload_resolution.h
@@ -31,7 +31,7 @@ auto CheckCppOverloadAccess(
 // migrations so that the migrated callers from C++ remain valid.
 auto PerformCppOverloadResolution(
     Context& context, SemIR::LocId loc_id,
-    SemIR::CppOverloadSetId overload_set_id,
+    const SemIR::CppOverloadSet& overload_set,
     llvm::ArrayRef<SemIR::InstId> template_arg_ids, SemIR::InstId self_id,
     llvm::ArrayRef<SemIR::InstId> arg_ids) -> SemIR::InstId;
 


### PR DESCRIPTION
`PerformCppOverloadResolution` computes an overload set from a `CppOverloadSetId`, but the compiler sometimes needs to synthesise a local overload set for witnesses. `PerformCppOverloadResolution` now requires callers to produce the `CppOverloadSet` to address this problem.
