### PR TITLE
Factor out textual headers from libcxx and libcxxabi

### DIFF
--- a/bazel/llvm_project/0005_Introduce_basic_sources_exporting_for_libcxx_and_libcxxabi.patch
+++ b/bazel/llvm_project/0005_Introduce_basic_sources_exporting_for_libcxx_and_libcxxabi.patch
@@ -1,13 +1,14 @@
-Commit ID: 3812a423c5ca98c5cf6ceee006a59d6c3a3b33df
+Commit ID: 1fd710ed69a0f47f454c386d39302ddb756a88b3
 Change ID: mstnwoqruyypnoouksnyqssllrsozpos
 Bookmarks: bz-libcxx* bz-libcxx@git
 Author   : Chandler Carruth <chandlerc@gmail.com> (2025-09-25 22:55:26)
-Committer: Chandler Carruth <chandlerc@gmail.com> (2026-02-14 04:12:09)
+Committer: Chandler Carruth <chandlerc@gmail.com> (2026-03-08 07:41:54)
 
     Introduce basic sources exporting for libcxx and libcxxabi
 
     This exports the source files directly so that they can be used to build
-    a libcxx runtime library on demand.
+    a libcxx runtime library on demand. It also differentiates between
+    normal sources and textual sources.
 
 diff --git a/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel b/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel
 new file mode 100644
@@ -199,10 +200,10 @@ index 0000000000..66f64f3610
 +libcxx_and_abi_copts = _libcxx_base_copts + _libcxx_defines + _libcxxabi_defines
 diff --git a/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel b/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel
 new file mode 100644
-index 0000000000..279030b097
+index 0000000000..2db70b54e2
 --- /dev/null
 +++ b/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel
-@@ -0,0 +1,24 @@
+@@ -0,0 +1,30 @@
 +# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 +# See https://llvm.org/LICENSE.txt for license information.
 +# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -223,6 +224,12 @@ index 0000000000..279030b097
 +    srcs = glob([
 +        "src/**/*.cpp",
 +        "src/**/*.h",
++    ]),
++)
++
++filegroup(
++    name = "libcxxabi_textual_srcs",
++    srcs = glob([
 +        "src/**/*.def",
 +        "src/**/*.inc",
 +    ]),

--- a/toolchain/base/runtimes_build_info.bzl
+++ b/toolchain/base/runtimes_build_info.bzl
@@ -41,20 +41,36 @@ BUILTINS_TEXTUAL_SRCS_FILEGROUPS = [
     "@llvm-project//compiler-rt:builtins_x86_64_textual_srcs",
 ]
 
-RUNTIMES_FILEGROUPS = {
-    "libcxx_linux": "@llvm-project//libcxx:libcxx_linux_srcs",
-    "libcxx_macos": "@llvm-project//libcxx:libcxx_macos_srcs",
-    "libcxx_win32": "@llvm-project//libcxx:libcxx_win32_srcs",
-    "libcxxabi": "@llvm-project//libcxxabi:libcxxabi_srcs",
-    "libunwind": "@llvm-project//libunwind:libunwind_srcs",
-}
+RUNTIMES_HDRS_FILEGROUPS = [
+    "@llvm-project//libc:libcxx_shared_headers_hdrs",
+    "@llvm-project//libcxx:libcxx_hdrs",
+    "@llvm-project//libcxxabi:libcxxabi_hdrs",
+    "@llvm-project//libunwind:libunwind_hdrs",
+]
+
+RUNTIMES_SRCS_FILEGROUPS = [
+    "@llvm-project//libcxx:libcxx_linux_srcs",
+    "@llvm-project//libcxx:libcxx_macos_srcs",
+    "@llvm-project//libcxx:libcxx_win32_srcs",
+    "@llvm-project//libcxxabi:libcxxabi_srcs",
+    "@llvm-project//libunwind:libunwind_srcs",
+]
+
+RUNTIMES_TEXTUAL_SRCS_FILEGROUPS = [
+    "@llvm-project//libcxxabi:libcxxabi_textual_srcs",
+]
 
 RUNTIMES_PREFIXES = {
-    "libcxx_linux": "libcxx/",
-    "libcxx_macos": "libcxx/",
-    "libcxx_win32": "libcxx/",
-    "libcxxabi": "libcxxabi/",
-    "libunwind": "libunwind/",
+    "libcxx_hdrs": "libcxx/",
+    "libcxx_linux_srcs": "libcxx/",
+    "libcxx_macos_srcs": "libcxx/",
+    "libcxx_shared_headers_hdrs": "libc/internal/",
+    "libcxx_win32_srcs": "libcxx/",
+    "libcxxabi_hdrs": "libcxxabi/",
+    "libcxxabi_srcs": "libcxxabi/",
+    "libcxxabi_textual_srcs": "libcxxabi/",
+    "libunwind_hdrs": "libunwind/",
+    "libunwind_srcs": "libunwind/",
 }
 
 def _get_name(target):
@@ -119,12 +135,15 @@ def _get_substitutions(ctx):
     } | {
         # Other runtimes are installed under separate directories named the
         # same as their key.
-        k.upper() + "_SRCS": _get_paths(
-            key_attr(k),
+        name.upper(): _get_paths(
+            key_attr(name),
             _runtimes_path,
-            RUNTIMES_PREFIXES[k],
+            RUNTIMES_PREFIXES[name],
         )
-        for k in RUNTIMES_FILEGROUPS.keys()
+        for name in [_get_name(g) for g in (
+            RUNTIMES_HDRS_FILEGROUPS + RUNTIMES_SRCS_FILEGROUPS +
+            RUNTIMES_TEXTUAL_SRCS_FILEGROUPS
+        )]
     }
 
 def _generate_runtimes_build_info_h_rule(ctx):
@@ -143,10 +162,13 @@ generate_runtimes_build_info_h = rule(
         for k, v in CRT_FILES.items()
     } | {
         "_" + _get_name(g): attr.label_list(default = [g], allow_files = True)
-        for g in BUILTINS_SRCS_FILEGROUPS + BUILTINS_TEXTUAL_SRCS_FILEGROUPS
-    } | {
-        "_" + k: attr.label_list(default = [v], allow_files = True)
-        for k, v in RUNTIMES_FILEGROUPS.items()
+        for g in (
+            BUILTINS_SRCS_FILEGROUPS +
+            BUILTINS_TEXTUAL_SRCS_FILEGROUPS +
+            RUNTIMES_HDRS_FILEGROUPS +
+            RUNTIMES_SRCS_FILEGROUPS +
+            RUNTIMES_TEXTUAL_SRCS_FILEGROUPS
+        )
     } | {
         "_template_file": attr.label(
             default = "runtimes_build_info.tpl.h",

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -279,6 +279,7 @@ filegroup(
     srcs = [
         "@llvm-project//libcxxabi:libcxxabi_hdrs",
         "@llvm-project//libcxxabi:libcxxabi_srcs",
+        "@llvm-project//libcxxabi:libcxxabi_textual_srcs",
     ],
 )
 


### PR DESCRIPTION
Also cleans up how the filegroups from these rules are organized --
separately tracking srcs, hdrs, and textual-srcs.