### PR TITLE
Update python version for black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@
 
 [tool.black]
 line-length = 80
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py310']
 include = '\.pyi?$'


### PR DESCRIPTION
This is making it consistent with other places we set a Python version:
- contribution_tools.md
- .python-version
- bench_runner.py
- build-setup-common/action.yml

Assisted-by: Google Antigravity with Gemini