### PR TITLE
Update clangd-tidy endpoint whitelist

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,6 +18,7 @@ the "Harden Runner" steps are
 Most jobs only have a few endpoints, but due to tools which do downloads, a few
 have significantly more. These are:
 
+-   clangd_tidy.yaml (Bazel)
 -   pre_commit.yaml (Bazel, pre-commit)
 -   nightly_release.yaml (Bazel)
 -   tests.yaml (Bazel)

--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -32,19 +32,27 @@ jobs:
           # When adding endpoints, see README.md.
           # prettier-ignore
           allowed-endpoints: >
-            *.dl.sourceforge.net:443
+            *.blob.storage.azure.net:443
+            *.githubapp.com:443
+            *.sourceforge.net:443
             api.github.com:443
+            api.ipify.org:443
             bcr.bazel.build:443
             downloads.sourceforge.net:443
+            files.pythonhosted.org:443
             github.com:443
+            go.dev:443
+            mirror.bazel.build:443
             mirrors.kernel.org:443
             nodejs.org:443
             oauth2.googleapis.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
             releases.bazel.build:443
-            sourceforge.net:443
             storage.googleapis.com:443
+            www.googleapis.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
Missed in #6848 (had it sitting in my workspace uncommitted, apparently have gotten too used to jj; using git here)

Assisted-by: Google Antigravity with Gemini