### PR TITLE
codifies Carbon specifier and qualifier order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,3 +23,5 @@ IfMacros:
     'CARBON_KIND_SWITCH',
   ]
 StatementMacros: ['ABSTRACT']
+QualifierAlignment: Custom
+QualifierOrder: [inline, static, friend, constexpr, const, volatile, restrict, type]

--- a/.clang-format
+++ b/.clang-format
@@ -24,4 +24,5 @@ IfMacros:
   ]
 StatementMacros: ['ABSTRACT']
 QualifierAlignment: Custom
-QualifierOrder: [inline, static, friend, constexpr, const, volatile, restrict, type]
+QualifierOrder:
+  [inline, static, friend, constexpr, const, volatile, restrict, type]

--- a/testing/base/source_gen.cpp
+++ b/testing/base/source_gen.cpp
@@ -28,8 +28,8 @@ auto SourceGen::Global() -> SourceGen& {
 SourceGen::SourceGen(Language language) : language_(language) {}
 
 // Heuristic numbers used in synthesizing various identifier sequences.
-constexpr static int MinClassNameLength = 5;
-constexpr static int MinMemberNameLength = 4;
+static constexpr int MinClassNameLength = 5;
+static constexpr int MinMemberNameLength = 4;
 
 // The shuffled state used to generate some number of classes.
 //
@@ -255,9 +255,9 @@ auto SourceGen::ClassGenState::BuildClassAndTypeNames(
 // not fit as well in C++, but we use the same heuristics across languages for
 // simplicity and to make the output in different languages more directly
 // comparable.
-constexpr static int NumSingleLineFunctionParams = 3;
-constexpr static int NumSingleLineMethodParams = 2;
-constexpr static int MaxParamsPerLine = 4;
+static constexpr int NumSingleLineFunctionParams = 3;
+static constexpr int NumSingleLineMethodParams = 2;
+static constexpr int MaxParamsPerLine = 4;
 
 static auto EstimateAvgFunctionDeclLines(SourceGen::FunctionDeclParams params)
     -> double {
@@ -466,7 +466,7 @@ static auto IdentifierChars() -> llvm::ArrayRef<char> {
   return chars;
 }
 
-constexpr static llvm::StringRef NonCarbonCppKeywords[] = {
+static constexpr llvm::StringRef NonCarbonCppKeywords[] = {
     "asm", "do",  "double", "float",    "int", "long", "new", "signed",
     "std", "try", "unix",   "unsigned", "xor", "NAN",  "M_E", "M_PI",
 };

--- a/toolchain/base/runtimes_build_info.tpl.h
+++ b/toolchain/base/runtimes_build_info.tpl.h
@@ -14,35 +14,35 @@
 
 namespace Carbon::RuntimesBuildInfo {
 
-constexpr inline llvm::StringLiteral CrtBegin = CRTBEGIN_SRC;
-constexpr inline llvm::StringLiteral CrtEnd = CRTEND_SRC;
+inline constexpr llvm::StringLiteral CrtBegin = CRTBEGIN_SRC;
+inline constexpr llvm::StringLiteral CrtEnd = CRTEND_SRC;
 
-constexpr inline llvm::StringLiteral CrtCopts[] = {CRT_COPTS};
+inline constexpr llvm::StringLiteral CrtCopts[] = {CRT_COPTS};
 
 // Prevent wrapping these lines -- the expansion of the variables will add line
 // breaks.
 //
 // clang-format off
-constexpr inline llvm::StringLiteral BuiltinsGenericSrcs[] = {BUILTINS_GENERIC_SRCS};
-constexpr inline llvm::StringLiteral BuiltinsMacosSrcs[] = {BUILTINS_MACOS_SRCS};
-constexpr inline llvm::StringLiteral BuiltinsBf16Srcs[] = {BUILTINS_BF16_SRCS};
-constexpr inline llvm::StringLiteral BuiltinsTfSrcs[] = {BUILTINS_TF_SRCS};
-constexpr inline llvm::StringLiteral BuiltinsX86ArchSrcs[] = {BUILTINS_X86_ARCH_SRCS};
-constexpr inline llvm::StringLiteral BuiltinsX86Fp80Srcs[] = {BUILTINS_X86_FP80_SRCS};
-constexpr inline llvm::StringLiteral BuiltinsAarch64Srcs[] = {BUILTINS_AARCH64_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsGenericSrcs[] = {BUILTINS_GENERIC_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsMacosSrcs[] = {BUILTINS_MACOS_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsBf16Srcs[] = {BUILTINS_BF16_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsTfSrcs[] = {BUILTINS_TF_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsX86ArchSrcs[] = {BUILTINS_X86_ARCH_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsX86Fp80Srcs[] = {BUILTINS_X86_FP80_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsAarch64Srcs[] = {BUILTINS_AARCH64_SRCS};
 // NOLINTNEXTLINE(readability-identifier-naming)
-constexpr inline llvm::StringLiteral BuiltinsX86_64Srcs[] = {BUILTINS_X86_64_SRCS};
-constexpr inline llvm::StringLiteral BuiltinsI386Srcs[] = {BUILTINS_I386_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsX86_64Srcs[] = {BUILTINS_X86_64_SRCS};
+inline constexpr llvm::StringLiteral BuiltinsI386Srcs[] = {BUILTINS_I386_SRCS};
 // clang-format on
 
-constexpr inline llvm::StringLiteral LibcxxLinuxSrcs[] = {LIBCXX_LINUX_SRCS};
-constexpr inline llvm::StringLiteral LibcxxMacosSrcs[] = {LIBCXX_MACOS_SRCS};
-constexpr inline llvm::StringLiteral LibcxxWin32Srcs[] = {LIBCXX_WIN32_SRCS};
-constexpr inline llvm::StringLiteral LibcxxabiSrcs[] = {LIBCXXABI_SRCS};
-constexpr inline llvm::StringLiteral LibcxxCopts[] = {LIBCXX_AND_ABI_COPTS};
+inline constexpr llvm::StringLiteral LibcxxLinuxSrcs[] = {LIBCXX_LINUX_SRCS};
+inline constexpr llvm::StringLiteral LibcxxMacosSrcs[] = {LIBCXX_MACOS_SRCS};
+inline constexpr llvm::StringLiteral LibcxxWin32Srcs[] = {LIBCXX_WIN32_SRCS};
+inline constexpr llvm::StringLiteral LibcxxabiSrcs[] = {LIBCXXABI_SRCS};
+inline constexpr llvm::StringLiteral LibcxxCopts[] = {LIBCXX_AND_ABI_COPTS};
 
-constexpr inline llvm::StringLiteral LibunwindSrcs[] = {LIBUNWIND_SRCS};
-constexpr inline llvm::StringLiteral LibunwindCopts[] = {LIBUNWIND_COPTS};
+inline constexpr llvm::StringLiteral LibunwindSrcs[] = {LIBUNWIND_SRCS};
+inline constexpr llvm::StringLiteral LibunwindCopts[] = {LIBUNWIND_COPTS};
 
 }  // namespace Carbon::RuntimesBuildInfo
 


### PR DESCRIPTION
The Carbon style guide prefers `const` to be on the left wherever possible, and also has a de-facto standard for specifier order. Since the order of specifiers and qualifiers tends to become a part of muscle-memory, deferring the checking of this to tooling should lift a small burden on both contributors and reviewers.