### PR TITLE
Switch llvm-raw to a git_override rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,14 +77,12 @@ bazel_dep(name = "zstd", version = "1.5.7.bcr.1", repo_name = "llvm_zstd")
 bazel_dep(name = "llvm-raw")
 git_override(
     module_name = "llvm-raw",
+    build_file_content = "# empty",
     # We pin to specific upstream commits and try to track top-of-tree
     # reasonably closely rather than pinning to a specific release.
     # HEAD as of 2026-02-12.
     commit = "b20d7d0278059735bb8eb538ac51e13b58895c1a",
-    patch_cmds = [
-        "touch BUILD.bazel",
-        "echo \"module(name='llvm-raw')\" > MODULE.bazel",
-    ],
+    patch_cmds = ["echo \"module(name='llvm-raw')\" > MODULE.bazel"],
     patch_strip = 1,
     patches = [
         "//bazel/llvm_project:0001_Patch_for_mallinfo2_when_using_Bazel_build_system.patch",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,11 +26,6 @@ versions.
 
 module(name = "carbon")
 
-http_archive = use_repo_rule(
-    "@bazel_tools//tools/build_defs/repo:http.bzl",
-    "http_archive",
-)
-
 bazel_dep(name = "abseil-cpp", version = "20260107.1")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "boost.unordered", version = "1.90.0.bcr.1")
@@ -78,26 +73,27 @@ bazel_dep(name = "zstd", version = "1.5.7.bcr.1", repo_name = "llvm_zstd")
 # llvm-project
 ###############################################################################
 
-# We pin to specific upstream commits and try to track top-of-tree reasonably
-# closely rather than pinning to a specific release.
-# HEAD as of 2026-02-12.
-llvm_project_version = "b20d7d0278059735bb8eb538ac51e13b58895c1a"
-
 # Load a repository for the raw llvm-project, pre-overlay.
-http_archive(
-    name = "llvm-raw",
-    build_file_content = "# empty",
-    integrity = "sha256-sRZjS3KippWoaVcr1mWtJ1kFZ+jrjb/KoNkzh+N8HOM=",
-    patch_args = ["-p1"],
-    patches = [
-        "@carbon//bazel/llvm_project:0001_Patch_for_mallinfo2_when_using_Bazel_build_system.patch",
-        "@carbon//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
-        "@carbon//bazel/llvm_project:0004_Introduce_basic_sources_exporting_for_libunwind.patch",
-        "@carbon//bazel/llvm_project:0005_Introduce_basic_sources_exporting_for_libcxx_and_libcxxabi.patch",
-        "@carbon//bazel/llvm_project:0009_Introduce_starlark_exporting_compiler-rt_build_information.patch",
+bazel_dep(name = "llvm-raw")
+git_override(
+    module_name = "llvm-raw",
+    # We pin to specific upstream commits and try to track top-of-tree
+    # reasonably closely rather than pinning to a specific release.
+    # HEAD as of 2026-02-12.
+    commit = "b20d7d0278059735bb8eb538ac51e13b58895c1a",
+    patch_cmds = [
+        "touch BUILD.bazel",
+        "echo \"module(name='llvm-raw')\" > MODULE.bazel",
     ],
-    strip_prefix = "llvm-project-{0}".format(llvm_project_version),
-    urls = ["https://github.com/llvm/llvm-project/archive/{0}.tar.gz".format(llvm_project_version)],
+    patch_strip = 1,
+    patches = [
+        "//bazel/llvm_project:0001_Patch_for_mallinfo2_when_using_Bazel_build_system.patch",
+        "//bazel/llvm_project:0002_Added_Bazel_build_for_compiler_rt_fuzzer.patch",
+        "//bazel/llvm_project:0004_Introduce_basic_sources_exporting_for_libunwind.patch",
+        "//bazel/llvm_project:0005_Introduce_basic_sources_exporting_for_libcxx_and_libcxxabi.patch",
+        "//bazel/llvm_project:0009_Introduce_starlark_exporting_compiler-rt_build_information.patch",
+    ],
+    remote = "https://github.com/llvm/llvm-project.git",
 )
 
 # Apply the overlay to produce llvm-project.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -324,7 +324,7 @@
         "envVariables": {},
         "generatedRepoSpecs": {
           "llvm-project": {
-            "repoRuleId": "@@+_repo_rules+llvm-raw//utils/bazel:configure.bzl%llvm_configure",
+            "repoRuleId": "@@llvm-raw+//utils/bazel:configure.bzl%llvm_configure",
             "attributes": {
               "targets": [
                 "AArch64",
@@ -337,7 +337,7 @@
           [
             "",
             "llvm-raw",
-            "+_repo_rules+llvm-raw"
+            "llvm-raw+"
           ]
         ]
       }


### PR DESCRIPTION
By using git_override, we get some validation from the sha, while removing the sha256 on the .tar.gz which has been brittle lately. Note the difference between downloading via sha is this still locally validates content.

Versus something like #6844, this doesn't update the llvm version, just how we get it.

Assisted-by: Google Antigravity with Gemini

