### PR TITLE
Add initial Windows CI for common tests

### DIFF
--- a/.github/workflows/tests_windows.yaml
+++ b/.github/workflows/tests_windows.yaml
@@ -1,0 +1,63 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Tests (Windows)
+
+on:
+  push:
+    branches: [trunk, action-test]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache LLVM and Clang installation
+        id: cache-llvm-windows
+        uses: actions/cache@v5
+        with:
+          path: ~/llvm
+          key: LLVM-19.1.7-Cache-windows-x64
+
+      - name: Download LLVM and Clang installation
+        if: steps.cache-llvm-windows.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $LLVM_RELEASE = "19.1.7"
+          $LLVM_TARBALL = "clang+llvm-$LLVM_RELEASE-x86_64-pc-windows-msvc.tar.xz"
+          $LLVM_PATH = "$HOME/llvm"
+          Write-Host "Downloading LLVM $LLVM_RELEASE"
+          Invoke-WebRequest "https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_RELEASE/$LLVM_TARBALL" -OutFile $LLVM_TARBALL
+          New-Item -ItemType Directory -Force -Path $LLVM_PATH
+          tar -xJf $LLVM_TARBALL --strip-components=1 -C $LLVM_PATH
+          Remove-Item $LLVM_TARBALL
+
+      - name: Setup LLVM and Clang paths
+        shell: pwsh
+        run: |
+          $LLVM_PATH = "$HOME/llvm"
+          echo "$LLVM_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Build and test common
+        shell: pwsh
+        run: |
+          bazel test //common/... `
+            --repo_env=CC=clang `
+            --repo_env=CXX=clang++ `
+            --deleted_packages=bazel/check_deps `
+            --nocheck_visibility `
+            --force_pic=false `
+            --features=archive_param_file `
+            --jobs=4 `
+            --test_output=errors


### PR DESCRIPTION
Add GitHub Actions workflow to build and test //common/... on Windows natively (without WSL).

Uses LLVM 19.1.7 downloaded from GitHub releases, following the same pattern as build-setup-ubuntu.

This is the first step toward full Windows CI coverage, starting with common/ tests as suggested in issue #298.

Assisted-by: Claude AI (https://claude.ai)

**Replace this paragraph with a description of what this PR is changing or
adding, and why.**

Closes #ISSUE
