### PR TITLE
Update action versions

### DIFF
--- a/.github/actions/build-setup-common/action.yml
+++ b/.github/actions/build-setup-common/action.yml
@@ -12,12 +12,12 @@ runs:
   using: composite
   steps:
     # Setup Python and related tools.
-    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         # Match the min version listed in docs/project/contribution_tools.md
         # or the oldest version available on the OS.
         python-version:
-          ${{ inputs.matrix_runner == 'macos-14' && '3.11' || '3.9' }}
+          ${{ inputs.matrix_runner == 'macos-14' && '3.11' || '3.10' }}
 
     - uses: ./.github/actions/build-setup-macos
       if: startsWith(inputs.matrix_runner, 'macos')

--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -28,7 +28,7 @@ runs:
     # minimum supported LLVM version.
     - name: Cache Homebrew
       id: cache-homebrew-macos
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         # Cover all the critical parts of Homebrew here. Homebrew on Arm macOS
         # uses its own prefix making this easy to cover, but we need a few

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -27,7 +27,7 @@ runs:
     # reliability.
     - name: Cache LLVM and Clang installation
       id: cache-llvm-ubuntu
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: ~/llvm
         key: LLVM-19.1.7-Cache-ubuntu-${{ runner.arch }}

--- a/.github/workflows/auto_label_prs.yaml
+++ b/.github/workflows/auto_label_prs.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: block
           # When adding endpoints, see README.md.
@@ -46,7 +46,7 @@ jobs:
             sourceforge.net:443
             storage.googleapis.com:443
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/discord_wiki.yaml
+++ b/.github/workflows/discord_wiki.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/gh_pages_ci.yaml
+++ b/.github/workflows/gh_pages_ci.yaml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prebuild actions
         run: ./website/prebuild.py
       - name: Setup Ruby
-        uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854 # v1.190.0
+        uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1.290.0
         with:
           # Runs 'bundle install' and caches installed gems automatically.
           bundler-cache: true

--- a/.github/workflows/gh_pages_deploy.yaml
+++ b/.github/workflows/gh_pages_deploy.yaml
@@ -29,18 +29,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prebuild actions
         run: ./website/prebuild.py
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Setup Ruby
-        uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854 # v1.190.0
+        uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1.290.0
         with:
           # Runs 'bundle install' and caches installed gems automatically.
           bundler-cache: true
@@ -57,7 +57,7 @@ jobs:
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by
         # default.
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
 
   deploy:
     environment:
@@ -67,7 +67,7 @@ jobs:
     needs: build
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -37,26 +37,36 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: block
           # When adding endpoints, see README.md.
           # prettier-ignore
           allowed-endpoints: >
-            *.dl.sourceforge.net:443
+            *.blob.storage.azure.net:443
+            *.githubapp.com:443
+            *.sourceforge.net:443
             api.github.com:443
+            api.ipify.org:443
             bcr.bazel.build:443
             downloads.sourceforge.net:443
+            files.pythonhosted.org:443
             github.com:443
+            go.dev:443
+            mirror.bazel.build:443
+            mirrors.kernel.org:443
+            nodejs.org:443
             oauth2.googleapis.com:443
             objects.githubusercontent.com:443
+            pypi.org:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
             releases.bazel.build:443
-            sourceforge.net:443
             storage.googleapis.com:443
-            uploads.github.com:443
+            www.googleapis.com:443
 
       - name: Checkout branch
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up remote cache access
         env:

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -18,30 +18,36 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
-          disable-sudo-and-containers: true
           egress-policy: block
           # When adding endpoints, see README.md.
           # prettier-ignore
           allowed-endpoints: >
-            *.dl.sourceforge.net:443
+            *.blob.storage.azure.net:443
+            *.githubapp.com:443
+            *.sourceforge.net:443
             api.github.com:443
+            api.ipify.org:443
             bcr.bazel.build:443
             downloads.sourceforge.net:443
             files.pythonhosted.org:443
             github.com:443
+            go.dev:443
             mirror.bazel.build:443
+            mirrors.kernel.org:443
             nodejs.org:443
+            oauth2.googleapis.com:443
             objects.githubusercontent.com:443
             pypi.org:443
             registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
             releases.bazel.build:443
             storage.googleapis.com:443
-            sourceforge.net:443
+            www.googleapis.com:443
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
       # Ensure LLVM is set up consistently.
       - uses: ./.github/actions/build-setup-common
@@ -63,7 +69,7 @@ jobs:
           mkdir -p pre-commit-output
           git diff > pre-commit-output/diff
           cp $GITHUB_EVENT_PATH pre-commit-output/event
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
           name: pre-commit output

--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           disable-sudo: true
           egress-policy: block
@@ -48,10 +48,10 @@ jobs:
         with:
           reviewdog_version: latest
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download pre-commit output
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: pre-commit output
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/proposal_labeled.yaml
+++ b/.github/workflows/proposal_labeled.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/proposal_ready.yaml
+++ b/.github/workflows/proposal_ready.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/sync_repos.yaml
+++ b/.github/workflows/sync_repos.yaml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: audit
 
       # Checkout our main repository.
       - name: Checkout the main repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Run the sync script.
       - name: Sync to other repositories

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,27 +31,35 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           egress-policy: block
           # When adding endpoints, see README.md.
           # prettier-ignore
           allowed-endpoints: >
-            *.dl.sourceforge.net:443
+            *.blob.storage.azure.net:443
+            *.githubapp.com:443
+            *.sourceforge.net:443
             api.github.com:443
+            api.ipify.org:443
             bcr.bazel.build:443
             downloads.sourceforge.net:443
+            files.pythonhosted.org:443
             github.com:443
+            go.dev:443
+            mirror.bazel.build:443
             mirrors.kernel.org:443
             nodejs.org:443
             oauth2.googleapis.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
             releases.bazel.build:443
-            sourceforge.net:443
             storage.googleapis.com:443
+            www.googleapis.com:443
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: test-setup
         uses: ./.github/actions/test-setup

--- a/.github/workflows/triage_inactive.yaml
+++ b/.github/workflows/triage_inactive.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
         with:
           disable-sudo: true
           egress-policy: block

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -161,7 +161,7 @@ These tools are essential for work on Carbon.
         -   To upgrade versions of `brew` packages, it will be necessary to
             periodically run `brew upgrade`.
     -   [Python](https://python.org)
-        -   Carbon requires Python 3.9 or newer.
+        -   Carbon requires Python 3.10 or newer.
         -   To upgrade versions of pip-installed packages, it will be necessary
             to periodically run `pipx list --outdated`, then
             `pipx install -U <package>` to upgrade desired packages.


### PR DESCRIPTION
In addition to the general updates, this switches to a required python 3.10 for pre-commit (3.9 is losing support from black).

Note endpoints for build actions are expanding significantly: see https://app.stepsecurity.io/github/carbon-language/carbon-lang/actions/runs/22779388360?tab=recommendations&jobId=66080970460 for example, I think just the sources are being increased as a side-effect of updates (and possibly also things not performing as well as they should have before).

Similarly allowing sudo in pre-commit because it was actually causing errors in part of build setup, which used sudo to remove files.

Assisted-by: Google Antigravity with Gemini