### PR TITLE
Make included files insert before main files

### DIFF
--- a/testing/file_test/run_test.cpp
+++ b/testing/file_test/run_test.cpp
@@ -104,10 +104,10 @@ static auto CollectOutputIfCapturing(TestFile& test_file) -> void {
 auto RunTestFile(const FileTestBase& test_base, bool dump_output,
                  TestFile& test_file) -> ErrorOr<Success> {
   llvm::SmallVector<TestFile::Split*> all_splits;
-  for (auto& split : test_file.file_splits) {
+  for (auto& split : test_file.include_file_splits) {
     all_splits.push_back(&split);
   }
-  for (auto& split : test_file.include_file_splits) {
+  for (auto& split : test_file.file_splits) {
     all_splits.push_back(&split);
   }
 

--- a/testing/file_test/testdata/include_empty.carbon
+++ b/testing/file_test/testdata/include_empty.carbon
@@ -10,4 +10,4 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/include_empty.carbon
 
-// CHECK:STDOUT: 3 args: `default_args`, `include_empty.carbon`, `empty.carbon`
+// CHECK:STDOUT: 3 args: `default_args`, `empty.carbon`, `include_empty.carbon`

--- a/testing/file_test/testdata/include_extra_args.carbon
+++ b/testing/file_test/testdata/include_extra_args.carbon
@@ -11,4 +11,4 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/include_extra_args.carbon
 
-// CHECK:STDOUT: 6 args: `default_args`, `include_extra_args.carbon`, `include_files/extra_args.carbon`, `bar`, `baz`, `foo`
+// CHECK:STDOUT: 6 args: `default_args`, `include_files/extra_args.carbon`, `include_extra_args.carbon`, `bar`, `baz`, `foo`

--- a/testing/file_test/testdata/include_no_split.carbon
+++ b/testing/file_test/testdata/include_no_split.carbon
@@ -10,5 +10,5 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/include_no_split.carbon
 
-// CHECK:STDOUT: 3 args: `default_args`, `include_no_split.carbon`, `include_files/no_split.carbon`
+// CHECK:STDOUT: 3 args: `default_args`, `include_files/no_split.carbon`, `include_no_split.carbon`
 // CHECK:STDOUT: include_files/no_split.carbon:5: no split

--- a/testing/file_test/testdata/include_recursive.carbon
+++ b/testing/file_test/testdata/include_recursive.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/include_recursive.carbon
 
-// CHECK:STDOUT: 6 args: `default_args`, `include_recursive.carbon`, `c.carbon`, `d.carbon`, `a.carbon`, `b.carbon`
+// CHECK:STDOUT: 6 args: `default_args`, `c.carbon`, `d.carbon`, `a.carbon`, `b.carbon`, `include_recursive.carbon`
 // CHECK:STDOUT: c.carbon:2: c
 // CHECK:STDOUT: d.carbon:2: d
 // CHECK:STDOUT: a.carbon:2: a

--- a/testing/file_test/testdata/include_repeated.carbon
+++ b/testing/file_test/testdata/include_repeated.carbon
@@ -12,5 +12,5 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/include_repeated.carbon
 
-// CHECK:STDOUT: 3 args: `default_args`, `include_repeated.carbon`, `include_files/no_split.carbon`
+// CHECK:STDOUT: 3 args: `default_args`, `include_files/no_split.carbon`, `include_repeated.carbon`
 // CHECK:STDOUT: include_files/no_split.carbon:5: no split

--- a/testing/file_test/testdata/include_split.carbon
+++ b/testing/file_test/testdata/include_split.carbon
@@ -10,6 +10,6 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //testing/file_test:file_test_base_test -- --dump_output --file_tests=testing/file_test/testdata/include_split.carbon
 
-// CHECK:STDOUT: 4 args: `default_args`, `include_split.carbon`, `a.carbon`, `b.carbon`
+// CHECK:STDOUT: 4 args: `default_args`, `a.carbon`, `b.carbon`, `include_split.carbon`
 // CHECK:STDOUT: a.carbon:2: a
 // CHECK:STDOUT: b.carbon:2: b

--- a/toolchain/check/testdata/basics/raw_sem_ir/builtins.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/builtins.carbon
@@ -86,7 +86,7 @@
 // CHECK:STDOUT:     generated:       {}
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block60000005:
+// CHECK:STDOUT:     inst_block50000005:
 // CHECK:STDOUT:       0:               instF
 // CHECK:STDOUT:   value_stores:
 // CHECK:STDOUT:     shared_values:

--- a/toolchain/check/testdata/basics/raw_sem_ir/cpp_interop.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/cpp_interop.carbon
@@ -47,39 +47,39 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:     'import_ir(ApiForImpl)': {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     'import_ir(Cpp)':  {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc60000000}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc60000001}
-// CHECK:STDOUT:     import_ir_inst2: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc60000002}
-// CHECK:STDOUT:     import_ir_inst3: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc60000003}
-// CHECK:STDOUT:     import_ir_inst4: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc60000004}
+// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc50000000}
+// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc50000001}
+// CHECK:STDOUT:     import_ir_inst2: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc50000002}
+// CHECK:STDOUT:     import_ir_inst3: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc50000003}
+// CHECK:STDOUT:     import_ir_inst4: {ir_id: import_ir(Cpp), clang_source_loc_id: clang_source_loc50000004}
 // CHECK:STDOUT:   clang_decls:
-// CHECK:STDOUT:     clang_decl_id60000000: {key: "<translation unit>", inst_id: inst60000011}
-// CHECK:STDOUT:     clang_decl_id60000001: {key: "struct X {}", inst_id: inst60000014}
-// CHECK:STDOUT:     clang_decl_id60000002: {key: "X * _Nonnull p", inst_id: inst60000022}
-// CHECK:STDOUT:     clang_decl_id60000003: {key: {decl: "void f(X x = {})", kind: normal, num_params: 0}, inst_id: inst6000002D}
-// CHECK:STDOUT:     clang_decl_id60000004: {key: {decl: "extern void f__carbon_thunk()", kind: normal, num_params: 0}, inst_id: inst60000030}
-// CHECK:STDOUT:     clang_decl_id60000005: {key: {decl: "void f(X x = {})", kind: normal, num_params: 1}, inst_id: inst6000003B}
-// CHECK:STDOUT:     clang_decl_id60000006: {key: {decl: "extern void f__carbon_thunk(X * _Nonnull x)", kind: normal, num_params: 1}, inst_id: inst60000043}
-// CHECK:STDOUT:     clang_decl_id60000007: {key: "X * _Nonnull global", inst_id: inst6000004E}
+// CHECK:STDOUT:     clang_decl_id50000000: {key: "<translation unit>", inst_id: inst50000011}
+// CHECK:STDOUT:     clang_decl_id50000001: {key: "struct X {}", inst_id: inst50000014}
+// CHECK:STDOUT:     clang_decl_id50000002: {key: "X * _Nonnull p", inst_id: inst50000022}
+// CHECK:STDOUT:     clang_decl_id50000003: {key: {decl: "void f(X x = {})", kind: normal, num_params: 0}, inst_id: inst5000002D}
+// CHECK:STDOUT:     clang_decl_id50000004: {key: {decl: "extern void f__carbon_thunk()", kind: normal, num_params: 0}, inst_id: inst50000030}
+// CHECK:STDOUT:     clang_decl_id50000005: {key: {decl: "void f(X x = {})", kind: normal, num_params: 1}, inst_id: inst5000003B}
+// CHECK:STDOUT:     clang_decl_id50000006: {key: {decl: "extern void f__carbon_thunk(X * _Nonnull x)", kind: normal, num_params: 1}, inst_id: inst50000043}
+// CHECK:STDOUT:     clang_decl_id50000007: {key: "X * _Nonnull global", inst_id: inst5000004E}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name(Cpp): inst60000011, name0: inst6000001D}}
-// CHECK:STDOUT:     name_scope60000001: {inst: inst60000011, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name2: inst60000014, name3: inst6000002A, name4: inst6000004E}}
-// CHECK:STDOUT:     name_scope60000002: {inst: inst60000014, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name(Cpp): inst50000011, name0: inst5000001D}}
+// CHECK:STDOUT:     name_scope50000001: {inst: inst50000011, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name2: inst50000014, name3: inst5000002A, name4: inst5000004E}}
+// CHECK:STDOUT:     name_scope50000002: {inst: inst50000014, parent_scope: name_scope50000001, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name60000000: {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000001: {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000002: {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000003: {name: name4, parent_scope: name_scope60000001, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name50000000: {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name50000001: {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name50000002: {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name50000003: {name: name4, parent_scope: name_scope50000001, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
 // CHECK:STDOUT:   cpp_global_vars:
-// CHECK:STDOUT:     cpp_global_var60000000: {key: {entity_name_id: entity_name60000003}, clang_decl_id: clang_decl_id60000007}
+// CHECK:STDOUT:     cpp_global_var50000000: {key: {entity_name_id: entity_name50000003}, clang_decl_id: clang_decl_id50000007}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block60000007, call_params_id: inst_block60000008, body: [inst_block6000000B]}
-// CHECK:STDOUT:     function60000001: {name: name3, parent_scope: name_scope60000001, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty}
-// CHECK:STDOUT:     function60000002: {name: name6, parent_scope: name_scope60000001, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty}
-// CHECK:STDOUT:     function60000003: {name: name3, parent_scope: name_scope60000001, call_param_patterns_id: inst_block6000000F, call_params_id: inst_block60000010}
-// CHECK:STDOUT:     function60000004: {name: name6, parent_scope: name_scope60000001, call_param_patterns_id: inst_block60000015, call_params_id: inst_block60000016}
+// CHECK:STDOUT:     function50000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block50000007, call_params_id: inst_block50000008, body: [inst_block5000000B]}
+// CHECK:STDOUT:     function50000001: {name: name3, parent_scope: name_scope50000001, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty}
+// CHECK:STDOUT:     function50000002: {name: name6, parent_scope: name_scope50000001, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty}
+// CHECK:STDOUT:     function50000003: {name: name3, parent_scope: name_scope50000001, call_param_patterns_id: inst_block5000000F, call_params_id: inst_block50000010}
+// CHECK:STDOUT:     function50000004: {name: name6, parent_scope: name_scope50000001, call_param_patterns_id: inst_block50000015, call_params_id: inst_block50000016}
 // CHECK:STDOUT:   classes:
-// CHECK:STDOUT:     class60000000:   {name: name2, parent_scope: name_scope60000001, self_type_id: type(inst60000015), inheritance_kind: Base, is_dynamic: 0, scope_id: name_scope60000002, body_block_id: inst_block6000000C, adapt_id: inst<none>, base_id: inst<none>, complete_type_witness_id: inst60000025, vtable_decl_id: inst<none>}}
+// CHECK:STDOUT:     class50000000:   {name: name2, parent_scope: name_scope50000001, self_type_id: type(inst50000015), inheritance_kind: Base, is_dynamic: 0, scope_id: name_scope50000002, body_block_id: inst_block5000000C, adapt_id: inst<none>, base_id: inst<none>, complete_type_witness_id: inst50000025, vtable_decl_id: inst<none>}}
 // CHECK:STDOUT:   interfaces:      {}
 // CHECK:STDOUT:   associated_constants: {}
 // CHECK:STDOUT:   impls:           {}
@@ -88,10 +88,10 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:   specific_interfaces: {}
 // CHECK:STDOUT:   struct_type_fields:
 // CHECK:STDOUT:     struct_type_fields_empty: {}
-// CHECK:STDOUT:     struct_type_fields60000001:
-// CHECK:STDOUT:       0:               {name_id: name5, type_inst_id: inst60000020}
-// CHECK:STDOUT:     struct_type_fields60000002:
-// CHECK:STDOUT:       0:               {name_id: name5, type_inst_id: inst60000020}
+// CHECK:STDOUT:     struct_type_fields50000001:
+// CHECK:STDOUT:       0:               {name_id: name5, type_inst_id: inst50000020}
+// CHECK:STDOUT:     struct_type_fields50000002:
+// CHECK:STDOUT:       0:               {name_id: name5, type_inst_id: inst50000020}
 // CHECK:STDOUT:   types:
 // CHECK:STDOUT:     'type(TypeType)':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(TypeType)}
@@ -102,31 +102,31 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:     'type(inst(NamespaceType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(NamespaceType))}
 // CHECK:STDOUT:     'type(inst(InstType))':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000013)}
-// CHECK:STDOUT:     'type(inst60000013)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000013)}
-// CHECK:STDOUT:     'type(inst6000001E)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000013)}
-// CHECK:STDOUT:     'type(inst60000020)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst60000020)}
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
+// CHECK:STDOUT:     'type(inst50000013)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
+// CHECK:STDOUT:     'type(inst5000001E)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
+// CHECK:STDOUT:     'type(inst50000020)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst50000020)}
 // CHECK:STDOUT:     'type(inst(WitnessType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     'type(inst60000027)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst60000027)}
-// CHECK:STDOUT:     'type(inst60000024)':
-// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(inst60000027)}
-// CHECK:STDOUT:     'type(inst60000015)':
-// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(inst60000027)}
-// CHECK:STDOUT:     'type(inst60000029)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000013)}
-// CHECK:STDOUT:     'type(inst6000002E)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000013)}
-// CHECK:STDOUT:     'type(inst60000031)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000013)}
-// CHECK:STDOUT:     'type(inst6000003C)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000013)}
-// CHECK:STDOUT:     'type(inst60000044)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000013)}
+// CHECK:STDOUT:     'type(inst50000027)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst50000027)}
+// CHECK:STDOUT:     'type(inst50000024)':
+// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(inst50000027)}
+// CHECK:STDOUT:     'type(inst50000015)':
+// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(inst50000027)}
+// CHECK:STDOUT:     'type(inst50000029)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
+// CHECK:STDOUT:     'type(inst5000002E)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
+// CHECK:STDOUT:     'type(inst50000031)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
+// CHECK:STDOUT:     'type(inst5000003C)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
+// CHECK:STDOUT:     'type(inst50000044)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000013)}
 // CHECK:STDOUT:   facet_types:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     'inst(TypeType)':  {kind: TypeType, type: type(TypeType)}
@@ -145,77 +145,77 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:     'inst(VtableType)': {kind: VtableType, type: type(TypeType)}
 // CHECK:STDOUT:     'inst(WitnessType)': {kind: WitnessType, type: type(TypeType)}
 // CHECK:STDOUT:     instF:           {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000010:    {kind: ImportCppDecl}
-// CHECK:STDOUT:     inst60000011:    {kind: Namespace, arg0: name_scope60000001, arg1: inst60000010, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000012:    {kind: NameRef, arg0: name(Cpp), arg1: inst60000011, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000013:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000014:    {kind: ClassDecl, arg0: class60000000, arg1: inst_block<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000015:    {kind: ClassType, arg0: class60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000016:    {kind: NameRef, arg0: name2, arg1: inst60000014, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000017:    {kind: ValueBinding, arg0: entity_name60000000, arg1: inst6000001B, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000018:    {kind: PatternType, arg0: inst60000015, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000019:    {kind: ValueBindingPattern, arg0: entity_name60000000, type: type(inst60000018)}
-// CHECK:STDOUT:     inst6000001A:    {kind: ValueParamPattern, arg0: inst60000019, type: type(inst60000018)}
-// CHECK:STDOUT:     inst6000001B:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst60000015)}
-// CHECK:STDOUT:     inst6000001C:    {kind: SpliceBlock, arg0: inst_block60000005, arg1: inst60000016, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001D:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block6000000A, type: type(inst6000001E)}
-// CHECK:STDOUT:     inst6000001E:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001F:    {kind: StructValue, arg0: inst_block_empty, type: type(inst6000001E)}
-// CHECK:STDOUT:     inst60000020:    {kind: PointerType, arg0: inst60000015, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000021:    {kind: UnboundElementType, arg0: inst60000015, arg1: inst60000020, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000022:    {kind: FieldDecl, arg0: name5, arg1: element0, type: type(inst60000021)}
-// CHECK:STDOUT:     inst60000023:    {kind: CustomLayoutType, arg0: struct_type_fields60000001, arg1: custom_layout60000001, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000024:    {kind: CustomLayoutType, arg0: struct_type_fields60000002, arg1: custom_layout60000001, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000025:    {kind: CompleteTypeWitness, arg0: inst60000023, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000026:    {kind: CompleteTypeWitness, arg0: inst60000024, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000027:    {kind: PointerType, arg0: inst60000024, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000028:    {kind: NameRef, arg0: name(Cpp), arg1: inst60000011, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000029:    {kind: CppOverloadSetType, arg0: cpp_overload_set60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002A:    {kind: CppOverloadSetValue, arg0: cpp_overload_set60000000, type: type(inst60000029)}
-// CHECK:STDOUT:     inst6000002B:    {kind: CppOverloadSetValue, arg0: cpp_overload_set60000000, type: type(inst60000029)}
-// CHECK:STDOUT:     inst6000002C:    {kind: NameRef, arg0: name3, arg1: inst6000002A, type: type(inst60000029)}
-// CHECK:STDOUT:     inst6000002D:    {kind: FunctionDecl, arg0: function60000001, arg1: inst_block_empty, type: type(inst6000002E)}
-// CHECK:STDOUT:     inst6000002E:    {kind: FunctionType, arg0: function60000001, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002F:    {kind: StructValue, arg0: inst_block_empty, type: type(inst6000002E)}
-// CHECK:STDOUT:     inst60000030:    {kind: FunctionDecl, arg0: function60000002, arg1: inst_block_empty, type: type(inst60000031)}
-// CHECK:STDOUT:     inst60000031:    {kind: FunctionType, arg0: function60000002, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000032:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000031)}
-// CHECK:STDOUT:     inst60000033:    {kind: Call, arg0: inst60000030, arg1: inst_block_empty, type: type(inst60000013)}
-// CHECK:STDOUT:     inst60000034:    {kind: NameRef, arg0: name(Cpp), arg1: inst60000011, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000035:    {kind: NameRef, arg0: name3, arg1: inst6000002A, type: type(inst60000029)}
-// CHECK:STDOUT:     inst60000036:    {kind: NameRef, arg0: name1, arg1: inst60000017, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000037:    {kind: ValueBinding, arg0: entity_name60000001, arg1: inst6000003A, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000038:    {kind: ValueBindingPattern, arg0: entity_name60000001, type: type(inst60000018)}
-// CHECK:STDOUT:     inst60000039:    {kind: ValueParamPattern, arg0: inst60000038, type: type(inst60000018)}
-// CHECK:STDOUT:     inst6000003A:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst60000015)}
-// CHECK:STDOUT:     inst6000003B:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block60000012, type: type(inst6000003C)}
-// CHECK:STDOUT:     inst6000003C:    {kind: FunctionType, arg0: function60000003, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000003D:    {kind: StructValue, arg0: inst_block_empty, type: type(inst6000003C)}
-// CHECK:STDOUT:     inst6000003E:    {kind: ValueBinding, arg0: entity_name60000002, arg1: inst60000042, type: type(inst60000020)}
-// CHECK:STDOUT:     inst6000003F:    {kind: PatternType, arg0: inst60000020, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000040:    {kind: ValueBindingPattern, arg0: entity_name60000002, type: type(inst6000003F)}
-// CHECK:STDOUT:     inst60000041:    {kind: ValueParamPattern, arg0: inst60000040, type: type(inst6000003F)}
-// CHECK:STDOUT:     inst60000042:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst60000020)}
-// CHECK:STDOUT:     inst60000043:    {kind: FunctionDecl, arg0: function60000004, arg1: inst_block60000018, type: type(inst60000044)}
-// CHECK:STDOUT:     inst60000044:    {kind: FunctionType, arg0: function60000004, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000045:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000044)}
-// CHECK:STDOUT:     inst60000046:    {kind: ValueAsRef, arg0: inst60000036, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000047:    {kind: AddrOf, arg0: inst60000046, type: type(inst60000020)}
-// CHECK:STDOUT:     inst60000048:    {kind: Call, arg0: inst60000043, arg1: inst_block6000001A, type: type(inst60000013)}
-// CHECK:STDOUT:     inst60000049:    {kind: NameRef, arg0: name(Cpp), arg1: inst60000011, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst6000004A:    {kind: NameRef, arg0: name3, arg1: inst6000002A, type: type(inst60000029)}
-// CHECK:STDOUT:     inst6000004B:    {kind: NameRef, arg0: name(Cpp), arg1: inst60000011, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst6000004C:    {kind: RefBindingPattern, arg0: entity_name60000003, type: type(inst6000003F)}
-// CHECK:STDOUT:     inst6000004D:    {kind: VarPattern, arg0: inst6000004C, type: type(inst6000003F)}
-// CHECK:STDOUT:     inst6000004E:    {kind: VarStorage, arg0: inst6000004D, type: type(inst60000020)}
-// CHECK:STDOUT:     inst6000004F:    {kind: NameRef, arg0: name4, arg1: inst6000004E, type: type(inst60000020)}
-// CHECK:STDOUT:     inst60000050:    {kind: AcquireValue, arg0: inst6000004F, type: type(inst60000020)}
-// CHECK:STDOUT:     inst60000051:    {kind: Deref, arg0: inst60000050, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000052:    {kind: AcquireValue, arg0: inst60000051, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000053:    {kind: ValueAsRef, arg0: inst60000052, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000054:    {kind: AddrOf, arg0: inst60000053, type: type(inst60000020)}
-// CHECK:STDOUT:     inst60000055:    {kind: Call, arg0: inst60000043, arg1: inst_block6000001C, type: type(inst60000013)}
-// CHECK:STDOUT:     inst60000056:    {kind: Return}
+// CHECK:STDOUT:     inst50000010:    {kind: ImportCppDecl}
+// CHECK:STDOUT:     inst50000011:    {kind: Namespace, arg0: name_scope50000001, arg1: inst50000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst50000012:    {kind: NameRef, arg0: name(Cpp), arg1: inst50000011, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst50000013:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000014:    {kind: ClassDecl, arg0: class50000000, arg1: inst_block<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000015:    {kind: ClassType, arg0: class50000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000016:    {kind: NameRef, arg0: name2, arg1: inst50000014, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000017:    {kind: ValueBinding, arg0: entity_name50000000, arg1: inst5000001B, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000018:    {kind: PatternType, arg0: inst50000015, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000019:    {kind: ValueBindingPattern, arg0: entity_name50000000, type: type(inst50000018)}
+// CHECK:STDOUT:     inst5000001A:    {kind: ValueParamPattern, arg0: inst50000019, type: type(inst50000018)}
+// CHECK:STDOUT:     inst5000001B:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst50000015)}
+// CHECK:STDOUT:     inst5000001C:    {kind: SpliceBlock, arg0: inst_block50000005, arg1: inst50000016, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000001D:    {kind: FunctionDecl, arg0: function50000000, arg1: inst_block5000000A, type: type(inst5000001E)}
+// CHECK:STDOUT:     inst5000001E:    {kind: FunctionType, arg0: function50000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000001F:    {kind: StructValue, arg0: inst_block_empty, type: type(inst5000001E)}
+// CHECK:STDOUT:     inst50000020:    {kind: PointerType, arg0: inst50000015, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000021:    {kind: UnboundElementType, arg0: inst50000015, arg1: inst50000020, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000022:    {kind: FieldDecl, arg0: name5, arg1: element0, type: type(inst50000021)}
+// CHECK:STDOUT:     inst50000023:    {kind: CustomLayoutType, arg0: struct_type_fields50000001, arg1: custom_layout50000001, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000024:    {kind: CustomLayoutType, arg0: struct_type_fields50000002, arg1: custom_layout50000001, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000025:    {kind: CompleteTypeWitness, arg0: inst50000023, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst50000026:    {kind: CompleteTypeWitness, arg0: inst50000024, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst50000027:    {kind: PointerType, arg0: inst50000024, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000028:    {kind: NameRef, arg0: name(Cpp), arg1: inst50000011, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst50000029:    {kind: CppOverloadSetType, arg0: cpp_overload_set50000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000002A:    {kind: CppOverloadSetValue, arg0: cpp_overload_set50000000, type: type(inst50000029)}
+// CHECK:STDOUT:     inst5000002B:    {kind: CppOverloadSetValue, arg0: cpp_overload_set50000000, type: type(inst50000029)}
+// CHECK:STDOUT:     inst5000002C:    {kind: NameRef, arg0: name3, arg1: inst5000002A, type: type(inst50000029)}
+// CHECK:STDOUT:     inst5000002D:    {kind: FunctionDecl, arg0: function50000001, arg1: inst_block_empty, type: type(inst5000002E)}
+// CHECK:STDOUT:     inst5000002E:    {kind: FunctionType, arg0: function50000001, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000002F:    {kind: StructValue, arg0: inst_block_empty, type: type(inst5000002E)}
+// CHECK:STDOUT:     inst50000030:    {kind: FunctionDecl, arg0: function50000002, arg1: inst_block_empty, type: type(inst50000031)}
+// CHECK:STDOUT:     inst50000031:    {kind: FunctionType, arg0: function50000002, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000032:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000031)}
+// CHECK:STDOUT:     inst50000033:    {kind: Call, arg0: inst50000030, arg1: inst_block_empty, type: type(inst50000013)}
+// CHECK:STDOUT:     inst50000034:    {kind: NameRef, arg0: name(Cpp), arg1: inst50000011, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst50000035:    {kind: NameRef, arg0: name3, arg1: inst5000002A, type: type(inst50000029)}
+// CHECK:STDOUT:     inst50000036:    {kind: NameRef, arg0: name1, arg1: inst50000017, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000037:    {kind: ValueBinding, arg0: entity_name50000001, arg1: inst5000003A, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000038:    {kind: ValueBindingPattern, arg0: entity_name50000001, type: type(inst50000018)}
+// CHECK:STDOUT:     inst50000039:    {kind: ValueParamPattern, arg0: inst50000038, type: type(inst50000018)}
+// CHECK:STDOUT:     inst5000003A:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst50000015)}
+// CHECK:STDOUT:     inst5000003B:    {kind: FunctionDecl, arg0: function50000003, arg1: inst_block50000012, type: type(inst5000003C)}
+// CHECK:STDOUT:     inst5000003C:    {kind: FunctionType, arg0: function50000003, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000003D:    {kind: StructValue, arg0: inst_block_empty, type: type(inst5000003C)}
+// CHECK:STDOUT:     inst5000003E:    {kind: ValueBinding, arg0: entity_name50000002, arg1: inst50000042, type: type(inst50000020)}
+// CHECK:STDOUT:     inst5000003F:    {kind: PatternType, arg0: inst50000020, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000040:    {kind: ValueBindingPattern, arg0: entity_name50000002, type: type(inst5000003F)}
+// CHECK:STDOUT:     inst50000041:    {kind: ValueParamPattern, arg0: inst50000040, type: type(inst5000003F)}
+// CHECK:STDOUT:     inst50000042:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst50000020)}
+// CHECK:STDOUT:     inst50000043:    {kind: FunctionDecl, arg0: function50000004, arg1: inst_block50000018, type: type(inst50000044)}
+// CHECK:STDOUT:     inst50000044:    {kind: FunctionType, arg0: function50000004, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000045:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000044)}
+// CHECK:STDOUT:     inst50000046:    {kind: ValueAsRef, arg0: inst50000036, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000047:    {kind: AddrOf, arg0: inst50000046, type: type(inst50000020)}
+// CHECK:STDOUT:     inst50000048:    {kind: Call, arg0: inst50000043, arg1: inst_block5000001A, type: type(inst50000013)}
+// CHECK:STDOUT:     inst50000049:    {kind: NameRef, arg0: name(Cpp), arg1: inst50000011, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst5000004A:    {kind: NameRef, arg0: name3, arg1: inst5000002A, type: type(inst50000029)}
+// CHECK:STDOUT:     inst5000004B:    {kind: NameRef, arg0: name(Cpp), arg1: inst50000011, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst5000004C:    {kind: RefBindingPattern, arg0: entity_name50000003, type: type(inst5000003F)}
+// CHECK:STDOUT:     inst5000004D:    {kind: VarPattern, arg0: inst5000004C, type: type(inst5000003F)}
+// CHECK:STDOUT:     inst5000004E:    {kind: VarStorage, arg0: inst5000004D, type: type(inst50000020)}
+// CHECK:STDOUT:     inst5000004F:    {kind: NameRef, arg0: name4, arg1: inst5000004E, type: type(inst50000020)}
+// CHECK:STDOUT:     inst50000050:    {kind: AcquireValue, arg0: inst5000004F, type: type(inst50000020)}
+// CHECK:STDOUT:     inst50000051:    {kind: Deref, arg0: inst50000050, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000052:    {kind: AcquireValue, arg0: inst50000051, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000053:    {kind: ValueAsRef, arg0: inst50000052, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000054:    {kind: AddrOf, arg0: inst50000053, type: type(inst50000020)}
+// CHECK:STDOUT:     inst50000055:    {kind: Call, arg0: inst50000043, arg1: inst_block5000001C, type: type(inst50000013)}
+// CHECK:STDOUT:     inst50000056:    {kind: Return}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       'inst(TypeType)':  concrete_constant(inst(TypeType))
@@ -234,155 +234,155 @@ fn G(x: Cpp.X) {
 // CHECK:STDOUT:       'inst(VtableType)': concrete_constant(inst(VtableType))
 // CHECK:STDOUT:       'inst(WitnessType)': concrete_constant(inst(WitnessType))
 // CHECK:STDOUT:       instF:           concrete_constant(instF)
-// CHECK:STDOUT:       inst60000011:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst60000012:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst60000013:    concrete_constant(inst60000013)
-// CHECK:STDOUT:       inst60000014:    concrete_constant(inst60000015)
-// CHECK:STDOUT:       inst60000015:    concrete_constant(inst60000015)
-// CHECK:STDOUT:       inst60000016:    concrete_constant(inst60000015)
-// CHECK:STDOUT:       inst60000018:    concrete_constant(inst60000018)
-// CHECK:STDOUT:       inst60000019:    concrete_constant(inst60000019)
-// CHECK:STDOUT:       inst6000001A:    concrete_constant(inst6000001A)
-// CHECK:STDOUT:       inst6000001C:    concrete_constant(inst60000015)
-// CHECK:STDOUT:       inst6000001D:    concrete_constant(inst6000001F)
-// CHECK:STDOUT:       inst6000001E:    concrete_constant(inst6000001E)
-// CHECK:STDOUT:       inst6000001F:    concrete_constant(inst6000001F)
-// CHECK:STDOUT:       inst60000020:    concrete_constant(inst60000020)
-// CHECK:STDOUT:       inst60000021:    concrete_constant(inst60000021)
-// CHECK:STDOUT:       inst60000022:    concrete_constant(inst60000022)
-// CHECK:STDOUT:       inst60000023:    concrete_constant(inst60000024)
-// CHECK:STDOUT:       inst60000024:    concrete_constant(inst60000024)
-// CHECK:STDOUT:       inst60000025:    concrete_constant(inst60000026)
-// CHECK:STDOUT:       inst60000026:    concrete_constant(inst60000026)
-// CHECK:STDOUT:       inst60000027:    concrete_constant(inst60000027)
-// CHECK:STDOUT:       inst60000028:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst60000029:    concrete_constant(inst60000029)
-// CHECK:STDOUT:       inst6000002A:    concrete_constant(inst6000002B)
-// CHECK:STDOUT:       inst6000002B:    concrete_constant(inst6000002B)
-// CHECK:STDOUT:       inst6000002C:    concrete_constant(inst6000002B)
-// CHECK:STDOUT:       inst6000002D:    concrete_constant(inst6000002F)
-// CHECK:STDOUT:       inst6000002E:    concrete_constant(inst6000002E)
-// CHECK:STDOUT:       inst6000002F:    concrete_constant(inst6000002F)
-// CHECK:STDOUT:       inst60000030:    concrete_constant(inst60000032)
-// CHECK:STDOUT:       inst60000031:    concrete_constant(inst60000031)
-// CHECK:STDOUT:       inst60000032:    concrete_constant(inst60000032)
-// CHECK:STDOUT:       inst60000034:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst60000035:    concrete_constant(inst6000002B)
-// CHECK:STDOUT:       inst60000038:    concrete_constant(inst60000038)
-// CHECK:STDOUT:       inst60000039:    concrete_constant(inst60000039)
-// CHECK:STDOUT:       inst6000003B:    concrete_constant(inst6000003D)
-// CHECK:STDOUT:       inst6000003C:    concrete_constant(inst6000003C)
-// CHECK:STDOUT:       inst6000003D:    concrete_constant(inst6000003D)
-// CHECK:STDOUT:       inst6000003F:    concrete_constant(inst6000003F)
-// CHECK:STDOUT:       inst60000040:    concrete_constant(inst60000040)
-// CHECK:STDOUT:       inst60000041:    concrete_constant(inst60000041)
-// CHECK:STDOUT:       inst60000043:    concrete_constant(inst60000045)
-// CHECK:STDOUT:       inst60000044:    concrete_constant(inst60000044)
-// CHECK:STDOUT:       inst60000045:    concrete_constant(inst60000045)
-// CHECK:STDOUT:       inst60000049:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst6000004A:    concrete_constant(inst6000002B)
-// CHECK:STDOUT:       inst6000004B:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst6000004C:    concrete_constant(inst6000004C)
-// CHECK:STDOUT:       inst6000004D:    concrete_constant(inst6000004D)
-// CHECK:STDOUT:       inst6000004E:    concrete_constant(inst6000004E)
-// CHECK:STDOUT:       inst6000004F:    concrete_constant(inst6000004E)
+// CHECK:STDOUT:       inst50000011:    concrete_constant(inst50000011)
+// CHECK:STDOUT:       inst50000012:    concrete_constant(inst50000011)
+// CHECK:STDOUT:       inst50000013:    concrete_constant(inst50000013)
+// CHECK:STDOUT:       inst50000014:    concrete_constant(inst50000015)
+// CHECK:STDOUT:       inst50000015:    concrete_constant(inst50000015)
+// CHECK:STDOUT:       inst50000016:    concrete_constant(inst50000015)
+// CHECK:STDOUT:       inst50000018:    concrete_constant(inst50000018)
+// CHECK:STDOUT:       inst50000019:    concrete_constant(inst50000019)
+// CHECK:STDOUT:       inst5000001A:    concrete_constant(inst5000001A)
+// CHECK:STDOUT:       inst5000001C:    concrete_constant(inst50000015)
+// CHECK:STDOUT:       inst5000001D:    concrete_constant(inst5000001F)
+// CHECK:STDOUT:       inst5000001E:    concrete_constant(inst5000001E)
+// CHECK:STDOUT:       inst5000001F:    concrete_constant(inst5000001F)
+// CHECK:STDOUT:       inst50000020:    concrete_constant(inst50000020)
+// CHECK:STDOUT:       inst50000021:    concrete_constant(inst50000021)
+// CHECK:STDOUT:       inst50000022:    concrete_constant(inst50000022)
+// CHECK:STDOUT:       inst50000023:    concrete_constant(inst50000024)
+// CHECK:STDOUT:       inst50000024:    concrete_constant(inst50000024)
+// CHECK:STDOUT:       inst50000025:    concrete_constant(inst50000026)
+// CHECK:STDOUT:       inst50000026:    concrete_constant(inst50000026)
+// CHECK:STDOUT:       inst50000027:    concrete_constant(inst50000027)
+// CHECK:STDOUT:       inst50000028:    concrete_constant(inst50000011)
+// CHECK:STDOUT:       inst50000029:    concrete_constant(inst50000029)
+// CHECK:STDOUT:       inst5000002A:    concrete_constant(inst5000002B)
+// CHECK:STDOUT:       inst5000002B:    concrete_constant(inst5000002B)
+// CHECK:STDOUT:       inst5000002C:    concrete_constant(inst5000002B)
+// CHECK:STDOUT:       inst5000002D:    concrete_constant(inst5000002F)
+// CHECK:STDOUT:       inst5000002E:    concrete_constant(inst5000002E)
+// CHECK:STDOUT:       inst5000002F:    concrete_constant(inst5000002F)
+// CHECK:STDOUT:       inst50000030:    concrete_constant(inst50000032)
+// CHECK:STDOUT:       inst50000031:    concrete_constant(inst50000031)
+// CHECK:STDOUT:       inst50000032:    concrete_constant(inst50000032)
+// CHECK:STDOUT:       inst50000034:    concrete_constant(inst50000011)
+// CHECK:STDOUT:       inst50000035:    concrete_constant(inst5000002B)
+// CHECK:STDOUT:       inst50000038:    concrete_constant(inst50000038)
+// CHECK:STDOUT:       inst50000039:    concrete_constant(inst50000039)
+// CHECK:STDOUT:       inst5000003B:    concrete_constant(inst5000003D)
+// CHECK:STDOUT:       inst5000003C:    concrete_constant(inst5000003C)
+// CHECK:STDOUT:       inst5000003D:    concrete_constant(inst5000003D)
+// CHECK:STDOUT:       inst5000003F:    concrete_constant(inst5000003F)
+// CHECK:STDOUT:       inst50000040:    concrete_constant(inst50000040)
+// CHECK:STDOUT:       inst50000041:    concrete_constant(inst50000041)
+// CHECK:STDOUT:       inst50000043:    concrete_constant(inst50000045)
+// CHECK:STDOUT:       inst50000044:    concrete_constant(inst50000044)
+// CHECK:STDOUT:       inst50000045:    concrete_constant(inst50000045)
+// CHECK:STDOUT:       inst50000049:    concrete_constant(inst50000011)
+// CHECK:STDOUT:       inst5000004A:    concrete_constant(inst5000002B)
+// CHECK:STDOUT:       inst5000004B:    concrete_constant(inst50000011)
+// CHECK:STDOUT:       inst5000004C:    concrete_constant(inst5000004C)
+// CHECK:STDOUT:       inst5000004D:    concrete_constant(inst5000004D)
+// CHECK:STDOUT:       inst5000004E:    concrete_constant(inst5000004E)
+// CHECK:STDOUT:       inst5000004F:    concrete_constant(inst5000004E)
 // CHECK:STDOUT:     symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst6000001D
+// CHECK:STDOUT:       0:               inst5000001D
 // CHECK:STDOUT:     generated:       {}
 // CHECK:STDOUT:     imports:
-// CHECK:STDOUT:       0:               inst60000011
-// CHECK:STDOUT:       1:               inst60000014
-// CHECK:STDOUT:       2:               inst6000002A
-// CHECK:STDOUT:       3:               inst6000002D
-// CHECK:STDOUT:       4:               inst60000030
-// CHECK:STDOUT:       5:               inst6000003B
-// CHECK:STDOUT:       6:               inst60000043
-// CHECK:STDOUT:       7:               inst6000004C
-// CHECK:STDOUT:       8:               inst6000004D
-// CHECK:STDOUT:       9:               inst6000004E
+// CHECK:STDOUT:       0:               inst50000011
+// CHECK:STDOUT:       1:               inst50000014
+// CHECK:STDOUT:       2:               inst5000002A
+// CHECK:STDOUT:       3:               inst5000002D
+// CHECK:STDOUT:       4:               inst50000030
+// CHECK:STDOUT:       5:               inst5000003B
+// CHECK:STDOUT:       6:               inst50000043
+// CHECK:STDOUT:       7:               inst5000004C
+// CHECK:STDOUT:       8:               inst5000004D
+// CHECK:STDOUT:       9:               inst5000004E
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block60000005:
-// CHECK:STDOUT:       0:               inst60000012
-// CHECK:STDOUT:       1:               inst60000016
-// CHECK:STDOUT:     inst_block60000006:
-// CHECK:STDOUT:       0:               inst6000001A
-// CHECK:STDOUT:     inst_block60000007:
-// CHECK:STDOUT:       0:               inst6000001A
-// CHECK:STDOUT:     inst_block60000008:
-// CHECK:STDOUT:       0:               inst6000001B
-// CHECK:STDOUT:     inst_block60000009:
-// CHECK:STDOUT:       0:               inst60000019
-// CHECK:STDOUT:       1:               inst6000001A
-// CHECK:STDOUT:     inst_block6000000A:
-// CHECK:STDOUT:       0:               inst6000001B
-// CHECK:STDOUT:       1:               inst6000001C
-// CHECK:STDOUT:       2:               inst60000017
-// CHECK:STDOUT:     inst_block6000000B:
-// CHECK:STDOUT:       0:               inst60000028
-// CHECK:STDOUT:       1:               inst6000002C
-// CHECK:STDOUT:       2:               inst60000033
-// CHECK:STDOUT:       3:               inst60000034
-// CHECK:STDOUT:       4:               inst60000035
-// CHECK:STDOUT:       5:               inst60000036
-// CHECK:STDOUT:       6:               inst60000046
-// CHECK:STDOUT:       7:               inst60000047
-// CHECK:STDOUT:       8:               inst60000048
-// CHECK:STDOUT:       9:               inst60000049
-// CHECK:STDOUT:       10:              inst6000004A
-// CHECK:STDOUT:       11:              inst6000004B
-// CHECK:STDOUT:       12:              inst6000004F
-// CHECK:STDOUT:       13:              inst60000050
-// CHECK:STDOUT:       14:              inst60000051
-// CHECK:STDOUT:       15:              inst60000052
-// CHECK:STDOUT:       16:              inst60000053
-// CHECK:STDOUT:       17:              inst60000054
-// CHECK:STDOUT:       18:              inst60000055
-// CHECK:STDOUT:       19:              inst60000056
-// CHECK:STDOUT:     inst_block6000000C:
-// CHECK:STDOUT:       0:               inst60000022
-// CHECK:STDOUT:       1:               inst60000023
-// CHECK:STDOUT:       2:               inst60000025
-// CHECK:STDOUT:     inst_block6000000D: {}
-// CHECK:STDOUT:     inst_block6000000E:
-// CHECK:STDOUT:       0:               inst60000039
-// CHECK:STDOUT:     inst_block6000000F:
-// CHECK:STDOUT:       0:               inst60000039
-// CHECK:STDOUT:     inst_block60000010:
-// CHECK:STDOUT:       0:               inst6000003A
-// CHECK:STDOUT:     inst_block60000011:
-// CHECK:STDOUT:       0:               inst60000038
-// CHECK:STDOUT:       1:               inst60000039
-// CHECK:STDOUT:     inst_block60000012:
-// CHECK:STDOUT:       0:               inst6000003A
-// CHECK:STDOUT:       1:               inst60000037
-// CHECK:STDOUT:     inst_block60000013: {}
-// CHECK:STDOUT:     inst_block60000014:
-// CHECK:STDOUT:       0:               inst60000041
-// CHECK:STDOUT:     inst_block60000015:
-// CHECK:STDOUT:       0:               inst60000041
-// CHECK:STDOUT:     inst_block60000016:
-// CHECK:STDOUT:       0:               inst60000042
-// CHECK:STDOUT:     inst_block60000017:
-// CHECK:STDOUT:       0:               inst60000040
-// CHECK:STDOUT:       1:               inst60000041
-// CHECK:STDOUT:     inst_block60000018:
-// CHECK:STDOUT:       0:               inst60000042
-// CHECK:STDOUT:       1:               inst6000003E
-// CHECK:STDOUT:     inst_block60000019:
-// CHECK:STDOUT:       0:               inst60000036
-// CHECK:STDOUT:     inst_block6000001A:
-// CHECK:STDOUT:       0:               inst60000047
-// CHECK:STDOUT:     inst_block6000001B:
-// CHECK:STDOUT:       0:               inst60000052
-// CHECK:STDOUT:     inst_block6000001C:
-// CHECK:STDOUT:       0:               inst60000054
-// CHECK:STDOUT:     inst_block6000001D:
+// CHECK:STDOUT:     inst_block50000005:
+// CHECK:STDOUT:       0:               inst50000012
+// CHECK:STDOUT:       1:               inst50000016
+// CHECK:STDOUT:     inst_block50000006:
+// CHECK:STDOUT:       0:               inst5000001A
+// CHECK:STDOUT:     inst_block50000007:
+// CHECK:STDOUT:       0:               inst5000001A
+// CHECK:STDOUT:     inst_block50000008:
+// CHECK:STDOUT:       0:               inst5000001B
+// CHECK:STDOUT:     inst_block50000009:
+// CHECK:STDOUT:       0:               inst50000019
+// CHECK:STDOUT:       1:               inst5000001A
+// CHECK:STDOUT:     inst_block5000000A:
+// CHECK:STDOUT:       0:               inst5000001B
+// CHECK:STDOUT:       1:               inst5000001C
+// CHECK:STDOUT:       2:               inst50000017
+// CHECK:STDOUT:     inst_block5000000B:
+// CHECK:STDOUT:       0:               inst50000028
+// CHECK:STDOUT:       1:               inst5000002C
+// CHECK:STDOUT:       2:               inst50000033
+// CHECK:STDOUT:       3:               inst50000034
+// CHECK:STDOUT:       4:               inst50000035
+// CHECK:STDOUT:       5:               inst50000036
+// CHECK:STDOUT:       6:               inst50000046
+// CHECK:STDOUT:       7:               inst50000047
+// CHECK:STDOUT:       8:               inst50000048
+// CHECK:STDOUT:       9:               inst50000049
+// CHECK:STDOUT:       10:              inst5000004A
+// CHECK:STDOUT:       11:              inst5000004B
+// CHECK:STDOUT:       12:              inst5000004F
+// CHECK:STDOUT:       13:              inst50000050
+// CHECK:STDOUT:       14:              inst50000051
+// CHECK:STDOUT:       15:              inst50000052
+// CHECK:STDOUT:       16:              inst50000053
+// CHECK:STDOUT:       17:              inst50000054
+// CHECK:STDOUT:       18:              inst50000055
+// CHECK:STDOUT:       19:              inst50000056
+// CHECK:STDOUT:     inst_block5000000C:
+// CHECK:STDOUT:       0:               inst50000022
+// CHECK:STDOUT:       1:               inst50000023
+// CHECK:STDOUT:       2:               inst50000025
+// CHECK:STDOUT:     inst_block5000000D: {}
+// CHECK:STDOUT:     inst_block5000000E:
+// CHECK:STDOUT:       0:               inst50000039
+// CHECK:STDOUT:     inst_block5000000F:
+// CHECK:STDOUT:       0:               inst50000039
+// CHECK:STDOUT:     inst_block50000010:
+// CHECK:STDOUT:       0:               inst5000003A
+// CHECK:STDOUT:     inst_block50000011:
+// CHECK:STDOUT:       0:               inst50000038
+// CHECK:STDOUT:       1:               inst50000039
+// CHECK:STDOUT:     inst_block50000012:
+// CHECK:STDOUT:       0:               inst5000003A
+// CHECK:STDOUT:       1:               inst50000037
+// CHECK:STDOUT:     inst_block50000013: {}
+// CHECK:STDOUT:     inst_block50000014:
+// CHECK:STDOUT:       0:               inst50000041
+// CHECK:STDOUT:     inst_block50000015:
+// CHECK:STDOUT:       0:               inst50000041
+// CHECK:STDOUT:     inst_block50000016:
+// CHECK:STDOUT:       0:               inst50000042
+// CHECK:STDOUT:     inst_block50000017:
+// CHECK:STDOUT:       0:               inst50000040
+// CHECK:STDOUT:       1:               inst50000041
+// CHECK:STDOUT:     inst_block50000018:
+// CHECK:STDOUT:       0:               inst50000042
+// CHECK:STDOUT:       1:               inst5000003E
+// CHECK:STDOUT:     inst_block50000019:
+// CHECK:STDOUT:       0:               inst50000036
+// CHECK:STDOUT:     inst_block5000001A:
+// CHECK:STDOUT:       0:               inst50000047
+// CHECK:STDOUT:     inst_block5000001B:
+// CHECK:STDOUT:       0:               inst50000052
+// CHECK:STDOUT:     inst_block5000001C:
+// CHECK:STDOUT:       0:               inst50000054
+// CHECK:STDOUT:     inst_block5000001D:
 // CHECK:STDOUT:       0:               instF
-// CHECK:STDOUT:       1:               inst60000010
-// CHECK:STDOUT:       2:               inst6000001D
+// CHECK:STDOUT:       1:               inst50000010
+// CHECK:STDOUT:       2:               inst5000001D
 // CHECK:STDOUT:   value_stores:
 // CHECK:STDOUT:     shared_values:
 // CHECK:STDOUT:       ints:            {}

--- a/toolchain/check/testdata/basics/raw_sem_ir/multifile.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/multifile.carbon
@@ -38,11 +38,11 @@ fn B() {
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst60000010}}
+// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst50000010}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty, body: [inst_block60000006]}
+// CHECK:STDOUT:     function50000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty, body: [inst_block50000006]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   interfaces:      {}
 // CHECK:STDOUT:   associated_constants: {}
@@ -61,39 +61,39 @@ fn B() {
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst60000011)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000012)}
-// CHECK:STDOUT:     'type(inst60000012)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000012)}
+// CHECK:STDOUT:     'type(inst50000011)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000012)}
+// CHECK:STDOUT:     'type(inst50000012)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000012)}
 // CHECK:STDOUT:   facet_types:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     instF:           {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000010:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block_empty, type: type(inst60000011)}
-// CHECK:STDOUT:     inst60000011:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000012:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000013:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000011)}
-// CHECK:STDOUT:     inst60000014:    {kind: Return}
+// CHECK:STDOUT:     inst50000010:    {kind: FunctionDecl, arg0: function50000000, arg1: inst_block_empty, type: type(inst50000011)}
+// CHECK:STDOUT:     inst50000011:    {kind: FunctionType, arg0: function50000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000012:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000013:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000011)}
+// CHECK:STDOUT:     inst50000014:    {kind: Return}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       instF:           concrete_constant(instF)
-// CHECK:STDOUT:       inst60000010:    concrete_constant(inst60000013)
-// CHECK:STDOUT:       inst60000011:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst60000012:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000013:    concrete_constant(inst60000013)
+// CHECK:STDOUT:       inst50000010:    concrete_constant(inst50000013)
+// CHECK:STDOUT:       inst50000011:    concrete_constant(inst50000011)
+// CHECK:STDOUT:       inst50000012:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000013:    concrete_constant(inst50000013)
 // CHECK:STDOUT:     symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst60000010
+// CHECK:STDOUT:       0:               inst50000010
 // CHECK:STDOUT:     generated:       {}
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block60000005: {}
-// CHECK:STDOUT:     inst_block60000006:
-// CHECK:STDOUT:       0:               inst60000014
-// CHECK:STDOUT:     inst_block60000007:
+// CHECK:STDOUT:     inst_block50000005: {}
+// CHECK:STDOUT:     inst_block50000006:
+// CHECK:STDOUT:       0:               inst50000014
+// CHECK:STDOUT:     inst_block50000007:
 // CHECK:STDOUT:       0:               instF
-// CHECK:STDOUT:       1:               inst60000010
+// CHECK:STDOUT:       1:               inst50000010
 // CHECK:STDOUT:   value_stores:
 // CHECK:STDOUT:     shared_values:
 // CHECK:STDOUT:       ints:            {}
@@ -112,20 +112,20 @@ fn B() {
 // CHECK:STDOUT:   import_irs:
 // CHECK:STDOUT:     'import_ir(ApiForImpl)': {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     'import_ir(Cpp)':  {decl_id: inst<none>, is_export: false}
-// CHECK:STDOUT:     import_ir50000002: {decl_id: inst50000010, is_export: false}
+// CHECK:STDOUT:     import_ir70000002: {decl_id: inst70000010, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir50000002, inst_id: inst60000010}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir50000002, inst_id: inst60000010}
+// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir70000002, inst_id: inst50000010}
+// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir70000002, inst_id: inst50000010}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name1: inst50000011, name0: inst50000012}}
-// CHECK:STDOUT:     name_scope50000001: {inst: inst50000011, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst50000017}}
+// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name1: inst70000011, name0: inst70000012}}
+// CHECK:STDOUT:     name_scope70000001: {inst: inst70000011, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst70000017}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name50000000: {name: name1, parent_scope: name_scope50000001, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name70000000: {name: name1, parent_scope: name_scope70000001, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function50000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty, body: [inst_block50000006]}
-// CHECK:STDOUT:     function50000001: {name: name1, parent_scope: name_scope50000001, call_param_patterns_id: inst_block_empty}
+// CHECK:STDOUT:     function70000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty, body: [inst_block70000006]}
+// CHECK:STDOUT:     function70000001: {name: name1, parent_scope: name_scope70000001, call_param_patterns_id: inst_block_empty}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   interfaces:      {}
 // CHECK:STDOUT:   associated_constants: {}
@@ -144,64 +144,64 @@ fn B() {
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst50000013)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000014)}
-// CHECK:STDOUT:     'type(inst50000014)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000014)}
+// CHECK:STDOUT:     'type(inst70000013)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst70000014)}
+// CHECK:STDOUT:     'type(inst70000014)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst70000014)}
 // CHECK:STDOUT:     'type(inst(InstType))':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000014)}
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst70000014)}
 // CHECK:STDOUT:   facet_types:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     instF:           {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst50000010:    {kind: ImportDecl, arg0: name1}
-// CHECK:STDOUT:     inst50000011:    {kind: Namespace, arg0: name_scope50000001, arg1: inst50000010, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst50000012:    {kind: FunctionDecl, arg0: function50000000, arg1: inst_block_empty, type: type(inst50000013)}
-// CHECK:STDOUT:     inst50000013:    {kind: FunctionType, arg0: function50000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst50000014:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst50000015:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000013)}
-// CHECK:STDOUT:     inst50000016:    {kind: NameRef, arg0: name1, arg1: inst50000011, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst50000017:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name50000000, type: type(inst50000019)}
-// CHECK:STDOUT:     inst50000018:    {kind: FunctionDecl, arg0: function50000001, arg1: inst_block_empty, type: type(inst50000019)}
-// CHECK:STDOUT:     inst50000019:    {kind: FunctionType, arg0: function50000001, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst5000001A:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000019)}
-// CHECK:STDOUT:     inst5000001B:    {kind: NameRef, arg0: name1, arg1: inst50000017, type: type(inst50000019)}
-// CHECK:STDOUT:     inst5000001C:    {kind: Call, arg0: inst5000001B, arg1: inst_block_empty, type: type(inst50000014)}
-// CHECK:STDOUT:     inst5000001D:    {kind: Return}
+// CHECK:STDOUT:     inst70000010:    {kind: ImportDecl, arg0: name1}
+// CHECK:STDOUT:     inst70000011:    {kind: Namespace, arg0: name_scope70000001, arg1: inst70000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst70000012:    {kind: FunctionDecl, arg0: function70000000, arg1: inst_block_empty, type: type(inst70000013)}
+// CHECK:STDOUT:     inst70000013:    {kind: FunctionType, arg0: function70000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst70000014:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst70000015:    {kind: StructValue, arg0: inst_block_empty, type: type(inst70000013)}
+// CHECK:STDOUT:     inst70000016:    {kind: NameRef, arg0: name1, arg1: inst70000011, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst70000017:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name70000000, type: type(inst70000019)}
+// CHECK:STDOUT:     inst70000018:    {kind: FunctionDecl, arg0: function70000001, arg1: inst_block_empty, type: type(inst70000019)}
+// CHECK:STDOUT:     inst70000019:    {kind: FunctionType, arg0: function70000001, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst7000001A:    {kind: StructValue, arg0: inst_block_empty, type: type(inst70000019)}
+// CHECK:STDOUT:     inst7000001B:    {kind: NameRef, arg0: name1, arg1: inst70000017, type: type(inst70000019)}
+// CHECK:STDOUT:     inst7000001C:    {kind: Call, arg0: inst7000001B, arg1: inst_block_empty, type: type(inst70000014)}
+// CHECK:STDOUT:     inst7000001D:    {kind: Return}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       instF:           concrete_constant(instF)
-// CHECK:STDOUT:       inst50000011:    concrete_constant(inst50000011)
-// CHECK:STDOUT:       inst50000012:    concrete_constant(inst50000015)
-// CHECK:STDOUT:       inst50000013:    concrete_constant(inst50000013)
-// CHECK:STDOUT:       inst50000014:    concrete_constant(inst50000014)
-// CHECK:STDOUT:       inst50000015:    concrete_constant(inst50000015)
-// CHECK:STDOUT:       inst50000016:    concrete_constant(inst50000011)
-// CHECK:STDOUT:       inst50000017:    concrete_constant(inst5000001A)
-// CHECK:STDOUT:       inst50000018:    concrete_constant(inst5000001A)
-// CHECK:STDOUT:       inst50000019:    concrete_constant(inst50000019)
-// CHECK:STDOUT:       inst5000001A:    concrete_constant(inst5000001A)
-// CHECK:STDOUT:       inst5000001B:    concrete_constant(inst5000001A)
+// CHECK:STDOUT:       inst70000011:    concrete_constant(inst70000011)
+// CHECK:STDOUT:       inst70000012:    concrete_constant(inst70000015)
+// CHECK:STDOUT:       inst70000013:    concrete_constant(inst70000013)
+// CHECK:STDOUT:       inst70000014:    concrete_constant(inst70000014)
+// CHECK:STDOUT:       inst70000015:    concrete_constant(inst70000015)
+// CHECK:STDOUT:       inst70000016:    concrete_constant(inst70000011)
+// CHECK:STDOUT:       inst70000017:    concrete_constant(inst7000001A)
+// CHECK:STDOUT:       inst70000018:    concrete_constant(inst7000001A)
+// CHECK:STDOUT:       inst70000019:    concrete_constant(inst70000019)
+// CHECK:STDOUT:       inst7000001A:    concrete_constant(inst7000001A)
+// CHECK:STDOUT:       inst7000001B:    concrete_constant(inst7000001A)
 // CHECK:STDOUT:     symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst50000012
+// CHECK:STDOUT:       0:               inst70000012
 // CHECK:STDOUT:     generated:       {}
 // CHECK:STDOUT:     imports:
-// CHECK:STDOUT:       0:               inst50000011
-// CHECK:STDOUT:       1:               inst50000017
-// CHECK:STDOUT:       2:               inst50000018
+// CHECK:STDOUT:       0:               inst70000011
+// CHECK:STDOUT:       1:               inst70000017
+// CHECK:STDOUT:       2:               inst70000018
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block50000005: {}
-// CHECK:STDOUT:     inst_block50000006:
-// CHECK:STDOUT:       0:               inst50000016
-// CHECK:STDOUT:       1:               inst5000001B
-// CHECK:STDOUT:       2:               inst5000001C
-// CHECK:STDOUT:       3:               inst5000001D
-// CHECK:STDOUT:     inst_block50000007:
+// CHECK:STDOUT:     inst_block70000005: {}
+// CHECK:STDOUT:     inst_block70000006:
+// CHECK:STDOUT:       0:               inst70000016
+// CHECK:STDOUT:       1:               inst7000001B
+// CHECK:STDOUT:       2:               inst7000001C
+// CHECK:STDOUT:       3:               inst7000001D
+// CHECK:STDOUT:     inst_block70000007:
 // CHECK:STDOUT:       0:               instF
-// CHECK:STDOUT:       1:               inst50000010
-// CHECK:STDOUT:       2:               inst50000012
+// CHECK:STDOUT:       1:               inst70000010
+// CHECK:STDOUT:       2:               inst70000012
 // CHECK:STDOUT:   value_stores:
 // CHECK:STDOUT:     shared_values:
 // CHECK:STDOUT:       ints:            {}

--- a/toolchain/check/testdata/basics/raw_sem_ir/multifile_with_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/multifile_with_textual_ir.carbon
@@ -38,11 +38,11 @@ fn B() {
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst60000010}}
+// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst50000010}}
 // CHECK:STDOUT:   entity_names:    {}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty, body: [inst_block60000006]}
+// CHECK:STDOUT:     function50000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty, body: [inst_block50000006]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   interfaces:      {}
 // CHECK:STDOUT:   associated_constants: {}
@@ -61,39 +61,39 @@ fn B() {
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst60000011)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000012)}
-// CHECK:STDOUT:     'type(inst60000012)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000012)}
+// CHECK:STDOUT:     'type(inst50000011)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000012)}
+// CHECK:STDOUT:     'type(inst50000012)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000012)}
 // CHECK:STDOUT:   facet_types:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     instF:           {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000010:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block_empty, type: type(inst60000011)}
-// CHECK:STDOUT:     inst60000011:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000012:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000013:    {kind: StructValue, arg0: inst_block_empty, type: type(inst60000011)}
-// CHECK:STDOUT:     inst60000014:    {kind: Return}
+// CHECK:STDOUT:     inst50000010:    {kind: FunctionDecl, arg0: function50000000, arg1: inst_block_empty, type: type(inst50000011)}
+// CHECK:STDOUT:     inst50000011:    {kind: FunctionType, arg0: function50000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000012:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000013:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000011)}
+// CHECK:STDOUT:     inst50000014:    {kind: Return}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       instF:           concrete_constant(instF)
-// CHECK:STDOUT:       inst60000010:    concrete_constant(inst60000013)
-// CHECK:STDOUT:       inst60000011:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst60000012:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000013:    concrete_constant(inst60000013)
+// CHECK:STDOUT:       inst50000010:    concrete_constant(inst50000013)
+// CHECK:STDOUT:       inst50000011:    concrete_constant(inst50000011)
+// CHECK:STDOUT:       inst50000012:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000013:    concrete_constant(inst50000013)
 // CHECK:STDOUT:     symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst60000010
+// CHECK:STDOUT:       0:               inst50000010
 // CHECK:STDOUT:     generated:       {}
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block60000005: {}
-// CHECK:STDOUT:     inst_block60000006:
-// CHECK:STDOUT:       0:               inst60000014
-// CHECK:STDOUT:     inst_block60000007:
+// CHECK:STDOUT:     inst_block50000005: {}
+// CHECK:STDOUT:     inst_block50000006:
+// CHECK:STDOUT:       0:               inst50000014
+// CHECK:STDOUT:     inst_block50000007:
 // CHECK:STDOUT:       0:               instF
-// CHECK:STDOUT:       1:               inst60000010
+// CHECK:STDOUT:       1:               inst50000010
 // CHECK:STDOUT:   value_stores:
 // CHECK:STDOUT:     shared_values:
 // CHECK:STDOUT:       ints:            {}
@@ -131,20 +131,20 @@ fn B() {
 // CHECK:STDOUT:   import_irs:
 // CHECK:STDOUT:     'import_ir(ApiForImpl)': {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     'import_ir(Cpp)':  {decl_id: inst<none>, is_export: false}
-// CHECK:STDOUT:     import_ir50000002: {decl_id: inst50000010, is_export: false}
+// CHECK:STDOUT:     import_ir70000002: {decl_id: inst70000010, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir50000002, inst_id: inst60000010}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir50000002, inst_id: inst60000010}
+// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir70000002, inst_id: inst50000010}
+// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir70000002, inst_id: inst50000010}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name1: inst50000011, name0: inst50000012}}
-// CHECK:STDOUT:     name_scope50000001: {inst: inst50000011, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst50000017}}
+// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name1: inst70000011, name0: inst70000012}}
+// CHECK:STDOUT:     name_scope70000001: {inst: inst70000011, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name1: inst70000017}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name50000000: {name: name1, parent_scope: name_scope50000001, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name70000000: {name: name1, parent_scope: name_scope70000001, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function50000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty, body: [inst_block50000006]}
-// CHECK:STDOUT:     function50000001: {name: name1, parent_scope: name_scope50000001, call_param_patterns_id: inst_block_empty}
+// CHECK:STDOUT:     function70000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block_empty, call_params_id: inst_block_empty, body: [inst_block70000006]}
+// CHECK:STDOUT:     function70000001: {name: name1, parent_scope: name_scope70000001, call_param_patterns_id: inst_block_empty}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   interfaces:      {}
 // CHECK:STDOUT:   associated_constants: {}
@@ -163,64 +163,64 @@ fn B() {
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst50000013)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000014)}
-// CHECK:STDOUT:     'type(inst50000014)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000014)}
+// CHECK:STDOUT:     'type(inst70000013)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst70000014)}
+// CHECK:STDOUT:     'type(inst70000014)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst70000014)}
 // CHECK:STDOUT:     'type(inst(InstType))':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000014)}
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst70000014)}
 // CHECK:STDOUT:   facet_types:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     instF:           {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst50000010:    {kind: ImportDecl, arg0: name1}
-// CHECK:STDOUT:     inst50000011:    {kind: Namespace, arg0: name_scope50000001, arg1: inst50000010, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst50000012:    {kind: FunctionDecl, arg0: function50000000, arg1: inst_block_empty, type: type(inst50000013)}
-// CHECK:STDOUT:     inst50000013:    {kind: FunctionType, arg0: function50000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst50000014:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst50000015:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000013)}
-// CHECK:STDOUT:     inst50000016:    {kind: NameRef, arg0: name1, arg1: inst50000011, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst50000017:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name50000000, type: type(inst50000019)}
-// CHECK:STDOUT:     inst50000018:    {kind: FunctionDecl, arg0: function50000001, arg1: inst_block_empty, type: type(inst50000019)}
-// CHECK:STDOUT:     inst50000019:    {kind: FunctionType, arg0: function50000001, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst5000001A:    {kind: StructValue, arg0: inst_block_empty, type: type(inst50000019)}
-// CHECK:STDOUT:     inst5000001B:    {kind: NameRef, arg0: name1, arg1: inst50000017, type: type(inst50000019)}
-// CHECK:STDOUT:     inst5000001C:    {kind: Call, arg0: inst5000001B, arg1: inst_block_empty, type: type(inst50000014)}
-// CHECK:STDOUT:     inst5000001D:    {kind: Return}
+// CHECK:STDOUT:     inst70000010:    {kind: ImportDecl, arg0: name1}
+// CHECK:STDOUT:     inst70000011:    {kind: Namespace, arg0: name_scope70000001, arg1: inst70000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst70000012:    {kind: FunctionDecl, arg0: function70000000, arg1: inst_block_empty, type: type(inst70000013)}
+// CHECK:STDOUT:     inst70000013:    {kind: FunctionType, arg0: function70000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst70000014:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst70000015:    {kind: StructValue, arg0: inst_block_empty, type: type(inst70000013)}
+// CHECK:STDOUT:     inst70000016:    {kind: NameRef, arg0: name1, arg1: inst70000011, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst70000017:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name70000000, type: type(inst70000019)}
+// CHECK:STDOUT:     inst70000018:    {kind: FunctionDecl, arg0: function70000001, arg1: inst_block_empty, type: type(inst70000019)}
+// CHECK:STDOUT:     inst70000019:    {kind: FunctionType, arg0: function70000001, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst7000001A:    {kind: StructValue, arg0: inst_block_empty, type: type(inst70000019)}
+// CHECK:STDOUT:     inst7000001B:    {kind: NameRef, arg0: name1, arg1: inst70000017, type: type(inst70000019)}
+// CHECK:STDOUT:     inst7000001C:    {kind: Call, arg0: inst7000001B, arg1: inst_block_empty, type: type(inst70000014)}
+// CHECK:STDOUT:     inst7000001D:    {kind: Return}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       instF:           concrete_constant(instF)
-// CHECK:STDOUT:       inst50000011:    concrete_constant(inst50000011)
-// CHECK:STDOUT:       inst50000012:    concrete_constant(inst50000015)
-// CHECK:STDOUT:       inst50000013:    concrete_constant(inst50000013)
-// CHECK:STDOUT:       inst50000014:    concrete_constant(inst50000014)
-// CHECK:STDOUT:       inst50000015:    concrete_constant(inst50000015)
-// CHECK:STDOUT:       inst50000016:    concrete_constant(inst50000011)
-// CHECK:STDOUT:       inst50000017:    concrete_constant(inst5000001A)
-// CHECK:STDOUT:       inst50000018:    concrete_constant(inst5000001A)
-// CHECK:STDOUT:       inst50000019:    concrete_constant(inst50000019)
-// CHECK:STDOUT:       inst5000001A:    concrete_constant(inst5000001A)
-// CHECK:STDOUT:       inst5000001B:    concrete_constant(inst5000001A)
+// CHECK:STDOUT:       inst70000011:    concrete_constant(inst70000011)
+// CHECK:STDOUT:       inst70000012:    concrete_constant(inst70000015)
+// CHECK:STDOUT:       inst70000013:    concrete_constant(inst70000013)
+// CHECK:STDOUT:       inst70000014:    concrete_constant(inst70000014)
+// CHECK:STDOUT:       inst70000015:    concrete_constant(inst70000015)
+// CHECK:STDOUT:       inst70000016:    concrete_constant(inst70000011)
+// CHECK:STDOUT:       inst70000017:    concrete_constant(inst7000001A)
+// CHECK:STDOUT:       inst70000018:    concrete_constant(inst7000001A)
+// CHECK:STDOUT:       inst70000019:    concrete_constant(inst70000019)
+// CHECK:STDOUT:       inst7000001A:    concrete_constant(inst7000001A)
+// CHECK:STDOUT:       inst7000001B:    concrete_constant(inst7000001A)
 // CHECK:STDOUT:     symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst50000012
+// CHECK:STDOUT:       0:               inst70000012
 // CHECK:STDOUT:     generated:       {}
 // CHECK:STDOUT:     imports:
-// CHECK:STDOUT:       0:               inst50000011
-// CHECK:STDOUT:       1:               inst50000017
-// CHECK:STDOUT:       2:               inst50000018
+// CHECK:STDOUT:       0:               inst70000011
+// CHECK:STDOUT:       1:               inst70000017
+// CHECK:STDOUT:       2:               inst70000018
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block50000005: {}
-// CHECK:STDOUT:     inst_block50000006:
-// CHECK:STDOUT:       0:               inst50000016
-// CHECK:STDOUT:       1:               inst5000001B
-// CHECK:STDOUT:       2:               inst5000001C
-// CHECK:STDOUT:       3:               inst5000001D
-// CHECK:STDOUT:     inst_block50000007:
+// CHECK:STDOUT:     inst_block70000005: {}
+// CHECK:STDOUT:     inst_block70000006:
+// CHECK:STDOUT:       0:               inst70000016
+// CHECK:STDOUT:       1:               inst7000001B
+// CHECK:STDOUT:       2:               inst7000001C
+// CHECK:STDOUT:       3:               inst7000001D
+// CHECK:STDOUT:     inst_block70000007:
 // CHECK:STDOUT:       0:               instF
-// CHECK:STDOUT:       1:               inst50000010
-// CHECK:STDOUT:       2:               inst50000012
+// CHECK:STDOUT:       1:               inst70000010
+// CHECK:STDOUT:       2:               inst70000012
 // CHECK:STDOUT:   value_stores:
 // CHECK:STDOUT:     shared_values:
 // CHECK:STDOUT:       ints:            {}

--- a/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/one_file.carbon
@@ -31,386 +31,386 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:   import_irs:
 // CHECK:STDOUT:     'import_ir(ApiForImpl)': {decl_id: inst<none>, is_export: false}
 // CHECK:STDOUT:     'import_ir(Cpp)':  {decl_id: inst<none>, is_export: false}
-// CHECK:STDOUT:     import_ir60000002: {decl_id: inst60000010, is_export: false}
-// CHECK:STDOUT:     import_ir60000003: {decl_id: inst60000010, is_export: false}
-// CHECK:STDOUT:     import_ir60000004: {decl_id: inst60000010, is_export: false}
-// CHECK:STDOUT:     import_ir60000005: {decl_id: inst60000010, is_export: false}
-// CHECK:STDOUT:     import_ir60000006: {decl_id: inst60000010, is_export: false}
+// CHECK:STDOUT:     import_ir58000002: {decl_id: inst58000010, is_export: false}
+// CHECK:STDOUT:     import_ir58000003: {decl_id: inst58000010, is_export: false}
+// CHECK:STDOUT:     import_ir58000004: {decl_id: inst58000010, is_export: false}
+// CHECK:STDOUT:     import_ir58000005: {decl_id: inst58000010, is_export: false}
+// CHECK:STDOUT:     import_ir58000006: {decl_id: inst58000010, is_export: false}
 // CHECK:STDOUT:   import_ir_insts:
-// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir60000004, inst_id: inst48000010}
-// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir60000004, inst_id: inst48000010}
-// CHECK:STDOUT:     import_ir_inst2: {ir_id: import_ir60000004, inst_id: inst48000015}
-// CHECK:STDOUT:     import_ir_inst3: {ir_id: import_ir60000004, inst_id: inst48000035}
-// CHECK:STDOUT:     import_ir_inst4: {ir_id: import_ir60000004, inst_id: inst4800002D}
-// CHECK:STDOUT:     import_ir_inst5: {ir_id: import_ir60000004, inst_id: inst48000012}
-// CHECK:STDOUT:     import_ir_inst6: {ir_id: import_ir60000004, inst_id: inst4800002D}
-// CHECK:STDOUT:     import_ir_inst7: {ir_id: import_ir60000004, inst_id: inst48000027}
-// CHECK:STDOUT:     import_ir_inst8: {ir_id: import_ir60000004, inst_id: inst48000028}
-// CHECK:STDOUT:     import_ir_inst9: {ir_id: import_ir60000004, inst_id: inst4800001E}
-// CHECK:STDOUT:     import_ir_instA: {ir_id: import_ir60000004, inst_id: inst48000020}
-// CHECK:STDOUT:     import_ir_instB: {ir_id: import_ir60000004, inst_id: inst48000023}
-// CHECK:STDOUT:     import_ir_instC: {ir_id: import_ir60000004, inst_id: inst48000024}
-// CHECK:STDOUT:     import_ir_instD: {ir_id: import_ir60000004, inst_id: inst48000012}
-// CHECK:STDOUT:     import_ir_instE: {ir_id: import_ir60000004, inst_id: inst48000017}
-// CHECK:STDOUT:     import_ir_instF: {ir_id: import_ir60000004, inst_id: inst4800001A}
-// CHECK:STDOUT:     import_ir_inst10: {ir_id: import_ir60000004, inst_id: inst4800001F}
-// CHECK:STDOUT:     import_ir_inst11: {ir_id: import_ir60000004, inst_id: inst48000026}
-// CHECK:STDOUT:     import_ir_inst12: {ir_id: import_ir60000004, inst_id: inst48000031}
-// CHECK:STDOUT:     import_ir_inst13: {ir_id: import_ir60000004, inst_id: inst48000032}
-// CHECK:STDOUT:     import_ir_inst14: {ir_id: import_ir60000004, inst_id: inst48000033}
-// CHECK:STDOUT:     import_ir_inst15: {ir_id: import_ir60000004, inst_id: inst48000012}
-// CHECK:STDOUT:     import_ir_inst16: {ir_id: import_ir60000004, inst_id: inst4800002D}
-// CHECK:STDOUT:     import_ir_inst17: {ir_id: import_ir60000004, inst_id: inst48000072}
-// CHECK:STDOUT:     import_ir_inst18: {ir_id: import_ir60000004, inst_id: inst48000070}
-// CHECK:STDOUT:     import_ir_inst19: {ir_id: import_ir60000004, inst_id: inst48000089}
-// CHECK:STDOUT:     import_ir_inst1A: {ir_id: import_ir60000004, inst_id: inst48000071}
-// CHECK:STDOUT:     import_ir_inst1B: {ir_id: import_ir60000004, inst_id: inst48000089}
-// CHECK:STDOUT:     import_ir_inst1C: {ir_id: import_ir60000004, inst_id: inst48000084}
-// CHECK:STDOUT:     import_ir_inst1D: {ir_id: import_ir60000004, inst_id: inst48000085}
-// CHECK:STDOUT:     import_ir_inst1E: {ir_id: import_ir60000004, inst_id: inst4800007D}
-// CHECK:STDOUT:     import_ir_inst1F: {ir_id: import_ir60000004, inst_id: inst4800007F}
-// CHECK:STDOUT:     import_ir_inst20: {ir_id: import_ir60000004, inst_id: inst48000080}
-// CHECK:STDOUT:     import_ir_inst21: {ir_id: import_ir60000004, inst_id: inst48000081}
-// CHECK:STDOUT:     import_ir_inst22: {ir_id: import_ir60000004, inst_id: inst48000061}
-// CHECK:STDOUT:     import_ir_inst23: {ir_id: import_ir60000004, inst_id: inst48000078}
-// CHECK:STDOUT:     import_ir_inst24: {ir_id: import_ir60000004, inst_id: inst48000079}
-// CHECK:STDOUT:     import_ir_inst25: {ir_id: import_ir60000004, inst_id: inst4800007A}
-// CHECK:STDOUT:     import_ir_inst26: {ir_id: import_ir60000004, inst_id: inst4800007E}
-// CHECK:STDOUT:     import_ir_inst27: {ir_id: import_ir60000004, inst_id: inst48000083}
-// CHECK:STDOUT:     import_ir_inst28: {ir_id: import_ir60000004, inst_id: inst48000093}
-// CHECK:STDOUT:     import_ir_inst29: {ir_id: import_ir60000004, inst_id: inst4800009A}
-// CHECK:STDOUT:     import_ir_inst2A: {ir_id: import_ir60000004, inst_id: inst480000A1}
-// CHECK:STDOUT:     import_ir_inst2B: {ir_id: import_ir60000004, inst_id: inst480000A7}
-// CHECK:STDOUT:     import_ir_inst2C: {ir_id: import_ir60000004, inst_id: inst480000A8}
-// CHECK:STDOUT:     import_ir_inst2D: {ir_id: import_ir60000004, inst_id: inst480000A9}
-// CHECK:STDOUT:     import_ir_inst2E: {ir_id: import_ir60000004, inst_id: inst480000AF}
-// CHECK:STDOUT:     import_ir_inst2F: {ir_id: import_ir60000004, inst_id: inst48000065}
-// CHECK:STDOUT:     import_ir_inst30: {ir_id: import_ir60000004, inst_id: inst4800006B}
-// CHECK:STDOUT:     import_ir_inst31: {ir_id: import_ir60000004, inst_id: inst4800006E}
-// CHECK:STDOUT:     import_ir_inst32: {ir_id: import_ir60000004, inst_id: inst48000061}
-// CHECK:STDOUT:     import_ir_inst33: {ir_id: import_ir60000004, inst_id: inst48000063}
-// CHECK:STDOUT:     import_ir_inst34: {ir_id: import_ir60000004, inst_id: inst48000069}
-// CHECK:STDOUT:     import_ir_inst35: {ir_id: import_ir60000004, inst_id: inst4800006D}
-// CHECK:STDOUT:     import_ir_inst36: {ir_id: import_ir60000004, inst_id: inst48000074}
-// CHECK:STDOUT:     import_ir_inst37: {ir_id: import_ir60000004, inst_id: inst4800008C}
-// CHECK:STDOUT:     import_ir_inst38: {ir_id: import_ir60000004, inst_id: inst4800008D}
-// CHECK:STDOUT:     import_ir_inst39: {ir_id: import_ir60000004, inst_id: inst480000C4}
-// CHECK:STDOUT:     import_ir_inst3A: {ir_id: import_ir60000004, inst_id: inst480000C2}
-// CHECK:STDOUT:     import_ir_inst3B: {ir_id: import_ir60000004, inst_id: inst480000C0}
-// CHECK:STDOUT:     import_ir_inst3C: {ir_id: import_ir60000004, inst_id: inst480000C1}
-// CHECK:STDOUT:     import_ir_inst3D: {ir_id: import_ir60000004, inst_id: inst480000E0}
-// CHECK:STDOUT:     import_ir_inst3E: {ir_id: import_ir60000004, inst_id: inst480000DE}
-// CHECK:STDOUT:     import_ir_inst3F: {ir_id: import_ir60000004, inst_id: inst480000DC}
-// CHECK:STDOUT:     import_ir_inst40: {ir_id: import_ir60000004, inst_id: inst480000DD}
-// CHECK:STDOUT:     import_ir_inst41: {ir_id: import_ir60000004, inst_id: inst480000FC}
-// CHECK:STDOUT:     import_ir_inst42: {ir_id: import_ir60000004, inst_id: inst480000FA}
-// CHECK:STDOUT:     import_ir_inst43: {ir_id: import_ir60000004, inst_id: inst480000F8}
-// CHECK:STDOUT:     import_ir_inst44: {ir_id: import_ir60000004, inst_id: inst480000F9}
-// CHECK:STDOUT:     import_ir_inst45: {ir_id: import_ir60000004, inst_id: inst48000118}
-// CHECK:STDOUT:     import_ir_inst46: {ir_id: import_ir60000004, inst_id: inst48000116}
-// CHECK:STDOUT:     import_ir_inst47: {ir_id: import_ir60000004, inst_id: inst48000114}
-// CHECK:STDOUT:     import_ir_inst48: {ir_id: import_ir60000004, inst_id: inst48000115}
-// CHECK:STDOUT:     import_ir_inst49: {ir_id: import_ir60000004, inst_id: inst4800013B}
-// CHECK:STDOUT:     import_ir_inst4A: {ir_id: import_ir60000004, inst_id: inst48000139}
-// CHECK:STDOUT:     import_ir_inst4B: {ir_id: import_ir60000004, inst_id: inst4800014F}
-// CHECK:STDOUT:     import_ir_inst4C: {ir_id: import_ir60000004, inst_id: inst4800013A}
-// CHECK:STDOUT:     import_ir_inst4D: {ir_id: import_ir60000004, inst_id: inst48000132}
-// CHECK:STDOUT:     import_ir_inst4E: {ir_id: import_ir60000004, inst_id: inst48000134}
-// CHECK:STDOUT:     import_ir_inst4F: {ir_id: import_ir60000004, inst_id: inst48000137}
-// CHECK:STDOUT:     import_ir_inst50: {ir_id: import_ir60000004, inst_id: inst4800012F}
-// CHECK:STDOUT:     import_ir_inst51: {ir_id: import_ir60000004, inst_id: inst48000131}
-// CHECK:STDOUT:     import_ir_inst52: {ir_id: import_ir60000004, inst_id: inst48000136}
-// CHECK:STDOUT:     import_ir_inst53: {ir_id: import_ir60000004, inst_id: inst4800013D}
-// CHECK:STDOUT:     import_ir_inst54: {ir_id: import_ir60000004, inst_id: inst4800014F}
-// CHECK:STDOUT:     import_ir_inst55: {ir_id: import_ir60000004, inst_id: inst4800014A}
-// CHECK:STDOUT:     import_ir_inst56: {ir_id: import_ir60000004, inst_id: inst4800014B}
-// CHECK:STDOUT:     import_ir_inst57: {ir_id: import_ir60000004, inst_id: inst48000143}
-// CHECK:STDOUT:     import_ir_inst58: {ir_id: import_ir60000004, inst_id: inst48000145}
-// CHECK:STDOUT:     import_ir_inst59: {ir_id: import_ir60000004, inst_id: inst48000146}
-// CHECK:STDOUT:     import_ir_inst5A: {ir_id: import_ir60000004, inst_id: inst48000147}
-// CHECK:STDOUT:     import_ir_inst5B: {ir_id: import_ir60000004, inst_id: inst4800012F}
-// CHECK:STDOUT:     import_ir_inst5C: {ir_id: import_ir60000004, inst_id: inst4800013F}
-// CHECK:STDOUT:     import_ir_inst5D: {ir_id: import_ir60000004, inst_id: inst48000140}
-// CHECK:STDOUT:     import_ir_inst5E: {ir_id: import_ir60000004, inst_id: inst48000144}
-// CHECK:STDOUT:     import_ir_inst5F: {ir_id: import_ir60000004, inst_id: inst48000149}
-// CHECK:STDOUT:     import_ir_inst60: {ir_id: import_ir60000004, inst_id: inst48000152}
-// CHECK:STDOUT:     import_ir_inst61: {ir_id: import_ir60000004, inst_id: inst48000153}
-// CHECK:STDOUT:     import_ir_inst62: {ir_id: import_ir60000004, inst_id: inst48000156}
-// CHECK:STDOUT:     import_ir_inst63: {ir_id: import_ir60000004, inst_id: inst4800015E}
-// CHECK:STDOUT:     import_ir_inst64: {ir_id: import_ir60000004, inst_id: inst4800015C}
-// CHECK:STDOUT:     import_ir_inst65: {ir_id: import_ir60000004, inst_id: inst4800015A}
-// CHECK:STDOUT:     import_ir_inst66: {ir_id: import_ir60000004, inst_id: inst4800015B}
-// CHECK:STDOUT:     import_ir_inst67: {ir_id: import_ir60000004, inst_id: inst48000177}
-// CHECK:STDOUT:     import_ir_inst68: {ir_id: import_ir60000004, inst_id: inst48000175}
-// CHECK:STDOUT:     import_ir_inst69: {ir_id: import_ir60000004, inst_id: inst48000173}
-// CHECK:STDOUT:     import_ir_inst6A: {ir_id: import_ir60000004, inst_id: inst48000174}
-// CHECK:STDOUT:     import_ir_inst6B: {ir_id: import_ir60000004, inst_id: inst480001AD}
-// CHECK:STDOUT:     import_ir_inst6C: {ir_id: import_ir60000004, inst_id: inst480001AB}
-// CHECK:STDOUT:     import_ir_inst6D: {ir_id: import_ir60000004, inst_id: inst480001C8}
-// CHECK:STDOUT:     import_ir_inst6E: {ir_id: import_ir60000004, inst_id: inst480001AC}
-// CHECK:STDOUT:     import_ir_inst6F: {ir_id: import_ir60000004, inst_id: inst480001C8}
-// CHECK:STDOUT:     import_ir_inst70: {ir_id: import_ir60000004, inst_id: inst480001C3}
-// CHECK:STDOUT:     import_ir_inst71: {ir_id: import_ir60000004, inst_id: inst480001C4}
-// CHECK:STDOUT:     import_ir_inst72: {ir_id: import_ir60000004, inst_id: inst480001BC}
-// CHECK:STDOUT:     import_ir_inst73: {ir_id: import_ir60000004, inst_id: inst480001BE}
-// CHECK:STDOUT:     import_ir_inst74: {ir_id: import_ir60000004, inst_id: inst480001BF}
-// CHECK:STDOUT:     import_ir_inst75: {ir_id: import_ir60000004, inst_id: inst480001C0}
-// CHECK:STDOUT:     import_ir_inst76: {ir_id: import_ir60000004, inst_id: inst4800018E}
-// CHECK:STDOUT:     import_ir_inst77: {ir_id: import_ir60000004, inst_id: inst48000193}
-// CHECK:STDOUT:     import_ir_inst78: {ir_id: import_ir60000004, inst_id: inst480001B5}
-// CHECK:STDOUT:     import_ir_inst79: {ir_id: import_ir60000004, inst_id: inst480001B6}
-// CHECK:STDOUT:     import_ir_inst7A: {ir_id: import_ir60000004, inst_id: inst480001B7}
-// CHECK:STDOUT:     import_ir_inst7B: {ir_id: import_ir60000004, inst_id: inst480001B8}
-// CHECK:STDOUT:     import_ir_inst7C: {ir_id: import_ir60000004, inst_id: inst480001B9}
-// CHECK:STDOUT:     import_ir_inst7D: {ir_id: import_ir60000004, inst_id: inst480001BD}
-// CHECK:STDOUT:     import_ir_inst7E: {ir_id: import_ir60000004, inst_id: inst480001C2}
-// CHECK:STDOUT:     import_ir_inst7F: {ir_id: import_ir60000004, inst_id: inst480001D3}
-// CHECK:STDOUT:     import_ir_inst80: {ir_id: import_ir60000004, inst_id: inst480001DA}
-// CHECK:STDOUT:     import_ir_inst81: {ir_id: import_ir60000004, inst_id: inst480001DE}
-// CHECK:STDOUT:     import_ir_inst82: {ir_id: import_ir60000004, inst_id: inst480001E0}
-// CHECK:STDOUT:     import_ir_inst83: {ir_id: import_ir60000004, inst_id: inst480001E1}
-// CHECK:STDOUT:     import_ir_inst84: {ir_id: import_ir60000004, inst_id: inst480001E2}
-// CHECK:STDOUT:     import_ir_inst85: {ir_id: import_ir60000004, inst_id: inst480001E5}
-// CHECK:STDOUT:     import_ir_inst86: {ir_id: import_ir60000004, inst_id: inst480001F1}
-// CHECK:STDOUT:     import_ir_inst87: {ir_id: import_ir60000004, inst_id: inst480001F8}
-// CHECK:STDOUT:     import_ir_inst88: {ir_id: import_ir60000004, inst_id: inst480001FC}
-// CHECK:STDOUT:     import_ir_inst89: {ir_id: import_ir60000004, inst_id: inst480001FD}
-// CHECK:STDOUT:     import_ir_inst8A: {ir_id: import_ir60000004, inst_id: inst480001FE}
-// CHECK:STDOUT:     import_ir_inst8B: {ir_id: import_ir60000004, inst_id: inst48000204}
-// CHECK:STDOUT:     import_ir_inst8C: {ir_id: import_ir60000004, inst_id: inst48000196}
-// CHECK:STDOUT:     import_ir_inst8D: {ir_id: import_ir60000004, inst_id: inst48000190}
-// CHECK:STDOUT:     import_ir_inst8E: {ir_id: import_ir60000004, inst_id: inst480001A6}
-// CHECK:STDOUT:     import_ir_inst8F: {ir_id: import_ir60000004, inst_id: inst480001A8}
-// CHECK:STDOUT:     import_ir_inst90: {ir_id: import_ir60000004, inst_id: inst4800018E}
-// CHECK:STDOUT:     import_ir_inst91: {ir_id: import_ir60000004, inst_id: inst48000193}
-// CHECK:STDOUT:     import_ir_inst92: {ir_id: import_ir60000004, inst_id: inst4800018F}
-// CHECK:STDOUT:     import_ir_inst93: {ir_id: import_ir60000004, inst_id: inst48000195}
-// CHECK:STDOUT:     import_ir_inst94: {ir_id: import_ir60000004, inst_id: inst4800019C}
-// CHECK:STDOUT:     import_ir_inst95: {ir_id: import_ir60000004, inst_id: inst4800019F}
-// CHECK:STDOUT:     import_ir_inst96: {ir_id: import_ir60000004, inst_id: inst480001A3}
-// CHECK:STDOUT:     import_ir_inst97: {ir_id: import_ir60000004, inst_id: inst480001A7}
-// CHECK:STDOUT:     import_ir_inst98: {ir_id: import_ir60000004, inst_id: inst480001AF}
-// CHECK:STDOUT:     import_ir_inst99: {ir_id: import_ir60000004, inst_id: inst480001CB}
-// CHECK:STDOUT:     import_ir_inst9A: {ir_id: import_ir60000004, inst_id: inst480001CC}
-// CHECK:STDOUT:     import_ir_inst9B: {ir_id: import_ir60000004, inst_id: inst4800023F}
-// CHECK:STDOUT:     import_ir_inst9C: {ir_id: import_ir60000004, inst_id: inst4800023D}
-// CHECK:STDOUT:     import_ir_inst9D: {ir_id: import_ir60000004, inst_id: inst4800025E}
-// CHECK:STDOUT:     import_ir_inst9E: {ir_id: import_ir60000004, inst_id: inst4800023E}
-// CHECK:STDOUT:     import_ir_inst9F: {ir_id: import_ir60000004, inst_id: inst4800025E}
-// CHECK:STDOUT:     import_ir_instA0: {ir_id: import_ir60000004, inst_id: inst48000259}
-// CHECK:STDOUT:     import_ir_instA1: {ir_id: import_ir60000004, inst_id: inst4800025A}
-// CHECK:STDOUT:     import_ir_instA2: {ir_id: import_ir60000004, inst_id: inst48000252}
-// CHECK:STDOUT:     import_ir_instA3: {ir_id: import_ir60000004, inst_id: inst48000254}
-// CHECK:STDOUT:     import_ir_instA4: {ir_id: import_ir60000004, inst_id: inst48000255}
-// CHECK:STDOUT:     import_ir_instA5: {ir_id: import_ir60000004, inst_id: inst48000256}
-// CHECK:STDOUT:     import_ir_instA6: {ir_id: import_ir60000004, inst_id: inst48000216}
-// CHECK:STDOUT:     import_ir_instA7: {ir_id: import_ir60000004, inst_id: inst4800021B}
-// CHECK:STDOUT:     import_ir_instA8: {ir_id: import_ir60000004, inst_id: inst48000220}
-// CHECK:STDOUT:     import_ir_instA9: {ir_id: import_ir60000004, inst_id: inst48000249}
-// CHECK:STDOUT:     import_ir_instAA: {ir_id: import_ir60000004, inst_id: inst4800024A}
-// CHECK:STDOUT:     import_ir_instAB: {ir_id: import_ir60000004, inst_id: inst4800024B}
-// CHECK:STDOUT:     import_ir_instAC: {ir_id: import_ir60000004, inst_id: inst4800024C}
-// CHECK:STDOUT:     import_ir_instAD: {ir_id: import_ir60000004, inst_id: inst4800024D}
-// CHECK:STDOUT:     import_ir_instAE: {ir_id: import_ir60000004, inst_id: inst4800024E}
-// CHECK:STDOUT:     import_ir_instAF: {ir_id: import_ir60000004, inst_id: inst4800024F}
-// CHECK:STDOUT:     import_ir_instB0: {ir_id: import_ir60000004, inst_id: inst48000253}
-// CHECK:STDOUT:     import_ir_instB1: {ir_id: import_ir60000004, inst_id: inst48000258}
-// CHECK:STDOUT:     import_ir_instB2: {ir_id: import_ir60000004, inst_id: inst48000269}
-// CHECK:STDOUT:     import_ir_instB3: {ir_id: import_ir60000004, inst_id: inst4800026F}
-// CHECK:STDOUT:     import_ir_instB4: {ir_id: import_ir60000004, inst_id: inst48000273}
-// CHECK:STDOUT:     import_ir_instB5: {ir_id: import_ir60000004, inst_id: inst48000275}
-// CHECK:STDOUT:     import_ir_instB6: {ir_id: import_ir60000004, inst_id: inst48000276}
-// CHECK:STDOUT:     import_ir_instB7: {ir_id: import_ir60000004, inst_id: inst48000277}
-// CHECK:STDOUT:     import_ir_instB8: {ir_id: import_ir60000004, inst_id: inst4800027A}
-// CHECK:STDOUT:     import_ir_instB9: {ir_id: import_ir60000004, inst_id: inst48000284}
-// CHECK:STDOUT:     import_ir_instBA: {ir_id: import_ir60000004, inst_id: inst48000288}
-// CHECK:STDOUT:     import_ir_instBB: {ir_id: import_ir60000004, inst_id: inst4800028A}
-// CHECK:STDOUT:     import_ir_instBC: {ir_id: import_ir60000004, inst_id: inst4800028B}
-// CHECK:STDOUT:     import_ir_instBD: {ir_id: import_ir60000004, inst_id: inst4800028C}
-// CHECK:STDOUT:     import_ir_instBE: {ir_id: import_ir60000004, inst_id: inst4800028F}
-// CHECK:STDOUT:     import_ir_instBF: {ir_id: import_ir60000004, inst_id: inst4800029B}
-// CHECK:STDOUT:     import_ir_instC0: {ir_id: import_ir60000004, inst_id: inst480002A2}
-// CHECK:STDOUT:     import_ir_instC1: {ir_id: import_ir60000004, inst_id: inst480002A6}
-// CHECK:STDOUT:     import_ir_instC2: {ir_id: import_ir60000004, inst_id: inst480002A7}
-// CHECK:STDOUT:     import_ir_instC3: {ir_id: import_ir60000004, inst_id: inst480002A8}
-// CHECK:STDOUT:     import_ir_instC4: {ir_id: import_ir60000004, inst_id: inst480002AE}
-// CHECK:STDOUT:     import_ir_instC5: {ir_id: import_ir60000004, inst_id: inst48000223}
-// CHECK:STDOUT:     import_ir_instC6: {ir_id: import_ir60000004, inst_id: inst4800021D}
-// CHECK:STDOUT:     import_ir_instC7: {ir_id: import_ir60000004, inst_id: inst48000218}
-// CHECK:STDOUT:     import_ir_instC8: {ir_id: import_ir60000004, inst_id: inst48000237}
-// CHECK:STDOUT:     import_ir_instC9: {ir_id: import_ir60000004, inst_id: inst48000239}
-// CHECK:STDOUT:     import_ir_instCA: {ir_id: import_ir60000004, inst_id: inst48000216}
-// CHECK:STDOUT:     import_ir_instCB: {ir_id: import_ir60000004, inst_id: inst4800021B}
-// CHECK:STDOUT:     import_ir_instCC: {ir_id: import_ir60000004, inst_id: inst48000220}
-// CHECK:STDOUT:     import_ir_instCD: {ir_id: import_ir60000004, inst_id: inst48000217}
-// CHECK:STDOUT:     import_ir_instCE: {ir_id: import_ir60000004, inst_id: inst4800021C}
-// CHECK:STDOUT:     import_ir_instCF: {ir_id: import_ir60000004, inst_id: inst48000222}
-// CHECK:STDOUT:     import_ir_instD0: {ir_id: import_ir60000004, inst_id: inst4800022A}
-// CHECK:STDOUT:     import_ir_instD1: {ir_id: import_ir60000004, inst_id: inst4800022D}
-// CHECK:STDOUT:     import_ir_instD2: {ir_id: import_ir60000004, inst_id: inst48000230}
-// CHECK:STDOUT:     import_ir_instD3: {ir_id: import_ir60000004, inst_id: inst48000234}
-// CHECK:STDOUT:     import_ir_instD4: {ir_id: import_ir60000004, inst_id: inst48000238}
-// CHECK:STDOUT:     import_ir_instD5: {ir_id: import_ir60000004, inst_id: inst48000241}
-// CHECK:STDOUT:     import_ir_instD6: {ir_id: import_ir60000004, inst_id: inst48000261}
-// CHECK:STDOUT:     import_ir_instD7: {ir_id: import_ir60000004, inst_id: inst48000262}
+// CHECK:STDOUT:     import_ir_inst0: {ir_id: import_ir58000004, inst_id: inst70000010}
+// CHECK:STDOUT:     import_ir_inst1: {ir_id: import_ir58000004, inst_id: inst70000010}
+// CHECK:STDOUT:     import_ir_inst2: {ir_id: import_ir58000004, inst_id: inst70000015}
+// CHECK:STDOUT:     import_ir_inst3: {ir_id: import_ir58000004, inst_id: inst70000035}
+// CHECK:STDOUT:     import_ir_inst4: {ir_id: import_ir58000004, inst_id: inst7000002D}
+// CHECK:STDOUT:     import_ir_inst5: {ir_id: import_ir58000004, inst_id: inst70000012}
+// CHECK:STDOUT:     import_ir_inst6: {ir_id: import_ir58000004, inst_id: inst7000002D}
+// CHECK:STDOUT:     import_ir_inst7: {ir_id: import_ir58000004, inst_id: inst70000027}
+// CHECK:STDOUT:     import_ir_inst8: {ir_id: import_ir58000004, inst_id: inst70000028}
+// CHECK:STDOUT:     import_ir_inst9: {ir_id: import_ir58000004, inst_id: inst7000001E}
+// CHECK:STDOUT:     import_ir_instA: {ir_id: import_ir58000004, inst_id: inst70000020}
+// CHECK:STDOUT:     import_ir_instB: {ir_id: import_ir58000004, inst_id: inst70000023}
+// CHECK:STDOUT:     import_ir_instC: {ir_id: import_ir58000004, inst_id: inst70000024}
+// CHECK:STDOUT:     import_ir_instD: {ir_id: import_ir58000004, inst_id: inst70000012}
+// CHECK:STDOUT:     import_ir_instE: {ir_id: import_ir58000004, inst_id: inst70000017}
+// CHECK:STDOUT:     import_ir_instF: {ir_id: import_ir58000004, inst_id: inst7000001A}
+// CHECK:STDOUT:     import_ir_inst10: {ir_id: import_ir58000004, inst_id: inst7000001F}
+// CHECK:STDOUT:     import_ir_inst11: {ir_id: import_ir58000004, inst_id: inst70000026}
+// CHECK:STDOUT:     import_ir_inst12: {ir_id: import_ir58000004, inst_id: inst70000031}
+// CHECK:STDOUT:     import_ir_inst13: {ir_id: import_ir58000004, inst_id: inst70000032}
+// CHECK:STDOUT:     import_ir_inst14: {ir_id: import_ir58000004, inst_id: inst70000033}
+// CHECK:STDOUT:     import_ir_inst15: {ir_id: import_ir58000004, inst_id: inst70000012}
+// CHECK:STDOUT:     import_ir_inst16: {ir_id: import_ir58000004, inst_id: inst7000002D}
+// CHECK:STDOUT:     import_ir_inst17: {ir_id: import_ir58000004, inst_id: inst70000072}
+// CHECK:STDOUT:     import_ir_inst18: {ir_id: import_ir58000004, inst_id: inst70000070}
+// CHECK:STDOUT:     import_ir_inst19: {ir_id: import_ir58000004, inst_id: inst70000089}
+// CHECK:STDOUT:     import_ir_inst1A: {ir_id: import_ir58000004, inst_id: inst70000071}
+// CHECK:STDOUT:     import_ir_inst1B: {ir_id: import_ir58000004, inst_id: inst70000089}
+// CHECK:STDOUT:     import_ir_inst1C: {ir_id: import_ir58000004, inst_id: inst70000084}
+// CHECK:STDOUT:     import_ir_inst1D: {ir_id: import_ir58000004, inst_id: inst70000085}
+// CHECK:STDOUT:     import_ir_inst1E: {ir_id: import_ir58000004, inst_id: inst7000007D}
+// CHECK:STDOUT:     import_ir_inst1F: {ir_id: import_ir58000004, inst_id: inst7000007F}
+// CHECK:STDOUT:     import_ir_inst20: {ir_id: import_ir58000004, inst_id: inst70000080}
+// CHECK:STDOUT:     import_ir_inst21: {ir_id: import_ir58000004, inst_id: inst70000081}
+// CHECK:STDOUT:     import_ir_inst22: {ir_id: import_ir58000004, inst_id: inst70000061}
+// CHECK:STDOUT:     import_ir_inst23: {ir_id: import_ir58000004, inst_id: inst70000078}
+// CHECK:STDOUT:     import_ir_inst24: {ir_id: import_ir58000004, inst_id: inst70000079}
+// CHECK:STDOUT:     import_ir_inst25: {ir_id: import_ir58000004, inst_id: inst7000007A}
+// CHECK:STDOUT:     import_ir_inst26: {ir_id: import_ir58000004, inst_id: inst7000007E}
+// CHECK:STDOUT:     import_ir_inst27: {ir_id: import_ir58000004, inst_id: inst70000083}
+// CHECK:STDOUT:     import_ir_inst28: {ir_id: import_ir58000004, inst_id: inst70000093}
+// CHECK:STDOUT:     import_ir_inst29: {ir_id: import_ir58000004, inst_id: inst7000009A}
+// CHECK:STDOUT:     import_ir_inst2A: {ir_id: import_ir58000004, inst_id: inst700000A1}
+// CHECK:STDOUT:     import_ir_inst2B: {ir_id: import_ir58000004, inst_id: inst700000A7}
+// CHECK:STDOUT:     import_ir_inst2C: {ir_id: import_ir58000004, inst_id: inst700000A8}
+// CHECK:STDOUT:     import_ir_inst2D: {ir_id: import_ir58000004, inst_id: inst700000A9}
+// CHECK:STDOUT:     import_ir_inst2E: {ir_id: import_ir58000004, inst_id: inst700000AF}
+// CHECK:STDOUT:     import_ir_inst2F: {ir_id: import_ir58000004, inst_id: inst70000065}
+// CHECK:STDOUT:     import_ir_inst30: {ir_id: import_ir58000004, inst_id: inst7000006B}
+// CHECK:STDOUT:     import_ir_inst31: {ir_id: import_ir58000004, inst_id: inst7000006E}
+// CHECK:STDOUT:     import_ir_inst32: {ir_id: import_ir58000004, inst_id: inst70000061}
+// CHECK:STDOUT:     import_ir_inst33: {ir_id: import_ir58000004, inst_id: inst70000063}
+// CHECK:STDOUT:     import_ir_inst34: {ir_id: import_ir58000004, inst_id: inst70000069}
+// CHECK:STDOUT:     import_ir_inst35: {ir_id: import_ir58000004, inst_id: inst7000006D}
+// CHECK:STDOUT:     import_ir_inst36: {ir_id: import_ir58000004, inst_id: inst70000074}
+// CHECK:STDOUT:     import_ir_inst37: {ir_id: import_ir58000004, inst_id: inst7000008C}
+// CHECK:STDOUT:     import_ir_inst38: {ir_id: import_ir58000004, inst_id: inst7000008D}
+// CHECK:STDOUT:     import_ir_inst39: {ir_id: import_ir58000004, inst_id: inst700000C4}
+// CHECK:STDOUT:     import_ir_inst3A: {ir_id: import_ir58000004, inst_id: inst700000C2}
+// CHECK:STDOUT:     import_ir_inst3B: {ir_id: import_ir58000004, inst_id: inst700000C0}
+// CHECK:STDOUT:     import_ir_inst3C: {ir_id: import_ir58000004, inst_id: inst700000C1}
+// CHECK:STDOUT:     import_ir_inst3D: {ir_id: import_ir58000004, inst_id: inst700000E0}
+// CHECK:STDOUT:     import_ir_inst3E: {ir_id: import_ir58000004, inst_id: inst700000DE}
+// CHECK:STDOUT:     import_ir_inst3F: {ir_id: import_ir58000004, inst_id: inst700000DC}
+// CHECK:STDOUT:     import_ir_inst40: {ir_id: import_ir58000004, inst_id: inst700000DD}
+// CHECK:STDOUT:     import_ir_inst41: {ir_id: import_ir58000004, inst_id: inst700000FC}
+// CHECK:STDOUT:     import_ir_inst42: {ir_id: import_ir58000004, inst_id: inst700000FA}
+// CHECK:STDOUT:     import_ir_inst43: {ir_id: import_ir58000004, inst_id: inst700000F8}
+// CHECK:STDOUT:     import_ir_inst44: {ir_id: import_ir58000004, inst_id: inst700000F9}
+// CHECK:STDOUT:     import_ir_inst45: {ir_id: import_ir58000004, inst_id: inst70000118}
+// CHECK:STDOUT:     import_ir_inst46: {ir_id: import_ir58000004, inst_id: inst70000116}
+// CHECK:STDOUT:     import_ir_inst47: {ir_id: import_ir58000004, inst_id: inst70000114}
+// CHECK:STDOUT:     import_ir_inst48: {ir_id: import_ir58000004, inst_id: inst70000115}
+// CHECK:STDOUT:     import_ir_inst49: {ir_id: import_ir58000004, inst_id: inst7000013B}
+// CHECK:STDOUT:     import_ir_inst4A: {ir_id: import_ir58000004, inst_id: inst70000139}
+// CHECK:STDOUT:     import_ir_inst4B: {ir_id: import_ir58000004, inst_id: inst7000014F}
+// CHECK:STDOUT:     import_ir_inst4C: {ir_id: import_ir58000004, inst_id: inst7000013A}
+// CHECK:STDOUT:     import_ir_inst4D: {ir_id: import_ir58000004, inst_id: inst70000132}
+// CHECK:STDOUT:     import_ir_inst4E: {ir_id: import_ir58000004, inst_id: inst70000134}
+// CHECK:STDOUT:     import_ir_inst4F: {ir_id: import_ir58000004, inst_id: inst70000137}
+// CHECK:STDOUT:     import_ir_inst50: {ir_id: import_ir58000004, inst_id: inst7000012F}
+// CHECK:STDOUT:     import_ir_inst51: {ir_id: import_ir58000004, inst_id: inst70000131}
+// CHECK:STDOUT:     import_ir_inst52: {ir_id: import_ir58000004, inst_id: inst70000136}
+// CHECK:STDOUT:     import_ir_inst53: {ir_id: import_ir58000004, inst_id: inst7000013D}
+// CHECK:STDOUT:     import_ir_inst54: {ir_id: import_ir58000004, inst_id: inst7000014F}
+// CHECK:STDOUT:     import_ir_inst55: {ir_id: import_ir58000004, inst_id: inst7000014A}
+// CHECK:STDOUT:     import_ir_inst56: {ir_id: import_ir58000004, inst_id: inst7000014B}
+// CHECK:STDOUT:     import_ir_inst57: {ir_id: import_ir58000004, inst_id: inst70000143}
+// CHECK:STDOUT:     import_ir_inst58: {ir_id: import_ir58000004, inst_id: inst70000145}
+// CHECK:STDOUT:     import_ir_inst59: {ir_id: import_ir58000004, inst_id: inst70000146}
+// CHECK:STDOUT:     import_ir_inst5A: {ir_id: import_ir58000004, inst_id: inst70000147}
+// CHECK:STDOUT:     import_ir_inst5B: {ir_id: import_ir58000004, inst_id: inst7000012F}
+// CHECK:STDOUT:     import_ir_inst5C: {ir_id: import_ir58000004, inst_id: inst7000013F}
+// CHECK:STDOUT:     import_ir_inst5D: {ir_id: import_ir58000004, inst_id: inst70000140}
+// CHECK:STDOUT:     import_ir_inst5E: {ir_id: import_ir58000004, inst_id: inst70000144}
+// CHECK:STDOUT:     import_ir_inst5F: {ir_id: import_ir58000004, inst_id: inst70000149}
+// CHECK:STDOUT:     import_ir_inst60: {ir_id: import_ir58000004, inst_id: inst70000152}
+// CHECK:STDOUT:     import_ir_inst61: {ir_id: import_ir58000004, inst_id: inst70000153}
+// CHECK:STDOUT:     import_ir_inst62: {ir_id: import_ir58000004, inst_id: inst70000156}
+// CHECK:STDOUT:     import_ir_inst63: {ir_id: import_ir58000004, inst_id: inst7000015E}
+// CHECK:STDOUT:     import_ir_inst64: {ir_id: import_ir58000004, inst_id: inst7000015C}
+// CHECK:STDOUT:     import_ir_inst65: {ir_id: import_ir58000004, inst_id: inst7000015A}
+// CHECK:STDOUT:     import_ir_inst66: {ir_id: import_ir58000004, inst_id: inst7000015B}
+// CHECK:STDOUT:     import_ir_inst67: {ir_id: import_ir58000004, inst_id: inst70000177}
+// CHECK:STDOUT:     import_ir_inst68: {ir_id: import_ir58000004, inst_id: inst70000175}
+// CHECK:STDOUT:     import_ir_inst69: {ir_id: import_ir58000004, inst_id: inst70000173}
+// CHECK:STDOUT:     import_ir_inst6A: {ir_id: import_ir58000004, inst_id: inst70000174}
+// CHECK:STDOUT:     import_ir_inst6B: {ir_id: import_ir58000004, inst_id: inst700001AD}
+// CHECK:STDOUT:     import_ir_inst6C: {ir_id: import_ir58000004, inst_id: inst700001AB}
+// CHECK:STDOUT:     import_ir_inst6D: {ir_id: import_ir58000004, inst_id: inst700001C8}
+// CHECK:STDOUT:     import_ir_inst6E: {ir_id: import_ir58000004, inst_id: inst700001AC}
+// CHECK:STDOUT:     import_ir_inst6F: {ir_id: import_ir58000004, inst_id: inst700001C8}
+// CHECK:STDOUT:     import_ir_inst70: {ir_id: import_ir58000004, inst_id: inst700001C3}
+// CHECK:STDOUT:     import_ir_inst71: {ir_id: import_ir58000004, inst_id: inst700001C4}
+// CHECK:STDOUT:     import_ir_inst72: {ir_id: import_ir58000004, inst_id: inst700001BC}
+// CHECK:STDOUT:     import_ir_inst73: {ir_id: import_ir58000004, inst_id: inst700001BE}
+// CHECK:STDOUT:     import_ir_inst74: {ir_id: import_ir58000004, inst_id: inst700001BF}
+// CHECK:STDOUT:     import_ir_inst75: {ir_id: import_ir58000004, inst_id: inst700001C0}
+// CHECK:STDOUT:     import_ir_inst76: {ir_id: import_ir58000004, inst_id: inst7000018E}
+// CHECK:STDOUT:     import_ir_inst77: {ir_id: import_ir58000004, inst_id: inst70000193}
+// CHECK:STDOUT:     import_ir_inst78: {ir_id: import_ir58000004, inst_id: inst700001B5}
+// CHECK:STDOUT:     import_ir_inst79: {ir_id: import_ir58000004, inst_id: inst700001B6}
+// CHECK:STDOUT:     import_ir_inst7A: {ir_id: import_ir58000004, inst_id: inst700001B7}
+// CHECK:STDOUT:     import_ir_inst7B: {ir_id: import_ir58000004, inst_id: inst700001B8}
+// CHECK:STDOUT:     import_ir_inst7C: {ir_id: import_ir58000004, inst_id: inst700001B9}
+// CHECK:STDOUT:     import_ir_inst7D: {ir_id: import_ir58000004, inst_id: inst700001BD}
+// CHECK:STDOUT:     import_ir_inst7E: {ir_id: import_ir58000004, inst_id: inst700001C2}
+// CHECK:STDOUT:     import_ir_inst7F: {ir_id: import_ir58000004, inst_id: inst700001D3}
+// CHECK:STDOUT:     import_ir_inst80: {ir_id: import_ir58000004, inst_id: inst700001DA}
+// CHECK:STDOUT:     import_ir_inst81: {ir_id: import_ir58000004, inst_id: inst700001DE}
+// CHECK:STDOUT:     import_ir_inst82: {ir_id: import_ir58000004, inst_id: inst700001E0}
+// CHECK:STDOUT:     import_ir_inst83: {ir_id: import_ir58000004, inst_id: inst700001E1}
+// CHECK:STDOUT:     import_ir_inst84: {ir_id: import_ir58000004, inst_id: inst700001E2}
+// CHECK:STDOUT:     import_ir_inst85: {ir_id: import_ir58000004, inst_id: inst700001E5}
+// CHECK:STDOUT:     import_ir_inst86: {ir_id: import_ir58000004, inst_id: inst700001F1}
+// CHECK:STDOUT:     import_ir_inst87: {ir_id: import_ir58000004, inst_id: inst700001F8}
+// CHECK:STDOUT:     import_ir_inst88: {ir_id: import_ir58000004, inst_id: inst700001FC}
+// CHECK:STDOUT:     import_ir_inst89: {ir_id: import_ir58000004, inst_id: inst700001FD}
+// CHECK:STDOUT:     import_ir_inst8A: {ir_id: import_ir58000004, inst_id: inst700001FE}
+// CHECK:STDOUT:     import_ir_inst8B: {ir_id: import_ir58000004, inst_id: inst70000204}
+// CHECK:STDOUT:     import_ir_inst8C: {ir_id: import_ir58000004, inst_id: inst70000196}
+// CHECK:STDOUT:     import_ir_inst8D: {ir_id: import_ir58000004, inst_id: inst70000190}
+// CHECK:STDOUT:     import_ir_inst8E: {ir_id: import_ir58000004, inst_id: inst700001A6}
+// CHECK:STDOUT:     import_ir_inst8F: {ir_id: import_ir58000004, inst_id: inst700001A8}
+// CHECK:STDOUT:     import_ir_inst90: {ir_id: import_ir58000004, inst_id: inst7000018E}
+// CHECK:STDOUT:     import_ir_inst91: {ir_id: import_ir58000004, inst_id: inst70000193}
+// CHECK:STDOUT:     import_ir_inst92: {ir_id: import_ir58000004, inst_id: inst7000018F}
+// CHECK:STDOUT:     import_ir_inst93: {ir_id: import_ir58000004, inst_id: inst70000195}
+// CHECK:STDOUT:     import_ir_inst94: {ir_id: import_ir58000004, inst_id: inst7000019C}
+// CHECK:STDOUT:     import_ir_inst95: {ir_id: import_ir58000004, inst_id: inst7000019F}
+// CHECK:STDOUT:     import_ir_inst96: {ir_id: import_ir58000004, inst_id: inst700001A3}
+// CHECK:STDOUT:     import_ir_inst97: {ir_id: import_ir58000004, inst_id: inst700001A7}
+// CHECK:STDOUT:     import_ir_inst98: {ir_id: import_ir58000004, inst_id: inst700001AF}
+// CHECK:STDOUT:     import_ir_inst99: {ir_id: import_ir58000004, inst_id: inst700001CB}
+// CHECK:STDOUT:     import_ir_inst9A: {ir_id: import_ir58000004, inst_id: inst700001CC}
+// CHECK:STDOUT:     import_ir_inst9B: {ir_id: import_ir58000004, inst_id: inst7000023F}
+// CHECK:STDOUT:     import_ir_inst9C: {ir_id: import_ir58000004, inst_id: inst7000023D}
+// CHECK:STDOUT:     import_ir_inst9D: {ir_id: import_ir58000004, inst_id: inst7000025E}
+// CHECK:STDOUT:     import_ir_inst9E: {ir_id: import_ir58000004, inst_id: inst7000023E}
+// CHECK:STDOUT:     import_ir_inst9F: {ir_id: import_ir58000004, inst_id: inst7000025E}
+// CHECK:STDOUT:     import_ir_instA0: {ir_id: import_ir58000004, inst_id: inst70000259}
+// CHECK:STDOUT:     import_ir_instA1: {ir_id: import_ir58000004, inst_id: inst7000025A}
+// CHECK:STDOUT:     import_ir_instA2: {ir_id: import_ir58000004, inst_id: inst70000252}
+// CHECK:STDOUT:     import_ir_instA3: {ir_id: import_ir58000004, inst_id: inst70000254}
+// CHECK:STDOUT:     import_ir_instA4: {ir_id: import_ir58000004, inst_id: inst70000255}
+// CHECK:STDOUT:     import_ir_instA5: {ir_id: import_ir58000004, inst_id: inst70000256}
+// CHECK:STDOUT:     import_ir_instA6: {ir_id: import_ir58000004, inst_id: inst70000216}
+// CHECK:STDOUT:     import_ir_instA7: {ir_id: import_ir58000004, inst_id: inst7000021B}
+// CHECK:STDOUT:     import_ir_instA8: {ir_id: import_ir58000004, inst_id: inst70000220}
+// CHECK:STDOUT:     import_ir_instA9: {ir_id: import_ir58000004, inst_id: inst70000249}
+// CHECK:STDOUT:     import_ir_instAA: {ir_id: import_ir58000004, inst_id: inst7000024A}
+// CHECK:STDOUT:     import_ir_instAB: {ir_id: import_ir58000004, inst_id: inst7000024B}
+// CHECK:STDOUT:     import_ir_instAC: {ir_id: import_ir58000004, inst_id: inst7000024C}
+// CHECK:STDOUT:     import_ir_instAD: {ir_id: import_ir58000004, inst_id: inst7000024D}
+// CHECK:STDOUT:     import_ir_instAE: {ir_id: import_ir58000004, inst_id: inst7000024E}
+// CHECK:STDOUT:     import_ir_instAF: {ir_id: import_ir58000004, inst_id: inst7000024F}
+// CHECK:STDOUT:     import_ir_instB0: {ir_id: import_ir58000004, inst_id: inst70000253}
+// CHECK:STDOUT:     import_ir_instB1: {ir_id: import_ir58000004, inst_id: inst70000258}
+// CHECK:STDOUT:     import_ir_instB2: {ir_id: import_ir58000004, inst_id: inst70000269}
+// CHECK:STDOUT:     import_ir_instB3: {ir_id: import_ir58000004, inst_id: inst7000026F}
+// CHECK:STDOUT:     import_ir_instB4: {ir_id: import_ir58000004, inst_id: inst70000273}
+// CHECK:STDOUT:     import_ir_instB5: {ir_id: import_ir58000004, inst_id: inst70000275}
+// CHECK:STDOUT:     import_ir_instB6: {ir_id: import_ir58000004, inst_id: inst70000276}
+// CHECK:STDOUT:     import_ir_instB7: {ir_id: import_ir58000004, inst_id: inst70000277}
+// CHECK:STDOUT:     import_ir_instB8: {ir_id: import_ir58000004, inst_id: inst7000027A}
+// CHECK:STDOUT:     import_ir_instB9: {ir_id: import_ir58000004, inst_id: inst70000284}
+// CHECK:STDOUT:     import_ir_instBA: {ir_id: import_ir58000004, inst_id: inst70000288}
+// CHECK:STDOUT:     import_ir_instBB: {ir_id: import_ir58000004, inst_id: inst7000028A}
+// CHECK:STDOUT:     import_ir_instBC: {ir_id: import_ir58000004, inst_id: inst7000028B}
+// CHECK:STDOUT:     import_ir_instBD: {ir_id: import_ir58000004, inst_id: inst7000028C}
+// CHECK:STDOUT:     import_ir_instBE: {ir_id: import_ir58000004, inst_id: inst7000028F}
+// CHECK:STDOUT:     import_ir_instBF: {ir_id: import_ir58000004, inst_id: inst7000029B}
+// CHECK:STDOUT:     import_ir_instC0: {ir_id: import_ir58000004, inst_id: inst700002A2}
+// CHECK:STDOUT:     import_ir_instC1: {ir_id: import_ir58000004, inst_id: inst700002A6}
+// CHECK:STDOUT:     import_ir_instC2: {ir_id: import_ir58000004, inst_id: inst700002A7}
+// CHECK:STDOUT:     import_ir_instC3: {ir_id: import_ir58000004, inst_id: inst700002A8}
+// CHECK:STDOUT:     import_ir_instC4: {ir_id: import_ir58000004, inst_id: inst700002AE}
+// CHECK:STDOUT:     import_ir_instC5: {ir_id: import_ir58000004, inst_id: inst70000223}
+// CHECK:STDOUT:     import_ir_instC6: {ir_id: import_ir58000004, inst_id: inst7000021D}
+// CHECK:STDOUT:     import_ir_instC7: {ir_id: import_ir58000004, inst_id: inst70000218}
+// CHECK:STDOUT:     import_ir_instC8: {ir_id: import_ir58000004, inst_id: inst70000237}
+// CHECK:STDOUT:     import_ir_instC9: {ir_id: import_ir58000004, inst_id: inst70000239}
+// CHECK:STDOUT:     import_ir_instCA: {ir_id: import_ir58000004, inst_id: inst70000216}
+// CHECK:STDOUT:     import_ir_instCB: {ir_id: import_ir58000004, inst_id: inst7000021B}
+// CHECK:STDOUT:     import_ir_instCC: {ir_id: import_ir58000004, inst_id: inst70000220}
+// CHECK:STDOUT:     import_ir_instCD: {ir_id: import_ir58000004, inst_id: inst70000217}
+// CHECK:STDOUT:     import_ir_instCE: {ir_id: import_ir58000004, inst_id: inst7000021C}
+// CHECK:STDOUT:     import_ir_instCF: {ir_id: import_ir58000004, inst_id: inst70000222}
+// CHECK:STDOUT:     import_ir_instD0: {ir_id: import_ir58000004, inst_id: inst7000022A}
+// CHECK:STDOUT:     import_ir_instD1: {ir_id: import_ir58000004, inst_id: inst7000022D}
+// CHECK:STDOUT:     import_ir_instD2: {ir_id: import_ir58000004, inst_id: inst70000230}
+// CHECK:STDOUT:     import_ir_instD3: {ir_id: import_ir58000004, inst_id: inst70000234}
+// CHECK:STDOUT:     import_ir_instD4: {ir_id: import_ir58000004, inst_id: inst70000238}
+// CHECK:STDOUT:     import_ir_instD5: {ir_id: import_ir58000004, inst_id: inst70000241}
+// CHECK:STDOUT:     import_ir_instD6: {ir_id: import_ir58000004, inst_id: inst70000261}
+// CHECK:STDOUT:     import_ir_instD7: {ir_id: import_ir58000004, inst_id: inst70000262}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name(Core): inst60000011, name0: inst6000003E}}
-// CHECK:STDOUT:     name_scope60000001: {inst: inst60000011, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name3: inst6000004E}}
-// CHECK:STDOUT:     name_scope60000002: {inst: inst6000004F, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {name(SelfType): inst6000006A}}
-// CHECK:STDOUT:     name_scope60000003: {inst: inst60000051, parent_scope: name_scope60000002, has_error: false, extended_scopes: [], names: {name4: inst60000053}}
-// CHECK:STDOUT:     name_scope60000004: {inst: inst60000070, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope60000005: {inst: inst600000A5, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope60000006: {inst: inst600000A9, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope60000007: {inst: inst600000AD, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope60000008: {inst: inst600000B1, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope60000009: {inst: inst600000B5, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope6000000A: {inst: inst600000D3, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope6000000B: {inst: inst600000D7, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope6000000C: {inst: inst600000DB, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
-// CHECK:STDOUT:     name_scope6000000D: {inst: inst6000011F, parent_scope: name_scope60000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name(Core): inst58000011, name0: inst5800003E}}
+// CHECK:STDOUT:     name_scope58000001: {inst: inst58000011, parent_scope: name_scope0, has_error: false, extended_scopes: [], names: {name3: inst5800004E}}
+// CHECK:STDOUT:     name_scope58000002: {inst: inst5800004F, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {name(SelfType): inst5800006A}}
+// CHECK:STDOUT:     name_scope58000003: {inst: inst58000051, parent_scope: name_scope58000002, has_error: false, extended_scopes: [], names: {name4: inst58000053}}
+// CHECK:STDOUT:     name_scope58000004: {inst: inst58000070, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope58000005: {inst: inst580000A5, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope58000006: {inst: inst580000A9, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope58000007: {inst: inst580000AD, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope58000008: {inst: inst580000B1, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope58000009: {inst: inst580000B5, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope5800000A: {inst: inst580000D3, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope5800000B: {inst: inst580000D7, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope5800000C: {inst: inst580000DB, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
+// CHECK:STDOUT:     name_scope5800000D: {inst: inst5800011F, parent_scope: name_scope58000001, has_error: false, extended_scopes: [], names: {}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name60000000: {name: name(PeriodSelf), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000001: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000002: {name: name2, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000003: {name: name3, parent_scope: name_scope60000001, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000004: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000005: {name: name4, parent_scope: name_scope60000003, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000006: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000007: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000008: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000009: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000000A: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000000B: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000000C: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000000D: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000000E: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000000F: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000010: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000011: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000012: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000013: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000014: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000015: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000016: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000017: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000018: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000019: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000001A: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000001B: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000001C: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000001D: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000001E: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000001F: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000020: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000021: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000022: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000023: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000024: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000025: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000026: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000027: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000028: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000029: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000002A: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000002B: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000002C: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000002D: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000002E: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000002F: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000030: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000031: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000032: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000033: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000034: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000035: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000036: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000037: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000038: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name60000039: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000003A: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000003B: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000003C: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000003D: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000003E: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
-// CHECK:STDOUT:     entity_name6000003F: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000000: {name: name(PeriodSelf), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000001: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000002: {name: name2, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000003: {name: name3, parent_scope: name_scope58000001, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000004: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000005: {name: name4, parent_scope: name_scope58000003, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000006: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000007: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000008: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000009: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800000A: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800000B: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800000C: {name: name(SelfType), parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800000D: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800000E: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800000F: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000010: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000011: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000012: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000013: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000014: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000015: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000016: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000017: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000018: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000019: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800001A: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800001B: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800001C: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800001D: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800001E: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800001F: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000020: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000021: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000022: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000023: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000024: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000025: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000026: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000027: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000028: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000029: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800002A: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800002B: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800002C: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800002D: {name: name(SelfValue), parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800002E: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800002F: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000030: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000031: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000032: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000033: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000034: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000035: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000036: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000037: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000038: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name58000039: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800003A: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800003B: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800003C: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800003D: {name: name6, parent_scope: name_scope<none>, index: 2, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800003E: {name: name5, parent_scope: name_scope<none>, index: 1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name5800003F: {name: name1, parent_scope: name_scope<none>, index: 0, is_template: 0, is_unused: 0, form: constant<none>}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block60000011, call_params_id: inst_block60000012, return_type_inst_id: inst60000030, return_form_inst_id: inst60000032, return_patterns_id: inst_block60000010, body: [inst_block60000019]}
-// CHECK:STDOUT:     function60000001: {name: name4, parent_scope: name_scope60000003, call_param_patterns_id: inst_block6000001F, return_type_inst_id: inst60000060, return_form_inst_id: inst60000061, return_patterns_id: inst_block60000021}
-// CHECK:STDOUT:     function60000002: {name: name4, parent_scope: name_scope60000004, call_param_patterns_id: inst_block6000002B, return_type_inst_id: inst60000080, return_form_inst_id: inst60000081, return_patterns_id: inst_block6000002D}
-// CHECK:STDOUT:     function60000003: {name: name4, parent_scope: name_scope60000009, call_param_patterns_id: inst_block60000042, return_type_inst_id: inst600000C8, return_form_inst_id: inst600000C9, return_patterns_id: inst_block60000044}
-// CHECK:STDOUT:     function60000004: {name: name4, parent_scope: name_scope6000000C, call_param_patterns_id: inst_block60000050, return_type_inst_id: inst600000ED, return_form_inst_id: inst600000EE, return_patterns_id: inst_block60000052}
-// CHECK:STDOUT:     function60000005: {name: name4, parent_scope: name_scope6000000D, call_param_patterns_id: inst_block6000006D, return_type_inst_id: inst60000131, return_form_inst_id: inst60000132, return_patterns_id: inst_block6000006F}
+// CHECK:STDOUT:     function58000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block58000011, call_params_id: inst_block58000012, return_type_inst_id: inst58000030, return_form_inst_id: inst58000032, return_patterns_id: inst_block58000010, body: [inst_block58000019]}
+// CHECK:STDOUT:     function58000001: {name: name4, parent_scope: name_scope58000003, call_param_patterns_id: inst_block5800001F, return_type_inst_id: inst58000060, return_form_inst_id: inst58000061, return_patterns_id: inst_block58000021}
+// CHECK:STDOUT:     function58000002: {name: name4, parent_scope: name_scope58000004, call_param_patterns_id: inst_block5800002B, return_type_inst_id: inst58000080, return_form_inst_id: inst58000081, return_patterns_id: inst_block5800002D}
+// CHECK:STDOUT:     function58000003: {name: name4, parent_scope: name_scope58000009, call_param_patterns_id: inst_block58000042, return_type_inst_id: inst580000C8, return_form_inst_id: inst580000C9, return_patterns_id: inst_block58000044}
+// CHECK:STDOUT:     function58000004: {name: name4, parent_scope: name_scope5800000C, call_param_patterns_id: inst_block58000050, return_type_inst_id: inst580000ED, return_form_inst_id: inst580000EE, return_patterns_id: inst_block58000052}
+// CHECK:STDOUT:     function58000005: {name: name4, parent_scope: name_scope5800000D, call_param_patterns_id: inst_block5800006D, return_type_inst_id: inst58000131, return_form_inst_id: inst58000132, return_patterns_id: inst_block5800006F}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   interfaces:
-// CHECK:STDOUT:     interface60000000: {name: name3, parent_scope: name_scope60000001, require_impls_block_id: require_block_empty}
+// CHECK:STDOUT:     interface58000000: {name: name3, parent_scope: name_scope58000001, require_impls_block_id: require_block_empty}
 // CHECK:STDOUT:   associated_constants: {}
 // CHECK:STDOUT:   impls:
-// CHECK:STDOUT:     impl60000000:    {self: inst6000009B, constraint: inst6000009C, witness: inst6000006F}
-// CHECK:STDOUT:     impl60000001:    {self: inst600000A6, constraint: inst600000A7, witness: inst600000A4}
-// CHECK:STDOUT:     impl60000002:    {self: inst600000AA, constraint: inst600000AB, witness: inst600000A8}
-// CHECK:STDOUT:     impl60000003:    {self: inst600000AE, constraint: inst600000AF, witness: inst600000AC}
-// CHECK:STDOUT:     impl60000004:    {self: inst600000B2, constraint: inst600000B3, witness: inst600000B0}
-// CHECK:STDOUT:     impl60000005:    {self: inst600000BA, constraint: inst600000BB, witness: inst600000B4}
-// CHECK:STDOUT:     impl60000006:    {self: inst600000D4, constraint: inst600000D5, witness: inst600000D2}
-// CHECK:STDOUT:     impl60000007:    {self: inst600000D8, constraint: inst600000D9, witness: inst600000D6}
-// CHECK:STDOUT:     impl60000008:    {self: inst60000111, constraint: inst60000112, witness: inst600000DA}
-// CHECK:STDOUT:     impl60000009:    {self: inst6000015F, constraint: inst60000160, witness: inst6000011E}
+// CHECK:STDOUT:     impl58000000:    {self: inst5800009B, constraint: inst5800009C, witness: inst5800006F}
+// CHECK:STDOUT:     impl58000001:    {self: inst580000A6, constraint: inst580000A7, witness: inst580000A4}
+// CHECK:STDOUT:     impl58000002:    {self: inst580000AA, constraint: inst580000AB, witness: inst580000A8}
+// CHECK:STDOUT:     impl58000003:    {self: inst580000AE, constraint: inst580000AF, witness: inst580000AC}
+// CHECK:STDOUT:     impl58000004:    {self: inst580000B2, constraint: inst580000B3, witness: inst580000B0}
+// CHECK:STDOUT:     impl58000005:    {self: inst580000BA, constraint: inst580000BB, witness: inst580000B4}
+// CHECK:STDOUT:     impl58000006:    {self: inst580000D4, constraint: inst580000D5, witness: inst580000D2}
+// CHECK:STDOUT:     impl58000007:    {self: inst580000D8, constraint: inst580000D9, witness: inst580000D6}
+// CHECK:STDOUT:     impl58000008:    {self: inst58000111, constraint: inst58000112, witness: inst580000DA}
+// CHECK:STDOUT:     impl58000009:    {self: inst5800015F, constraint: inst58000160, witness: inst5800011E}
 // CHECK:STDOUT:   generics:
-// CHECK:STDOUT:     generic60000000: {decl: inst6000003E, bindings: inst_block60000015, self_specific_id: specific60000000, decl_block_id: inst_block60000017, definition_block_id: inst_block60000091}
-// CHECK:STDOUT:     generic60000001: {decl: inst60000051, bindings: inst_block6000001C, self_specific_id: specific60000001, decl_block_id: inst_block_empty, definition_block_id: inst_block60000026}
-// CHECK:STDOUT:     generic60000002: {decl: inst60000056, bindings: inst_block60000022, self_specific_id: specific60000002, decl_block_id: inst_block60000023, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     generic60000003: {decl: inst60000070, bindings: inst_block60000037, self_specific_id: specific60000004, decl_block_id: inst_block60000039, definition_block_id: inst_block6000003B}
-// CHECK:STDOUT:     generic60000004: {decl: inst60000077, bindings: inst_block6000002E, self_specific_id: specific60000007, decl_block_id: inst_block6000002F, definition_block_id: inst_block60000034}
-// CHECK:STDOUT:     generic60000005: {decl: inst600000B5, bindings: inst_block6000003F, self_specific_id: specific6000000B, decl_block_id: inst_block60000041, definition_block_id: inst_block60000049}
-// CHECK:STDOUT:     generic60000006: {decl: inst600000C0, bindings: inst_block60000045, self_specific_id: specific6000000D, decl_block_id: inst_block60000046, definition_block_id: inst_block_empty}
-// CHECK:STDOUT:     generic60000007: {decl: inst600000DB, bindings: inst_block60000060, self_specific_id: specific6000000E, decl_block_id: inst_block60000064, definition_block_id: inst_block60000066}
-// CHECK:STDOUT:     generic60000008: {decl: inst600000E2, bindings: inst_block60000053, self_specific_id: specific60000011, decl_block_id: inst_block60000055, definition_block_id: inst_block6000005D}
-// CHECK:STDOUT:     generic60000009: {decl: inst6000011F, bindings: inst_block6000007F, self_specific_id: specific60000017, decl_block_id: inst_block60000083, definition_block_id: inst_block60000085}
-// CHECK:STDOUT:     generic6000000A: {decl: inst60000126, bindings: inst_block60000070, self_specific_id: specific6000001A, decl_block_id: inst_block60000072, definition_block_id: inst_block6000007C}
+// CHECK:STDOUT:     generic58000000: {decl: inst5800003E, bindings: inst_block58000015, self_specific_id: specific58000000, decl_block_id: inst_block58000017, definition_block_id: inst_block58000091}
+// CHECK:STDOUT:     generic58000001: {decl: inst58000051, bindings: inst_block5800001C, self_specific_id: specific58000001, decl_block_id: inst_block_empty, definition_block_id: inst_block58000026}
+// CHECK:STDOUT:     generic58000002: {decl: inst58000056, bindings: inst_block58000022, self_specific_id: specific58000002, decl_block_id: inst_block58000023, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     generic58000003: {decl: inst58000070, bindings: inst_block58000037, self_specific_id: specific58000004, decl_block_id: inst_block58000039, definition_block_id: inst_block5800003B}
+// CHECK:STDOUT:     generic58000004: {decl: inst58000077, bindings: inst_block5800002E, self_specific_id: specific58000007, decl_block_id: inst_block5800002F, definition_block_id: inst_block58000034}
+// CHECK:STDOUT:     generic58000005: {decl: inst580000B5, bindings: inst_block5800003F, self_specific_id: specific5800000B, decl_block_id: inst_block58000041, definition_block_id: inst_block58000049}
+// CHECK:STDOUT:     generic58000006: {decl: inst580000C0, bindings: inst_block58000045, self_specific_id: specific5800000D, decl_block_id: inst_block58000046, definition_block_id: inst_block_empty}
+// CHECK:STDOUT:     generic58000007: {decl: inst580000DB, bindings: inst_block58000060, self_specific_id: specific5800000E, decl_block_id: inst_block58000064, definition_block_id: inst_block58000066}
+// CHECK:STDOUT:     generic58000008: {decl: inst580000E2, bindings: inst_block58000053, self_specific_id: specific58000011, decl_block_id: inst_block58000055, definition_block_id: inst_block5800005D}
+// CHECK:STDOUT:     generic58000009: {decl: inst5800011F, bindings: inst_block5800007F, self_specific_id: specific58000017, decl_block_id: inst_block58000083, definition_block_id: inst_block58000085}
+// CHECK:STDOUT:     generic5800000A: {decl: inst58000126, bindings: inst_block58000070, self_specific_id: specific5800001A, decl_block_id: inst_block58000072, definition_block_id: inst_block5800007C}
 // CHECK:STDOUT:   specifics:
-// CHECK:STDOUT:     specific60000000: {generic: generic60000000, args: inst_block60000016, decl_block_id: inst_block60000018, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000001: {generic: generic60000001, args: inst_block6000001D, decl_block_id: inst_block_empty, definition_block_id: inst_block6000001E}
-// CHECK:STDOUT:     specific60000002: {generic: generic60000002, args: inst_block6000001D, decl_block_id: inst_block60000024, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000003: {generic: generic60000001, args: inst_block60000025, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000004: {generic: generic60000003, args: inst_block60000028, decl_block_id: inst_block60000029, definition_block_id: inst_block6000002A}
-// CHECK:STDOUT:     specific60000005: {generic: generic60000001, args: inst_block60000028, decl_block_id: inst_block_empty, definition_block_id: inst_block60000030}
-// CHECK:STDOUT:     specific60000006: {generic: generic60000002, args: inst_block60000028, decl_block_id: inst_block60000031, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000007: {generic: generic60000004, args: inst_block60000028, decl_block_id: inst_block60000035, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000008: {generic: generic60000001, args: inst_block60000032, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000009: {generic: generic60000002, args: inst_block60000032, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000000A: {generic: generic60000003, args: inst_block60000038, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000000B: {generic: generic60000005, args: inst_block60000016, decl_block_id: inst_block6000003D, definition_block_id: inst_block60000086}
-// CHECK:STDOUT:     specific6000000C: {generic: generic60000005, args: inst_block60000040, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000000D: {generic: generic60000006, args: inst_block60000016, decl_block_id: inst_block60000047, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000000E: {generic: generic60000007, args: inst_block6000004C, decl_block_id: inst_block6000004E, definition_block_id: inst_block6000004F}
-// CHECK:STDOUT:     specific6000000F: {generic: generic60000001, args: inst_block60000056, decl_block_id: inst_block_empty, definition_block_id: inst_block60000057}
-// CHECK:STDOUT:     specific60000010: {generic: generic60000002, args: inst_block60000056, decl_block_id: inst_block60000058, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000011: {generic: generic60000008, args: inst_block6000004C, decl_block_id: inst_block6000005E, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000012: {generic: generic60000001, args: inst_block60000059, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000013: {generic: generic60000002, args: inst_block60000059, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000014: {generic: generic60000001, args: inst_block6000005B, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000015: {generic: generic60000002, args: inst_block6000005B, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000016: {generic: generic60000007, args: inst_block60000061, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000017: {generic: generic60000009, args: inst_block60000069, decl_block_id: inst_block6000006B, definition_block_id: inst_block6000006C}
-// CHECK:STDOUT:     specific60000018: {generic: generic60000001, args: inst_block60000073, decl_block_id: inst_block_empty, definition_block_id: inst_block60000074}
-// CHECK:STDOUT:     specific60000019: {generic: generic60000002, args: inst_block60000073, decl_block_id: inst_block60000075, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000001A: {generic: generic6000000A, args: inst_block60000069, decl_block_id: inst_block6000007D, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000001B: {generic: generic60000001, args: inst_block60000076, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000001C: {generic: generic60000002, args: inst_block60000076, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000001D: {generic: generic60000001, args: inst_block60000078, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000001E: {generic: generic60000002, args: inst_block60000078, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific6000001F: {generic: generic60000001, args: inst_block6000007A, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000020: {generic: generic60000002, args: inst_block6000007A, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000021: {generic: generic60000009, args: inst_block60000080, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000022: {generic: generic60000005, args: inst_block60000087, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000023: {generic: generic60000001, args: inst_block60000089, decl_block_id: inst_block_empty, definition_block_id: inst_block6000008A}
-// CHECK:STDOUT:     specific60000024: {generic: generic60000001, args: inst_block6000008C, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000025: {generic: generic60000002, args: inst_block60000089, decl_block_id: inst_block6000008D, definition_block_id: inst_block<none>}
-// CHECK:STDOUT:     specific60000026: {generic: generic60000002, args: inst_block6000008C, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000000: {generic: generic58000000, args: inst_block58000016, decl_block_id: inst_block58000018, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000001: {generic: generic58000001, args: inst_block5800001D, decl_block_id: inst_block_empty, definition_block_id: inst_block5800001E}
+// CHECK:STDOUT:     specific58000002: {generic: generic58000002, args: inst_block5800001D, decl_block_id: inst_block58000024, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000003: {generic: generic58000001, args: inst_block58000025, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000004: {generic: generic58000003, args: inst_block58000028, decl_block_id: inst_block58000029, definition_block_id: inst_block5800002A}
+// CHECK:STDOUT:     specific58000005: {generic: generic58000001, args: inst_block58000028, decl_block_id: inst_block_empty, definition_block_id: inst_block58000030}
+// CHECK:STDOUT:     specific58000006: {generic: generic58000002, args: inst_block58000028, decl_block_id: inst_block58000031, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000007: {generic: generic58000004, args: inst_block58000028, decl_block_id: inst_block58000035, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000008: {generic: generic58000001, args: inst_block58000032, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000009: {generic: generic58000002, args: inst_block58000032, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800000A: {generic: generic58000003, args: inst_block58000038, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800000B: {generic: generic58000005, args: inst_block58000016, decl_block_id: inst_block5800003D, definition_block_id: inst_block58000086}
+// CHECK:STDOUT:     specific5800000C: {generic: generic58000005, args: inst_block58000040, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800000D: {generic: generic58000006, args: inst_block58000016, decl_block_id: inst_block58000047, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800000E: {generic: generic58000007, args: inst_block5800004C, decl_block_id: inst_block5800004E, definition_block_id: inst_block5800004F}
+// CHECK:STDOUT:     specific5800000F: {generic: generic58000001, args: inst_block58000056, decl_block_id: inst_block_empty, definition_block_id: inst_block58000057}
+// CHECK:STDOUT:     specific58000010: {generic: generic58000002, args: inst_block58000056, decl_block_id: inst_block58000058, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000011: {generic: generic58000008, args: inst_block5800004C, decl_block_id: inst_block5800005E, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000012: {generic: generic58000001, args: inst_block58000059, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000013: {generic: generic58000002, args: inst_block58000059, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000014: {generic: generic58000001, args: inst_block5800005B, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000015: {generic: generic58000002, args: inst_block5800005B, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000016: {generic: generic58000007, args: inst_block58000061, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000017: {generic: generic58000009, args: inst_block58000069, decl_block_id: inst_block5800006B, definition_block_id: inst_block5800006C}
+// CHECK:STDOUT:     specific58000018: {generic: generic58000001, args: inst_block58000073, decl_block_id: inst_block_empty, definition_block_id: inst_block58000074}
+// CHECK:STDOUT:     specific58000019: {generic: generic58000002, args: inst_block58000073, decl_block_id: inst_block58000075, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800001A: {generic: generic5800000A, args: inst_block58000069, decl_block_id: inst_block5800007D, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800001B: {generic: generic58000001, args: inst_block58000076, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800001C: {generic: generic58000002, args: inst_block58000076, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800001D: {generic: generic58000001, args: inst_block58000078, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800001E: {generic: generic58000002, args: inst_block58000078, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific5800001F: {generic: generic58000001, args: inst_block5800007A, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000020: {generic: generic58000002, args: inst_block5800007A, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000021: {generic: generic58000009, args: inst_block58000080, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000022: {generic: generic58000005, args: inst_block58000087, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000023: {generic: generic58000001, args: inst_block58000089, decl_block_id: inst_block_empty, definition_block_id: inst_block5800008A}
+// CHECK:STDOUT:     specific58000024: {generic: generic58000001, args: inst_block5800008C, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000025: {generic: generic58000002, args: inst_block58000089, decl_block_id: inst_block5800008D, definition_block_id: inst_block<none>}
+// CHECK:STDOUT:     specific58000026: {generic: generic58000002, args: inst_block5800008C, decl_block_id: inst_block<none>, definition_block_id: inst_block<none>}
 // CHECK:STDOUT:   specific_interfaces:
-// CHECK:STDOUT:     specific_interface60000000: {interface_id: interface60000000, specific_id: specific<none>}
+// CHECK:STDOUT:     specific_interface58000000: {interface_id: interface58000000, specific_id: specific<none>}
 // CHECK:STDOUT:   struct_type_fields:
 // CHECK:STDOUT:     struct_type_fields_empty: {}
 // CHECK:STDOUT:   types:
@@ -422,1793 +422,1793 @@ fn Foo[T:! type](p: T*) -> (T*, ()) {
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst60000026)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000026)}
-// CHECK:STDOUT:     'type(inst6000002D)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst6000002D)}
-// CHECK:STDOUT:     'type(inst60000029)':
-// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(inst6000002D)}
-// CHECK:STDOUT:     'type(inst6000003F)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000026)}
-// CHECK:STDOUT:     'type(symbolic_constant60000003)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant60000003)}
+// CHECK:STDOUT:     'type(inst58000026)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst58000026)}
+// CHECK:STDOUT:     'type(inst5800002D)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst5800002D)}
+// CHECK:STDOUT:     'type(inst58000029)':
+// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(inst5800002D)}
+// CHECK:STDOUT:     'type(inst5800003F)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst58000026)}
+// CHECK:STDOUT:     'type(symbolic_constant58000003)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant58000003)}
 // CHECK:STDOUT:     'type(inst(WitnessType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     'type(symbolic_constant60000011)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant60000011)}
-// CHECK:STDOUT:     'type(symbolic_constant60000009)':
-// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(symbolic_constant60000011)}
-// CHECK:STDOUT:     'type(symbolic_constant60000004)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant60000004)}
-// CHECK:STDOUT:     'type(symbolic_constant6000000A)':
-// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(symbolic_constant60000011)}
+// CHECK:STDOUT:     'type(symbolic_constant58000011)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant58000011)}
+// CHECK:STDOUT:     'type(symbolic_constant58000009)':
+// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(symbolic_constant58000011)}
+// CHECK:STDOUT:     'type(symbolic_constant58000004)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(symbolic_constant58000004)}
+// CHECK:STDOUT:     'type(symbolic_constant5800000A)':
+// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(symbolic_constant58000011)}
 // CHECK:STDOUT:     'type(inst(InstType))':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000026)}
-// CHECK:STDOUT:     'type(inst60000050)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst60000050)}
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst58000026)}
+// CHECK:STDOUT:     'type(inst58000050)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst58000050)}
 // CHECK:STDOUT:     'type(inst(SpecificFunctionType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(SpecificFunctionType))}
 // CHECK:STDOUT:     'type(inst(RequireSpecificDefinitionType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(RequireSpecificDefinitionType))}
-// CHECK:STDOUT:     'type(symbolic_constant60000146)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000026)}
-// CHECK:STDOUT:     'type(symbolic_constant6000014A)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000026)}
+// CHECK:STDOUT:     'type(symbolic_constant58000146)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst58000026)}
+// CHECK:STDOUT:     'type(symbolic_constant5800014A)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst58000026)}
 // CHECK:STDOUT:     'type(inst(BoundMethodType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(BoundMethodType))}
 // CHECK:STDOUT:   facet_types:
-// CHECK:STDOUT:     facet_type60000000: {}
-// CHECK:STDOUT:     facet_type60000001: {extends interface: interface60000000}
+// CHECK:STDOUT:     facet_type58000000: {}
+// CHECK:STDOUT:     facet_type58000001: {extends interface: interface58000000}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     instF:           {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000010:    {kind: ImportDecl, arg0: name(Core)}
-// CHECK:STDOUT:     inst60000011:    {kind: Namespace, arg0: name_scope60000001, arg1: inst60000010, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000012:    {kind: FacetType, arg0: facet_type60000000, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000013:    {kind: SymbolicBinding, arg0: entity_name60000000, arg1: inst<none>, type: type(inst60000012)}
-// CHECK:STDOUT:     inst60000014:    {kind: SymbolicBinding, arg0: entity_name60000000, arg1: inst<none>, type: type(inst60000012)}
-// CHECK:STDOUT:     inst60000015:    {kind: TypeLiteral, arg0: inst(TypeType), type: type(TypeType)}
-// CHECK:STDOUT:     inst60000016:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000017:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000018:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000019:    {kind: PatternType, arg0: inst(TypeType), type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001A:    {kind: SymbolicBindingPattern, arg0: entity_name60000001, type: type(inst60000019)}
-// CHECK:STDOUT:     inst6000001B:    {kind: NameRef, arg0: name1, arg1: inst60000016, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001C:    {kind: PointerType, arg0: inst6000001B, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001D:    {kind: PointerType, arg0: inst60000017, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001E:    {kind: PointerType, arg0: inst60000018, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001F:    {kind: ValueBinding, arg0: entity_name60000002, arg1: inst6000003A, type: type(symbolic_constant60000004)}
-// CHECK:STDOUT:     inst60000020:    {kind: PatternType, arg0: inst6000001D, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000021:    {kind: ValueBindingPattern, arg0: entity_name60000002, type: type(symbolic_constant60000006)}
-// CHECK:STDOUT:     inst60000022:    {kind: PatternType, arg0: inst6000001E, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000023:    {kind: ValueParamPattern, arg0: inst60000021, type: type(symbolic_constant60000006)}
-// CHECK:STDOUT:     inst60000024:    {kind: NameRef, arg0: name1, arg1: inst60000016, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000025:    {kind: PointerType, arg0: inst60000024, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000026:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000027:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst60000026)}
-// CHECK:STDOUT:     inst60000028:    {kind: TupleValue, arg0: inst_block_empty, type: type(inst60000026)}
-// CHECK:STDOUT:     inst60000029:    {kind: TupleType, arg0: inst_block6000000A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002A:    {kind: TupleLiteral, arg0: inst_block60000009, type: type(inst60000029)}
-// CHECK:STDOUT:     inst6000002B:    {kind: TupleValue, arg0: inst_block6000000B, type: type(inst60000029)}
-// CHECK:STDOUT:     inst6000002C:    {kind: TupleValue, arg0: inst_block6000000C, type: type(inst60000029)}
-// CHECK:STDOUT:     inst6000002D:    {kind: PointerType, arg0: inst60000029, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002E:    {kind: Converted, arg0: inst60000028, arg1: inst60000026, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002F:    {kind: TupleType, arg0: inst_block6000000E, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000030:    {kind: Converted, arg0: inst6000002A, arg1: inst6000002F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000031:    {kind: TupleType, arg0: inst_block6000000F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000032:    {kind: InitForm, arg0: inst60000030, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000033:    {kind: InitForm, arg0: inst6000002F, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000034:    {kind: InitForm, arg0: inst60000031, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000035:    {kind: PatternType, arg0: inst6000002F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000036:    {kind: ReturnSlotPattern, arg0: inst60000030, type: type(symbolic_constant6000000E)}
-// CHECK:STDOUT:     inst60000037:    {kind: PatternType, arg0: inst60000031, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000038:    {kind: OutParamPattern, arg0: inst60000036, type: type(symbolic_constant6000000E)}
-// CHECK:STDOUT:     inst60000039:    {kind: SpliceBlock, arg0: inst_block60000005, arg1: inst60000015, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000003A:    {kind: ValueParam, arg0: call_param0, arg1: name2, type: type(symbolic_constant60000004)}
-// CHECK:STDOUT:     inst6000003B:    {kind: SpliceBlock, arg0: inst_block60000007, arg1: inst6000001C, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000003C:    {kind: OutParam, arg0: call_param1, arg1: name(ReturnSlot), type: type(symbolic_constant6000000A)}
-// CHECK:STDOUT:     inst6000003D:    {kind: ReturnSlot, arg0: inst6000002F, arg1: inst6000003C, type: type(symbolic_constant6000000A)}
-// CHECK:STDOUT:     inst6000003E:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block60000014, type: type(inst6000003F)}
-// CHECK:STDOUT:     inst6000003F:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000040:    {kind: StructValue, arg0: inst_block_empty, type: type(inst6000003F)}
-// CHECK:STDOUT:     inst60000041:    {kind: RequireCompleteType, arg0: inst6000001D, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000042:    {kind: RequireCompleteType, arg0: inst6000001D, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000043:    {kind: RequireCompleteType, arg0: inst6000001E, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000044:    {kind: PointerType, arg0: inst6000002F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000045:    {kind: RequireCompleteType, arg0: inst6000002F, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000046:    {kind: RequireCompleteType, arg0: inst6000002F, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000047:    {kind: RequireCompleteType, arg0: inst60000031, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000048:    {kind: NameRef, arg0: name2, arg1: inst6000001F, type: type(symbolic_constant60000004)}
-// CHECK:STDOUT:     inst60000049:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst60000026)}
-// CHECK:STDOUT:     inst6000004A:    {kind: TupleLiteral, arg0: inst_block6000001A, type: type(symbolic_constant6000000A)}
-// CHECK:STDOUT:     inst6000004B:    {kind: RequireCompleteType, arg0: inst6000002F, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000004C:    {kind: TupleAccess, arg0: inst6000003C, arg1: element0, type: type(symbolic_constant60000004)}
-// CHECK:STDOUT:     inst6000004D:    {kind: RequireCompleteType, arg0: inst6000001D, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000004E:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name60000003, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000004F:    {kind: InterfaceDecl, arg0: interface60000000, arg1: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000050:    {kind: FacetType, arg0: facet_type60000001, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000051:    {kind: InterfaceWithSelfDecl, arg0: interface60000000}
-// CHECK:STDOUT:     inst60000052:    {kind: SymbolicBinding, arg0: entity_name60000004, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000053:    {kind: ImportRefLoaded, arg0: import_ir_inst3, arg1: entity_name<none>, type: type(inst6000006B)}
-// CHECK:STDOUT:     inst60000054:    {kind: ImportRefUnloaded, arg0: import_ir_inst4, arg1: entity_name60000005}
-// CHECK:STDOUT:     inst60000055:    {kind: ImportRefLoaded, arg0: import_ir_inst5, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000056:    {kind: FunctionDecl, arg0: function60000001, arg1: inst_block_empty, type: type(symbolic_constant60000015)}
-// CHECK:STDOUT:     inst60000057:    {kind: FunctionType, arg0: function60000001, arg1: specific60000001, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000058:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000015)}
-// CHECK:STDOUT:     inst60000059:    {kind: SymbolicBindingType, arg0: entity_name60000004, arg1: inst60000052, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000005A:    {kind: PatternType, arg0: inst60000059, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000005B:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant6000001B)}
-// CHECK:STDOUT:     inst6000005C:    {kind: OutParamPattern, arg0: inst6000005B, type: type(symbolic_constant6000001B)}
-// CHECK:STDOUT:     inst6000005D:    {kind: ValueBindingPattern, arg0: entity_name60000008, type: type(symbolic_constant6000001B)}
-// CHECK:STDOUT:     inst6000005E:    {kind: ValueParamPattern, arg0: inst6000005D, type: type(symbolic_constant6000001B)}
-// CHECK:STDOUT:     inst6000005F:    {kind: InitForm, arg0: inst60000059, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000060:    {kind: ImportRefLoaded, arg0: import_ir_instB, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000061:    {kind: ImportRefLoaded, arg0: import_ir_instC, arg1: entity_name<none>, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000062:    {kind: ImportRefLoaded, arg0: import_ir_instD, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000063:    {kind: SymbolicBinding, arg0: entity_name60000004, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000064:    {kind: SymbolicBindingType, arg0: entity_name60000004, arg1: inst60000063, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000065:    {kind: PatternType, arg0: inst60000064, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000066:    {kind: InitForm, arg0: inst60000064, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000067:    {kind: SymbolicBinding, arg0: entity_name60000004, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000068:    {kind: FunctionType, arg0: function60000001, arg1: specific60000003, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000069:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000029)}
-// CHECK:STDOUT:     inst6000006A:    {kind: ImportRefUnloaded, arg0: import_ir_inst15, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst6000006B:    {kind: AssociatedEntityType, arg0: interface60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000006C:    {kind: ImportRefLoaded, arg0: import_ir_inst16, arg1: entity_name<none>, type: type(symbolic_constant60000019)}
-// CHECK:STDOUT:     inst6000006D:    {kind: AssociatedEntity, arg0: element0, arg1: inst6000006C, type: type(inst6000006B)}
-// CHECK:STDOUT:     inst6000006E:    {kind: LookupImplWitness, arg0: inst6000001D, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000006F:    {kind: ImportRefUnloaded, arg0: import_ir_inst17, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst60000070:    {kind: ImplDecl, arg0: impl60000000, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst60000071:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000072:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst60000071, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000073:    {kind: ConstType, arg0: inst60000072, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000074:    {kind: ImportRefUnloaded, arg0: import_ir_inst19, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst60000075:    {kind: ImplWitnessTable, arg0: inst_block60000027, arg1: impl60000000}
-// CHECK:STDOUT:     inst60000076:    {kind: ImplWitness, arg0: inst60000075, arg1: specific60000004, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000077:    {kind: FunctionDecl, arg0: function60000002, arg1: inst_block_empty, type: type(symbolic_constant60000031)}
-// CHECK:STDOUT:     inst60000078:    {kind: FunctionType, arg0: function60000002, arg1: specific60000004, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000079:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000031)}
-// CHECK:STDOUT:     inst6000007A:    {kind: PatternType, arg0: inst60000073, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000007B:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant60000036)}
-// CHECK:STDOUT:     inst6000007C:    {kind: OutParamPattern, arg0: inst6000007B, type: type(symbolic_constant60000036)}
-// CHECK:STDOUT:     inst6000007D:    {kind: ValueBindingPattern, arg0: entity_name6000000F, type: type(symbolic_constant60000036)}
-// CHECK:STDOUT:     inst6000007E:    {kind: ValueParamPattern, arg0: inst6000007D, type: type(symbolic_constant60000036)}
-// CHECK:STDOUT:     inst6000007F:    {kind: InitForm, arg0: inst60000073, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000080:    {kind: ImportRefLoaded, arg0: import_ir_inst20, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000081:    {kind: ImportRefLoaded, arg0: import_ir_inst21, arg1: entity_name<none>, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000082:    {kind: ImportRefLoaded, arg0: import_ir_inst22, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000083:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000084:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst60000083, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000085:    {kind: ConstType, arg0: inst60000084, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000086:    {kind: PatternType, arg0: inst60000085, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000087:    {kind: InitForm, arg0: inst60000085, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000088:    {kind: LookupImplWitness, arg0: inst60000071, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000089:    {kind: FunctionType, arg0: function60000001, arg1: specific60000005, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000008A:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000045)}
-// CHECK:STDOUT:     inst6000008B:    {kind: FunctionTypeWithSelfType, arg0: inst60000089, arg1: inst60000071, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000008C:    {kind: ImplWitnessAccess, arg0: inst60000088, arg1: element0, type: type(symbolic_constant60000047)}
-// CHECK:STDOUT:     inst6000008D:    {kind: SpecificImplFunction, arg0: inst6000008C, arg1: specific60000006, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst6000008E:    {kind: InitForm, arg0: inst60000072, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst6000008F:    {kind: PatternType, arg0: inst60000072, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000090:    {kind: RequireCompleteType, arg0: inst60000072, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000091:    {kind: RequireCompleteType, arg0: inst60000073, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000092:    {kind: RequireCompleteType, arg0: inst60000085, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000093:    {kind: RequireCompleteType, arg0: inst60000084, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000094:    {kind: LookupImplWitness, arg0: inst60000083, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000095:    {kind: FunctionType, arg0: function60000001, arg1: specific60000008, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000096:    {kind: FunctionTypeWithSelfType, arg0: inst60000095, arg1: inst60000083, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000097:    {kind: ImplWitnessAccess, arg0: inst60000094, arg1: element0, type: type(symbolic_constant60000059)}
-// CHECK:STDOUT:     inst60000098:    {kind: SpecificImplFunction, arg0: inst60000097, arg1: specific60000009, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000099:    {kind: PatternType, arg0: inst60000050, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000009A:    {kind: SymbolicBindingPattern, arg0: entity_name60000015, type: type(inst60000099)}
-// CHECK:STDOUT:     inst6000009B:    {kind: ImportRefLoaded, arg0: import_ir_inst30, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000009C:    {kind: ImportRefLoaded, arg0: import_ir_inst31, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000009D:    {kind: ImportRefLoaded, arg0: import_ir_inst32, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst6000009E:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst6000009F:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst6000009E, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A0:    {kind: ConstType, arg0: inst6000009F, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A1:    {kind: ImplWitness, arg0: inst60000075, arg1: specific6000000A, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000A2:    {kind: FunctionType, arg0: function60000002, arg1: specific6000000A, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A3:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000064)}
-// CHECK:STDOUT:     inst600000A4:    {kind: ImportRefUnloaded, arg0: import_ir_inst39, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000A5:    {kind: ImplDecl, arg0: impl60000001, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000A6:    {kind: ImportRefLoaded, arg0: import_ir_inst3B, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A7:    {kind: ImportRefLoaded, arg0: import_ir_inst3C, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000A8:    {kind: ImportRefUnloaded, arg0: import_ir_inst3D, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000A9:    {kind: ImplDecl, arg0: impl60000002, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000AA:    {kind: ImportRefLoaded, arg0: import_ir_inst3F, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000AB:    {kind: ImportRefLoaded, arg0: import_ir_inst40, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000AC:    {kind: ImportRefUnloaded, arg0: import_ir_inst41, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000AD:    {kind: ImplDecl, arg0: impl60000003, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000AE:    {kind: ImportRefLoaded, arg0: import_ir_inst43, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000AF:    {kind: ImportRefLoaded, arg0: import_ir_inst44, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000B0:    {kind: ImportRefUnloaded, arg0: import_ir_inst45, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000B1:    {kind: ImplDecl, arg0: impl60000004, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000B2:    {kind: ImportRefLoaded, arg0: import_ir_inst47, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000B3:    {kind: ImportRefLoaded, arg0: import_ir_inst48, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000B4:    {kind: ImportRefLoaded, arg0: import_ir_inst49, arg1: entity_name<none>, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000B5:    {kind: ImplDecl, arg0: impl60000005, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000B6:    {kind: ImportRefUnloaded, arg0: import_ir_inst4B, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000B7:    {kind: ImplWitnessTable, arg0: inst_block6000003C, arg1: impl60000005}
-// CHECK:STDOUT:     inst600000B8:    {kind: ImplWitness, arg0: inst600000B7, arg1: specific6000000B, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000B9:    {kind: SymbolicBindingPattern, arg0: entity_name60000019, type: type(inst60000019)}
-// CHECK:STDOUT:     inst600000BA:    {kind: ImportRefLoaded, arg0: import_ir_inst4E, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000BB:    {kind: ImportRefLoaded, arg0: import_ir_inst4F, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000BC:    {kind: ImportRefLoaded, arg0: import_ir_inst50, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000BD:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000BE:    {kind: PointerType, arg0: inst600000BD, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000BF:    {kind: ImplWitness, arg0: inst600000B7, arg1: specific6000000C, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000C0:    {kind: FunctionDecl, arg0: function60000003, arg1: inst_block_empty, type: type(symbolic_constant60000070)}
-// CHECK:STDOUT:     inst600000C1:    {kind: FunctionType, arg0: function60000003, arg1: specific6000000B, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000C2:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000070)}
-// CHECK:STDOUT:     inst600000C3:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant60000074)}
-// CHECK:STDOUT:     inst600000C4:    {kind: OutParamPattern, arg0: inst600000C3, type: type(symbolic_constant60000074)}
-// CHECK:STDOUT:     inst600000C5:    {kind: ValueBindingPattern, arg0: entity_name6000001A, type: type(symbolic_constant60000074)}
-// CHECK:STDOUT:     inst600000C6:    {kind: ValueParamPattern, arg0: inst600000C5, type: type(symbolic_constant60000074)}
-// CHECK:STDOUT:     inst600000C7:    {kind: InitForm, arg0: inst6000001D, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst600000C8:    {kind: ImportRefLoaded, arg0: import_ir_inst59, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000C9:    {kind: ImportRefLoaded, arg0: import_ir_inst5A, arg1: entity_name<none>, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst600000CA:    {kind: ImportRefLoaded, arg0: import_ir_inst5B, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000CB:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000CC:    {kind: PointerType, arg0: inst600000CB, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000CD:    {kind: PatternType, arg0: inst600000CC, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000CE:    {kind: InitForm, arg0: inst600000CC, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst600000CF:    {kind: FunctionType, arg0: function60000003, arg1: specific6000000C, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000D0:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000080)}
-// CHECK:STDOUT:     inst600000D1:    {kind: RequireCompleteType, arg0: inst600000BE, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000D2:    {kind: ImportRefUnloaded, arg0: import_ir_inst63, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000D3:    {kind: ImplDecl, arg0: impl60000006, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000D4:    {kind: ImportRefLoaded, arg0: import_ir_inst65, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000D5:    {kind: ImportRefLoaded, arg0: import_ir_inst66, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000D6:    {kind: ImportRefUnloaded, arg0: import_ir_inst67, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000D7:    {kind: ImplDecl, arg0: impl60000007, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000D8:    {kind: ImportRefLoaded, arg0: import_ir_inst69, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000D9:    {kind: ImportRefLoaded, arg0: import_ir_inst6A, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000DA:    {kind: ImportRefUnloaded, arg0: import_ir_inst6B, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000DB:    {kind: ImplDecl, arg0: impl60000008, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst600000DC:    {kind: SymbolicBinding, arg0: entity_name6000001C, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst600000DD:    {kind: SymbolicBindingType, arg0: entity_name6000001C, arg1: inst600000DC, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000DE:    {kind: TupleType, arg0: inst_block6000004A, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000DF:    {kind: ImportRefUnloaded, arg0: import_ir_inst6D, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst600000E0:    {kind: ImplWitnessTable, arg0: inst_block6000004B, arg1: impl60000008}
-// CHECK:STDOUT:     inst600000E1:    {kind: ImplWitness, arg0: inst600000E0, arg1: specific6000000E, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000E2:    {kind: FunctionDecl, arg0: function60000004, arg1: inst_block_empty, type: type(symbolic_constant60000089)}
-// CHECK:STDOUT:     inst600000E3:    {kind: FunctionType, arg0: function60000004, arg1: specific6000000E, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000E4:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000089)}
-// CHECK:STDOUT:     inst600000E5:    {kind: TupleType, arg0: inst_block6000004D, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000E6:    {kind: TupleValue, arg0: inst_block6000004C, type: type(inst600000E5)}
-// CHECK:STDOUT:     inst600000E7:    {kind: PatternType, arg0: inst600000DE, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000E8:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant6000008F)}
-// CHECK:STDOUT:     inst600000E9:    {kind: OutParamPattern, arg0: inst600000E8, type: type(symbolic_constant6000008F)}
-// CHECK:STDOUT:     inst600000EA:    {kind: ValueBindingPattern, arg0: entity_name6000001E, type: type(symbolic_constant6000008F)}
-// CHECK:STDOUT:     inst600000EB:    {kind: ValueParamPattern, arg0: inst600000EA, type: type(symbolic_constant6000008F)}
-// CHECK:STDOUT:     inst600000EC:    {kind: InitForm, arg0: inst600000DE, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst600000ED:    {kind: ImportRefLoaded, arg0: import_ir_inst74, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000EE:    {kind: ImportRefLoaded, arg0: import_ir_inst75, arg1: entity_name<none>, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst600000EF:    {kind: ImportRefLoaded, arg0: import_ir_inst76, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst600000F0:    {kind: ImportRefLoaded, arg0: import_ir_inst77, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst600000F1:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst600000F2:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst600000F1, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F3:    {kind: SymbolicBinding, arg0: entity_name6000001C, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst600000F4:    {kind: SymbolicBindingType, arg0: entity_name6000001C, arg1: inst600000F3, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F5:    {kind: TupleType, arg0: inst_block60000054, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F6:    {kind: PatternType, arg0: inst600000F5, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000F7:    {kind: InitForm, arg0: inst600000F5, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst600000F8:    {kind: LookupImplWitness, arg0: inst600000DC, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst600000F9:    {kind: FunctionType, arg0: function60000001, arg1: specific6000000F, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000FA:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant600000A3)}
-// CHECK:STDOUT:     inst600000FB:    {kind: FunctionTypeWithSelfType, arg0: inst600000F9, arg1: inst600000DC, type: type(TypeType)}
-// CHECK:STDOUT:     inst600000FC:    {kind: ImplWitnessAccess, arg0: inst600000F8, arg1: element0, type: type(symbolic_constant600000A5)}
-// CHECK:STDOUT:     inst600000FD:    {kind: SpecificImplFunction, arg0: inst600000FC, arg1: specific60000010, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst600000FE:    {kind: InitForm, arg0: inst600000DD, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst600000FF:    {kind: PatternType, arg0: inst600000DD, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000100:    {kind: RequireCompleteType, arg0: inst600000DD, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000101:    {kind: RequireCompleteType, arg0: inst600000DE, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000102:    {kind: RequireCompleteType, arg0: inst600000F5, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000103:    {kind: RequireCompleteType, arg0: inst600000F2, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000104:    {kind: LookupImplWitness, arg0: inst600000F1, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000105:    {kind: FunctionType, arg0: function60000001, arg1: specific60000012, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000106:    {kind: FunctionTypeWithSelfType, arg0: inst60000105, arg1: inst600000F1, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000107:    {kind: ImplWitnessAccess, arg0: inst60000104, arg1: element0, type: type(symbolic_constant600000BD)}
-// CHECK:STDOUT:     inst60000108:    {kind: SpecificImplFunction, arg0: inst60000107, arg1: specific60000013, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000109:    {kind: RequireCompleteType, arg0: inst600000F4, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000010A:    {kind: LookupImplWitness, arg0: inst600000F3, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000010B:    {kind: FunctionType, arg0: function60000001, arg1: specific60000014, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000010C:    {kind: FunctionTypeWithSelfType, arg0: inst6000010B, arg1: inst600000F3, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000010D:    {kind: ImplWitnessAccess, arg0: inst6000010A, arg1: element0, type: type(symbolic_constant600000C3)}
-// CHECK:STDOUT:     inst6000010E:    {kind: SpecificImplFunction, arg0: inst6000010D, arg1: specific60000015, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst6000010F:    {kind: SymbolicBindingPattern, arg0: entity_name60000029, type: type(inst60000099)}
-// CHECK:STDOUT:     inst60000110:    {kind: SymbolicBindingPattern, arg0: entity_name6000002A, type: type(inst60000099)}
-// CHECK:STDOUT:     inst60000111:    {kind: ImportRefLoaded, arg0: import_ir_inst8E, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000112:    {kind: ImportRefLoaded, arg0: import_ir_inst8F, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000113:    {kind: ImportRefLoaded, arg0: import_ir_inst90, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000114:    {kind: ImportRefLoaded, arg0: import_ir_inst91, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000115:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000116:    {kind: SymbolicBinding, arg0: entity_name6000001C, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000117:    {kind: TupleValue, arg0: inst_block60000061, type: type(inst600000E5)}
-// CHECK:STDOUT:     inst60000118:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst60000115, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000119:    {kind: SymbolicBindingType, arg0: entity_name6000001C, arg1: inst60000116, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000011A:    {kind: TupleType, arg0: inst_block60000062, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000011B:    {kind: ImplWitness, arg0: inst600000E0, arg1: specific60000016, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000011C:    {kind: FunctionType, arg0: function60000004, arg1: specific60000016, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000011D:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant600000D4)}
-// CHECK:STDOUT:     inst6000011E:    {kind: ImportRefUnloaded, arg0: import_ir_inst9B, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst6000011F:    {kind: ImplDecl, arg0: impl60000009, arg1: inst_block_empty}
-// CHECK:STDOUT:     inst60000120:    {kind: SymbolicBinding, arg0: entity_name6000002B, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000121:    {kind: SymbolicBindingType, arg0: entity_name6000002B, arg1: inst60000120, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000122:    {kind: TupleType, arg0: inst_block60000067, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000123:    {kind: ImportRefUnloaded, arg0: import_ir_inst9D, arg1: entity_name<none>}
-// CHECK:STDOUT:     inst60000124:    {kind: ImplWitnessTable, arg0: inst_block60000068, arg1: impl60000009}
-// CHECK:STDOUT:     inst60000125:    {kind: ImplWitness, arg0: inst60000124, arg1: specific60000017, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000126:    {kind: FunctionDecl, arg0: function60000005, arg1: inst_block_empty, type: type(symbolic_constant600000DC)}
-// CHECK:STDOUT:     inst60000127:    {kind: FunctionType, arg0: function60000005, arg1: specific60000017, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000128:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant600000DC)}
-// CHECK:STDOUT:     inst60000129:    {kind: TupleType, arg0: inst_block6000006A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000012A:    {kind: TupleValue, arg0: inst_block60000069, type: type(inst60000129)}
-// CHECK:STDOUT:     inst6000012B:    {kind: PatternType, arg0: inst60000122, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000012C:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant600000E2)}
-// CHECK:STDOUT:     inst6000012D:    {kind: OutParamPattern, arg0: inst6000012C, type: type(symbolic_constant600000E2)}
-// CHECK:STDOUT:     inst6000012E:    {kind: ValueBindingPattern, arg0: entity_name6000002D, type: type(symbolic_constant600000E2)}
-// CHECK:STDOUT:     inst6000012F:    {kind: ValueParamPattern, arg0: inst6000012E, type: type(symbolic_constant600000E2)}
-// CHECK:STDOUT:     inst60000130:    {kind: InitForm, arg0: inst60000122, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000131:    {kind: ImportRefLoaded, arg0: import_ir_instA4, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000132:    {kind: ImportRefLoaded, arg0: import_ir_instA5, arg1: entity_name<none>, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000133:    {kind: ImportRefLoaded, arg0: import_ir_instA6, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000134:    {kind: ImportRefLoaded, arg0: import_ir_instA7, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000135:    {kind: ImportRefLoaded, arg0: import_ir_instA8, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000136:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000137:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst60000136, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000138:    {kind: SymbolicBinding, arg0: entity_name6000001C, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000139:    {kind: SymbolicBindingType, arg0: entity_name6000001C, arg1: inst60000138, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000013A:    {kind: SymbolicBinding, arg0: entity_name6000002B, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst6000013B:    {kind: SymbolicBindingType, arg0: entity_name6000002B, arg1: inst6000013A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000013C:    {kind: TupleType, arg0: inst_block60000071, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000013D:    {kind: PatternType, arg0: inst6000013C, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000013E:    {kind: InitForm, arg0: inst6000013C, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst6000013F:    {kind: LookupImplWitness, arg0: inst60000120, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000140:    {kind: FunctionType, arg0: function60000001, arg1: specific60000018, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000141:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant600000FB)}
-// CHECK:STDOUT:     inst60000142:    {kind: FunctionTypeWithSelfType, arg0: inst60000140, arg1: inst60000120, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000143:    {kind: ImplWitnessAccess, arg0: inst6000013F, arg1: element0, type: type(symbolic_constant600000FD)}
-// CHECK:STDOUT:     inst60000144:    {kind: SpecificImplFunction, arg0: inst60000143, arg1: specific60000019, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000145:    {kind: InitForm, arg0: inst60000121, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000146:    {kind: PatternType, arg0: inst60000121, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000147:    {kind: RequireCompleteType, arg0: inst60000121, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000148:    {kind: RequireCompleteType, arg0: inst60000122, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000149:    {kind: RequireCompleteType, arg0: inst6000013C, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000014A:    {kind: RequireCompleteType, arg0: inst60000137, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000014B:    {kind: LookupImplWitness, arg0: inst60000136, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000014C:    {kind: FunctionType, arg0: function60000001, arg1: specific6000001B, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000014D:    {kind: FunctionTypeWithSelfType, arg0: inst6000014C, arg1: inst60000136, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000014E:    {kind: ImplWitnessAccess, arg0: inst6000014B, arg1: element0, type: type(symbolic_constant6000011B)}
-// CHECK:STDOUT:     inst6000014F:    {kind: SpecificImplFunction, arg0: inst6000014E, arg1: specific6000001C, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000150:    {kind: RequireCompleteType, arg0: inst60000139, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000151:    {kind: LookupImplWitness, arg0: inst60000138, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000152:    {kind: FunctionType, arg0: function60000001, arg1: specific6000001D, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000153:    {kind: FunctionTypeWithSelfType, arg0: inst60000152, arg1: inst60000138, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000154:    {kind: ImplWitnessAccess, arg0: inst60000151, arg1: element0, type: type(symbolic_constant60000121)}
-// CHECK:STDOUT:     inst60000155:    {kind: SpecificImplFunction, arg0: inst60000154, arg1: specific6000001E, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000156:    {kind: RequireCompleteType, arg0: inst6000013B, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000157:    {kind: LookupImplWitness, arg0: inst6000013A, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000158:    {kind: FunctionType, arg0: function60000001, arg1: specific6000001F, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000159:    {kind: FunctionTypeWithSelfType, arg0: inst60000158, arg1: inst6000013A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000015A:    {kind: ImplWitnessAccess, arg0: inst60000157, arg1: element0, type: type(symbolic_constant60000127)}
-// CHECK:STDOUT:     inst6000015B:    {kind: SpecificImplFunction, arg0: inst6000015A, arg1: specific60000020, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst6000015C:    {kind: SymbolicBindingPattern, arg0: entity_name6000003D, type: type(inst60000099)}
-// CHECK:STDOUT:     inst6000015D:    {kind: SymbolicBindingPattern, arg0: entity_name6000003E, type: type(inst60000099)}
-// CHECK:STDOUT:     inst6000015E:    {kind: SymbolicBindingPattern, arg0: entity_name6000003F, type: type(inst60000099)}
-// CHECK:STDOUT:     inst6000015F:    {kind: ImportRefLoaded, arg0: import_ir_instC8, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000160:    {kind: ImportRefLoaded, arg0: import_ir_instC9, arg1: entity_name<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000161:    {kind: ImportRefLoaded, arg0: import_ir_instCA, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000162:    {kind: ImportRefLoaded, arg0: import_ir_instCB, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000163:    {kind: ImportRefLoaded, arg0: import_ir_instCC, arg1: entity_name<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000164:    {kind: SymbolicBinding, arg0: entity_name60000001, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000165:    {kind: SymbolicBinding, arg0: entity_name6000001C, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000166:    {kind: SymbolicBinding, arg0: entity_name6000002B, arg1: inst<none>, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000167:    {kind: TupleValue, arg0: inst_block60000080, type: type(inst60000129)}
-// CHECK:STDOUT:     inst60000168:    {kind: SymbolicBindingType, arg0: entity_name60000001, arg1: inst60000164, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000169:    {kind: SymbolicBindingType, arg0: entity_name6000001C, arg1: inst60000165, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000016A:    {kind: SymbolicBindingType, arg0: entity_name6000002B, arg1: inst60000166, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000016B:    {kind: TupleType, arg0: inst_block60000081, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000016C:    {kind: ImplWitness, arg0: inst60000124, arg1: specific60000021, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst6000016D:    {kind: FunctionType, arg0: function60000005, arg1: specific60000021, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000016E:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant6000013C)}
-// CHECK:STDOUT:     inst6000016F:    {kind: RequireSpecificDefinition, arg0: specific6000000B, type: type(inst(RequireSpecificDefinitionType))}
-// CHECK:STDOUT:     inst60000170:    {kind: RequireSpecificDefinition, arg0: specific6000000B, type: type(inst(RequireSpecificDefinitionType))}
-// CHECK:STDOUT:     inst60000171:    {kind: RequireSpecificDefinition, arg0: specific60000022, type: type(inst(RequireSpecificDefinitionType))}
-// CHECK:STDOUT:     inst60000172:    {kind: LookupImplWitness, arg0: inst6000001D, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000173:    {kind: LookupImplWitness, arg0: inst6000001E, arg1: specific_interface60000000, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000174:    {kind: FacetValue, arg0: inst6000001D, arg1: inst_block60000088, type: type(inst60000050)}
-// CHECK:STDOUT:     inst60000175:    {kind: FunctionType, arg0: function60000001, arg1: specific60000023, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000176:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant60000144)}
-// CHECK:STDOUT:     inst60000177:    {kind: FunctionTypeWithSelfType, arg0: inst60000175, arg1: inst60000174, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000178:    {kind: ImplWitnessAccess, arg0: inst60000172, arg1: element0, type: type(symbolic_constant6000014A)}
-// CHECK:STDOUT:     inst60000179:    {kind: ImplWitnessAccess, arg0: inst60000172, arg1: element0, type: type(symbolic_constant60000146)}
-// CHECK:STDOUT:     inst6000017A:    {kind: FacetValue, arg0: inst6000001E, arg1: inst_block6000008B, type: type(inst60000050)}
-// CHECK:STDOUT:     inst6000017B:    {kind: FunctionType, arg0: function60000001, arg1: specific60000024, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000017C:    {kind: FunctionTypeWithSelfType, arg0: inst6000017B, arg1: inst6000017A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000017D:    {kind: ImplWitnessAccess, arg0: inst60000173, arg1: element0, type: type(symbolic_constant6000014A)}
-// CHECK:STDOUT:     inst6000017E:    {kind: BoundMethod, arg0: inst60000048, arg1: inst60000178, type: type(inst(BoundMethodType))}
-// CHECK:STDOUT:     inst6000017F:    {kind: SpecificImplFunction, arg0: inst60000178, arg1: specific60000025, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000180:    {kind: SpecificImplFunction, arg0: inst60000179, arg1: specific60000025, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000181:    {kind: SpecificImplFunction, arg0: inst6000017D, arg1: specific60000026, type: type(inst(SpecificFunctionType))}
-// CHECK:STDOUT:     inst60000182:    {kind: BoundMethod, arg0: inst60000048, arg1: inst6000017F, type: type(inst(BoundMethodType))}
-// CHECK:STDOUT:     inst60000183:    {kind: RequireCompleteType, arg0: inst6000001D, type: type(inst(WitnessType))}
-// CHECK:STDOUT:     inst60000184:    {kind: Call, arg0: inst60000182, arg1: inst_block6000008F, type: type(symbolic_constant60000004)}
-// CHECK:STDOUT:     inst60000185:    {kind: InPlaceInit, arg0: inst60000184, arg1: inst6000004C, type: type(symbolic_constant60000004)}
-// CHECK:STDOUT:     inst60000186:    {kind: TupleAccess, arg0: inst6000003C, arg1: element1, type: type(inst60000026)}
-// CHECK:STDOUT:     inst60000187:    {kind: TupleInit, arg0: inst_block_empty, arg1: inst<none>, type: type(inst60000026)}
-// CHECK:STDOUT:     inst60000188:    {kind: Converted, arg0: inst60000049, arg1: inst60000187, type: type(inst60000026)}
-// CHECK:STDOUT:     inst60000189:    {kind: TupleInit, arg0: inst_block60000090, arg1: inst6000003C, type: type(symbolic_constant6000000A)}
-// CHECK:STDOUT:     inst6000018A:    {kind: Converted, arg0: inst6000004A, arg1: inst60000189, type: type(symbolic_constant6000000A)}
-// CHECK:STDOUT:     inst6000018B:    {kind: ReturnExpr, arg0: inst6000018A, arg1: inst6000003C}
+// CHECK:STDOUT:     inst58000010:    {kind: ImportDecl, arg0: name(Core)}
+// CHECK:STDOUT:     inst58000011:    {kind: Namespace, arg0: name_scope58000001, arg1: inst58000010, type: type(inst(NamespaceType))}
+// CHECK:STDOUT:     inst58000012:    {kind: FacetType, arg0: facet_type58000000, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000013:    {kind: SymbolicBinding, arg0: entity_name58000000, arg1: inst<none>, type: type(inst58000012)}
+// CHECK:STDOUT:     inst58000014:    {kind: SymbolicBinding, arg0: entity_name58000000, arg1: inst<none>, type: type(inst58000012)}
+// CHECK:STDOUT:     inst58000015:    {kind: TypeLiteral, arg0: inst(TypeType), type: type(TypeType)}
+// CHECK:STDOUT:     inst58000016:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000017:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000018:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000019:    {kind: PatternType, arg0: inst(TypeType), type: type(TypeType)}
+// CHECK:STDOUT:     inst5800001A:    {kind: SymbolicBindingPattern, arg0: entity_name58000001, type: type(inst58000019)}
+// CHECK:STDOUT:     inst5800001B:    {kind: NameRef, arg0: name1, arg1: inst58000016, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800001C:    {kind: PointerType, arg0: inst5800001B, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800001D:    {kind: PointerType, arg0: inst58000017, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800001E:    {kind: PointerType, arg0: inst58000018, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800001F:    {kind: ValueBinding, arg0: entity_name58000002, arg1: inst5800003A, type: type(symbolic_constant58000004)}
+// CHECK:STDOUT:     inst58000020:    {kind: PatternType, arg0: inst5800001D, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000021:    {kind: ValueBindingPattern, arg0: entity_name58000002, type: type(symbolic_constant58000006)}
+// CHECK:STDOUT:     inst58000022:    {kind: PatternType, arg0: inst5800001E, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000023:    {kind: ValueParamPattern, arg0: inst58000021, type: type(symbolic_constant58000006)}
+// CHECK:STDOUT:     inst58000024:    {kind: NameRef, arg0: name1, arg1: inst58000016, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000025:    {kind: PointerType, arg0: inst58000024, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000026:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000027:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst58000026)}
+// CHECK:STDOUT:     inst58000028:    {kind: TupleValue, arg0: inst_block_empty, type: type(inst58000026)}
+// CHECK:STDOUT:     inst58000029:    {kind: TupleType, arg0: inst_block5800000A, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800002A:    {kind: TupleLiteral, arg0: inst_block58000009, type: type(inst58000029)}
+// CHECK:STDOUT:     inst5800002B:    {kind: TupleValue, arg0: inst_block5800000B, type: type(inst58000029)}
+// CHECK:STDOUT:     inst5800002C:    {kind: TupleValue, arg0: inst_block5800000C, type: type(inst58000029)}
+// CHECK:STDOUT:     inst5800002D:    {kind: PointerType, arg0: inst58000029, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800002E:    {kind: Converted, arg0: inst58000028, arg1: inst58000026, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800002F:    {kind: TupleType, arg0: inst_block5800000E, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000030:    {kind: Converted, arg0: inst5800002A, arg1: inst5800002F, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000031:    {kind: TupleType, arg0: inst_block5800000F, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000032:    {kind: InitForm, arg0: inst58000030, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000033:    {kind: InitForm, arg0: inst5800002F, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000034:    {kind: InitForm, arg0: inst58000031, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000035:    {kind: PatternType, arg0: inst5800002F, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000036:    {kind: ReturnSlotPattern, arg0: inst58000030, type: type(symbolic_constant5800000E)}
+// CHECK:STDOUT:     inst58000037:    {kind: PatternType, arg0: inst58000031, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000038:    {kind: OutParamPattern, arg0: inst58000036, type: type(symbolic_constant5800000E)}
+// CHECK:STDOUT:     inst58000039:    {kind: SpliceBlock, arg0: inst_block58000005, arg1: inst58000015, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800003A:    {kind: ValueParam, arg0: call_param0, arg1: name2, type: type(symbolic_constant58000004)}
+// CHECK:STDOUT:     inst5800003B:    {kind: SpliceBlock, arg0: inst_block58000007, arg1: inst5800001C, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800003C:    {kind: OutParam, arg0: call_param1, arg1: name(ReturnSlot), type: type(symbolic_constant5800000A)}
+// CHECK:STDOUT:     inst5800003D:    {kind: ReturnSlot, arg0: inst5800002F, arg1: inst5800003C, type: type(symbolic_constant5800000A)}
+// CHECK:STDOUT:     inst5800003E:    {kind: FunctionDecl, arg0: function58000000, arg1: inst_block58000014, type: type(inst5800003F)}
+// CHECK:STDOUT:     inst5800003F:    {kind: FunctionType, arg0: function58000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000040:    {kind: StructValue, arg0: inst_block_empty, type: type(inst5800003F)}
+// CHECK:STDOUT:     inst58000041:    {kind: RequireCompleteType, arg0: inst5800001D, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000042:    {kind: RequireCompleteType, arg0: inst5800001D, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000043:    {kind: RequireCompleteType, arg0: inst5800001E, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000044:    {kind: PointerType, arg0: inst5800002F, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000045:    {kind: RequireCompleteType, arg0: inst5800002F, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000046:    {kind: RequireCompleteType, arg0: inst5800002F, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000047:    {kind: RequireCompleteType, arg0: inst58000031, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000048:    {kind: NameRef, arg0: name2, arg1: inst5800001F, type: type(symbolic_constant58000004)}
+// CHECK:STDOUT:     inst58000049:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst58000026)}
+// CHECK:STDOUT:     inst5800004A:    {kind: TupleLiteral, arg0: inst_block5800001A, type: type(symbolic_constant5800000A)}
+// CHECK:STDOUT:     inst5800004B:    {kind: RequireCompleteType, arg0: inst5800002F, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800004C:    {kind: TupleAccess, arg0: inst5800003C, arg1: element0, type: type(symbolic_constant58000004)}
+// CHECK:STDOUT:     inst5800004D:    {kind: RequireCompleteType, arg0: inst5800001D, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800004E:    {kind: ImportRefLoaded, arg0: import_ir_inst0, arg1: entity_name58000003, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800004F:    {kind: InterfaceDecl, arg0: interface58000000, arg1: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000050:    {kind: FacetType, arg0: facet_type58000001, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000051:    {kind: InterfaceWithSelfDecl, arg0: interface58000000}
+// CHECK:STDOUT:     inst58000052:    {kind: SymbolicBinding, arg0: entity_name58000004, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000053:    {kind: ImportRefLoaded, arg0: import_ir_inst3, arg1: entity_name<none>, type: type(inst5800006B)}
+// CHECK:STDOUT:     inst58000054:    {kind: ImportRefUnloaded, arg0: import_ir_inst4, arg1: entity_name58000005}
+// CHECK:STDOUT:     inst58000055:    {kind: ImportRefLoaded, arg0: import_ir_inst5, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000056:    {kind: FunctionDecl, arg0: function58000001, arg1: inst_block_empty, type: type(symbolic_constant58000015)}
+// CHECK:STDOUT:     inst58000057:    {kind: FunctionType, arg0: function58000001, arg1: specific58000001, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000058:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000015)}
+// CHECK:STDOUT:     inst58000059:    {kind: SymbolicBindingType, arg0: entity_name58000004, arg1: inst58000052, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800005A:    {kind: PatternType, arg0: inst58000059, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800005B:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant5800001B)}
+// CHECK:STDOUT:     inst5800005C:    {kind: OutParamPattern, arg0: inst5800005B, type: type(symbolic_constant5800001B)}
+// CHECK:STDOUT:     inst5800005D:    {kind: ValueBindingPattern, arg0: entity_name58000008, type: type(symbolic_constant5800001B)}
+// CHECK:STDOUT:     inst5800005E:    {kind: ValueParamPattern, arg0: inst5800005D, type: type(symbolic_constant5800001B)}
+// CHECK:STDOUT:     inst5800005F:    {kind: InitForm, arg0: inst58000059, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000060:    {kind: ImportRefLoaded, arg0: import_ir_instB, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000061:    {kind: ImportRefLoaded, arg0: import_ir_instC, arg1: entity_name<none>, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000062:    {kind: ImportRefLoaded, arg0: import_ir_instD, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000063:    {kind: SymbolicBinding, arg0: entity_name58000004, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000064:    {kind: SymbolicBindingType, arg0: entity_name58000004, arg1: inst58000063, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000065:    {kind: PatternType, arg0: inst58000064, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000066:    {kind: InitForm, arg0: inst58000064, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000067:    {kind: SymbolicBinding, arg0: entity_name58000004, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000068:    {kind: FunctionType, arg0: function58000001, arg1: specific58000003, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000069:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000029)}
+// CHECK:STDOUT:     inst5800006A:    {kind: ImportRefUnloaded, arg0: import_ir_inst15, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst5800006B:    {kind: AssociatedEntityType, arg0: interface58000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800006C:    {kind: ImportRefLoaded, arg0: import_ir_inst16, arg1: entity_name<none>, type: type(symbolic_constant58000019)}
+// CHECK:STDOUT:     inst5800006D:    {kind: AssociatedEntity, arg0: element0, arg1: inst5800006C, type: type(inst5800006B)}
+// CHECK:STDOUT:     inst5800006E:    {kind: LookupImplWitness, arg0: inst5800001D, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800006F:    {kind: ImportRefUnloaded, arg0: import_ir_inst17, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst58000070:    {kind: ImplDecl, arg0: impl58000000, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst58000071:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000072:    {kind: SymbolicBindingType, arg0: entity_name58000001, arg1: inst58000071, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000073:    {kind: ConstType, arg0: inst58000072, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000074:    {kind: ImportRefUnloaded, arg0: import_ir_inst19, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst58000075:    {kind: ImplWitnessTable, arg0: inst_block58000027, arg1: impl58000000}
+// CHECK:STDOUT:     inst58000076:    {kind: ImplWitness, arg0: inst58000075, arg1: specific58000004, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000077:    {kind: FunctionDecl, arg0: function58000002, arg1: inst_block_empty, type: type(symbolic_constant58000031)}
+// CHECK:STDOUT:     inst58000078:    {kind: FunctionType, arg0: function58000002, arg1: specific58000004, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000079:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000031)}
+// CHECK:STDOUT:     inst5800007A:    {kind: PatternType, arg0: inst58000073, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800007B:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant58000036)}
+// CHECK:STDOUT:     inst5800007C:    {kind: OutParamPattern, arg0: inst5800007B, type: type(symbolic_constant58000036)}
+// CHECK:STDOUT:     inst5800007D:    {kind: ValueBindingPattern, arg0: entity_name5800000F, type: type(symbolic_constant58000036)}
+// CHECK:STDOUT:     inst5800007E:    {kind: ValueParamPattern, arg0: inst5800007D, type: type(symbolic_constant58000036)}
+// CHECK:STDOUT:     inst5800007F:    {kind: InitForm, arg0: inst58000073, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000080:    {kind: ImportRefLoaded, arg0: import_ir_inst20, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000081:    {kind: ImportRefLoaded, arg0: import_ir_inst21, arg1: entity_name<none>, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000082:    {kind: ImportRefLoaded, arg0: import_ir_inst22, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000083:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000084:    {kind: SymbolicBindingType, arg0: entity_name58000001, arg1: inst58000083, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000085:    {kind: ConstType, arg0: inst58000084, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000086:    {kind: PatternType, arg0: inst58000085, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000087:    {kind: InitForm, arg0: inst58000085, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000088:    {kind: LookupImplWitness, arg0: inst58000071, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000089:    {kind: FunctionType, arg0: function58000001, arg1: specific58000005, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800008A:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000045)}
+// CHECK:STDOUT:     inst5800008B:    {kind: FunctionTypeWithSelfType, arg0: inst58000089, arg1: inst58000071, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800008C:    {kind: ImplWitnessAccess, arg0: inst58000088, arg1: element0, type: type(symbolic_constant58000047)}
+// CHECK:STDOUT:     inst5800008D:    {kind: SpecificImplFunction, arg0: inst5800008C, arg1: specific58000006, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst5800008E:    {kind: InitForm, arg0: inst58000072, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst5800008F:    {kind: PatternType, arg0: inst58000072, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000090:    {kind: RequireCompleteType, arg0: inst58000072, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000091:    {kind: RequireCompleteType, arg0: inst58000073, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000092:    {kind: RequireCompleteType, arg0: inst58000085, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000093:    {kind: RequireCompleteType, arg0: inst58000084, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000094:    {kind: LookupImplWitness, arg0: inst58000083, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000095:    {kind: FunctionType, arg0: function58000001, arg1: specific58000008, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000096:    {kind: FunctionTypeWithSelfType, arg0: inst58000095, arg1: inst58000083, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000097:    {kind: ImplWitnessAccess, arg0: inst58000094, arg1: element0, type: type(symbolic_constant58000059)}
+// CHECK:STDOUT:     inst58000098:    {kind: SpecificImplFunction, arg0: inst58000097, arg1: specific58000009, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst58000099:    {kind: PatternType, arg0: inst58000050, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800009A:    {kind: SymbolicBindingPattern, arg0: entity_name58000015, type: type(inst58000099)}
+// CHECK:STDOUT:     inst5800009B:    {kind: ImportRefLoaded, arg0: import_ir_inst30, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800009C:    {kind: ImportRefLoaded, arg0: import_ir_inst31, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800009D:    {kind: ImportRefLoaded, arg0: import_ir_inst32, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst5800009E:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst5800009F:    {kind: SymbolicBindingType, arg0: entity_name58000001, arg1: inst5800009E, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000A0:    {kind: ConstType, arg0: inst5800009F, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000A1:    {kind: ImplWitness, arg0: inst58000075, arg1: specific5800000A, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst580000A2:    {kind: FunctionType, arg0: function58000002, arg1: specific5800000A, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000A3:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000064)}
+// CHECK:STDOUT:     inst580000A4:    {kind: ImportRefUnloaded, arg0: import_ir_inst39, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000A5:    {kind: ImplDecl, arg0: impl58000001, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst580000A6:    {kind: ImportRefLoaded, arg0: import_ir_inst3B, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000A7:    {kind: ImportRefLoaded, arg0: import_ir_inst3C, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000A8:    {kind: ImportRefUnloaded, arg0: import_ir_inst3D, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000A9:    {kind: ImplDecl, arg0: impl58000002, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst580000AA:    {kind: ImportRefLoaded, arg0: import_ir_inst3F, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000AB:    {kind: ImportRefLoaded, arg0: import_ir_inst40, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000AC:    {kind: ImportRefUnloaded, arg0: import_ir_inst41, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000AD:    {kind: ImplDecl, arg0: impl58000003, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst580000AE:    {kind: ImportRefLoaded, arg0: import_ir_inst43, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000AF:    {kind: ImportRefLoaded, arg0: import_ir_inst44, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000B0:    {kind: ImportRefUnloaded, arg0: import_ir_inst45, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000B1:    {kind: ImplDecl, arg0: impl58000004, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst580000B2:    {kind: ImportRefLoaded, arg0: import_ir_inst47, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000B3:    {kind: ImportRefLoaded, arg0: import_ir_inst48, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000B4:    {kind: ImportRefLoaded, arg0: import_ir_inst49, arg1: entity_name<none>, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst580000B5:    {kind: ImplDecl, arg0: impl58000005, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst580000B6:    {kind: ImportRefUnloaded, arg0: import_ir_inst4B, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000B7:    {kind: ImplWitnessTable, arg0: inst_block5800003C, arg1: impl58000005}
+// CHECK:STDOUT:     inst580000B8:    {kind: ImplWitness, arg0: inst580000B7, arg1: specific5800000B, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst580000B9:    {kind: SymbolicBindingPattern, arg0: entity_name58000019, type: type(inst58000019)}
+// CHECK:STDOUT:     inst580000BA:    {kind: ImportRefLoaded, arg0: import_ir_inst4E, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000BB:    {kind: ImportRefLoaded, arg0: import_ir_inst4F, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000BC:    {kind: ImportRefLoaded, arg0: import_ir_inst50, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000BD:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000BE:    {kind: PointerType, arg0: inst580000BD, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000BF:    {kind: ImplWitness, arg0: inst580000B7, arg1: specific5800000C, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst580000C0:    {kind: FunctionDecl, arg0: function58000003, arg1: inst_block_empty, type: type(symbolic_constant58000070)}
+// CHECK:STDOUT:     inst580000C1:    {kind: FunctionType, arg0: function58000003, arg1: specific5800000B, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000C2:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000070)}
+// CHECK:STDOUT:     inst580000C3:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant58000074)}
+// CHECK:STDOUT:     inst580000C4:    {kind: OutParamPattern, arg0: inst580000C3, type: type(symbolic_constant58000074)}
+// CHECK:STDOUT:     inst580000C5:    {kind: ValueBindingPattern, arg0: entity_name5800001A, type: type(symbolic_constant58000074)}
+// CHECK:STDOUT:     inst580000C6:    {kind: ValueParamPattern, arg0: inst580000C5, type: type(symbolic_constant58000074)}
+// CHECK:STDOUT:     inst580000C7:    {kind: InitForm, arg0: inst5800001D, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst580000C8:    {kind: ImportRefLoaded, arg0: import_ir_inst59, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000C9:    {kind: ImportRefLoaded, arg0: import_ir_inst5A, arg1: entity_name<none>, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst580000CA:    {kind: ImportRefLoaded, arg0: import_ir_inst5B, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000CB:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000CC:    {kind: PointerType, arg0: inst580000CB, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000CD:    {kind: PatternType, arg0: inst580000CC, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000CE:    {kind: InitForm, arg0: inst580000CC, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst580000CF:    {kind: FunctionType, arg0: function58000003, arg1: specific5800000C, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000D0:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000080)}
+// CHECK:STDOUT:     inst580000D1:    {kind: RequireCompleteType, arg0: inst580000BE, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst580000D2:    {kind: ImportRefUnloaded, arg0: import_ir_inst63, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000D3:    {kind: ImplDecl, arg0: impl58000006, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst580000D4:    {kind: ImportRefLoaded, arg0: import_ir_inst65, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000D5:    {kind: ImportRefLoaded, arg0: import_ir_inst66, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000D6:    {kind: ImportRefUnloaded, arg0: import_ir_inst67, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000D7:    {kind: ImplDecl, arg0: impl58000007, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst580000D8:    {kind: ImportRefLoaded, arg0: import_ir_inst69, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000D9:    {kind: ImportRefLoaded, arg0: import_ir_inst6A, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000DA:    {kind: ImportRefUnloaded, arg0: import_ir_inst6B, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000DB:    {kind: ImplDecl, arg0: impl58000008, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst580000DC:    {kind: SymbolicBinding, arg0: entity_name5800001C, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst580000DD:    {kind: SymbolicBindingType, arg0: entity_name5800001C, arg1: inst580000DC, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000DE:    {kind: TupleType, arg0: inst_block5800004A, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000DF:    {kind: ImportRefUnloaded, arg0: import_ir_inst6D, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst580000E0:    {kind: ImplWitnessTable, arg0: inst_block5800004B, arg1: impl58000008}
+// CHECK:STDOUT:     inst580000E1:    {kind: ImplWitness, arg0: inst580000E0, arg1: specific5800000E, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst580000E2:    {kind: FunctionDecl, arg0: function58000004, arg1: inst_block_empty, type: type(symbolic_constant58000089)}
+// CHECK:STDOUT:     inst580000E3:    {kind: FunctionType, arg0: function58000004, arg1: specific5800000E, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000E4:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000089)}
+// CHECK:STDOUT:     inst580000E5:    {kind: TupleType, arg0: inst_block5800004D, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000E6:    {kind: TupleValue, arg0: inst_block5800004C, type: type(inst580000E5)}
+// CHECK:STDOUT:     inst580000E7:    {kind: PatternType, arg0: inst580000DE, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000E8:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant5800008F)}
+// CHECK:STDOUT:     inst580000E9:    {kind: OutParamPattern, arg0: inst580000E8, type: type(symbolic_constant5800008F)}
+// CHECK:STDOUT:     inst580000EA:    {kind: ValueBindingPattern, arg0: entity_name5800001E, type: type(symbolic_constant5800008F)}
+// CHECK:STDOUT:     inst580000EB:    {kind: ValueParamPattern, arg0: inst580000EA, type: type(symbolic_constant5800008F)}
+// CHECK:STDOUT:     inst580000EC:    {kind: InitForm, arg0: inst580000DE, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst580000ED:    {kind: ImportRefLoaded, arg0: import_ir_inst74, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000EE:    {kind: ImportRefLoaded, arg0: import_ir_inst75, arg1: entity_name<none>, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst580000EF:    {kind: ImportRefLoaded, arg0: import_ir_inst76, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst580000F0:    {kind: ImportRefLoaded, arg0: import_ir_inst77, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst580000F1:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst580000F2:    {kind: SymbolicBindingType, arg0: entity_name58000001, arg1: inst580000F1, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000F3:    {kind: SymbolicBinding, arg0: entity_name5800001C, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst580000F4:    {kind: SymbolicBindingType, arg0: entity_name5800001C, arg1: inst580000F3, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000F5:    {kind: TupleType, arg0: inst_block58000054, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000F6:    {kind: PatternType, arg0: inst580000F5, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000F7:    {kind: InitForm, arg0: inst580000F5, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst580000F8:    {kind: LookupImplWitness, arg0: inst580000DC, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst580000F9:    {kind: FunctionType, arg0: function58000001, arg1: specific5800000F, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000FA:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant580000A3)}
+// CHECK:STDOUT:     inst580000FB:    {kind: FunctionTypeWithSelfType, arg0: inst580000F9, arg1: inst580000DC, type: type(TypeType)}
+// CHECK:STDOUT:     inst580000FC:    {kind: ImplWitnessAccess, arg0: inst580000F8, arg1: element0, type: type(symbolic_constant580000A5)}
+// CHECK:STDOUT:     inst580000FD:    {kind: SpecificImplFunction, arg0: inst580000FC, arg1: specific58000010, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst580000FE:    {kind: InitForm, arg0: inst580000DD, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst580000FF:    {kind: PatternType, arg0: inst580000DD, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000100:    {kind: RequireCompleteType, arg0: inst580000DD, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000101:    {kind: RequireCompleteType, arg0: inst580000DE, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000102:    {kind: RequireCompleteType, arg0: inst580000F5, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000103:    {kind: RequireCompleteType, arg0: inst580000F2, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000104:    {kind: LookupImplWitness, arg0: inst580000F1, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000105:    {kind: FunctionType, arg0: function58000001, arg1: specific58000012, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000106:    {kind: FunctionTypeWithSelfType, arg0: inst58000105, arg1: inst580000F1, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000107:    {kind: ImplWitnessAccess, arg0: inst58000104, arg1: element0, type: type(symbolic_constant580000BD)}
+// CHECK:STDOUT:     inst58000108:    {kind: SpecificImplFunction, arg0: inst58000107, arg1: specific58000013, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst58000109:    {kind: RequireCompleteType, arg0: inst580000F4, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800010A:    {kind: LookupImplWitness, arg0: inst580000F3, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800010B:    {kind: FunctionType, arg0: function58000001, arg1: specific58000014, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800010C:    {kind: FunctionTypeWithSelfType, arg0: inst5800010B, arg1: inst580000F3, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800010D:    {kind: ImplWitnessAccess, arg0: inst5800010A, arg1: element0, type: type(symbolic_constant580000C3)}
+// CHECK:STDOUT:     inst5800010E:    {kind: SpecificImplFunction, arg0: inst5800010D, arg1: specific58000015, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst5800010F:    {kind: SymbolicBindingPattern, arg0: entity_name58000029, type: type(inst58000099)}
+// CHECK:STDOUT:     inst58000110:    {kind: SymbolicBindingPattern, arg0: entity_name5800002A, type: type(inst58000099)}
+// CHECK:STDOUT:     inst58000111:    {kind: ImportRefLoaded, arg0: import_ir_inst8E, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000112:    {kind: ImportRefLoaded, arg0: import_ir_inst8F, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000113:    {kind: ImportRefLoaded, arg0: import_ir_inst90, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000114:    {kind: ImportRefLoaded, arg0: import_ir_inst91, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000115:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000116:    {kind: SymbolicBinding, arg0: entity_name5800001C, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000117:    {kind: TupleValue, arg0: inst_block58000061, type: type(inst580000E5)}
+// CHECK:STDOUT:     inst58000118:    {kind: SymbolicBindingType, arg0: entity_name58000001, arg1: inst58000115, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000119:    {kind: SymbolicBindingType, arg0: entity_name5800001C, arg1: inst58000116, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800011A:    {kind: TupleType, arg0: inst_block58000062, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800011B:    {kind: ImplWitness, arg0: inst580000E0, arg1: specific58000016, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800011C:    {kind: FunctionType, arg0: function58000004, arg1: specific58000016, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800011D:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant580000D4)}
+// CHECK:STDOUT:     inst5800011E:    {kind: ImportRefUnloaded, arg0: import_ir_inst9B, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst5800011F:    {kind: ImplDecl, arg0: impl58000009, arg1: inst_block_empty}
+// CHECK:STDOUT:     inst58000120:    {kind: SymbolicBinding, arg0: entity_name5800002B, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000121:    {kind: SymbolicBindingType, arg0: entity_name5800002B, arg1: inst58000120, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000122:    {kind: TupleType, arg0: inst_block58000067, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000123:    {kind: ImportRefUnloaded, arg0: import_ir_inst9D, arg1: entity_name<none>}
+// CHECK:STDOUT:     inst58000124:    {kind: ImplWitnessTable, arg0: inst_block58000068, arg1: impl58000009}
+// CHECK:STDOUT:     inst58000125:    {kind: ImplWitness, arg0: inst58000124, arg1: specific58000017, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000126:    {kind: FunctionDecl, arg0: function58000005, arg1: inst_block_empty, type: type(symbolic_constant580000DC)}
+// CHECK:STDOUT:     inst58000127:    {kind: FunctionType, arg0: function58000005, arg1: specific58000017, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000128:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant580000DC)}
+// CHECK:STDOUT:     inst58000129:    {kind: TupleType, arg0: inst_block5800006A, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800012A:    {kind: TupleValue, arg0: inst_block58000069, type: type(inst58000129)}
+// CHECK:STDOUT:     inst5800012B:    {kind: PatternType, arg0: inst58000122, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800012C:    {kind: ReturnSlotPattern, arg0: inst<none>, type: type(symbolic_constant580000E2)}
+// CHECK:STDOUT:     inst5800012D:    {kind: OutParamPattern, arg0: inst5800012C, type: type(symbolic_constant580000E2)}
+// CHECK:STDOUT:     inst5800012E:    {kind: ValueBindingPattern, arg0: entity_name5800002D, type: type(symbolic_constant580000E2)}
+// CHECK:STDOUT:     inst5800012F:    {kind: ValueParamPattern, arg0: inst5800012E, type: type(symbolic_constant580000E2)}
+// CHECK:STDOUT:     inst58000130:    {kind: InitForm, arg0: inst58000122, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000131:    {kind: ImportRefLoaded, arg0: import_ir_instA4, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000132:    {kind: ImportRefLoaded, arg0: import_ir_instA5, arg1: entity_name<none>, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000133:    {kind: ImportRefLoaded, arg0: import_ir_instA6, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000134:    {kind: ImportRefLoaded, arg0: import_ir_instA7, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000135:    {kind: ImportRefLoaded, arg0: import_ir_instA8, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000136:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000137:    {kind: SymbolicBindingType, arg0: entity_name58000001, arg1: inst58000136, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000138:    {kind: SymbolicBinding, arg0: entity_name5800001C, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000139:    {kind: SymbolicBindingType, arg0: entity_name5800001C, arg1: inst58000138, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800013A:    {kind: SymbolicBinding, arg0: entity_name5800002B, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst5800013B:    {kind: SymbolicBindingType, arg0: entity_name5800002B, arg1: inst5800013A, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800013C:    {kind: TupleType, arg0: inst_block58000071, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800013D:    {kind: PatternType, arg0: inst5800013C, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800013E:    {kind: InitForm, arg0: inst5800013C, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst5800013F:    {kind: LookupImplWitness, arg0: inst58000120, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000140:    {kind: FunctionType, arg0: function58000001, arg1: specific58000018, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000141:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant580000FB)}
+// CHECK:STDOUT:     inst58000142:    {kind: FunctionTypeWithSelfType, arg0: inst58000140, arg1: inst58000120, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000143:    {kind: ImplWitnessAccess, arg0: inst5800013F, arg1: element0, type: type(symbolic_constant580000FD)}
+// CHECK:STDOUT:     inst58000144:    {kind: SpecificImplFunction, arg0: inst58000143, arg1: specific58000019, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst58000145:    {kind: InitForm, arg0: inst58000121, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst58000146:    {kind: PatternType, arg0: inst58000121, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000147:    {kind: RequireCompleteType, arg0: inst58000121, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000148:    {kind: RequireCompleteType, arg0: inst58000122, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000149:    {kind: RequireCompleteType, arg0: inst5800013C, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800014A:    {kind: RequireCompleteType, arg0: inst58000137, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800014B:    {kind: LookupImplWitness, arg0: inst58000136, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800014C:    {kind: FunctionType, arg0: function58000001, arg1: specific5800001B, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800014D:    {kind: FunctionTypeWithSelfType, arg0: inst5800014C, arg1: inst58000136, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800014E:    {kind: ImplWitnessAccess, arg0: inst5800014B, arg1: element0, type: type(symbolic_constant5800011B)}
+// CHECK:STDOUT:     inst5800014F:    {kind: SpecificImplFunction, arg0: inst5800014E, arg1: specific5800001C, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst58000150:    {kind: RequireCompleteType, arg0: inst58000139, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000151:    {kind: LookupImplWitness, arg0: inst58000138, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000152:    {kind: FunctionType, arg0: function58000001, arg1: specific5800001D, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000153:    {kind: FunctionTypeWithSelfType, arg0: inst58000152, arg1: inst58000138, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000154:    {kind: ImplWitnessAccess, arg0: inst58000151, arg1: element0, type: type(symbolic_constant58000121)}
+// CHECK:STDOUT:     inst58000155:    {kind: SpecificImplFunction, arg0: inst58000154, arg1: specific5800001E, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst58000156:    {kind: RequireCompleteType, arg0: inst5800013B, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000157:    {kind: LookupImplWitness, arg0: inst5800013A, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000158:    {kind: FunctionType, arg0: function58000001, arg1: specific5800001F, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000159:    {kind: FunctionTypeWithSelfType, arg0: inst58000158, arg1: inst5800013A, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800015A:    {kind: ImplWitnessAccess, arg0: inst58000157, arg1: element0, type: type(symbolic_constant58000127)}
+// CHECK:STDOUT:     inst5800015B:    {kind: SpecificImplFunction, arg0: inst5800015A, arg1: specific58000020, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst5800015C:    {kind: SymbolicBindingPattern, arg0: entity_name5800003D, type: type(inst58000099)}
+// CHECK:STDOUT:     inst5800015D:    {kind: SymbolicBindingPattern, arg0: entity_name5800003E, type: type(inst58000099)}
+// CHECK:STDOUT:     inst5800015E:    {kind: SymbolicBindingPattern, arg0: entity_name5800003F, type: type(inst58000099)}
+// CHECK:STDOUT:     inst5800015F:    {kind: ImportRefLoaded, arg0: import_ir_instC8, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000160:    {kind: ImportRefLoaded, arg0: import_ir_instC9, arg1: entity_name<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000161:    {kind: ImportRefLoaded, arg0: import_ir_instCA, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000162:    {kind: ImportRefLoaded, arg0: import_ir_instCB, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000163:    {kind: ImportRefLoaded, arg0: import_ir_instCC, arg1: entity_name<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000164:    {kind: SymbolicBinding, arg0: entity_name58000001, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000165:    {kind: SymbolicBinding, arg0: entity_name5800001C, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000166:    {kind: SymbolicBinding, arg0: entity_name5800002B, arg1: inst<none>, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000167:    {kind: TupleValue, arg0: inst_block58000080, type: type(inst58000129)}
+// CHECK:STDOUT:     inst58000168:    {kind: SymbolicBindingType, arg0: entity_name58000001, arg1: inst58000164, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000169:    {kind: SymbolicBindingType, arg0: entity_name5800001C, arg1: inst58000165, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800016A:    {kind: SymbolicBindingType, arg0: entity_name5800002B, arg1: inst58000166, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800016B:    {kind: TupleType, arg0: inst_block58000081, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800016C:    {kind: ImplWitness, arg0: inst58000124, arg1: specific58000021, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst5800016D:    {kind: FunctionType, arg0: function58000005, arg1: specific58000021, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800016E:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant5800013C)}
+// CHECK:STDOUT:     inst5800016F:    {kind: RequireSpecificDefinition, arg0: specific5800000B, type: type(inst(RequireSpecificDefinitionType))}
+// CHECK:STDOUT:     inst58000170:    {kind: RequireSpecificDefinition, arg0: specific5800000B, type: type(inst(RequireSpecificDefinitionType))}
+// CHECK:STDOUT:     inst58000171:    {kind: RequireSpecificDefinition, arg0: specific58000022, type: type(inst(RequireSpecificDefinitionType))}
+// CHECK:STDOUT:     inst58000172:    {kind: LookupImplWitness, arg0: inst5800001D, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000173:    {kind: LookupImplWitness, arg0: inst5800001E, arg1: specific_interface58000000, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000174:    {kind: FacetValue, arg0: inst5800001D, arg1: inst_block58000088, type: type(inst58000050)}
+// CHECK:STDOUT:     inst58000175:    {kind: FunctionType, arg0: function58000001, arg1: specific58000023, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000176:    {kind: StructValue, arg0: inst_block_empty, type: type(symbolic_constant58000144)}
+// CHECK:STDOUT:     inst58000177:    {kind: FunctionTypeWithSelfType, arg0: inst58000175, arg1: inst58000174, type: type(TypeType)}
+// CHECK:STDOUT:     inst58000178:    {kind: ImplWitnessAccess, arg0: inst58000172, arg1: element0, type: type(symbolic_constant5800014A)}
+// CHECK:STDOUT:     inst58000179:    {kind: ImplWitnessAccess, arg0: inst58000172, arg1: element0, type: type(symbolic_constant58000146)}
+// CHECK:STDOUT:     inst5800017A:    {kind: FacetValue, arg0: inst5800001E, arg1: inst_block5800008B, type: type(inst58000050)}
+// CHECK:STDOUT:     inst5800017B:    {kind: FunctionType, arg0: function58000001, arg1: specific58000024, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800017C:    {kind: FunctionTypeWithSelfType, arg0: inst5800017B, arg1: inst5800017A, type: type(TypeType)}
+// CHECK:STDOUT:     inst5800017D:    {kind: ImplWitnessAccess, arg0: inst58000173, arg1: element0, type: type(symbolic_constant5800014A)}
+// CHECK:STDOUT:     inst5800017E:    {kind: BoundMethod, arg0: inst58000048, arg1: inst58000178, type: type(inst(BoundMethodType))}
+// CHECK:STDOUT:     inst5800017F:    {kind: SpecificImplFunction, arg0: inst58000178, arg1: specific58000025, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst58000180:    {kind: SpecificImplFunction, arg0: inst58000179, arg1: specific58000025, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst58000181:    {kind: SpecificImplFunction, arg0: inst5800017D, arg1: specific58000026, type: type(inst(SpecificFunctionType))}
+// CHECK:STDOUT:     inst58000182:    {kind: BoundMethod, arg0: inst58000048, arg1: inst5800017F, type: type(inst(BoundMethodType))}
+// CHECK:STDOUT:     inst58000183:    {kind: RequireCompleteType, arg0: inst5800001D, type: type(inst(WitnessType))}
+// CHECK:STDOUT:     inst58000184:    {kind: Call, arg0: inst58000182, arg1: inst_block5800008F, type: type(symbolic_constant58000004)}
+// CHECK:STDOUT:     inst58000185:    {kind: InPlaceInit, arg0: inst58000184, arg1: inst5800004C, type: type(symbolic_constant58000004)}
+// CHECK:STDOUT:     inst58000186:    {kind: TupleAccess, arg0: inst5800003C, arg1: element1, type: type(inst58000026)}
+// CHECK:STDOUT:     inst58000187:    {kind: TupleInit, arg0: inst_block_empty, arg1: inst<none>, type: type(inst58000026)}
+// CHECK:STDOUT:     inst58000188:    {kind: Converted, arg0: inst58000049, arg1: inst58000187, type: type(inst58000026)}
+// CHECK:STDOUT:     inst58000189:    {kind: TupleInit, arg0: inst_block58000090, arg1: inst5800003C, type: type(symbolic_constant5800000A)}
+// CHECK:STDOUT:     inst5800018A:    {kind: Converted, arg0: inst5800004A, arg1: inst58000189, type: type(symbolic_constant5800000A)}
+// CHECK:STDOUT:     inst5800018B:    {kind: ReturnExpr, arg0: inst5800018A, arg1: inst5800003C}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       instF:           concrete_constant(instF)
-// CHECK:STDOUT:       inst60000011:    concrete_constant(inst60000011)
-// CHECK:STDOUT:       inst60000012:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000013:    symbolic_constant60000000
-// CHECK:STDOUT:       inst60000014:    symbolic_constant60000000
-// CHECK:STDOUT:       inst60000015:    concrete_constant(inst(TypeType))
-// CHECK:STDOUT:       inst60000016:    symbolic_constant60000002
-// CHECK:STDOUT:       inst60000017:    symbolic_constant60000001
-// CHECK:STDOUT:       inst60000018:    symbolic_constant60000002
-// CHECK:STDOUT:       inst60000019:    concrete_constant(inst60000019)
-// CHECK:STDOUT:       inst6000001A:    concrete_constant(inst6000001A)
-// CHECK:STDOUT:       inst6000001B:    symbolic_constant60000002
-// CHECK:STDOUT:       inst6000001C:    symbolic_constant60000004
-// CHECK:STDOUT:       inst6000001D:    symbolic_constant60000003
-// CHECK:STDOUT:       inst6000001E:    symbolic_constant60000004
-// CHECK:STDOUT:       inst60000020:    symbolic_constant60000005
-// CHECK:STDOUT:       inst60000021:    concrete_constant(inst60000021)
-// CHECK:STDOUT:       inst60000022:    symbolic_constant60000006
-// CHECK:STDOUT:       inst60000023:    concrete_constant(inst60000023)
-// CHECK:STDOUT:       inst60000024:    symbolic_constant60000002
-// CHECK:STDOUT:       inst60000025:    symbolic_constant60000004
-// CHECK:STDOUT:       inst60000026:    concrete_constant(inst60000026)
-// CHECK:STDOUT:       inst60000027:    concrete_constant(inst60000028)
-// CHECK:STDOUT:       inst60000028:    concrete_constant(inst60000028)
-// CHECK:STDOUT:       inst60000029:    concrete_constant(inst60000029)
-// CHECK:STDOUT:       inst6000002A:    symbolic_constant60000008
-// CHECK:STDOUT:       inst6000002B:    symbolic_constant60000007
-// CHECK:STDOUT:       inst6000002C:    symbolic_constant60000008
-// CHECK:STDOUT:       inst6000002D:    concrete_constant(inst6000002D)
-// CHECK:STDOUT:       inst6000002E:    concrete_constant(inst60000026)
-// CHECK:STDOUT:       inst6000002F:    symbolic_constant60000009
-// CHECK:STDOUT:       inst60000030:    symbolic_constant6000000A
-// CHECK:STDOUT:       inst60000031:    symbolic_constant6000000A
-// CHECK:STDOUT:       inst60000032:    symbolic_constant6000000C
-// CHECK:STDOUT:       inst60000033:    symbolic_constant6000000B
-// CHECK:STDOUT:       inst60000034:    symbolic_constant6000000C
-// CHECK:STDOUT:       inst60000035:    symbolic_constant6000000D
-// CHECK:STDOUT:       inst60000036:    concrete_constant(inst60000036)
-// CHECK:STDOUT:       inst60000037:    symbolic_constant6000000E
-// CHECK:STDOUT:       inst60000038:    concrete_constant(inst60000038)
-// CHECK:STDOUT:       inst60000039:    concrete_constant(inst(TypeType))
-// CHECK:STDOUT:       inst6000003B:    symbolic_constant60000004
-// CHECK:STDOUT:       inst6000003E:    concrete_constant(inst60000040)
-// CHECK:STDOUT:       inst6000003F:    concrete_constant(inst6000003F)
-// CHECK:STDOUT:       inst60000040:    concrete_constant(inst60000040)
-// CHECK:STDOUT:       inst60000041:    symbolic_constant60000010
-// CHECK:STDOUT:       inst60000042:    symbolic_constant6000000F
-// CHECK:STDOUT:       inst60000043:    symbolic_constant60000010
-// CHECK:STDOUT:       inst60000044:    symbolic_constant60000011
-// CHECK:STDOUT:       inst60000045:    symbolic_constant60000013
-// CHECK:STDOUT:       inst60000046:    symbolic_constant60000012
-// CHECK:STDOUT:       inst60000047:    symbolic_constant60000013
-// CHECK:STDOUT:       inst60000049:    concrete_constant(inst60000028)
-// CHECK:STDOUT:       inst6000004B:    symbolic_constant60000013
-// CHECK:STDOUT:       inst6000004D:    symbolic_constant60000010
-// CHECK:STDOUT:       inst6000004E:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst6000004F:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst60000050:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst60000051:    concrete_constant(inst60000051)
-// CHECK:STDOUT:       inst60000052:    symbolic_constant60000014
-// CHECK:STDOUT:       inst60000053:    concrete_constant(inst6000006D)
-// CHECK:STDOUT:       inst60000054:    constant<none>
-// CHECK:STDOUT:       inst60000055:    symbolic_constant60000014
-// CHECK:STDOUT:       inst60000056:    symbolic_constant60000017
-// CHECK:STDOUT:       inst60000057:    symbolic_constant60000015
-// CHECK:STDOUT:       inst60000058:    symbolic_constant60000016
-// CHECK:STDOUT:       inst60000059:    symbolic_constant60000018
-// CHECK:STDOUT:       inst6000005A:    symbolic_constant6000001A
-// CHECK:STDOUT:       inst6000005B:    concrete_constant(inst6000005B)
-// CHECK:STDOUT:       inst6000005C:    concrete_constant(inst6000005C)
-// CHECK:STDOUT:       inst6000005D:    concrete_constant(inst6000005D)
-// CHECK:STDOUT:       inst6000005E:    concrete_constant(inst6000005E)
-// CHECK:STDOUT:       inst6000005F:    symbolic_constant6000001C
-// CHECK:STDOUT:       inst60000060:    symbolic_constant60000021
-// CHECK:STDOUT:       inst60000061:    symbolic_constant60000020
-// CHECK:STDOUT:       inst60000062:    symbolic_constant60000014
-// CHECK:STDOUT:       inst60000063:    symbolic_constant60000022
-// CHECK:STDOUT:       inst60000064:    symbolic_constant60000023
-// CHECK:STDOUT:       inst60000065:    symbolic_constant60000024
-// CHECK:STDOUT:       inst60000066:    symbolic_constant60000025
-// CHECK:STDOUT:       inst60000067:    symbolic_constant60000028
-// CHECK:STDOUT:       inst60000068:    symbolic_constant60000029
-// CHECK:STDOUT:       inst60000069:    symbolic_constant6000002A
-// CHECK:STDOUT:       inst6000006A:    constant<none>
-// CHECK:STDOUT:       inst6000006B:    concrete_constant(inst6000006B)
-// CHECK:STDOUT:       inst6000006C:    symbolic_constant60000017
-// CHECK:STDOUT:       inst6000006D:    concrete_constant(inst6000006D)
-// CHECK:STDOUT:       inst6000006E:    symbolic_constant60000142
-// CHECK:STDOUT:       inst6000006F:    constant<none>
-// CHECK:STDOUT:       inst60000070:    concrete_constant(inst60000070)
-// CHECK:STDOUT:       inst60000071:    symbolic_constant6000002B
-// CHECK:STDOUT:       inst60000072:    symbolic_constant6000002C
-// CHECK:STDOUT:       inst60000073:    symbolic_constant6000002D
-// CHECK:STDOUT:       inst60000074:    constant<none>
-// CHECK:STDOUT:       inst60000075:    concrete_constant(inst60000075)
-// CHECK:STDOUT:       inst60000076:    symbolic_constant6000002F
-// CHECK:STDOUT:       inst60000077:    symbolic_constant60000033
-// CHECK:STDOUT:       inst60000078:    symbolic_constant60000031
-// CHECK:STDOUT:       inst60000079:    symbolic_constant60000032
-// CHECK:STDOUT:       inst6000007A:    symbolic_constant60000035
-// CHECK:STDOUT:       inst6000007B:    concrete_constant(inst6000007B)
-// CHECK:STDOUT:       inst6000007C:    concrete_constant(inst6000007C)
-// CHECK:STDOUT:       inst6000007D:    concrete_constant(inst6000007D)
-// CHECK:STDOUT:       inst6000007E:    concrete_constant(inst6000007E)
-// CHECK:STDOUT:       inst6000007F:    symbolic_constant60000037
-// CHECK:STDOUT:       inst60000080:    symbolic_constant6000003E
-// CHECK:STDOUT:       inst60000081:    symbolic_constant6000003D
-// CHECK:STDOUT:       inst60000082:    symbolic_constant6000003C
-// CHECK:STDOUT:       inst60000083:    symbolic_constant6000003F
-// CHECK:STDOUT:       inst60000084:    symbolic_constant60000040
-// CHECK:STDOUT:       inst60000085:    symbolic_constant60000041
-// CHECK:STDOUT:       inst60000086:    symbolic_constant60000042
-// CHECK:STDOUT:       inst60000087:    symbolic_constant60000043
-// CHECK:STDOUT:       inst60000088:    symbolic_constant60000044
-// CHECK:STDOUT:       inst60000089:    symbolic_constant60000045
-// CHECK:STDOUT:       inst6000008A:    symbolic_constant60000046
-// CHECK:STDOUT:       inst6000008B:    symbolic_constant60000047
-// CHECK:STDOUT:       inst6000008C:    symbolic_constant60000048
-// CHECK:STDOUT:       inst6000008D:    symbolic_constant60000049
-// CHECK:STDOUT:       inst6000008E:    symbolic_constant6000004B
-// CHECK:STDOUT:       inst6000008F:    symbolic_constant6000004C
-// CHECK:STDOUT:       inst60000090:    symbolic_constant60000051
-// CHECK:STDOUT:       inst60000091:    symbolic_constant60000053
-// CHECK:STDOUT:       inst60000092:    symbolic_constant60000055
-// CHECK:STDOUT:       inst60000093:    symbolic_constant60000056
-// CHECK:STDOUT:       inst60000094:    symbolic_constant60000057
-// CHECK:STDOUT:       inst60000095:    symbolic_constant60000058
-// CHECK:STDOUT:       inst60000096:    symbolic_constant60000059
-// CHECK:STDOUT:       inst60000097:    symbolic_constant6000005A
-// CHECK:STDOUT:       inst60000098:    symbolic_constant6000005B
-// CHECK:STDOUT:       inst60000099:    concrete_constant(inst60000099)
-// CHECK:STDOUT:       inst6000009A:    concrete_constant(inst6000009A)
-// CHECK:STDOUT:       inst6000009B:    symbolic_constant6000002E
-// CHECK:STDOUT:       inst6000009C:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst6000009D:    symbolic_constant6000003C
-// CHECK:STDOUT:       inst6000009E:    symbolic_constant6000005F
-// CHECK:STDOUT:       inst6000009F:    symbolic_constant60000060
-// CHECK:STDOUT:       inst600000A0:    symbolic_constant60000061
-// CHECK:STDOUT:       inst600000A1:    symbolic_constant60000062
-// CHECK:STDOUT:       inst600000A2:    symbolic_constant60000064
-// CHECK:STDOUT:       inst600000A3:    symbolic_constant60000065
-// CHECK:STDOUT:       inst600000A4:    constant<none>
-// CHECK:STDOUT:       inst600000A5:    concrete_constant(inst600000A5)
-// CHECK:STDOUT:       inst600000A6:    concrete_constant(inst(BoolType))
-// CHECK:STDOUT:       inst600000A7:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst600000A8:    constant<none>
-// CHECK:STDOUT:       inst600000A9:    concrete_constant(inst600000A9)
-// CHECK:STDOUT:       inst600000AA:    concrete_constant(inst(CharLiteralType))
-// CHECK:STDOUT:       inst600000AB:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst600000AC:    constant<none>
-// CHECK:STDOUT:       inst600000AD:    concrete_constant(inst600000AD)
-// CHECK:STDOUT:       inst600000AE:    concrete_constant(inst(FloatLiteralType))
-// CHECK:STDOUT:       inst600000AF:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst600000B0:    constant<none>
-// CHECK:STDOUT:       inst600000B1:    concrete_constant(inst600000B1)
-// CHECK:STDOUT:       inst600000B2:    concrete_constant(inst(IntLiteralType))
-// CHECK:STDOUT:       inst600000B3:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst600000B4:    symbolic_constant6000013E
-// CHECK:STDOUT:       inst600000B5:    concrete_constant(inst600000B5)
-// CHECK:STDOUT:       inst600000B6:    constant<none>
-// CHECK:STDOUT:       inst600000B7:    concrete_constant(inst600000B7)
-// CHECK:STDOUT:       inst600000B8:    symbolic_constant60000067
-// CHECK:STDOUT:       inst600000B9:    concrete_constant(inst600000B9)
-// CHECK:STDOUT:       inst600000BA:    symbolic_constant60000066
-// CHECK:STDOUT:       inst600000BB:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst600000BC:    symbolic_constant6000006B
-// CHECK:STDOUT:       inst600000BD:    symbolic_constant6000006C
-// CHECK:STDOUT:       inst600000BE:    symbolic_constant6000006D
-// CHECK:STDOUT:       inst600000BF:    symbolic_constant6000006E
-// CHECK:STDOUT:       inst600000C0:    symbolic_constant60000072
-// CHECK:STDOUT:       inst600000C1:    symbolic_constant60000070
-// CHECK:STDOUT:       inst600000C2:    symbolic_constant60000071
-// CHECK:STDOUT:       inst600000C3:    concrete_constant(inst600000C3)
-// CHECK:STDOUT:       inst600000C4:    concrete_constant(inst600000C4)
-// CHECK:STDOUT:       inst600000C5:    concrete_constant(inst600000C5)
-// CHECK:STDOUT:       inst600000C6:    concrete_constant(inst600000C6)
-// CHECK:STDOUT:       inst600000C7:    symbolic_constant60000075
-// CHECK:STDOUT:       inst600000C8:    symbolic_constant6000007A
-// CHECK:STDOUT:       inst600000C9:    symbolic_constant60000079
-// CHECK:STDOUT:       inst600000CA:    symbolic_constant6000006B
-// CHECK:STDOUT:       inst600000CB:    symbolic_constant6000007B
-// CHECK:STDOUT:       inst600000CC:    symbolic_constant6000007C
-// CHECK:STDOUT:       inst600000CD:    symbolic_constant6000007D
-// CHECK:STDOUT:       inst600000CE:    symbolic_constant6000007E
-// CHECK:STDOUT:       inst600000CF:    symbolic_constant60000080
-// CHECK:STDOUT:       inst600000D0:    symbolic_constant60000081
-// CHECK:STDOUT:       inst600000D1:    symbolic_constant60000082
-// CHECK:STDOUT:       inst600000D2:    constant<none>
-// CHECK:STDOUT:       inst600000D3:    concrete_constant(inst600000D3)
-// CHECK:STDOUT:       inst600000D4:    concrete_constant(inst(TypeType))
-// CHECK:STDOUT:       inst600000D5:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst600000D6:    constant<none>
-// CHECK:STDOUT:       inst600000D7:    concrete_constant(inst600000D7)
-// CHECK:STDOUT:       inst600000D8:    concrete_constant(inst60000026)
-// CHECK:STDOUT:       inst600000D9:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst600000DA:    constant<none>
-// CHECK:STDOUT:       inst600000DB:    concrete_constant(inst600000DB)
-// CHECK:STDOUT:       inst600000DC:    symbolic_constant60000083
-// CHECK:STDOUT:       inst600000DD:    symbolic_constant60000084
-// CHECK:STDOUT:       inst600000DE:    symbolic_constant60000085
-// CHECK:STDOUT:       inst600000DF:    constant<none>
-// CHECK:STDOUT:       inst600000E0:    concrete_constant(inst600000E0)
-// CHECK:STDOUT:       inst600000E1:    symbolic_constant60000087
-// CHECK:STDOUT:       inst600000E2:    symbolic_constant6000008B
-// CHECK:STDOUT:       inst600000E3:    symbolic_constant60000089
-// CHECK:STDOUT:       inst600000E4:    symbolic_constant6000008A
-// CHECK:STDOUT:       inst600000E5:    concrete_constant(inst600000E5)
-// CHECK:STDOUT:       inst600000E6:    symbolic_constant6000008D
-// CHECK:STDOUT:       inst600000E7:    symbolic_constant6000008E
-// CHECK:STDOUT:       inst600000E8:    concrete_constant(inst600000E8)
-// CHECK:STDOUT:       inst600000E9:    concrete_constant(inst600000E9)
-// CHECK:STDOUT:       inst600000EA:    concrete_constant(inst600000EA)
-// CHECK:STDOUT:       inst600000EB:    concrete_constant(inst600000EB)
-// CHECK:STDOUT:       inst600000EC:    symbolic_constant60000090
-// CHECK:STDOUT:       inst600000ED:    symbolic_constant6000009A
-// CHECK:STDOUT:       inst600000EE:    symbolic_constant60000099
-// CHECK:STDOUT:       inst600000EF:    symbolic_constant60000098
-// CHECK:STDOUT:       inst600000F0:    symbolic_constant60000097
-// CHECK:STDOUT:       inst600000F1:    symbolic_constant6000009B
-// CHECK:STDOUT:       inst600000F2:    symbolic_constant6000009C
-// CHECK:STDOUT:       inst600000F3:    symbolic_constant6000009D
-// CHECK:STDOUT:       inst600000F4:    symbolic_constant6000009E
-// CHECK:STDOUT:       inst600000F5:    symbolic_constant6000009F
-// CHECK:STDOUT:       inst600000F6:    symbolic_constant600000A0
-// CHECK:STDOUT:       inst600000F7:    symbolic_constant600000A1
-// CHECK:STDOUT:       inst600000F8:    symbolic_constant600000A2
-// CHECK:STDOUT:       inst600000F9:    symbolic_constant600000A3
-// CHECK:STDOUT:       inst600000FA:    symbolic_constant600000A4
-// CHECK:STDOUT:       inst600000FB:    symbolic_constant600000A5
-// CHECK:STDOUT:       inst600000FC:    symbolic_constant600000A6
-// CHECK:STDOUT:       inst600000FD:    symbolic_constant600000A7
-// CHECK:STDOUT:       inst600000FE:    symbolic_constant600000A9
-// CHECK:STDOUT:       inst600000FF:    symbolic_constant600000AA
-// CHECK:STDOUT:       inst60000100:    symbolic_constant600000AF
-// CHECK:STDOUT:       inst60000101:    symbolic_constant600000B7
-// CHECK:STDOUT:       inst60000102:    symbolic_constant600000B9
-// CHECK:STDOUT:       inst60000103:    symbolic_constant600000BA
-// CHECK:STDOUT:       inst60000104:    symbolic_constant600000BB
-// CHECK:STDOUT:       inst60000105:    symbolic_constant600000BC
-// CHECK:STDOUT:       inst60000106:    symbolic_constant600000BD
-// CHECK:STDOUT:       inst60000107:    symbolic_constant600000BE
-// CHECK:STDOUT:       inst60000108:    symbolic_constant600000BF
-// CHECK:STDOUT:       inst60000109:    symbolic_constant600000C0
-// CHECK:STDOUT:       inst6000010A:    symbolic_constant600000C1
-// CHECK:STDOUT:       inst6000010B:    symbolic_constant600000C2
-// CHECK:STDOUT:       inst6000010C:    symbolic_constant600000C3
-// CHECK:STDOUT:       inst6000010D:    symbolic_constant600000C4
-// CHECK:STDOUT:       inst6000010E:    symbolic_constant600000C5
-// CHECK:STDOUT:       inst6000010F:    concrete_constant(inst6000010F)
-// CHECK:STDOUT:       inst60000110:    concrete_constant(inst60000110)
-// CHECK:STDOUT:       inst60000111:    symbolic_constant60000086
-// CHECK:STDOUT:       inst60000112:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst60000113:    symbolic_constant60000098
-// CHECK:STDOUT:       inst60000114:    symbolic_constant60000097
-// CHECK:STDOUT:       inst60000115:    symbolic_constant600000CC
-// CHECK:STDOUT:       inst60000116:    symbolic_constant600000CD
-// CHECK:STDOUT:       inst60000117:    symbolic_constant600000CE
-// CHECK:STDOUT:       inst60000118:    symbolic_constant600000CF
-// CHECK:STDOUT:       inst60000119:    symbolic_constant600000D0
-// CHECK:STDOUT:       inst6000011A:    symbolic_constant600000D1
-// CHECK:STDOUT:       inst6000011B:    symbolic_constant600000D2
-// CHECK:STDOUT:       inst6000011C:    symbolic_constant600000D4
-// CHECK:STDOUT:       inst6000011D:    symbolic_constant600000D5
-// CHECK:STDOUT:       inst6000011E:    constant<none>
-// CHECK:STDOUT:       inst6000011F:    concrete_constant(inst6000011F)
-// CHECK:STDOUT:       inst60000120:    symbolic_constant600000D6
-// CHECK:STDOUT:       inst60000121:    symbolic_constant600000D7
-// CHECK:STDOUT:       inst60000122:    symbolic_constant600000D8
-// CHECK:STDOUT:       inst60000123:    constant<none>
-// CHECK:STDOUT:       inst60000124:    concrete_constant(inst60000124)
-// CHECK:STDOUT:       inst60000125:    symbolic_constant600000DA
-// CHECK:STDOUT:       inst60000126:    symbolic_constant600000DE
-// CHECK:STDOUT:       inst60000127:    symbolic_constant600000DC
-// CHECK:STDOUT:       inst60000128:    symbolic_constant600000DD
-// CHECK:STDOUT:       inst60000129:    concrete_constant(inst60000129)
-// CHECK:STDOUT:       inst6000012A:    symbolic_constant600000E0
-// CHECK:STDOUT:       inst6000012B:    symbolic_constant600000E1
-// CHECK:STDOUT:       inst6000012C:    concrete_constant(inst6000012C)
-// CHECK:STDOUT:       inst6000012D:    concrete_constant(inst6000012D)
-// CHECK:STDOUT:       inst6000012E:    concrete_constant(inst6000012E)
-// CHECK:STDOUT:       inst6000012F:    concrete_constant(inst6000012F)
-// CHECK:STDOUT:       inst60000130:    symbolic_constant600000E3
-// CHECK:STDOUT:       inst60000131:    symbolic_constant600000F0
-// CHECK:STDOUT:       inst60000132:    symbolic_constant600000EF
-// CHECK:STDOUT:       inst60000133:    symbolic_constant600000EE
-// CHECK:STDOUT:       inst60000134:    symbolic_constant600000ED
-// CHECK:STDOUT:       inst60000135:    symbolic_constant600000EC
-// CHECK:STDOUT:       inst60000136:    symbolic_constant600000F1
-// CHECK:STDOUT:       inst60000137:    symbolic_constant600000F2
-// CHECK:STDOUT:       inst60000138:    symbolic_constant600000F3
-// CHECK:STDOUT:       inst60000139:    symbolic_constant600000F4
-// CHECK:STDOUT:       inst6000013A:    symbolic_constant600000F5
-// CHECK:STDOUT:       inst6000013B:    symbolic_constant600000F6
-// CHECK:STDOUT:       inst6000013C:    symbolic_constant600000F7
-// CHECK:STDOUT:       inst6000013D:    symbolic_constant600000F8
-// CHECK:STDOUT:       inst6000013E:    symbolic_constant600000F9
-// CHECK:STDOUT:       inst6000013F:    symbolic_constant600000FA
-// CHECK:STDOUT:       inst60000140:    symbolic_constant600000FB
-// CHECK:STDOUT:       inst60000141:    symbolic_constant600000FC
-// CHECK:STDOUT:       inst60000142:    symbolic_constant600000FD
-// CHECK:STDOUT:       inst60000143:    symbolic_constant600000FE
-// CHECK:STDOUT:       inst60000144:    symbolic_constant600000FF
-// CHECK:STDOUT:       inst60000145:    symbolic_constant60000101
-// CHECK:STDOUT:       inst60000146:    symbolic_constant60000102
-// CHECK:STDOUT:       inst60000147:    symbolic_constant60000107
-// CHECK:STDOUT:       inst60000148:    symbolic_constant60000115
-// CHECK:STDOUT:       inst60000149:    symbolic_constant60000117
-// CHECK:STDOUT:       inst6000014A:    symbolic_constant60000118
-// CHECK:STDOUT:       inst6000014B:    symbolic_constant60000119
-// CHECK:STDOUT:       inst6000014C:    symbolic_constant6000011A
-// CHECK:STDOUT:       inst6000014D:    symbolic_constant6000011B
-// CHECK:STDOUT:       inst6000014E:    symbolic_constant6000011C
-// CHECK:STDOUT:       inst6000014F:    symbolic_constant6000011D
-// CHECK:STDOUT:       inst60000150:    symbolic_constant6000011E
-// CHECK:STDOUT:       inst60000151:    symbolic_constant6000011F
-// CHECK:STDOUT:       inst60000152:    symbolic_constant60000120
-// CHECK:STDOUT:       inst60000153:    symbolic_constant60000121
-// CHECK:STDOUT:       inst60000154:    symbolic_constant60000122
-// CHECK:STDOUT:       inst60000155:    symbolic_constant60000123
-// CHECK:STDOUT:       inst60000156:    symbolic_constant60000124
-// CHECK:STDOUT:       inst60000157:    symbolic_constant60000125
-// CHECK:STDOUT:       inst60000158:    symbolic_constant60000126
-// CHECK:STDOUT:       inst60000159:    symbolic_constant60000127
-// CHECK:STDOUT:       inst6000015A:    symbolic_constant60000128
-// CHECK:STDOUT:       inst6000015B:    symbolic_constant60000129
-// CHECK:STDOUT:       inst6000015C:    concrete_constant(inst6000015C)
-// CHECK:STDOUT:       inst6000015D:    concrete_constant(inst6000015D)
-// CHECK:STDOUT:       inst6000015E:    concrete_constant(inst6000015E)
-// CHECK:STDOUT:       inst6000015F:    symbolic_constant600000D9
-// CHECK:STDOUT:       inst60000160:    concrete_constant(inst60000050)
-// CHECK:STDOUT:       inst60000161:    symbolic_constant600000EE
-// CHECK:STDOUT:       inst60000162:    symbolic_constant600000ED
-// CHECK:STDOUT:       inst60000163:    symbolic_constant600000EC
-// CHECK:STDOUT:       inst60000164:    symbolic_constant60000132
-// CHECK:STDOUT:       inst60000165:    symbolic_constant60000133
-// CHECK:STDOUT:       inst60000166:    symbolic_constant60000134
-// CHECK:STDOUT:       inst60000167:    symbolic_constant60000135
-// CHECK:STDOUT:       inst60000168:    symbolic_constant60000136
-// CHECK:STDOUT:       inst60000169:    symbolic_constant60000137
-// CHECK:STDOUT:       inst6000016A:    symbolic_constant60000138
-// CHECK:STDOUT:       inst6000016B:    symbolic_constant60000139
-// CHECK:STDOUT:       inst6000016C:    symbolic_constant6000013A
-// CHECK:STDOUT:       inst6000016D:    symbolic_constant6000013C
-// CHECK:STDOUT:       inst6000016E:    symbolic_constant6000013D
-// CHECK:STDOUT:       inst6000016F:    symbolic_constant60000140
-// CHECK:STDOUT:       inst60000170:    symbolic_constant6000013F
-// CHECK:STDOUT:       inst60000171:    symbolic_constant60000140
-// CHECK:STDOUT:       inst60000172:    symbolic_constant60000141
-// CHECK:STDOUT:       inst60000173:    symbolic_constant60000142
-// CHECK:STDOUT:       inst60000174:    symbolic_constant60000143
-// CHECK:STDOUT:       inst60000175:    symbolic_constant60000144
-// CHECK:STDOUT:       inst60000176:    symbolic_constant60000145
-// CHECK:STDOUT:       inst60000177:    symbolic_constant60000146
-// CHECK:STDOUT:       inst60000178:    symbolic_constant6000014B
-// CHECK:STDOUT:       inst60000179:    symbolic_constant60000147
-// CHECK:STDOUT:       inst6000017A:    symbolic_constant60000148
-// CHECK:STDOUT:       inst6000017B:    symbolic_constant60000149
-// CHECK:STDOUT:       inst6000017C:    symbolic_constant6000014A
-// CHECK:STDOUT:       inst6000017D:    symbolic_constant6000014B
-// CHECK:STDOUT:       inst6000017F:    symbolic_constant6000014D
-// CHECK:STDOUT:       inst60000180:    symbolic_constant6000014C
-// CHECK:STDOUT:       inst60000181:    symbolic_constant6000014D
-// CHECK:STDOUT:       inst60000183:    symbolic_constant60000010
-// CHECK:STDOUT:       inst60000187:    concrete_constant(inst60000028)
-// CHECK:STDOUT:       inst60000188:    concrete_constant(inst60000028)
+// CHECK:STDOUT:       inst58000011:    concrete_constant(inst58000011)
+// CHECK:STDOUT:       inst58000012:    concrete_constant(inst58000012)
+// CHECK:STDOUT:       inst58000013:    symbolic_constant58000000
+// CHECK:STDOUT:       inst58000014:    symbolic_constant58000000
+// CHECK:STDOUT:       inst58000015:    concrete_constant(inst(TypeType))
+// CHECK:STDOUT:       inst58000016:    symbolic_constant58000002
+// CHECK:STDOUT:       inst58000017:    symbolic_constant58000001
+// CHECK:STDOUT:       inst58000018:    symbolic_constant58000002
+// CHECK:STDOUT:       inst58000019:    concrete_constant(inst58000019)
+// CHECK:STDOUT:       inst5800001A:    concrete_constant(inst5800001A)
+// CHECK:STDOUT:       inst5800001B:    symbolic_constant58000002
+// CHECK:STDOUT:       inst5800001C:    symbolic_constant58000004
+// CHECK:STDOUT:       inst5800001D:    symbolic_constant58000003
+// CHECK:STDOUT:       inst5800001E:    symbolic_constant58000004
+// CHECK:STDOUT:       inst58000020:    symbolic_constant58000005
+// CHECK:STDOUT:       inst58000021:    concrete_constant(inst58000021)
+// CHECK:STDOUT:       inst58000022:    symbolic_constant58000006
+// CHECK:STDOUT:       inst58000023:    concrete_constant(inst58000023)
+// CHECK:STDOUT:       inst58000024:    symbolic_constant58000002
+// CHECK:STDOUT:       inst58000025:    symbolic_constant58000004
+// CHECK:STDOUT:       inst58000026:    concrete_constant(inst58000026)
+// CHECK:STDOUT:       inst58000027:    concrete_constant(inst58000028)
+// CHECK:STDOUT:       inst58000028:    concrete_constant(inst58000028)
+// CHECK:STDOUT:       inst58000029:    concrete_constant(inst58000029)
+// CHECK:STDOUT:       inst5800002A:    symbolic_constant58000008
+// CHECK:STDOUT:       inst5800002B:    symbolic_constant58000007
+// CHECK:STDOUT:       inst5800002C:    symbolic_constant58000008
+// CHECK:STDOUT:       inst5800002D:    concrete_constant(inst5800002D)
+// CHECK:STDOUT:       inst5800002E:    concrete_constant(inst58000026)
+// CHECK:STDOUT:       inst5800002F:    symbolic_constant58000009
+// CHECK:STDOUT:       inst58000030:    symbolic_constant5800000A
+// CHECK:STDOUT:       inst58000031:    symbolic_constant5800000A
+// CHECK:STDOUT:       inst58000032:    symbolic_constant5800000C
+// CHECK:STDOUT:       inst58000033:    symbolic_constant5800000B
+// CHECK:STDOUT:       inst58000034:    symbolic_constant5800000C
+// CHECK:STDOUT:       inst58000035:    symbolic_constant5800000D
+// CHECK:STDOUT:       inst58000036:    concrete_constant(inst58000036)
+// CHECK:STDOUT:       inst58000037:    symbolic_constant5800000E
+// CHECK:STDOUT:       inst58000038:    concrete_constant(inst58000038)
+// CHECK:STDOUT:       inst58000039:    concrete_constant(inst(TypeType))
+// CHECK:STDOUT:       inst5800003B:    symbolic_constant58000004
+// CHECK:STDOUT:       inst5800003E:    concrete_constant(inst58000040)
+// CHECK:STDOUT:       inst5800003F:    concrete_constant(inst5800003F)
+// CHECK:STDOUT:       inst58000040:    concrete_constant(inst58000040)
+// CHECK:STDOUT:       inst58000041:    symbolic_constant58000010
+// CHECK:STDOUT:       inst58000042:    symbolic_constant5800000F
+// CHECK:STDOUT:       inst58000043:    symbolic_constant58000010
+// CHECK:STDOUT:       inst58000044:    symbolic_constant58000011
+// CHECK:STDOUT:       inst58000045:    symbolic_constant58000013
+// CHECK:STDOUT:       inst58000046:    symbolic_constant58000012
+// CHECK:STDOUT:       inst58000047:    symbolic_constant58000013
+// CHECK:STDOUT:       inst58000049:    concrete_constant(inst58000028)
+// CHECK:STDOUT:       inst5800004B:    symbolic_constant58000013
+// CHECK:STDOUT:       inst5800004D:    symbolic_constant58000010
+// CHECK:STDOUT:       inst5800004E:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst5800004F:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst58000050:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst58000051:    concrete_constant(inst58000051)
+// CHECK:STDOUT:       inst58000052:    symbolic_constant58000014
+// CHECK:STDOUT:       inst58000053:    concrete_constant(inst5800006D)
+// CHECK:STDOUT:       inst58000054:    constant<none>
+// CHECK:STDOUT:       inst58000055:    symbolic_constant58000014
+// CHECK:STDOUT:       inst58000056:    symbolic_constant58000017
+// CHECK:STDOUT:       inst58000057:    symbolic_constant58000015
+// CHECK:STDOUT:       inst58000058:    symbolic_constant58000016
+// CHECK:STDOUT:       inst58000059:    symbolic_constant58000018
+// CHECK:STDOUT:       inst5800005A:    symbolic_constant5800001A
+// CHECK:STDOUT:       inst5800005B:    concrete_constant(inst5800005B)
+// CHECK:STDOUT:       inst5800005C:    concrete_constant(inst5800005C)
+// CHECK:STDOUT:       inst5800005D:    concrete_constant(inst5800005D)
+// CHECK:STDOUT:       inst5800005E:    concrete_constant(inst5800005E)
+// CHECK:STDOUT:       inst5800005F:    symbolic_constant5800001C
+// CHECK:STDOUT:       inst58000060:    symbolic_constant58000021
+// CHECK:STDOUT:       inst58000061:    symbolic_constant58000020
+// CHECK:STDOUT:       inst58000062:    symbolic_constant58000014
+// CHECK:STDOUT:       inst58000063:    symbolic_constant58000022
+// CHECK:STDOUT:       inst58000064:    symbolic_constant58000023
+// CHECK:STDOUT:       inst58000065:    symbolic_constant58000024
+// CHECK:STDOUT:       inst58000066:    symbolic_constant58000025
+// CHECK:STDOUT:       inst58000067:    symbolic_constant58000028
+// CHECK:STDOUT:       inst58000068:    symbolic_constant58000029
+// CHECK:STDOUT:       inst58000069:    symbolic_constant5800002A
+// CHECK:STDOUT:       inst5800006A:    constant<none>
+// CHECK:STDOUT:       inst5800006B:    concrete_constant(inst5800006B)
+// CHECK:STDOUT:       inst5800006C:    symbolic_constant58000017
+// CHECK:STDOUT:       inst5800006D:    concrete_constant(inst5800006D)
+// CHECK:STDOUT:       inst5800006E:    symbolic_constant58000142
+// CHECK:STDOUT:       inst5800006F:    constant<none>
+// CHECK:STDOUT:       inst58000070:    concrete_constant(inst58000070)
+// CHECK:STDOUT:       inst58000071:    symbolic_constant5800002B
+// CHECK:STDOUT:       inst58000072:    symbolic_constant5800002C
+// CHECK:STDOUT:       inst58000073:    symbolic_constant5800002D
+// CHECK:STDOUT:       inst58000074:    constant<none>
+// CHECK:STDOUT:       inst58000075:    concrete_constant(inst58000075)
+// CHECK:STDOUT:       inst58000076:    symbolic_constant5800002F
+// CHECK:STDOUT:       inst58000077:    symbolic_constant58000033
+// CHECK:STDOUT:       inst58000078:    symbolic_constant58000031
+// CHECK:STDOUT:       inst58000079:    symbolic_constant58000032
+// CHECK:STDOUT:       inst5800007A:    symbolic_constant58000035
+// CHECK:STDOUT:       inst5800007B:    concrete_constant(inst5800007B)
+// CHECK:STDOUT:       inst5800007C:    concrete_constant(inst5800007C)
+// CHECK:STDOUT:       inst5800007D:    concrete_constant(inst5800007D)
+// CHECK:STDOUT:       inst5800007E:    concrete_constant(inst5800007E)
+// CHECK:STDOUT:       inst5800007F:    symbolic_constant58000037
+// CHECK:STDOUT:       inst58000080:    symbolic_constant5800003E
+// CHECK:STDOUT:       inst58000081:    symbolic_constant5800003D
+// CHECK:STDOUT:       inst58000082:    symbolic_constant5800003C
+// CHECK:STDOUT:       inst58000083:    symbolic_constant5800003F
+// CHECK:STDOUT:       inst58000084:    symbolic_constant58000040
+// CHECK:STDOUT:       inst58000085:    symbolic_constant58000041
+// CHECK:STDOUT:       inst58000086:    symbolic_constant58000042
+// CHECK:STDOUT:       inst58000087:    symbolic_constant58000043
+// CHECK:STDOUT:       inst58000088:    symbolic_constant58000044
+// CHECK:STDOUT:       inst58000089:    symbolic_constant58000045
+// CHECK:STDOUT:       inst5800008A:    symbolic_constant58000046
+// CHECK:STDOUT:       inst5800008B:    symbolic_constant58000047
+// CHECK:STDOUT:       inst5800008C:    symbolic_constant58000048
+// CHECK:STDOUT:       inst5800008D:    symbolic_constant58000049
+// CHECK:STDOUT:       inst5800008E:    symbolic_constant5800004B
+// CHECK:STDOUT:       inst5800008F:    symbolic_constant5800004C
+// CHECK:STDOUT:       inst58000090:    symbolic_constant58000051
+// CHECK:STDOUT:       inst58000091:    symbolic_constant58000053
+// CHECK:STDOUT:       inst58000092:    symbolic_constant58000055
+// CHECK:STDOUT:       inst58000093:    symbolic_constant58000056
+// CHECK:STDOUT:       inst58000094:    symbolic_constant58000057
+// CHECK:STDOUT:       inst58000095:    symbolic_constant58000058
+// CHECK:STDOUT:       inst58000096:    symbolic_constant58000059
+// CHECK:STDOUT:       inst58000097:    symbolic_constant5800005A
+// CHECK:STDOUT:       inst58000098:    symbolic_constant5800005B
+// CHECK:STDOUT:       inst58000099:    concrete_constant(inst58000099)
+// CHECK:STDOUT:       inst5800009A:    concrete_constant(inst5800009A)
+// CHECK:STDOUT:       inst5800009B:    symbolic_constant5800002E
+// CHECK:STDOUT:       inst5800009C:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst5800009D:    symbolic_constant5800003C
+// CHECK:STDOUT:       inst5800009E:    symbolic_constant5800005F
+// CHECK:STDOUT:       inst5800009F:    symbolic_constant58000060
+// CHECK:STDOUT:       inst580000A0:    symbolic_constant58000061
+// CHECK:STDOUT:       inst580000A1:    symbolic_constant58000062
+// CHECK:STDOUT:       inst580000A2:    symbolic_constant58000064
+// CHECK:STDOUT:       inst580000A3:    symbolic_constant58000065
+// CHECK:STDOUT:       inst580000A4:    constant<none>
+// CHECK:STDOUT:       inst580000A5:    concrete_constant(inst580000A5)
+// CHECK:STDOUT:       inst580000A6:    concrete_constant(inst(BoolType))
+// CHECK:STDOUT:       inst580000A7:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst580000A8:    constant<none>
+// CHECK:STDOUT:       inst580000A9:    concrete_constant(inst580000A9)
+// CHECK:STDOUT:       inst580000AA:    concrete_constant(inst(CharLiteralType))
+// CHECK:STDOUT:       inst580000AB:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst580000AC:    constant<none>
+// CHECK:STDOUT:       inst580000AD:    concrete_constant(inst580000AD)
+// CHECK:STDOUT:       inst580000AE:    concrete_constant(inst(FloatLiteralType))
+// CHECK:STDOUT:       inst580000AF:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst580000B0:    constant<none>
+// CHECK:STDOUT:       inst580000B1:    concrete_constant(inst580000B1)
+// CHECK:STDOUT:       inst580000B2:    concrete_constant(inst(IntLiteralType))
+// CHECK:STDOUT:       inst580000B3:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst580000B4:    symbolic_constant5800013E
+// CHECK:STDOUT:       inst580000B5:    concrete_constant(inst580000B5)
+// CHECK:STDOUT:       inst580000B6:    constant<none>
+// CHECK:STDOUT:       inst580000B7:    concrete_constant(inst580000B7)
+// CHECK:STDOUT:       inst580000B8:    symbolic_constant58000067
+// CHECK:STDOUT:       inst580000B9:    concrete_constant(inst580000B9)
+// CHECK:STDOUT:       inst580000BA:    symbolic_constant58000066
+// CHECK:STDOUT:       inst580000BB:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst580000BC:    symbolic_constant5800006B
+// CHECK:STDOUT:       inst580000BD:    symbolic_constant5800006C
+// CHECK:STDOUT:       inst580000BE:    symbolic_constant5800006D
+// CHECK:STDOUT:       inst580000BF:    symbolic_constant5800006E
+// CHECK:STDOUT:       inst580000C0:    symbolic_constant58000072
+// CHECK:STDOUT:       inst580000C1:    symbolic_constant58000070
+// CHECK:STDOUT:       inst580000C2:    symbolic_constant58000071
+// CHECK:STDOUT:       inst580000C3:    concrete_constant(inst580000C3)
+// CHECK:STDOUT:       inst580000C4:    concrete_constant(inst580000C4)
+// CHECK:STDOUT:       inst580000C5:    concrete_constant(inst580000C5)
+// CHECK:STDOUT:       inst580000C6:    concrete_constant(inst580000C6)
+// CHECK:STDOUT:       inst580000C7:    symbolic_constant58000075
+// CHECK:STDOUT:       inst580000C8:    symbolic_constant5800007A
+// CHECK:STDOUT:       inst580000C9:    symbolic_constant58000079
+// CHECK:STDOUT:       inst580000CA:    symbolic_constant5800006B
+// CHECK:STDOUT:       inst580000CB:    symbolic_constant5800007B
+// CHECK:STDOUT:       inst580000CC:    symbolic_constant5800007C
+// CHECK:STDOUT:       inst580000CD:    symbolic_constant5800007D
+// CHECK:STDOUT:       inst580000CE:    symbolic_constant5800007E
+// CHECK:STDOUT:       inst580000CF:    symbolic_constant58000080
+// CHECK:STDOUT:       inst580000D0:    symbolic_constant58000081
+// CHECK:STDOUT:       inst580000D1:    symbolic_constant58000082
+// CHECK:STDOUT:       inst580000D2:    constant<none>
+// CHECK:STDOUT:       inst580000D3:    concrete_constant(inst580000D3)
+// CHECK:STDOUT:       inst580000D4:    concrete_constant(inst(TypeType))
+// CHECK:STDOUT:       inst580000D5:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst580000D6:    constant<none>
+// CHECK:STDOUT:       inst580000D7:    concrete_constant(inst580000D7)
+// CHECK:STDOUT:       inst580000D8:    concrete_constant(inst58000026)
+// CHECK:STDOUT:       inst580000D9:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst580000DA:    constant<none>
+// CHECK:STDOUT:       inst580000DB:    concrete_constant(inst580000DB)
+// CHECK:STDOUT:       inst580000DC:    symbolic_constant58000083
+// CHECK:STDOUT:       inst580000DD:    symbolic_constant58000084
+// CHECK:STDOUT:       inst580000DE:    symbolic_constant58000085
+// CHECK:STDOUT:       inst580000DF:    constant<none>
+// CHECK:STDOUT:       inst580000E0:    concrete_constant(inst580000E0)
+// CHECK:STDOUT:       inst580000E1:    symbolic_constant58000087
+// CHECK:STDOUT:       inst580000E2:    symbolic_constant5800008B
+// CHECK:STDOUT:       inst580000E3:    symbolic_constant58000089
+// CHECK:STDOUT:       inst580000E4:    symbolic_constant5800008A
+// CHECK:STDOUT:       inst580000E5:    concrete_constant(inst580000E5)
+// CHECK:STDOUT:       inst580000E6:    symbolic_constant5800008D
+// CHECK:STDOUT:       inst580000E7:    symbolic_constant5800008E
+// CHECK:STDOUT:       inst580000E8:    concrete_constant(inst580000E8)
+// CHECK:STDOUT:       inst580000E9:    concrete_constant(inst580000E9)
+// CHECK:STDOUT:       inst580000EA:    concrete_constant(inst580000EA)
+// CHECK:STDOUT:       inst580000EB:    concrete_constant(inst580000EB)
+// CHECK:STDOUT:       inst580000EC:    symbolic_constant58000090
+// CHECK:STDOUT:       inst580000ED:    symbolic_constant5800009A
+// CHECK:STDOUT:       inst580000EE:    symbolic_constant58000099
+// CHECK:STDOUT:       inst580000EF:    symbolic_constant58000098
+// CHECK:STDOUT:       inst580000F0:    symbolic_constant58000097
+// CHECK:STDOUT:       inst580000F1:    symbolic_constant5800009B
+// CHECK:STDOUT:       inst580000F2:    symbolic_constant5800009C
+// CHECK:STDOUT:       inst580000F3:    symbolic_constant5800009D
+// CHECK:STDOUT:       inst580000F4:    symbolic_constant5800009E
+// CHECK:STDOUT:       inst580000F5:    symbolic_constant5800009F
+// CHECK:STDOUT:       inst580000F6:    symbolic_constant580000A0
+// CHECK:STDOUT:       inst580000F7:    symbolic_constant580000A1
+// CHECK:STDOUT:       inst580000F8:    symbolic_constant580000A2
+// CHECK:STDOUT:       inst580000F9:    symbolic_constant580000A3
+// CHECK:STDOUT:       inst580000FA:    symbolic_constant580000A4
+// CHECK:STDOUT:       inst580000FB:    symbolic_constant580000A5
+// CHECK:STDOUT:       inst580000FC:    symbolic_constant580000A6
+// CHECK:STDOUT:       inst580000FD:    symbolic_constant580000A7
+// CHECK:STDOUT:       inst580000FE:    symbolic_constant580000A9
+// CHECK:STDOUT:       inst580000FF:    symbolic_constant580000AA
+// CHECK:STDOUT:       inst58000100:    symbolic_constant580000AF
+// CHECK:STDOUT:       inst58000101:    symbolic_constant580000B7
+// CHECK:STDOUT:       inst58000102:    symbolic_constant580000B9
+// CHECK:STDOUT:       inst58000103:    symbolic_constant580000BA
+// CHECK:STDOUT:       inst58000104:    symbolic_constant580000BB
+// CHECK:STDOUT:       inst58000105:    symbolic_constant580000BC
+// CHECK:STDOUT:       inst58000106:    symbolic_constant580000BD
+// CHECK:STDOUT:       inst58000107:    symbolic_constant580000BE
+// CHECK:STDOUT:       inst58000108:    symbolic_constant580000BF
+// CHECK:STDOUT:       inst58000109:    symbolic_constant580000C0
+// CHECK:STDOUT:       inst5800010A:    symbolic_constant580000C1
+// CHECK:STDOUT:       inst5800010B:    symbolic_constant580000C2
+// CHECK:STDOUT:       inst5800010C:    symbolic_constant580000C3
+// CHECK:STDOUT:       inst5800010D:    symbolic_constant580000C4
+// CHECK:STDOUT:       inst5800010E:    symbolic_constant580000C5
+// CHECK:STDOUT:       inst5800010F:    concrete_constant(inst5800010F)
+// CHECK:STDOUT:       inst58000110:    concrete_constant(inst58000110)
+// CHECK:STDOUT:       inst58000111:    symbolic_constant58000086
+// CHECK:STDOUT:       inst58000112:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst58000113:    symbolic_constant58000098
+// CHECK:STDOUT:       inst58000114:    symbolic_constant58000097
+// CHECK:STDOUT:       inst58000115:    symbolic_constant580000CC
+// CHECK:STDOUT:       inst58000116:    symbolic_constant580000CD
+// CHECK:STDOUT:       inst58000117:    symbolic_constant580000CE
+// CHECK:STDOUT:       inst58000118:    symbolic_constant580000CF
+// CHECK:STDOUT:       inst58000119:    symbolic_constant580000D0
+// CHECK:STDOUT:       inst5800011A:    symbolic_constant580000D1
+// CHECK:STDOUT:       inst5800011B:    symbolic_constant580000D2
+// CHECK:STDOUT:       inst5800011C:    symbolic_constant580000D4
+// CHECK:STDOUT:       inst5800011D:    symbolic_constant580000D5
+// CHECK:STDOUT:       inst5800011E:    constant<none>
+// CHECK:STDOUT:       inst5800011F:    concrete_constant(inst5800011F)
+// CHECK:STDOUT:       inst58000120:    symbolic_constant580000D6
+// CHECK:STDOUT:       inst58000121:    symbolic_constant580000D7
+// CHECK:STDOUT:       inst58000122:    symbolic_constant580000D8
+// CHECK:STDOUT:       inst58000123:    constant<none>
+// CHECK:STDOUT:       inst58000124:    concrete_constant(inst58000124)
+// CHECK:STDOUT:       inst58000125:    symbolic_constant580000DA
+// CHECK:STDOUT:       inst58000126:    symbolic_constant580000DE
+// CHECK:STDOUT:       inst58000127:    symbolic_constant580000DC
+// CHECK:STDOUT:       inst58000128:    symbolic_constant580000DD
+// CHECK:STDOUT:       inst58000129:    concrete_constant(inst58000129)
+// CHECK:STDOUT:       inst5800012A:    symbolic_constant580000E0
+// CHECK:STDOUT:       inst5800012B:    symbolic_constant580000E1
+// CHECK:STDOUT:       inst5800012C:    concrete_constant(inst5800012C)
+// CHECK:STDOUT:       inst5800012D:    concrete_constant(inst5800012D)
+// CHECK:STDOUT:       inst5800012E:    concrete_constant(inst5800012E)
+// CHECK:STDOUT:       inst5800012F:    concrete_constant(inst5800012F)
+// CHECK:STDOUT:       inst58000130:    symbolic_constant580000E3
+// CHECK:STDOUT:       inst58000131:    symbolic_constant580000F0
+// CHECK:STDOUT:       inst58000132:    symbolic_constant580000EF
+// CHECK:STDOUT:       inst58000133:    symbolic_constant580000EE
+// CHECK:STDOUT:       inst58000134:    symbolic_constant580000ED
+// CHECK:STDOUT:       inst58000135:    symbolic_constant580000EC
+// CHECK:STDOUT:       inst58000136:    symbolic_constant580000F1
+// CHECK:STDOUT:       inst58000137:    symbolic_constant580000F2
+// CHECK:STDOUT:       inst58000138:    symbolic_constant580000F3
+// CHECK:STDOUT:       inst58000139:    symbolic_constant580000F4
+// CHECK:STDOUT:       inst5800013A:    symbolic_constant580000F5
+// CHECK:STDOUT:       inst5800013B:    symbolic_constant580000F6
+// CHECK:STDOUT:       inst5800013C:    symbolic_constant580000F7
+// CHECK:STDOUT:       inst5800013D:    symbolic_constant580000F8
+// CHECK:STDOUT:       inst5800013E:    symbolic_constant580000F9
+// CHECK:STDOUT:       inst5800013F:    symbolic_constant580000FA
+// CHECK:STDOUT:       inst58000140:    symbolic_constant580000FB
+// CHECK:STDOUT:       inst58000141:    symbolic_constant580000FC
+// CHECK:STDOUT:       inst58000142:    symbolic_constant580000FD
+// CHECK:STDOUT:       inst58000143:    symbolic_constant580000FE
+// CHECK:STDOUT:       inst58000144:    symbolic_constant580000FF
+// CHECK:STDOUT:       inst58000145:    symbolic_constant58000101
+// CHECK:STDOUT:       inst58000146:    symbolic_constant58000102
+// CHECK:STDOUT:       inst58000147:    symbolic_constant58000107
+// CHECK:STDOUT:       inst58000148:    symbolic_constant58000115
+// CHECK:STDOUT:       inst58000149:    symbolic_constant58000117
+// CHECK:STDOUT:       inst5800014A:    symbolic_constant58000118
+// CHECK:STDOUT:       inst5800014B:    symbolic_constant58000119
+// CHECK:STDOUT:       inst5800014C:    symbolic_constant5800011A
+// CHECK:STDOUT:       inst5800014D:    symbolic_constant5800011B
+// CHECK:STDOUT:       inst5800014E:    symbolic_constant5800011C
+// CHECK:STDOUT:       inst5800014F:    symbolic_constant5800011D
+// CHECK:STDOUT:       inst58000150:    symbolic_constant5800011E
+// CHECK:STDOUT:       inst58000151:    symbolic_constant5800011F
+// CHECK:STDOUT:       inst58000152:    symbolic_constant58000120
+// CHECK:STDOUT:       inst58000153:    symbolic_constant58000121
+// CHECK:STDOUT:       inst58000154:    symbolic_constant58000122
+// CHECK:STDOUT:       inst58000155:    symbolic_constant58000123
+// CHECK:STDOUT:       inst58000156:    symbolic_constant58000124
+// CHECK:STDOUT:       inst58000157:    symbolic_constant58000125
+// CHECK:STDOUT:       inst58000158:    symbolic_constant58000126
+// CHECK:STDOUT:       inst58000159:    symbolic_constant58000127
+// CHECK:STDOUT:       inst5800015A:    symbolic_constant58000128
+// CHECK:STDOUT:       inst5800015B:    symbolic_constant58000129
+// CHECK:STDOUT:       inst5800015C:    concrete_constant(inst5800015C)
+// CHECK:STDOUT:       inst5800015D:    concrete_constant(inst5800015D)
+// CHECK:STDOUT:       inst5800015E:    concrete_constant(inst5800015E)
+// CHECK:STDOUT:       inst5800015F:    symbolic_constant580000D9
+// CHECK:STDOUT:       inst58000160:    concrete_constant(inst58000050)
+// CHECK:STDOUT:       inst58000161:    symbolic_constant580000EE
+// CHECK:STDOUT:       inst58000162:    symbolic_constant580000ED
+// CHECK:STDOUT:       inst58000163:    symbolic_constant580000EC
+// CHECK:STDOUT:       inst58000164:    symbolic_constant58000132
+// CHECK:STDOUT:       inst58000165:    symbolic_constant58000133
+// CHECK:STDOUT:       inst58000166:    symbolic_constant58000134
+// CHECK:STDOUT:       inst58000167:    symbolic_constant58000135
+// CHECK:STDOUT:       inst58000168:    symbolic_constant58000136
+// CHECK:STDOUT:       inst58000169:    symbolic_constant58000137
+// CHECK:STDOUT:       inst5800016A:    symbolic_constant58000138
+// CHECK:STDOUT:       inst5800016B:    symbolic_constant58000139
+// CHECK:STDOUT:       inst5800016C:    symbolic_constant5800013A
+// CHECK:STDOUT:       inst5800016D:    symbolic_constant5800013C
+// CHECK:STDOUT:       inst5800016E:    symbolic_constant5800013D
+// CHECK:STDOUT:       inst5800016F:    symbolic_constant58000140
+// CHECK:STDOUT:       inst58000170:    symbolic_constant5800013F
+// CHECK:STDOUT:       inst58000171:    symbolic_constant58000140
+// CHECK:STDOUT:       inst58000172:    symbolic_constant58000141
+// CHECK:STDOUT:       inst58000173:    symbolic_constant58000142
+// CHECK:STDOUT:       inst58000174:    symbolic_constant58000143
+// CHECK:STDOUT:       inst58000175:    symbolic_constant58000144
+// CHECK:STDOUT:       inst58000176:    symbolic_constant58000145
+// CHECK:STDOUT:       inst58000177:    symbolic_constant58000146
+// CHECK:STDOUT:       inst58000178:    symbolic_constant5800014B
+// CHECK:STDOUT:       inst58000179:    symbolic_constant58000147
+// CHECK:STDOUT:       inst5800017A:    symbolic_constant58000148
+// CHECK:STDOUT:       inst5800017B:    symbolic_constant58000149
+// CHECK:STDOUT:       inst5800017C:    symbolic_constant5800014A
+// CHECK:STDOUT:       inst5800017D:    symbolic_constant5800014B
+// CHECK:STDOUT:       inst5800017F:    symbolic_constant5800014D
+// CHECK:STDOUT:       inst58000180:    symbolic_constant5800014C
+// CHECK:STDOUT:       inst58000181:    symbolic_constant5800014D
+// CHECK:STDOUT:       inst58000183:    symbolic_constant58000010
+// CHECK:STDOUT:       inst58000187:    concrete_constant(inst58000028)
+// CHECK:STDOUT:       inst58000188:    concrete_constant(inst58000028)
 // CHECK:STDOUT:     symbolic_constants:
-// CHECK:STDOUT:       symbolic_constant60000000: {inst: inst60000014, kind: self, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000001: {inst: inst60000017, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000002: {inst: inst60000017, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000003: {inst: inst6000001D, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000004: {inst: inst6000001D, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000005: {inst: inst60000020, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000006: {inst: inst60000020, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000007: {inst: inst6000002B, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000008: {inst: inst6000002B, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000009: {inst: inst6000002F, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000000A: {inst: inst6000002F, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant6000000B: {inst: inst60000033, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000000C: {inst: inst60000033, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant6000000D: {inst: inst60000035, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000000E: {inst: inst60000035, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant6000000F: {inst: inst60000042, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000010: {inst: inst60000042, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000011: {inst: inst60000044, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000012: {inst: inst60000046, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000013: {inst: inst60000046, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000014: {inst: inst60000052, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000015: {inst: inst60000057, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000016: {inst: inst60000058, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000017: {inst: inst60000058, kind: checked, attached: {generic: generic60000001, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant60000018: {inst: inst60000059, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000019: {inst: inst60000057, kind: checked, attached: {generic: generic60000001, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant6000001A: {inst: inst6000005A, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000001B: {inst: inst6000005A, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000001C: {inst: inst6000005F, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000001D: {inst: inst6000005F, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant6000001E: {inst: inst60000059, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant6000001F: {inst: inst60000052, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000020: {inst: inst6000005F, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000021: {inst: inst60000059, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000022: {inst: inst60000052, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000023: {inst: inst60000059, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000024: {inst: inst6000005A, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000025: {inst: inst6000005F, kind: checked, attached: {generic: generic60000002, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000026: {inst: inst60000058, kind: checked, attached: {generic: generic60000001, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant60000027: {inst: inst60000052, kind: checked, attached: {generic: generic60000001, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000028: {inst: inst60000052, kind: checked, attached: {generic: generic60000001, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000029: {inst: inst60000057, kind: checked, attached: {generic: generic60000001, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant6000002A: {inst: inst60000058, kind: checked, attached: {generic: generic60000001, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant6000002B: {inst: inst60000071, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000002C: {inst: inst60000072, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000002D: {inst: inst60000073, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000002E: {inst: inst60000073, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000002F: {inst: inst60000076, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000030: {inst: inst60000076, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000031: {inst: inst60000078, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000032: {inst: inst60000079, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000033: {inst: inst60000079, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000034: {inst: inst60000078, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000035: {inst: inst6000007A, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000036: {inst: inst6000007A, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000037: {inst: inst6000007F, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000038: {inst: inst6000007F, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant60000039: {inst: inst60000073, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000003A: {inst: inst60000072, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant6000003B: {inst: inst60000071, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant6000003C: {inst: inst60000071, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant6000003D: {inst: inst6000007F, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant6000003E: {inst: inst60000073, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000003F: {inst: inst60000071, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000040: {inst: inst60000072, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000041: {inst: inst60000073, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000042: {inst: inst6000007A, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000043: {inst: inst6000007F, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant60000044: {inst: inst60000088, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000045: {inst: inst60000089, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000046: {inst: inst6000008A, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000047: {inst: inst6000008B, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000048: {inst: inst6000008C, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000049: {inst: inst6000008D, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000004A: {inst: inst6000008D, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def6}}
-// CHECK:STDOUT:       symbolic_constant6000004B: {inst: inst6000008E, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000004C: {inst: inst6000008F, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000004D: {inst: inst6000008C, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def5}}
-// CHECK:STDOUT:       symbolic_constant6000004E: {inst: inst6000008B, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def4}}
-// CHECK:STDOUT:       symbolic_constant6000004F: {inst: inst60000089, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def3}}
-// CHECK:STDOUT:       symbolic_constant60000050: {inst: inst60000088, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant60000051: {inst: inst60000090, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000052: {inst: inst60000090, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000053: {inst: inst60000091, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000054: {inst: inst60000091, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000055: {inst: inst60000091, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000056: {inst: inst60000090, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000057: {inst: inst60000088, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant60000058: {inst: inst60000089, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def3}}
-// CHECK:STDOUT:       symbolic_constant60000059: {inst: inst6000008B, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def4}}
-// CHECK:STDOUT:       symbolic_constant6000005A: {inst: inst6000008C, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def5}}
-// CHECK:STDOUT:       symbolic_constant6000005B: {inst: inst6000008D, kind: checked, attached: {generic: generic60000004, index: generic_inst_in_def6}}
-// CHECK:STDOUT:       symbolic_constant6000005C: {inst: inst60000073, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000005D: {inst: inst60000072, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant6000005E: {inst: inst60000071, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant6000005F: {inst: inst60000071, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000060: {inst: inst60000072, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000061: {inst: inst60000073, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000062: {inst: inst60000076, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000063: {inst: inst60000079, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000064: {inst: inst60000078, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000065: {inst: inst60000079, kind: checked, attached: {generic: generic60000003, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000066: {inst: inst6000001D, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000067: {inst: inst600000B8, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000068: {inst: inst600000B8, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000069: {inst: inst6000001D, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant6000006A: {inst: inst60000017, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant6000006B: {inst: inst60000017, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant6000006C: {inst: inst60000017, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant6000006D: {inst: inst6000001D, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant6000006E: {inst: inst600000B8, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000006F: {inst: inst60000042, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant60000070: {inst: inst600000C1, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000071: {inst: inst600000C2, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000072: {inst: inst600000C2, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000073: {inst: inst600000C1, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000074: {inst: inst60000020, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000075: {inst: inst600000C7, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000076: {inst: inst600000C7, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000077: {inst: inst6000001D, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000078: {inst: inst60000017, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000079: {inst: inst600000C7, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant6000007A: {inst: inst6000001D, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant6000007B: {inst: inst60000017, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant6000007C: {inst: inst6000001D, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant6000007D: {inst: inst60000020, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000007E: {inst: inst600000C7, kind: checked, attached: {generic: generic60000006, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant6000007F: {inst: inst600000C2, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000080: {inst: inst600000C1, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000081: {inst: inst600000C2, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000082: {inst: inst60000042, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant60000083: {inst: inst600000DC, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000084: {inst: inst600000DD, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000085: {inst: inst600000DE, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000086: {inst: inst600000DE, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant60000087: {inst: inst600000E1, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000088: {inst: inst600000E1, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant60000089: {inst: inst600000E3, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000008A: {inst: inst600000E4, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000008B: {inst: inst600000E4, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant6000008C: {inst: inst600000E3, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant6000008D: {inst: inst600000E6, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000008E: {inst: inst600000E7, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000008F: {inst: inst600000E7, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant60000090: {inst: inst600000EC, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000091: {inst: inst600000EC, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant60000092: {inst: inst600000DE, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant60000093: {inst: inst600000DD, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000094: {inst: inst600000DC, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000095: {inst: inst60000072, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000096: {inst: inst60000071, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000097: {inst: inst600000DC, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000098: {inst: inst60000071, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000099: {inst: inst600000EC, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant6000009A: {inst: inst600000DE, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant6000009B: {inst: inst60000071, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant6000009C: {inst: inst60000072, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant6000009D: {inst: inst600000DC, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000009E: {inst: inst600000DD, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant6000009F: {inst: inst600000DE, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant600000A0: {inst: inst600000E7, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant600000A1: {inst: inst600000EC, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant600000A2: {inst: inst600000F8, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000A3: {inst: inst600000F9, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000A4: {inst: inst600000FA, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000A5: {inst: inst600000FB, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000A6: {inst: inst600000FC, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000A7: {inst: inst600000FD, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000A8: {inst: inst600000FD, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def12}}
-// CHECK:STDOUT:       symbolic_constant600000A9: {inst: inst600000FE, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000AA: {inst: inst600000FF, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000AB: {inst: inst600000FC, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def11}}
-// CHECK:STDOUT:       symbolic_constant600000AC: {inst: inst600000FB, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def10}}
-// CHECK:STDOUT:       symbolic_constant600000AD: {inst: inst600000F9, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def9}}
-// CHECK:STDOUT:       symbolic_constant600000AE: {inst: inst600000F8, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def8}}
-// CHECK:STDOUT:       symbolic_constant600000AF: {inst: inst60000100, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000B0: {inst: inst60000100, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def7}}
-// CHECK:STDOUT:       symbolic_constant600000B1: {inst: inst6000008D, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def6}}
-// CHECK:STDOUT:       symbolic_constant600000B2: {inst: inst6000008C, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def5}}
-// CHECK:STDOUT:       symbolic_constant600000B3: {inst: inst6000008B, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def4}}
-// CHECK:STDOUT:       symbolic_constant600000B4: {inst: inst60000089, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def3}}
-// CHECK:STDOUT:       symbolic_constant600000B5: {inst: inst60000088, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant600000B6: {inst: inst60000090, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant600000B7: {inst: inst60000101, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000B8: {inst: inst60000101, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant600000B9: {inst: inst60000101, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant600000BA: {inst: inst60000090, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant600000BB: {inst: inst60000088, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant600000BC: {inst: inst60000089, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def3}}
-// CHECK:STDOUT:       symbolic_constant600000BD: {inst: inst6000008B, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def4}}
-// CHECK:STDOUT:       symbolic_constant600000BE: {inst: inst6000008C, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def5}}
-// CHECK:STDOUT:       symbolic_constant600000BF: {inst: inst6000008D, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def6}}
-// CHECK:STDOUT:       symbolic_constant600000C0: {inst: inst60000100, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def7}}
-// CHECK:STDOUT:       symbolic_constant600000C1: {inst: inst600000F8, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def8}}
-// CHECK:STDOUT:       symbolic_constant600000C2: {inst: inst600000F9, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def9}}
-// CHECK:STDOUT:       symbolic_constant600000C3: {inst: inst600000FB, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def10}}
-// CHECK:STDOUT:       symbolic_constant600000C4: {inst: inst600000FC, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def11}}
-// CHECK:STDOUT:       symbolic_constant600000C5: {inst: inst600000FD, kind: checked, attached: {generic: generic60000008, index: generic_inst_in_def12}}
-// CHECK:STDOUT:       symbolic_constant600000C6: {inst: inst600000DE, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant600000C7: {inst: inst600000DD, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant600000C8: {inst: inst60000072, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant600000C9: {inst: inst600000E6, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant600000CA: {inst: inst600000DC, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant600000CB: {inst: inst60000071, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant600000CC: {inst: inst60000071, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant600000CD: {inst: inst600000DC, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant600000CE: {inst: inst600000E6, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant600000CF: {inst: inst60000072, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant600000D0: {inst: inst600000DD, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant600000D1: {inst: inst600000DE, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant600000D2: {inst: inst600000E1, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant600000D3: {inst: inst600000E4, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant600000D4: {inst: inst600000E3, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant600000D5: {inst: inst600000E4, kind: checked, attached: {generic: generic60000007, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant600000D6: {inst: inst60000120, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000D7: {inst: inst60000121, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000D8: {inst: inst60000122, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000D9: {inst: inst60000122, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl7}}
-// CHECK:STDOUT:       symbolic_constant600000DA: {inst: inst60000125, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000DB: {inst: inst60000125, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl8}}
-// CHECK:STDOUT:       symbolic_constant600000DC: {inst: inst60000127, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000DD: {inst: inst60000128, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000DE: {inst: inst60000128, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant600000DF: {inst: inst60000127, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant600000E0: {inst: inst6000012A, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000E1: {inst: inst6000012B, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000E2: {inst: inst6000012B, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl7}}
-// CHECK:STDOUT:       symbolic_constant600000E3: {inst: inst60000130, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000E4: {inst: inst60000130, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl8}}
-// CHECK:STDOUT:       symbolic_constant600000E5: {inst: inst60000122, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant600000E6: {inst: inst60000121, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant600000E7: {inst: inst60000120, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant600000E8: {inst: inst600000DD, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant600000E9: {inst: inst600000DC, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant600000EA: {inst: inst60000072, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant600000EB: {inst: inst60000071, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant600000EC: {inst: inst60000120, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant600000ED: {inst: inst600000DC, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant600000EE: {inst: inst60000071, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant600000EF: {inst: inst60000130, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl8}}
-// CHECK:STDOUT:       symbolic_constant600000F0: {inst: inst60000122, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant600000F1: {inst: inst60000071, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant600000F2: {inst: inst60000072, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant600000F3: {inst: inst600000DC, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant600000F4: {inst: inst600000DD, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant600000F5: {inst: inst60000120, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant600000F6: {inst: inst60000121, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant600000F7: {inst: inst60000122, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant600000F8: {inst: inst6000012B, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl7}}
-// CHECK:STDOUT:       symbolic_constant600000F9: {inst: inst60000130, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_decl8}}
-// CHECK:STDOUT:       symbolic_constant600000FA: {inst: inst6000013F, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000FB: {inst: inst60000140, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000FC: {inst: inst60000141, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000FD: {inst: inst60000142, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000FE: {inst: inst60000143, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant600000FF: {inst: inst60000144, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000100: {inst: inst60000144, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def18}}
-// CHECK:STDOUT:       symbolic_constant60000101: {inst: inst60000145, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000102: {inst: inst60000146, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000103: {inst: inst60000143, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def17}}
-// CHECK:STDOUT:       symbolic_constant60000104: {inst: inst60000142, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def16}}
-// CHECK:STDOUT:       symbolic_constant60000105: {inst: inst60000140, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def15}}
-// CHECK:STDOUT:       symbolic_constant60000106: {inst: inst6000013F, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def14}}
-// CHECK:STDOUT:       symbolic_constant60000107: {inst: inst60000147, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000108: {inst: inst60000147, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def13}}
-// CHECK:STDOUT:       symbolic_constant60000109: {inst: inst600000FD, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def12}}
-// CHECK:STDOUT:       symbolic_constant6000010A: {inst: inst600000FC, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def11}}
-// CHECK:STDOUT:       symbolic_constant6000010B: {inst: inst600000FB, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def10}}
-// CHECK:STDOUT:       symbolic_constant6000010C: {inst: inst600000F9, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def9}}
-// CHECK:STDOUT:       symbolic_constant6000010D: {inst: inst600000F8, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def8}}
-// CHECK:STDOUT:       symbolic_constant6000010E: {inst: inst60000100, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def7}}
-// CHECK:STDOUT:       symbolic_constant6000010F: {inst: inst6000008D, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def6}}
-// CHECK:STDOUT:       symbolic_constant60000110: {inst: inst6000008C, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def5}}
-// CHECK:STDOUT:       symbolic_constant60000111: {inst: inst6000008B, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def4}}
-// CHECK:STDOUT:       symbolic_constant60000112: {inst: inst60000089, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def3}}
-// CHECK:STDOUT:       symbolic_constant60000113: {inst: inst60000088, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant60000114: {inst: inst60000090, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000115: {inst: inst60000148, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000116: {inst: inst60000148, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000117: {inst: inst60000148, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant60000118: {inst: inst60000090, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant60000119: {inst: inst60000088, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant6000011A: {inst: inst60000089, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def3}}
-// CHECK:STDOUT:       symbolic_constant6000011B: {inst: inst6000008B, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def4}}
-// CHECK:STDOUT:       symbolic_constant6000011C: {inst: inst6000008C, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def5}}
-// CHECK:STDOUT:       symbolic_constant6000011D: {inst: inst6000008D, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def6}}
-// CHECK:STDOUT:       symbolic_constant6000011E: {inst: inst60000100, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def7}}
-// CHECK:STDOUT:       symbolic_constant6000011F: {inst: inst600000F8, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def8}}
-// CHECK:STDOUT:       symbolic_constant60000120: {inst: inst600000F9, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def9}}
-// CHECK:STDOUT:       symbolic_constant60000121: {inst: inst600000FB, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def10}}
-// CHECK:STDOUT:       symbolic_constant60000122: {inst: inst600000FC, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def11}}
-// CHECK:STDOUT:       symbolic_constant60000123: {inst: inst600000FD, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def12}}
-// CHECK:STDOUT:       symbolic_constant60000124: {inst: inst60000147, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def13}}
-// CHECK:STDOUT:       symbolic_constant60000125: {inst: inst6000013F, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def14}}
-// CHECK:STDOUT:       symbolic_constant60000126: {inst: inst60000140, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def15}}
-// CHECK:STDOUT:       symbolic_constant60000127: {inst: inst60000142, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def16}}
-// CHECK:STDOUT:       symbolic_constant60000128: {inst: inst60000143, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def17}}
-// CHECK:STDOUT:       symbolic_constant60000129: {inst: inst60000144, kind: checked, attached: {generic: generic6000000A, index: generic_inst_in_def18}}
-// CHECK:STDOUT:       symbolic_constant6000012A: {inst: inst60000122, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl7}}
-// CHECK:STDOUT:       symbolic_constant6000012B: {inst: inst60000121, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant6000012C: {inst: inst600000DD, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant6000012D: {inst: inst60000072, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant6000012E: {inst: inst6000012A, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant6000012F: {inst: inst60000120, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000130: {inst: inst600000DC, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000131: {inst: inst60000071, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000132: {inst: inst60000071, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl0}}
-// CHECK:STDOUT:       symbolic_constant60000133: {inst: inst600000DC, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl1}}
-// CHECK:STDOUT:       symbolic_constant60000134: {inst: inst60000120, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant60000135: {inst: inst6000012A, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl3}}
-// CHECK:STDOUT:       symbolic_constant60000136: {inst: inst60000072, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl4}}
-// CHECK:STDOUT:       symbolic_constant60000137: {inst: inst600000DD, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl5}}
-// CHECK:STDOUT:       symbolic_constant60000138: {inst: inst60000121, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl6}}
-// CHECK:STDOUT:       symbolic_constant60000139: {inst: inst60000122, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl7}}
-// CHECK:STDOUT:       symbolic_constant6000013A: {inst: inst60000125, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_decl8}}
-// CHECK:STDOUT:       symbolic_constant6000013B: {inst: inst60000128, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant6000013C: {inst: inst60000127, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_def0}}
-// CHECK:STDOUT:       symbolic_constant6000013D: {inst: inst60000128, kind: checked, attached: {generic: generic60000009, index: generic_inst_in_def1}}
-// CHECK:STDOUT:       symbolic_constant6000013E: {inst: inst600000B8, kind: checked, attached: {generic: generic60000005, index: generic_inst_in_decl2}}
-// CHECK:STDOUT:       symbolic_constant6000013F: {inst: inst60000170, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000140: {inst: inst60000170, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def2}}
-// CHECK:STDOUT:       symbolic_constant60000141: {inst: inst60000172, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000142: {inst: inst60000172, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def3}}
-// CHECK:STDOUT:       symbolic_constant60000143: {inst: inst60000174, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000144: {inst: inst60000175, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000145: {inst: inst60000176, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000146: {inst: inst60000177, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000147: {inst: inst60000179, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant60000148: {inst: inst60000174, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def4}}
-// CHECK:STDOUT:       symbolic_constant60000149: {inst: inst60000175, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def5}}
-// CHECK:STDOUT:       symbolic_constant6000014A: {inst: inst60000177, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def6}}
-// CHECK:STDOUT:       symbolic_constant6000014B: {inst: inst60000179, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def7}}
-// CHECK:STDOUT:       symbolic_constant6000014C: {inst: inst60000180, kind: checked, attached: null}
-// CHECK:STDOUT:       symbolic_constant6000014D: {inst: inst60000180, kind: checked, attached: {generic: generic60000000, index: generic_inst_in_def8}}
+// CHECK:STDOUT:       symbolic_constant58000000: {inst: inst58000014, kind: self, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000001: {inst: inst58000017, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000002: {inst: inst58000017, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000003: {inst: inst5800001D, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000004: {inst: inst5800001D, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000005: {inst: inst58000020, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000006: {inst: inst58000020, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000007: {inst: inst5800002B, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000008: {inst: inst5800002B, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000009: {inst: inst5800002F, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800000A: {inst: inst5800002F, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant5800000B: {inst: inst58000033, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800000C: {inst: inst58000033, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant5800000D: {inst: inst58000035, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800000E: {inst: inst58000035, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant5800000F: {inst: inst58000042, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000010: {inst: inst58000042, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000011: {inst: inst58000044, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000012: {inst: inst58000046, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000013: {inst: inst58000046, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000014: {inst: inst58000052, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000015: {inst: inst58000057, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000016: {inst: inst58000058, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000017: {inst: inst58000058, kind: checked, attached: {generic: generic58000001, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant58000018: {inst: inst58000059, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000019: {inst: inst58000057, kind: checked, attached: {generic: generic58000001, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant5800001A: {inst: inst5800005A, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800001B: {inst: inst5800005A, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800001C: {inst: inst5800005F, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800001D: {inst: inst5800005F, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant5800001E: {inst: inst58000059, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant5800001F: {inst: inst58000052, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000020: {inst: inst5800005F, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000021: {inst: inst58000059, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000022: {inst: inst58000052, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000023: {inst: inst58000059, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000024: {inst: inst5800005A, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000025: {inst: inst5800005F, kind: checked, attached: {generic: generic58000002, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000026: {inst: inst58000058, kind: checked, attached: {generic: generic58000001, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant58000027: {inst: inst58000052, kind: checked, attached: {generic: generic58000001, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000028: {inst: inst58000052, kind: checked, attached: {generic: generic58000001, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000029: {inst: inst58000057, kind: checked, attached: {generic: generic58000001, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant5800002A: {inst: inst58000058, kind: checked, attached: {generic: generic58000001, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant5800002B: {inst: inst58000071, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800002C: {inst: inst58000072, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800002D: {inst: inst58000073, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800002E: {inst: inst58000073, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800002F: {inst: inst58000076, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000030: {inst: inst58000076, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000031: {inst: inst58000078, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000032: {inst: inst58000079, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000033: {inst: inst58000079, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000034: {inst: inst58000078, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000035: {inst: inst5800007A, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000036: {inst: inst5800007A, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000037: {inst: inst5800007F, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000038: {inst: inst5800007F, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant58000039: {inst: inst58000073, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800003A: {inst: inst58000072, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant5800003B: {inst: inst58000071, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant5800003C: {inst: inst58000071, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant5800003D: {inst: inst5800007F, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant5800003E: {inst: inst58000073, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800003F: {inst: inst58000071, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000040: {inst: inst58000072, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000041: {inst: inst58000073, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000042: {inst: inst5800007A, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000043: {inst: inst5800007F, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant58000044: {inst: inst58000088, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000045: {inst: inst58000089, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000046: {inst: inst5800008A, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000047: {inst: inst5800008B, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000048: {inst: inst5800008C, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000049: {inst: inst5800008D, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800004A: {inst: inst5800008D, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def6}}
+// CHECK:STDOUT:       symbolic_constant5800004B: {inst: inst5800008E, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800004C: {inst: inst5800008F, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800004D: {inst: inst5800008C, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def5}}
+// CHECK:STDOUT:       symbolic_constant5800004E: {inst: inst5800008B, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def4}}
+// CHECK:STDOUT:       symbolic_constant5800004F: {inst: inst58000089, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def3}}
+// CHECK:STDOUT:       symbolic_constant58000050: {inst: inst58000088, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant58000051: {inst: inst58000090, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000052: {inst: inst58000090, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000053: {inst: inst58000091, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000054: {inst: inst58000091, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000055: {inst: inst58000091, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000056: {inst: inst58000090, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000057: {inst: inst58000088, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant58000058: {inst: inst58000089, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def3}}
+// CHECK:STDOUT:       symbolic_constant58000059: {inst: inst5800008B, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def4}}
+// CHECK:STDOUT:       symbolic_constant5800005A: {inst: inst5800008C, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def5}}
+// CHECK:STDOUT:       symbolic_constant5800005B: {inst: inst5800008D, kind: checked, attached: {generic: generic58000004, index: generic_inst_in_def6}}
+// CHECK:STDOUT:       symbolic_constant5800005C: {inst: inst58000073, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800005D: {inst: inst58000072, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant5800005E: {inst: inst58000071, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant5800005F: {inst: inst58000071, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000060: {inst: inst58000072, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000061: {inst: inst58000073, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000062: {inst: inst58000076, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000063: {inst: inst58000079, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000064: {inst: inst58000078, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000065: {inst: inst58000079, kind: checked, attached: {generic: generic58000003, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000066: {inst: inst5800001D, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000067: {inst: inst580000B8, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000068: {inst: inst580000B8, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000069: {inst: inst5800001D, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant5800006A: {inst: inst58000017, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant5800006B: {inst: inst58000017, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant5800006C: {inst: inst58000017, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant5800006D: {inst: inst5800001D, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant5800006E: {inst: inst580000B8, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800006F: {inst: inst58000042, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant58000070: {inst: inst580000C1, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000071: {inst: inst580000C2, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000072: {inst: inst580000C2, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000073: {inst: inst580000C1, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000074: {inst: inst58000020, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000075: {inst: inst580000C7, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000076: {inst: inst580000C7, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000077: {inst: inst5800001D, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000078: {inst: inst58000017, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000079: {inst: inst580000C7, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant5800007A: {inst: inst5800001D, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant5800007B: {inst: inst58000017, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant5800007C: {inst: inst5800001D, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant5800007D: {inst: inst58000020, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800007E: {inst: inst580000C7, kind: checked, attached: {generic: generic58000006, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant5800007F: {inst: inst580000C2, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000080: {inst: inst580000C1, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000081: {inst: inst580000C2, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000082: {inst: inst58000042, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant58000083: {inst: inst580000DC, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000084: {inst: inst580000DD, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000085: {inst: inst580000DE, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000086: {inst: inst580000DE, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant58000087: {inst: inst580000E1, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000088: {inst: inst580000E1, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant58000089: {inst: inst580000E3, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800008A: {inst: inst580000E4, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800008B: {inst: inst580000E4, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant5800008C: {inst: inst580000E3, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant5800008D: {inst: inst580000E6, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800008E: {inst: inst580000E7, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800008F: {inst: inst580000E7, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant58000090: {inst: inst580000EC, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000091: {inst: inst580000EC, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant58000092: {inst: inst580000DE, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant58000093: {inst: inst580000DD, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000094: {inst: inst580000DC, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000095: {inst: inst58000072, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000096: {inst: inst58000071, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000097: {inst: inst580000DC, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000098: {inst: inst58000071, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000099: {inst: inst580000EC, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant5800009A: {inst: inst580000DE, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant5800009B: {inst: inst58000071, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant5800009C: {inst: inst58000072, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant5800009D: {inst: inst580000DC, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800009E: {inst: inst580000DD, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant5800009F: {inst: inst580000DE, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant580000A0: {inst: inst580000E7, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant580000A1: {inst: inst580000EC, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant580000A2: {inst: inst580000F8, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000A3: {inst: inst580000F9, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000A4: {inst: inst580000FA, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000A5: {inst: inst580000FB, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000A6: {inst: inst580000FC, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000A7: {inst: inst580000FD, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000A8: {inst: inst580000FD, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def12}}
+// CHECK:STDOUT:       symbolic_constant580000A9: {inst: inst580000FE, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000AA: {inst: inst580000FF, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000AB: {inst: inst580000FC, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def11}}
+// CHECK:STDOUT:       symbolic_constant580000AC: {inst: inst580000FB, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def10}}
+// CHECK:STDOUT:       symbolic_constant580000AD: {inst: inst580000F9, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def9}}
+// CHECK:STDOUT:       symbolic_constant580000AE: {inst: inst580000F8, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def8}}
+// CHECK:STDOUT:       symbolic_constant580000AF: {inst: inst58000100, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000B0: {inst: inst58000100, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def7}}
+// CHECK:STDOUT:       symbolic_constant580000B1: {inst: inst5800008D, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def6}}
+// CHECK:STDOUT:       symbolic_constant580000B2: {inst: inst5800008C, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def5}}
+// CHECK:STDOUT:       symbolic_constant580000B3: {inst: inst5800008B, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def4}}
+// CHECK:STDOUT:       symbolic_constant580000B4: {inst: inst58000089, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def3}}
+// CHECK:STDOUT:       symbolic_constant580000B5: {inst: inst58000088, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant580000B6: {inst: inst58000090, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant580000B7: {inst: inst58000101, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000B8: {inst: inst58000101, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant580000B9: {inst: inst58000101, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant580000BA: {inst: inst58000090, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant580000BB: {inst: inst58000088, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant580000BC: {inst: inst58000089, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def3}}
+// CHECK:STDOUT:       symbolic_constant580000BD: {inst: inst5800008B, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def4}}
+// CHECK:STDOUT:       symbolic_constant580000BE: {inst: inst5800008C, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def5}}
+// CHECK:STDOUT:       symbolic_constant580000BF: {inst: inst5800008D, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def6}}
+// CHECK:STDOUT:       symbolic_constant580000C0: {inst: inst58000100, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def7}}
+// CHECK:STDOUT:       symbolic_constant580000C1: {inst: inst580000F8, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def8}}
+// CHECK:STDOUT:       symbolic_constant580000C2: {inst: inst580000F9, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def9}}
+// CHECK:STDOUT:       symbolic_constant580000C3: {inst: inst580000FB, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def10}}
+// CHECK:STDOUT:       symbolic_constant580000C4: {inst: inst580000FC, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def11}}
+// CHECK:STDOUT:       symbolic_constant580000C5: {inst: inst580000FD, kind: checked, attached: {generic: generic58000008, index: generic_inst_in_def12}}
+// CHECK:STDOUT:       symbolic_constant580000C6: {inst: inst580000DE, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant580000C7: {inst: inst580000DD, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant580000C8: {inst: inst58000072, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant580000C9: {inst: inst580000E6, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant580000CA: {inst: inst580000DC, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant580000CB: {inst: inst58000071, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant580000CC: {inst: inst58000071, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant580000CD: {inst: inst580000DC, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant580000CE: {inst: inst580000E6, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant580000CF: {inst: inst58000072, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant580000D0: {inst: inst580000DD, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant580000D1: {inst: inst580000DE, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant580000D2: {inst: inst580000E1, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant580000D3: {inst: inst580000E4, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant580000D4: {inst: inst580000E3, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant580000D5: {inst: inst580000E4, kind: checked, attached: {generic: generic58000007, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant580000D6: {inst: inst58000120, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000D7: {inst: inst58000121, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000D8: {inst: inst58000122, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000D9: {inst: inst58000122, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl7}}
+// CHECK:STDOUT:       symbolic_constant580000DA: {inst: inst58000125, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000DB: {inst: inst58000125, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl8}}
+// CHECK:STDOUT:       symbolic_constant580000DC: {inst: inst58000127, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000DD: {inst: inst58000128, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000DE: {inst: inst58000128, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant580000DF: {inst: inst58000127, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant580000E0: {inst: inst5800012A, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000E1: {inst: inst5800012B, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000E2: {inst: inst5800012B, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl7}}
+// CHECK:STDOUT:       symbolic_constant580000E3: {inst: inst58000130, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000E4: {inst: inst58000130, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl8}}
+// CHECK:STDOUT:       symbolic_constant580000E5: {inst: inst58000122, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant580000E6: {inst: inst58000121, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant580000E7: {inst: inst58000120, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant580000E8: {inst: inst580000DD, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant580000E9: {inst: inst580000DC, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant580000EA: {inst: inst58000072, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant580000EB: {inst: inst58000071, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant580000EC: {inst: inst58000120, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant580000ED: {inst: inst580000DC, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant580000EE: {inst: inst58000071, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant580000EF: {inst: inst58000130, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl8}}
+// CHECK:STDOUT:       symbolic_constant580000F0: {inst: inst58000122, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant580000F1: {inst: inst58000071, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant580000F2: {inst: inst58000072, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant580000F3: {inst: inst580000DC, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant580000F4: {inst: inst580000DD, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant580000F5: {inst: inst58000120, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant580000F6: {inst: inst58000121, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant580000F7: {inst: inst58000122, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant580000F8: {inst: inst5800012B, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl7}}
+// CHECK:STDOUT:       symbolic_constant580000F9: {inst: inst58000130, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_decl8}}
+// CHECK:STDOUT:       symbolic_constant580000FA: {inst: inst5800013F, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000FB: {inst: inst58000140, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000FC: {inst: inst58000141, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000FD: {inst: inst58000142, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000FE: {inst: inst58000143, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant580000FF: {inst: inst58000144, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000100: {inst: inst58000144, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def18}}
+// CHECK:STDOUT:       symbolic_constant58000101: {inst: inst58000145, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000102: {inst: inst58000146, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000103: {inst: inst58000143, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def17}}
+// CHECK:STDOUT:       symbolic_constant58000104: {inst: inst58000142, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def16}}
+// CHECK:STDOUT:       symbolic_constant58000105: {inst: inst58000140, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def15}}
+// CHECK:STDOUT:       symbolic_constant58000106: {inst: inst5800013F, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def14}}
+// CHECK:STDOUT:       symbolic_constant58000107: {inst: inst58000147, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000108: {inst: inst58000147, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def13}}
+// CHECK:STDOUT:       symbolic_constant58000109: {inst: inst580000FD, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def12}}
+// CHECK:STDOUT:       symbolic_constant5800010A: {inst: inst580000FC, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def11}}
+// CHECK:STDOUT:       symbolic_constant5800010B: {inst: inst580000FB, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def10}}
+// CHECK:STDOUT:       symbolic_constant5800010C: {inst: inst580000F9, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def9}}
+// CHECK:STDOUT:       symbolic_constant5800010D: {inst: inst580000F8, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def8}}
+// CHECK:STDOUT:       symbolic_constant5800010E: {inst: inst58000100, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def7}}
+// CHECK:STDOUT:       symbolic_constant5800010F: {inst: inst5800008D, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def6}}
+// CHECK:STDOUT:       symbolic_constant58000110: {inst: inst5800008C, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def5}}
+// CHECK:STDOUT:       symbolic_constant58000111: {inst: inst5800008B, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def4}}
+// CHECK:STDOUT:       symbolic_constant58000112: {inst: inst58000089, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def3}}
+// CHECK:STDOUT:       symbolic_constant58000113: {inst: inst58000088, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant58000114: {inst: inst58000090, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000115: {inst: inst58000148, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000116: {inst: inst58000148, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000117: {inst: inst58000148, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant58000118: {inst: inst58000090, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant58000119: {inst: inst58000088, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant5800011A: {inst: inst58000089, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def3}}
+// CHECK:STDOUT:       symbolic_constant5800011B: {inst: inst5800008B, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def4}}
+// CHECK:STDOUT:       symbolic_constant5800011C: {inst: inst5800008C, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def5}}
+// CHECK:STDOUT:       symbolic_constant5800011D: {inst: inst5800008D, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def6}}
+// CHECK:STDOUT:       symbolic_constant5800011E: {inst: inst58000100, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def7}}
+// CHECK:STDOUT:       symbolic_constant5800011F: {inst: inst580000F8, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def8}}
+// CHECK:STDOUT:       symbolic_constant58000120: {inst: inst580000F9, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def9}}
+// CHECK:STDOUT:       symbolic_constant58000121: {inst: inst580000FB, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def10}}
+// CHECK:STDOUT:       symbolic_constant58000122: {inst: inst580000FC, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def11}}
+// CHECK:STDOUT:       symbolic_constant58000123: {inst: inst580000FD, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def12}}
+// CHECK:STDOUT:       symbolic_constant58000124: {inst: inst58000147, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def13}}
+// CHECK:STDOUT:       symbolic_constant58000125: {inst: inst5800013F, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def14}}
+// CHECK:STDOUT:       symbolic_constant58000126: {inst: inst58000140, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def15}}
+// CHECK:STDOUT:       symbolic_constant58000127: {inst: inst58000142, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def16}}
+// CHECK:STDOUT:       symbolic_constant58000128: {inst: inst58000143, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def17}}
+// CHECK:STDOUT:       symbolic_constant58000129: {inst: inst58000144, kind: checked, attached: {generic: generic5800000A, index: generic_inst_in_def18}}
+// CHECK:STDOUT:       symbolic_constant5800012A: {inst: inst58000122, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl7}}
+// CHECK:STDOUT:       symbolic_constant5800012B: {inst: inst58000121, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant5800012C: {inst: inst580000DD, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant5800012D: {inst: inst58000072, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant5800012E: {inst: inst5800012A, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant5800012F: {inst: inst58000120, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000130: {inst: inst580000DC, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000131: {inst: inst58000071, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000132: {inst: inst58000071, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl0}}
+// CHECK:STDOUT:       symbolic_constant58000133: {inst: inst580000DC, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl1}}
+// CHECK:STDOUT:       symbolic_constant58000134: {inst: inst58000120, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant58000135: {inst: inst5800012A, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl3}}
+// CHECK:STDOUT:       symbolic_constant58000136: {inst: inst58000072, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl4}}
+// CHECK:STDOUT:       symbolic_constant58000137: {inst: inst580000DD, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl5}}
+// CHECK:STDOUT:       symbolic_constant58000138: {inst: inst58000121, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl6}}
+// CHECK:STDOUT:       symbolic_constant58000139: {inst: inst58000122, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl7}}
+// CHECK:STDOUT:       symbolic_constant5800013A: {inst: inst58000125, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_decl8}}
+// CHECK:STDOUT:       symbolic_constant5800013B: {inst: inst58000128, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant5800013C: {inst: inst58000127, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_def0}}
+// CHECK:STDOUT:       symbolic_constant5800013D: {inst: inst58000128, kind: checked, attached: {generic: generic58000009, index: generic_inst_in_def1}}
+// CHECK:STDOUT:       symbolic_constant5800013E: {inst: inst580000B8, kind: checked, attached: {generic: generic58000005, index: generic_inst_in_decl2}}
+// CHECK:STDOUT:       symbolic_constant5800013F: {inst: inst58000170, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000140: {inst: inst58000170, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def2}}
+// CHECK:STDOUT:       symbolic_constant58000141: {inst: inst58000172, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000142: {inst: inst58000172, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def3}}
+// CHECK:STDOUT:       symbolic_constant58000143: {inst: inst58000174, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000144: {inst: inst58000175, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000145: {inst: inst58000176, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000146: {inst: inst58000177, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000147: {inst: inst58000179, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant58000148: {inst: inst58000174, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def4}}
+// CHECK:STDOUT:       symbolic_constant58000149: {inst: inst58000175, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def5}}
+// CHECK:STDOUT:       symbolic_constant5800014A: {inst: inst58000177, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def6}}
+// CHECK:STDOUT:       symbolic_constant5800014B: {inst: inst58000179, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def7}}
+// CHECK:STDOUT:       symbolic_constant5800014C: {inst: inst58000180, kind: checked, attached: null}
+// CHECK:STDOUT:       symbolic_constant5800014D: {inst: inst58000180, kind: checked, attached: {generic: generic58000000, index: generic_inst_in_def8}}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst6000003E
+// CHECK:STDOUT:       0:               inst5800003E
 // CHECK:STDOUT:     generated:       {}
 // CHECK:STDOUT:     imports:
-// CHECK:STDOUT:       0:               inst60000011
-// CHECK:STDOUT:       1:               inst6000004E
-// CHECK:STDOUT:       2:               inst6000004F
-// CHECK:STDOUT:       3:               inst60000051
-// CHECK:STDOUT:       4:               inst60000053
-// CHECK:STDOUT:       5:               inst60000054
-// CHECK:STDOUT:       6:               inst60000055
-// CHECK:STDOUT:       7:               inst60000056
-// CHECK:STDOUT:       8:               inst6000005B
-// CHECK:STDOUT:       9:               inst6000005C
-// CHECK:STDOUT:       10:              inst6000005D
-// CHECK:STDOUT:       11:              inst6000005E
-// CHECK:STDOUT:       12:              inst60000060
-// CHECK:STDOUT:       13:              inst60000061
-// CHECK:STDOUT:       14:              inst60000062
-// CHECK:STDOUT:       15:              inst6000006A
-// CHECK:STDOUT:       16:              inst6000006C
-// CHECK:STDOUT:       17:              inst6000006F
-// CHECK:STDOUT:       18:              inst60000070
-// CHECK:STDOUT:       19:              inst60000074
-// CHECK:STDOUT:       20:              inst60000075
-// CHECK:STDOUT:       21:              inst60000077
-// CHECK:STDOUT:       22:              inst6000007B
-// CHECK:STDOUT:       23:              inst6000007C
-// CHECK:STDOUT:       24:              inst6000007D
-// CHECK:STDOUT:       25:              inst6000007E
-// CHECK:STDOUT:       26:              inst60000080
-// CHECK:STDOUT:       27:              inst60000081
-// CHECK:STDOUT:       28:              inst60000082
-// CHECK:STDOUT:       29:              inst6000009A
-// CHECK:STDOUT:       30:              inst6000009B
-// CHECK:STDOUT:       31:              inst6000009C
-// CHECK:STDOUT:       32:              inst6000009D
-// CHECK:STDOUT:       33:              inst600000A4
-// CHECK:STDOUT:       34:              inst600000A5
-// CHECK:STDOUT:       35:              inst600000A6
-// CHECK:STDOUT:       36:              inst600000A7
-// CHECK:STDOUT:       37:              inst600000A8
-// CHECK:STDOUT:       38:              inst600000A9
-// CHECK:STDOUT:       39:              inst600000AA
-// CHECK:STDOUT:       40:              inst600000AB
-// CHECK:STDOUT:       41:              inst600000AC
-// CHECK:STDOUT:       42:              inst600000AD
-// CHECK:STDOUT:       43:              inst600000AE
-// CHECK:STDOUT:       44:              inst600000AF
-// CHECK:STDOUT:       45:              inst600000B0
-// CHECK:STDOUT:       46:              inst600000B1
-// CHECK:STDOUT:       47:              inst600000B2
-// CHECK:STDOUT:       48:              inst600000B3
-// CHECK:STDOUT:       49:              inst600000B4
-// CHECK:STDOUT:       50:              inst600000B5
-// CHECK:STDOUT:       51:              inst600000B6
-// CHECK:STDOUT:       52:              inst600000B7
-// CHECK:STDOUT:       53:              inst600000B9
-// CHECK:STDOUT:       54:              inst600000BA
-// CHECK:STDOUT:       55:              inst600000BB
-// CHECK:STDOUT:       56:              inst600000BC
-// CHECK:STDOUT:       57:              inst600000C0
-// CHECK:STDOUT:       58:              inst600000C3
-// CHECK:STDOUT:       59:              inst600000C4
-// CHECK:STDOUT:       60:              inst600000C5
-// CHECK:STDOUT:       61:              inst600000C6
-// CHECK:STDOUT:       62:              inst600000C8
-// CHECK:STDOUT:       63:              inst600000C9
-// CHECK:STDOUT:       64:              inst600000CA
-// CHECK:STDOUT:       65:              inst600000D2
-// CHECK:STDOUT:       66:              inst600000D3
-// CHECK:STDOUT:       67:              inst600000D4
-// CHECK:STDOUT:       68:              inst600000D5
-// CHECK:STDOUT:       69:              inst600000D6
-// CHECK:STDOUT:       70:              inst600000D7
-// CHECK:STDOUT:       71:              inst600000D8
-// CHECK:STDOUT:       72:              inst600000D9
-// CHECK:STDOUT:       73:              inst600000DA
-// CHECK:STDOUT:       74:              inst600000DB
-// CHECK:STDOUT:       75:              inst600000DF
-// CHECK:STDOUT:       76:              inst600000E0
-// CHECK:STDOUT:       77:              inst600000E2
-// CHECK:STDOUT:       78:              inst600000E8
-// CHECK:STDOUT:       79:              inst600000E9
-// CHECK:STDOUT:       80:              inst600000EA
-// CHECK:STDOUT:       81:              inst600000EB
-// CHECK:STDOUT:       82:              inst600000ED
-// CHECK:STDOUT:       83:              inst600000EE
-// CHECK:STDOUT:       84:              inst600000EF
-// CHECK:STDOUT:       85:              inst600000F0
-// CHECK:STDOUT:       86:              inst6000010F
-// CHECK:STDOUT:       87:              inst60000110
-// CHECK:STDOUT:       88:              inst60000111
-// CHECK:STDOUT:       89:              inst60000112
-// CHECK:STDOUT:       90:              inst60000113
-// CHECK:STDOUT:       91:              inst60000114
-// CHECK:STDOUT:       92:              inst6000011E
-// CHECK:STDOUT:       93:              inst6000011F
-// CHECK:STDOUT:       94:              inst60000123
-// CHECK:STDOUT:       95:              inst60000124
-// CHECK:STDOUT:       96:              inst60000126
-// CHECK:STDOUT:       97:              inst6000012C
-// CHECK:STDOUT:       98:              inst6000012D
-// CHECK:STDOUT:       99:              inst6000012E
-// CHECK:STDOUT:       100:             inst6000012F
-// CHECK:STDOUT:       101:             inst60000131
-// CHECK:STDOUT:       102:             inst60000132
-// CHECK:STDOUT:       103:             inst60000133
-// CHECK:STDOUT:       104:             inst60000134
-// CHECK:STDOUT:       105:             inst60000135
-// CHECK:STDOUT:       106:             inst6000015C
-// CHECK:STDOUT:       107:             inst6000015D
-// CHECK:STDOUT:       108:             inst6000015E
-// CHECK:STDOUT:       109:             inst6000015F
-// CHECK:STDOUT:       110:             inst60000160
-// CHECK:STDOUT:       111:             inst60000161
-// CHECK:STDOUT:       112:             inst60000162
-// CHECK:STDOUT:       113:             inst60000163
+// CHECK:STDOUT:       0:               inst58000011
+// CHECK:STDOUT:       1:               inst5800004E
+// CHECK:STDOUT:       2:               inst5800004F
+// CHECK:STDOUT:       3:               inst58000051
+// CHECK:STDOUT:       4:               inst58000053
+// CHECK:STDOUT:       5:               inst58000054
+// CHECK:STDOUT:       6:               inst58000055
+// CHECK:STDOUT:       7:               inst58000056
+// CHECK:STDOUT:       8:               inst5800005B
+// CHECK:STDOUT:       9:               inst5800005C
+// CHECK:STDOUT:       10:              inst5800005D
+// CHECK:STDOUT:       11:              inst5800005E
+// CHECK:STDOUT:       12:              inst58000060
+// CHECK:STDOUT:       13:              inst58000061
+// CHECK:STDOUT:       14:              inst58000062
+// CHECK:STDOUT:       15:              inst5800006A
+// CHECK:STDOUT:       16:              inst5800006C
+// CHECK:STDOUT:       17:              inst5800006F
+// CHECK:STDOUT:       18:              inst58000070
+// CHECK:STDOUT:       19:              inst58000074
+// CHECK:STDOUT:       20:              inst58000075
+// CHECK:STDOUT:       21:              inst58000077
+// CHECK:STDOUT:       22:              inst5800007B
+// CHECK:STDOUT:       23:              inst5800007C
+// CHECK:STDOUT:       24:              inst5800007D
+// CHECK:STDOUT:       25:              inst5800007E
+// CHECK:STDOUT:       26:              inst58000080
+// CHECK:STDOUT:       27:              inst58000081
+// CHECK:STDOUT:       28:              inst58000082
+// CHECK:STDOUT:       29:              inst5800009A
+// CHECK:STDOUT:       30:              inst5800009B
+// CHECK:STDOUT:       31:              inst5800009C
+// CHECK:STDOUT:       32:              inst5800009D
+// CHECK:STDOUT:       33:              inst580000A4
+// CHECK:STDOUT:       34:              inst580000A5
+// CHECK:STDOUT:       35:              inst580000A6
+// CHECK:STDOUT:       36:              inst580000A7
+// CHECK:STDOUT:       37:              inst580000A8
+// CHECK:STDOUT:       38:              inst580000A9
+// CHECK:STDOUT:       39:              inst580000AA
+// CHECK:STDOUT:       40:              inst580000AB
+// CHECK:STDOUT:       41:              inst580000AC
+// CHECK:STDOUT:       42:              inst580000AD
+// CHECK:STDOUT:       43:              inst580000AE
+// CHECK:STDOUT:       44:              inst580000AF
+// CHECK:STDOUT:       45:              inst580000B0
+// CHECK:STDOUT:       46:              inst580000B1
+// CHECK:STDOUT:       47:              inst580000B2
+// CHECK:STDOUT:       48:              inst580000B3
+// CHECK:STDOUT:       49:              inst580000B4
+// CHECK:STDOUT:       50:              inst580000B5
+// CHECK:STDOUT:       51:              inst580000B6
+// CHECK:STDOUT:       52:              inst580000B7
+// CHECK:STDOUT:       53:              inst580000B9
+// CHECK:STDOUT:       54:              inst580000BA
+// CHECK:STDOUT:       55:              inst580000BB
+// CHECK:STDOUT:       56:              inst580000BC
+// CHECK:STDOUT:       57:              inst580000C0
+// CHECK:STDOUT:       58:              inst580000C3
+// CHECK:STDOUT:       59:              inst580000C4
+// CHECK:STDOUT:       60:              inst580000C5
+// CHECK:STDOUT:       61:              inst580000C6
+// CHECK:STDOUT:       62:              inst580000C8
+// CHECK:STDOUT:       63:              inst580000C9
+// CHECK:STDOUT:       64:              inst580000CA
+// CHECK:STDOUT:       65:              inst580000D2
+// CHECK:STDOUT:       66:              inst580000D3
+// CHECK:STDOUT:       67:              inst580000D4
+// CHECK:STDOUT:       68:              inst580000D5
+// CHECK:STDOUT:       69:              inst580000D6
+// CHECK:STDOUT:       70:              inst580000D7
+// CHECK:STDOUT:       71:              inst580000D8
+// CHECK:STDOUT:       72:              inst580000D9
+// CHECK:STDOUT:       73:              inst580000DA
+// CHECK:STDOUT:       74:              inst580000DB
+// CHECK:STDOUT:       75:              inst580000DF
+// CHECK:STDOUT:       76:              inst580000E0
+// CHECK:STDOUT:       77:              inst580000E2
+// CHECK:STDOUT:       78:              inst580000E8
+// CHECK:STDOUT:       79:              inst580000E9
+// CHECK:STDOUT:       80:              inst580000EA
+// CHECK:STDOUT:       81:              inst580000EB
+// CHECK:STDOUT:       82:              inst580000ED
+// CHECK:STDOUT:       83:              inst580000EE
+// CHECK:STDOUT:       84:              inst580000EF
+// CHECK:STDOUT:       85:              inst580000F0
+// CHECK:STDOUT:       86:              inst5800010F
+// CHECK:STDOUT:       87:              inst58000110
+// CHECK:STDOUT:       88:              inst58000111
+// CHECK:STDOUT:       89:              inst58000112
+// CHECK:STDOUT:       90:              inst58000113
+// CHECK:STDOUT:       91:              inst58000114
+// CHECK:STDOUT:       92:              inst5800011E
+// CHECK:STDOUT:       93:              inst5800011F
+// CHECK:STDOUT:       94:              inst58000123
+// CHECK:STDOUT:       95:              inst58000124
+// CHECK:STDOUT:       96:              inst58000126
+// CHECK:STDOUT:       97:              inst5800012C
+// CHECK:STDOUT:       98:              inst5800012D
+// CHECK:STDOUT:       99:              inst5800012E
+// CHECK:STDOUT:       100:             inst5800012F
+// CHECK:STDOUT:       101:             inst58000131
+// CHECK:STDOUT:       102:             inst58000132
+// CHECK:STDOUT:       103:             inst58000133
+// CHECK:STDOUT:       104:             inst58000134
+// CHECK:STDOUT:       105:             inst58000135
+// CHECK:STDOUT:       106:             inst5800015C
+// CHECK:STDOUT:       107:             inst5800015D
+// CHECK:STDOUT:       108:             inst5800015E
+// CHECK:STDOUT:       109:             inst5800015F
+// CHECK:STDOUT:       110:             inst58000160
+// CHECK:STDOUT:       111:             inst58000161
+// CHECK:STDOUT:       112:             inst58000162
+// CHECK:STDOUT:       113:             inst58000163
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block60000005:
-// CHECK:STDOUT:       0:               inst60000013
-// CHECK:STDOUT:       1:               inst60000015
-// CHECK:STDOUT:     inst_block60000006:
-// CHECK:STDOUT:       0:               inst6000001A
-// CHECK:STDOUT:     inst_block60000007:
-// CHECK:STDOUT:       0:               inst6000001B
-// CHECK:STDOUT:       1:               inst6000001C
-// CHECK:STDOUT:     inst_block60000008:
-// CHECK:STDOUT:       0:               inst60000023
-// CHECK:STDOUT:     inst_block60000009:
-// CHECK:STDOUT:       0:               inst60000025
-// CHECK:STDOUT:       1:               inst60000027
-// CHECK:STDOUT:     inst_block6000000A:
+// CHECK:STDOUT:     inst_block58000005:
+// CHECK:STDOUT:       0:               inst58000013
+// CHECK:STDOUT:       1:               inst58000015
+// CHECK:STDOUT:     inst_block58000006:
+// CHECK:STDOUT:       0:               inst5800001A
+// CHECK:STDOUT:     inst_block58000007:
+// CHECK:STDOUT:       0:               inst5800001B
+// CHECK:STDOUT:       1:               inst5800001C
+// CHECK:STDOUT:     inst_block58000008:
+// CHECK:STDOUT:       0:               inst58000023
+// CHECK:STDOUT:     inst_block58000009:
+// CHECK:STDOUT:       0:               inst58000025
+// CHECK:STDOUT:       1:               inst58000027
+// CHECK:STDOUT:     inst_block5800000A:
 // CHECK:STDOUT:       0:               inst(TypeType)
-// CHECK:STDOUT:       1:               inst60000026
-// CHECK:STDOUT:     inst_block6000000B:
-// CHECK:STDOUT:       0:               inst6000001D
-// CHECK:STDOUT:       1:               inst60000028
-// CHECK:STDOUT:     inst_block6000000C:
-// CHECK:STDOUT:       0:               inst6000001E
-// CHECK:STDOUT:       1:               inst60000028
-// CHECK:STDOUT:     inst_block6000000D:
-// CHECK:STDOUT:       0:               inst6000001D
-// CHECK:STDOUT:       1:               inst6000002E
-// CHECK:STDOUT:     inst_block6000000E:
-// CHECK:STDOUT:       0:               inst6000001D
-// CHECK:STDOUT:       1:               inst60000026
-// CHECK:STDOUT:     inst_block6000000F:
-// CHECK:STDOUT:       0:               inst6000001E
-// CHECK:STDOUT:       1:               inst60000026
-// CHECK:STDOUT:     inst_block60000010:
-// CHECK:STDOUT:       0:               inst60000038
-// CHECK:STDOUT:     inst_block60000011:
-// CHECK:STDOUT:       0:               inst60000023
-// CHECK:STDOUT:       1:               inst60000038
-// CHECK:STDOUT:     inst_block60000012:
-// CHECK:STDOUT:       0:               inst6000003A
-// CHECK:STDOUT:       1:               inst6000003C
-// CHECK:STDOUT:     inst_block60000013:
-// CHECK:STDOUT:       0:               inst6000001A
-// CHECK:STDOUT:       1:               inst60000021
-// CHECK:STDOUT:       2:               inst60000023
-// CHECK:STDOUT:       3:               inst60000036
-// CHECK:STDOUT:       4:               inst60000038
-// CHECK:STDOUT:     inst_block60000014:
-// CHECK:STDOUT:       0:               inst60000024
-// CHECK:STDOUT:       1:               inst60000025
-// CHECK:STDOUT:       2:               inst60000027
-// CHECK:STDOUT:       3:               inst6000002A
-// CHECK:STDOUT:       4:               inst6000002E
-// CHECK:STDOUT:       5:               inst60000030
-// CHECK:STDOUT:       6:               inst60000032
-// CHECK:STDOUT:       7:               inst60000039
-// CHECK:STDOUT:       8:               inst60000016
-// CHECK:STDOUT:       9:               inst6000003A
-// CHECK:STDOUT:       10:              inst6000003B
-// CHECK:STDOUT:       11:              inst6000001F
-// CHECK:STDOUT:       12:              inst6000003C
-// CHECK:STDOUT:       13:              inst6000003D
-// CHECK:STDOUT:     inst_block60000015:
-// CHECK:STDOUT:       0:               inst60000016
-// CHECK:STDOUT:     inst_block60000016:
-// CHECK:STDOUT:       0:               inst60000017
-// CHECK:STDOUT:     inst_block60000017:
-// CHECK:STDOUT:       0:               inst60000018
-// CHECK:STDOUT:       1:               inst6000001E
-// CHECK:STDOUT:       2:               inst60000022
-// CHECK:STDOUT:       3:               inst6000002C
-// CHECK:STDOUT:       4:               inst60000031
-// CHECK:STDOUT:       5:               inst60000034
-// CHECK:STDOUT:       6:               inst60000037
-// CHECK:STDOUT:     inst_block60000018:
-// CHECK:STDOUT:       0:               inst60000017
-// CHECK:STDOUT:       1:               inst6000001D
-// CHECK:STDOUT:       2:               inst60000020
-// CHECK:STDOUT:       3:               inst6000002B
-// CHECK:STDOUT:       4:               inst6000002F
-// CHECK:STDOUT:       5:               inst60000033
-// CHECK:STDOUT:       6:               inst60000035
-// CHECK:STDOUT:     inst_block60000019:
-// CHECK:STDOUT:       0:               inst60000048
-// CHECK:STDOUT:       1:               inst60000049
-// CHECK:STDOUT:       2:               inst6000004A
-// CHECK:STDOUT:       3:               inst60000178
-// CHECK:STDOUT:       4:               inst6000017E
-// CHECK:STDOUT:       5:               inst6000017F
-// CHECK:STDOUT:       6:               inst60000182
-// CHECK:STDOUT:       7:               inst60000184
-// CHECK:STDOUT:       8:               inst6000004C
-// CHECK:STDOUT:       9:               inst60000185
-// CHECK:STDOUT:       10:              inst60000186
-// CHECK:STDOUT:       11:              inst60000187
-// CHECK:STDOUT:       12:              inst60000188
-// CHECK:STDOUT:       13:              inst60000189
-// CHECK:STDOUT:       14:              inst6000018A
-// CHECK:STDOUT:       15:              inst6000018B
-// CHECK:STDOUT:     inst_block6000001A:
-// CHECK:STDOUT:       0:               inst60000048
-// CHECK:STDOUT:       1:               inst60000049
-// CHECK:STDOUT:     inst_block6000001B:
-// CHECK:STDOUT:       0:               inst60000054
-// CHECK:STDOUT:     inst_block6000001C:
-// CHECK:STDOUT:       0:               inst60000055
-// CHECK:STDOUT:     inst_block6000001D:
-// CHECK:STDOUT:       0:               inst60000052
-// CHECK:STDOUT:     inst_block6000001E:
-// CHECK:STDOUT:       0:               inst60000052
-// CHECK:STDOUT:       1:               inst60000057
-// CHECK:STDOUT:       2:               inst60000058
-// CHECK:STDOUT:     inst_block6000001F:
-// CHECK:STDOUT:       0:               inst6000005E
-// CHECK:STDOUT:       1:               inst6000005C
-// CHECK:STDOUT:     inst_block60000020:
-// CHECK:STDOUT:       0:               inst6000005E
-// CHECK:STDOUT:     inst_block60000021:
-// CHECK:STDOUT:       0:               inst6000005C
-// CHECK:STDOUT:     inst_block60000022:
-// CHECK:STDOUT:       0:               inst60000062
-// CHECK:STDOUT:     inst_block60000023:
-// CHECK:STDOUT:       0:               inst60000063
-// CHECK:STDOUT:       1:               inst60000064
-// CHECK:STDOUT:       2:               inst60000065
-// CHECK:STDOUT:       3:               inst60000066
-// CHECK:STDOUT:     inst_block60000024:
-// CHECK:STDOUT:       0:               inst60000052
-// CHECK:STDOUT:       1:               inst60000059
-// CHECK:STDOUT:       2:               inst6000005A
-// CHECK:STDOUT:       3:               inst6000005F
-// CHECK:STDOUT:     inst_block60000025:
-// CHECK:STDOUT:       0:               inst60000067
-// CHECK:STDOUT:     inst_block60000026:
-// CHECK:STDOUT:       0:               inst60000067
-// CHECK:STDOUT:       1:               inst60000068
-// CHECK:STDOUT:       2:               inst60000069
-// CHECK:STDOUT:     inst_block60000027:
-// CHECK:STDOUT:       0:               inst60000074
-// CHECK:STDOUT:     inst_block60000028:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:     inst_block60000029:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst60000072
-// CHECK:STDOUT:       2:               inst60000073
-// CHECK:STDOUT:       3:               inst60000076
-// CHECK:STDOUT:     inst_block6000002A:
-// CHECK:STDOUT:       0:               inst60000078
-// CHECK:STDOUT:       1:               inst60000079
-// CHECK:STDOUT:     inst_block6000002B:
-// CHECK:STDOUT:       0:               inst6000007E
-// CHECK:STDOUT:       1:               inst6000007C
-// CHECK:STDOUT:     inst_block6000002C:
-// CHECK:STDOUT:       0:               inst6000007E
-// CHECK:STDOUT:     inst_block6000002D:
-// CHECK:STDOUT:       0:               inst6000007C
-// CHECK:STDOUT:     inst_block6000002E:
-// CHECK:STDOUT:       0:               inst60000082
-// CHECK:STDOUT:     inst_block6000002F:
-// CHECK:STDOUT:       0:               inst60000083
-// CHECK:STDOUT:       1:               inst60000084
-// CHECK:STDOUT:       2:               inst60000085
-// CHECK:STDOUT:       3:               inst60000086
-// CHECK:STDOUT:       4:               inst60000087
-// CHECK:STDOUT:     inst_block60000030:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst60000089
-// CHECK:STDOUT:       2:               inst6000008A
-// CHECK:STDOUT:     inst_block60000031:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst60000072
-// CHECK:STDOUT:       2:               inst6000008F
-// CHECK:STDOUT:       3:               inst6000008E
-// CHECK:STDOUT:     inst_block60000032:
-// CHECK:STDOUT:       0:               inst60000083
-// CHECK:STDOUT:     inst_block60000033:
-// CHECK:STDOUT:       0:               inst60000083
-// CHECK:STDOUT:     inst_block60000034:
-// CHECK:STDOUT:       0:               inst60000092
-// CHECK:STDOUT:       1:               inst60000093
-// CHECK:STDOUT:       2:               inst60000094
-// CHECK:STDOUT:       3:               inst60000095
-// CHECK:STDOUT:       4:               inst60000096
-// CHECK:STDOUT:       5:               inst60000097
-// CHECK:STDOUT:       6:               inst60000098
-// CHECK:STDOUT:     inst_block60000035:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst60000072
-// CHECK:STDOUT:       2:               inst60000073
-// CHECK:STDOUT:       3:               inst6000007A
-// CHECK:STDOUT:       4:               inst6000007F
-// CHECK:STDOUT:     inst_block60000036:
-// CHECK:STDOUT:       0:               inst6000009A
-// CHECK:STDOUT:     inst_block60000037:
-// CHECK:STDOUT:       0:               inst6000009D
-// CHECK:STDOUT:     inst_block60000038:
-// CHECK:STDOUT:       0:               inst6000009E
-// CHECK:STDOUT:     inst_block60000039:
-// CHECK:STDOUT:       0:               inst6000009E
-// CHECK:STDOUT:       1:               inst6000009F
-// CHECK:STDOUT:       2:               inst600000A0
-// CHECK:STDOUT:       3:               inst600000A1
-// CHECK:STDOUT:     inst_block6000003A:
-// CHECK:STDOUT:       0:               inst6000009E
-// CHECK:STDOUT:     inst_block6000003B:
-// CHECK:STDOUT:       0:               inst600000A2
-// CHECK:STDOUT:       1:               inst600000A3
-// CHECK:STDOUT:     inst_block6000003C:
-// CHECK:STDOUT:       0:               inst600000B6
-// CHECK:STDOUT:     inst_block6000003D:
-// CHECK:STDOUT:       0:               inst60000017
-// CHECK:STDOUT:       1:               inst6000001D
-// CHECK:STDOUT:       2:               inst600000B8
-// CHECK:STDOUT:     inst_block6000003E:
-// CHECK:STDOUT:       0:               inst600000B9
-// CHECK:STDOUT:     inst_block6000003F:
-// CHECK:STDOUT:       0:               inst600000BC
-// CHECK:STDOUT:     inst_block60000040:
-// CHECK:STDOUT:       0:               inst600000BD
-// CHECK:STDOUT:     inst_block60000041:
-// CHECK:STDOUT:       0:               inst600000BD
-// CHECK:STDOUT:       1:               inst600000BE
-// CHECK:STDOUT:       2:               inst600000BF
-// CHECK:STDOUT:     inst_block60000042:
-// CHECK:STDOUT:       0:               inst600000C6
-// CHECK:STDOUT:       1:               inst600000C4
-// CHECK:STDOUT:     inst_block60000043:
-// CHECK:STDOUT:       0:               inst600000C6
-// CHECK:STDOUT:     inst_block60000044:
-// CHECK:STDOUT:       0:               inst600000C4
-// CHECK:STDOUT:     inst_block60000045:
-// CHECK:STDOUT:       0:               inst600000CA
-// CHECK:STDOUT:     inst_block60000046:
-// CHECK:STDOUT:       0:               inst600000CB
-// CHECK:STDOUT:       1:               inst600000CC
-// CHECK:STDOUT:       2:               inst600000CD
-// CHECK:STDOUT:       3:               inst600000CE
-// CHECK:STDOUT:     inst_block60000047:
-// CHECK:STDOUT:       0:               inst60000017
-// CHECK:STDOUT:       1:               inst6000001D
-// CHECK:STDOUT:       2:               inst60000020
-// CHECK:STDOUT:       3:               inst600000C7
-// CHECK:STDOUT:     inst_block60000048:
-// CHECK:STDOUT:       0:               inst600000BD
-// CHECK:STDOUT:     inst_block60000049:
-// CHECK:STDOUT:       0:               inst600000CF
-// CHECK:STDOUT:       1:               inst600000D0
-// CHECK:STDOUT:       2:               inst600000D1
-// CHECK:STDOUT:     inst_block6000004A:
-// CHECK:STDOUT:       0:               inst60000072
-// CHECK:STDOUT:       1:               inst600000DD
-// CHECK:STDOUT:     inst_block6000004B:
-// CHECK:STDOUT:       0:               inst600000DF
-// CHECK:STDOUT:     inst_block6000004C:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst600000DC
-// CHECK:STDOUT:     inst_block6000004D:
-// CHECK:STDOUT:       0:               inst60000050
-// CHECK:STDOUT:       1:               inst60000050
-// CHECK:STDOUT:     inst_block6000004E:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst600000DC
-// CHECK:STDOUT:       2:               inst600000E6
-// CHECK:STDOUT:       3:               inst60000072
-// CHECK:STDOUT:       4:               inst600000DD
-// CHECK:STDOUT:       5:               inst600000DE
-// CHECK:STDOUT:       6:               inst600000E1
-// CHECK:STDOUT:     inst_block6000004F:
-// CHECK:STDOUT:       0:               inst600000E3
-// CHECK:STDOUT:       1:               inst600000E4
-// CHECK:STDOUT:     inst_block60000050:
-// CHECK:STDOUT:       0:               inst600000EB
-// CHECK:STDOUT:       1:               inst600000E9
-// CHECK:STDOUT:     inst_block60000051:
-// CHECK:STDOUT:       0:               inst600000EB
-// CHECK:STDOUT:     inst_block60000052:
-// CHECK:STDOUT:       0:               inst600000E9
-// CHECK:STDOUT:     inst_block60000053:
-// CHECK:STDOUT:       0:               inst600000EF
-// CHECK:STDOUT:       1:               inst600000F0
-// CHECK:STDOUT:     inst_block60000054:
-// CHECK:STDOUT:       0:               inst600000F2
-// CHECK:STDOUT:       1:               inst600000F4
-// CHECK:STDOUT:     inst_block60000055:
-// CHECK:STDOUT:       0:               inst600000F1
-// CHECK:STDOUT:       1:               inst600000F2
-// CHECK:STDOUT:       2:               inst600000F3
-// CHECK:STDOUT:       3:               inst600000F4
-// CHECK:STDOUT:       4:               inst600000F5
-// CHECK:STDOUT:       5:               inst600000F6
-// CHECK:STDOUT:       6:               inst600000F7
-// CHECK:STDOUT:     inst_block60000056:
-// CHECK:STDOUT:       0:               inst600000DC
-// CHECK:STDOUT:     inst_block60000057:
-// CHECK:STDOUT:       0:               inst600000DC
-// CHECK:STDOUT:       1:               inst600000F9
-// CHECK:STDOUT:       2:               inst600000FA
-// CHECK:STDOUT:     inst_block60000058:
-// CHECK:STDOUT:       0:               inst600000DC
-// CHECK:STDOUT:       1:               inst600000DD
-// CHECK:STDOUT:       2:               inst600000FF
-// CHECK:STDOUT:       3:               inst600000FE
-// CHECK:STDOUT:     inst_block60000059:
-// CHECK:STDOUT:       0:               inst600000F1
-// CHECK:STDOUT:     inst_block6000005A:
-// CHECK:STDOUT:       0:               inst600000F1
-// CHECK:STDOUT:     inst_block6000005B:
-// CHECK:STDOUT:       0:               inst600000F3
-// CHECK:STDOUT:     inst_block6000005C:
-// CHECK:STDOUT:       0:               inst600000F3
-// CHECK:STDOUT:     inst_block6000005D:
-// CHECK:STDOUT:       0:               inst60000102
-// CHECK:STDOUT:       1:               inst60000103
-// CHECK:STDOUT:       2:               inst60000104
-// CHECK:STDOUT:       3:               inst60000105
-// CHECK:STDOUT:       4:               inst60000106
-// CHECK:STDOUT:       5:               inst60000107
-// CHECK:STDOUT:       6:               inst60000108
-// CHECK:STDOUT:       7:               inst60000109
-// CHECK:STDOUT:       8:               inst6000010A
-// CHECK:STDOUT:       9:               inst6000010B
-// CHECK:STDOUT:       10:              inst6000010C
-// CHECK:STDOUT:       11:              inst6000010D
-// CHECK:STDOUT:       12:              inst6000010E
-// CHECK:STDOUT:     inst_block6000005E:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst60000072
-// CHECK:STDOUT:       2:               inst600000DC
-// CHECK:STDOUT:       3:               inst600000DD
-// CHECK:STDOUT:       4:               inst600000DE
-// CHECK:STDOUT:       5:               inst600000E7
-// CHECK:STDOUT:       6:               inst600000EC
-// CHECK:STDOUT:     inst_block6000005F:
-// CHECK:STDOUT:       0:               inst60000110
-// CHECK:STDOUT:       1:               inst6000010F
-// CHECK:STDOUT:     inst_block60000060:
-// CHECK:STDOUT:       0:               inst60000113
-// CHECK:STDOUT:       1:               inst60000114
-// CHECK:STDOUT:     inst_block60000061:
-// CHECK:STDOUT:       0:               inst60000115
-// CHECK:STDOUT:       1:               inst60000116
-// CHECK:STDOUT:     inst_block60000062:
-// CHECK:STDOUT:       0:               inst60000118
-// CHECK:STDOUT:       1:               inst60000119
-// CHECK:STDOUT:     inst_block60000063:
-// CHECK:STDOUT:       0:               inst60000115
-// CHECK:STDOUT:       1:               inst60000116
-// CHECK:STDOUT:     inst_block60000064:
-// CHECK:STDOUT:       0:               inst60000115
-// CHECK:STDOUT:       1:               inst60000116
-// CHECK:STDOUT:       2:               inst60000117
-// CHECK:STDOUT:       3:               inst60000118
-// CHECK:STDOUT:       4:               inst60000119
-// CHECK:STDOUT:       5:               inst6000011A
-// CHECK:STDOUT:       6:               inst6000011B
-// CHECK:STDOUT:     inst_block60000065:
-// CHECK:STDOUT:       0:               inst60000115
-// CHECK:STDOUT:       1:               inst60000116
-// CHECK:STDOUT:     inst_block60000066:
-// CHECK:STDOUT:       0:               inst6000011C
-// CHECK:STDOUT:       1:               inst6000011D
-// CHECK:STDOUT:     inst_block60000067:
-// CHECK:STDOUT:       0:               inst60000072
-// CHECK:STDOUT:       1:               inst600000DD
-// CHECK:STDOUT:       2:               inst60000121
-// CHECK:STDOUT:     inst_block60000068:
-// CHECK:STDOUT:       0:               inst60000123
-// CHECK:STDOUT:     inst_block60000069:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst600000DC
-// CHECK:STDOUT:       2:               inst60000120
-// CHECK:STDOUT:     inst_block6000006A:
-// CHECK:STDOUT:       0:               inst60000050
-// CHECK:STDOUT:       1:               inst60000050
-// CHECK:STDOUT:       2:               inst60000050
-// CHECK:STDOUT:     inst_block6000006B:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst600000DC
-// CHECK:STDOUT:       2:               inst60000120
-// CHECK:STDOUT:       3:               inst6000012A
-// CHECK:STDOUT:       4:               inst60000072
-// CHECK:STDOUT:       5:               inst600000DD
-// CHECK:STDOUT:       6:               inst60000121
-// CHECK:STDOUT:       7:               inst60000122
-// CHECK:STDOUT:       8:               inst60000125
-// CHECK:STDOUT:     inst_block6000006C:
-// CHECK:STDOUT:       0:               inst60000127
-// CHECK:STDOUT:       1:               inst60000128
-// CHECK:STDOUT:     inst_block6000006D:
-// CHECK:STDOUT:       0:               inst6000012F
-// CHECK:STDOUT:       1:               inst6000012D
-// CHECK:STDOUT:     inst_block6000006E:
-// CHECK:STDOUT:       0:               inst6000012F
-// CHECK:STDOUT:     inst_block6000006F:
-// CHECK:STDOUT:       0:               inst6000012D
-// CHECK:STDOUT:     inst_block60000070:
-// CHECK:STDOUT:       0:               inst60000133
-// CHECK:STDOUT:       1:               inst60000134
-// CHECK:STDOUT:       2:               inst60000135
-// CHECK:STDOUT:     inst_block60000071:
-// CHECK:STDOUT:       0:               inst60000137
-// CHECK:STDOUT:       1:               inst60000139
-// CHECK:STDOUT:       2:               inst6000013B
-// CHECK:STDOUT:     inst_block60000072:
-// CHECK:STDOUT:       0:               inst60000136
-// CHECK:STDOUT:       1:               inst60000137
-// CHECK:STDOUT:       2:               inst60000138
-// CHECK:STDOUT:       3:               inst60000139
-// CHECK:STDOUT:       4:               inst6000013A
-// CHECK:STDOUT:       5:               inst6000013B
-// CHECK:STDOUT:       6:               inst6000013C
-// CHECK:STDOUT:       7:               inst6000013D
-// CHECK:STDOUT:       8:               inst6000013E
-// CHECK:STDOUT:     inst_block60000073:
-// CHECK:STDOUT:       0:               inst60000120
-// CHECK:STDOUT:     inst_block60000074:
-// CHECK:STDOUT:       0:               inst60000120
-// CHECK:STDOUT:       1:               inst60000140
-// CHECK:STDOUT:       2:               inst60000141
-// CHECK:STDOUT:     inst_block60000075:
-// CHECK:STDOUT:       0:               inst60000120
-// CHECK:STDOUT:       1:               inst60000121
-// CHECK:STDOUT:       2:               inst60000146
-// CHECK:STDOUT:       3:               inst60000145
-// CHECK:STDOUT:     inst_block60000076:
-// CHECK:STDOUT:       0:               inst60000136
-// CHECK:STDOUT:     inst_block60000077:
-// CHECK:STDOUT:       0:               inst60000136
-// CHECK:STDOUT:     inst_block60000078:
-// CHECK:STDOUT:       0:               inst60000138
-// CHECK:STDOUT:     inst_block60000079:
-// CHECK:STDOUT:       0:               inst60000138
-// CHECK:STDOUT:     inst_block6000007A:
-// CHECK:STDOUT:       0:               inst6000013A
-// CHECK:STDOUT:     inst_block6000007B:
-// CHECK:STDOUT:       0:               inst6000013A
-// CHECK:STDOUT:     inst_block6000007C:
-// CHECK:STDOUT:       0:               inst60000149
-// CHECK:STDOUT:       1:               inst6000014A
-// CHECK:STDOUT:       2:               inst6000014B
-// CHECK:STDOUT:       3:               inst6000014C
-// CHECK:STDOUT:       4:               inst6000014D
-// CHECK:STDOUT:       5:               inst6000014E
-// CHECK:STDOUT:       6:               inst6000014F
-// CHECK:STDOUT:       7:               inst60000150
-// CHECK:STDOUT:       8:               inst60000151
-// CHECK:STDOUT:       9:               inst60000152
-// CHECK:STDOUT:       10:              inst60000153
-// CHECK:STDOUT:       11:              inst60000154
-// CHECK:STDOUT:       12:              inst60000155
-// CHECK:STDOUT:       13:              inst60000156
-// CHECK:STDOUT:       14:              inst60000157
-// CHECK:STDOUT:       15:              inst60000158
-// CHECK:STDOUT:       16:              inst60000159
-// CHECK:STDOUT:       17:              inst6000015A
-// CHECK:STDOUT:       18:              inst6000015B
-// CHECK:STDOUT:     inst_block6000007D:
-// CHECK:STDOUT:       0:               inst60000071
-// CHECK:STDOUT:       1:               inst60000072
-// CHECK:STDOUT:       2:               inst600000DC
-// CHECK:STDOUT:       3:               inst600000DD
-// CHECK:STDOUT:       4:               inst60000120
-// CHECK:STDOUT:       5:               inst60000121
-// CHECK:STDOUT:       6:               inst60000122
-// CHECK:STDOUT:       7:               inst6000012B
-// CHECK:STDOUT:       8:               inst60000130
-// CHECK:STDOUT:     inst_block6000007E:
-// CHECK:STDOUT:       0:               inst6000015E
-// CHECK:STDOUT:       1:               inst6000015D
-// CHECK:STDOUT:       2:               inst6000015C
-// CHECK:STDOUT:     inst_block6000007F:
-// CHECK:STDOUT:       0:               inst60000161
-// CHECK:STDOUT:       1:               inst60000162
-// CHECK:STDOUT:       2:               inst60000163
-// CHECK:STDOUT:     inst_block60000080:
-// CHECK:STDOUT:       0:               inst60000164
-// CHECK:STDOUT:       1:               inst60000165
-// CHECK:STDOUT:       2:               inst60000166
-// CHECK:STDOUT:     inst_block60000081:
-// CHECK:STDOUT:       0:               inst60000168
-// CHECK:STDOUT:       1:               inst60000169
-// CHECK:STDOUT:       2:               inst6000016A
-// CHECK:STDOUT:     inst_block60000082:
-// CHECK:STDOUT:       0:               inst60000164
-// CHECK:STDOUT:       1:               inst60000165
-// CHECK:STDOUT:       2:               inst60000166
-// CHECK:STDOUT:     inst_block60000083:
-// CHECK:STDOUT:       0:               inst60000164
-// CHECK:STDOUT:       1:               inst60000165
-// CHECK:STDOUT:       2:               inst60000166
-// CHECK:STDOUT:       3:               inst60000167
-// CHECK:STDOUT:       4:               inst60000168
-// CHECK:STDOUT:       5:               inst60000169
-// CHECK:STDOUT:       6:               inst6000016A
-// CHECK:STDOUT:       7:               inst6000016B
-// CHECK:STDOUT:       8:               inst6000016C
-// CHECK:STDOUT:     inst_block60000084:
-// CHECK:STDOUT:       0:               inst60000164
-// CHECK:STDOUT:       1:               inst60000165
-// CHECK:STDOUT:       2:               inst60000166
-// CHECK:STDOUT:     inst_block60000085:
-// CHECK:STDOUT:       0:               inst6000016D
-// CHECK:STDOUT:       1:               inst6000016E
-// CHECK:STDOUT:     inst_block60000086:
-// CHECK:STDOUT:       0:               inst600000C1
-// CHECK:STDOUT:       1:               inst600000C2
-// CHECK:STDOUT:       2:               inst60000042
-// CHECK:STDOUT:     inst_block60000087:
-// CHECK:STDOUT:       0:               inst60000018
-// CHECK:STDOUT:     inst_block60000088:
-// CHECK:STDOUT:       0:               inst60000172
-// CHECK:STDOUT:     inst_block60000089:
-// CHECK:STDOUT:       0:               inst60000174
-// CHECK:STDOUT:     inst_block6000008A:
-// CHECK:STDOUT:       0:               inst60000174
-// CHECK:STDOUT:       1:               inst60000175
-// CHECK:STDOUT:       2:               inst60000176
-// CHECK:STDOUT:     inst_block6000008B:
-// CHECK:STDOUT:       0:               inst60000173
-// CHECK:STDOUT:     inst_block6000008C:
-// CHECK:STDOUT:       0:               inst6000017A
-// CHECK:STDOUT:     inst_block6000008D:
-// CHECK:STDOUT:       0:               inst60000174
-// CHECK:STDOUT:       1:               inst6000001D
-// CHECK:STDOUT:       2:               inst60000020
-// CHECK:STDOUT:       3:               inst600000C7
-// CHECK:STDOUT:     inst_block6000008E:
-// CHECK:STDOUT:       0:               inst6000017A
-// CHECK:STDOUT:     inst_block6000008F:
-// CHECK:STDOUT:       0:               inst60000048
-// CHECK:STDOUT:     inst_block60000090:
-// CHECK:STDOUT:       0:               inst60000185
-// CHECK:STDOUT:       1:               inst60000188
-// CHECK:STDOUT:     inst_block60000091:
-// CHECK:STDOUT:       0:               inst60000043
-// CHECK:STDOUT:       1:               inst60000047
-// CHECK:STDOUT:       2:               inst60000171
-// CHECK:STDOUT:       3:               inst60000173
-// CHECK:STDOUT:       4:               inst6000017A
-// CHECK:STDOUT:       5:               inst6000017B
-// CHECK:STDOUT:       6:               inst6000017C
-// CHECK:STDOUT:       7:               inst6000017D
-// CHECK:STDOUT:       8:               inst60000181
-// CHECK:STDOUT:     inst_block60000092:
+// CHECK:STDOUT:       1:               inst58000026
+// CHECK:STDOUT:     inst_block5800000B:
+// CHECK:STDOUT:       0:               inst5800001D
+// CHECK:STDOUT:       1:               inst58000028
+// CHECK:STDOUT:     inst_block5800000C:
+// CHECK:STDOUT:       0:               inst5800001E
+// CHECK:STDOUT:       1:               inst58000028
+// CHECK:STDOUT:     inst_block5800000D:
+// CHECK:STDOUT:       0:               inst5800001D
+// CHECK:STDOUT:       1:               inst5800002E
+// CHECK:STDOUT:     inst_block5800000E:
+// CHECK:STDOUT:       0:               inst5800001D
+// CHECK:STDOUT:       1:               inst58000026
+// CHECK:STDOUT:     inst_block5800000F:
+// CHECK:STDOUT:       0:               inst5800001E
+// CHECK:STDOUT:       1:               inst58000026
+// CHECK:STDOUT:     inst_block58000010:
+// CHECK:STDOUT:       0:               inst58000038
+// CHECK:STDOUT:     inst_block58000011:
+// CHECK:STDOUT:       0:               inst58000023
+// CHECK:STDOUT:       1:               inst58000038
+// CHECK:STDOUT:     inst_block58000012:
+// CHECK:STDOUT:       0:               inst5800003A
+// CHECK:STDOUT:       1:               inst5800003C
+// CHECK:STDOUT:     inst_block58000013:
+// CHECK:STDOUT:       0:               inst5800001A
+// CHECK:STDOUT:       1:               inst58000021
+// CHECK:STDOUT:       2:               inst58000023
+// CHECK:STDOUT:       3:               inst58000036
+// CHECK:STDOUT:       4:               inst58000038
+// CHECK:STDOUT:     inst_block58000014:
+// CHECK:STDOUT:       0:               inst58000024
+// CHECK:STDOUT:       1:               inst58000025
+// CHECK:STDOUT:       2:               inst58000027
+// CHECK:STDOUT:       3:               inst5800002A
+// CHECK:STDOUT:       4:               inst5800002E
+// CHECK:STDOUT:       5:               inst58000030
+// CHECK:STDOUT:       6:               inst58000032
+// CHECK:STDOUT:       7:               inst58000039
+// CHECK:STDOUT:       8:               inst58000016
+// CHECK:STDOUT:       9:               inst5800003A
+// CHECK:STDOUT:       10:              inst5800003B
+// CHECK:STDOUT:       11:              inst5800001F
+// CHECK:STDOUT:       12:              inst5800003C
+// CHECK:STDOUT:       13:              inst5800003D
+// CHECK:STDOUT:     inst_block58000015:
+// CHECK:STDOUT:       0:               inst58000016
+// CHECK:STDOUT:     inst_block58000016:
+// CHECK:STDOUT:       0:               inst58000017
+// CHECK:STDOUT:     inst_block58000017:
+// CHECK:STDOUT:       0:               inst58000018
+// CHECK:STDOUT:       1:               inst5800001E
+// CHECK:STDOUT:       2:               inst58000022
+// CHECK:STDOUT:       3:               inst5800002C
+// CHECK:STDOUT:       4:               inst58000031
+// CHECK:STDOUT:       5:               inst58000034
+// CHECK:STDOUT:       6:               inst58000037
+// CHECK:STDOUT:     inst_block58000018:
+// CHECK:STDOUT:       0:               inst58000017
+// CHECK:STDOUT:       1:               inst5800001D
+// CHECK:STDOUT:       2:               inst58000020
+// CHECK:STDOUT:       3:               inst5800002B
+// CHECK:STDOUT:       4:               inst5800002F
+// CHECK:STDOUT:       5:               inst58000033
+// CHECK:STDOUT:       6:               inst58000035
+// CHECK:STDOUT:     inst_block58000019:
+// CHECK:STDOUT:       0:               inst58000048
+// CHECK:STDOUT:       1:               inst58000049
+// CHECK:STDOUT:       2:               inst5800004A
+// CHECK:STDOUT:       3:               inst58000178
+// CHECK:STDOUT:       4:               inst5800017E
+// CHECK:STDOUT:       5:               inst5800017F
+// CHECK:STDOUT:       6:               inst58000182
+// CHECK:STDOUT:       7:               inst58000184
+// CHECK:STDOUT:       8:               inst5800004C
+// CHECK:STDOUT:       9:               inst58000185
+// CHECK:STDOUT:       10:              inst58000186
+// CHECK:STDOUT:       11:              inst58000187
+// CHECK:STDOUT:       12:              inst58000188
+// CHECK:STDOUT:       13:              inst58000189
+// CHECK:STDOUT:       14:              inst5800018A
+// CHECK:STDOUT:       15:              inst5800018B
+// CHECK:STDOUT:     inst_block5800001A:
+// CHECK:STDOUT:       0:               inst58000048
+// CHECK:STDOUT:       1:               inst58000049
+// CHECK:STDOUT:     inst_block5800001B:
+// CHECK:STDOUT:       0:               inst58000054
+// CHECK:STDOUT:     inst_block5800001C:
+// CHECK:STDOUT:       0:               inst58000055
+// CHECK:STDOUT:     inst_block5800001D:
+// CHECK:STDOUT:       0:               inst58000052
+// CHECK:STDOUT:     inst_block5800001E:
+// CHECK:STDOUT:       0:               inst58000052
+// CHECK:STDOUT:       1:               inst58000057
+// CHECK:STDOUT:       2:               inst58000058
+// CHECK:STDOUT:     inst_block5800001F:
+// CHECK:STDOUT:       0:               inst5800005E
+// CHECK:STDOUT:       1:               inst5800005C
+// CHECK:STDOUT:     inst_block58000020:
+// CHECK:STDOUT:       0:               inst5800005E
+// CHECK:STDOUT:     inst_block58000021:
+// CHECK:STDOUT:       0:               inst5800005C
+// CHECK:STDOUT:     inst_block58000022:
+// CHECK:STDOUT:       0:               inst58000062
+// CHECK:STDOUT:     inst_block58000023:
+// CHECK:STDOUT:       0:               inst58000063
+// CHECK:STDOUT:       1:               inst58000064
+// CHECK:STDOUT:       2:               inst58000065
+// CHECK:STDOUT:       3:               inst58000066
+// CHECK:STDOUT:     inst_block58000024:
+// CHECK:STDOUT:       0:               inst58000052
+// CHECK:STDOUT:       1:               inst58000059
+// CHECK:STDOUT:       2:               inst5800005A
+// CHECK:STDOUT:       3:               inst5800005F
+// CHECK:STDOUT:     inst_block58000025:
+// CHECK:STDOUT:       0:               inst58000067
+// CHECK:STDOUT:     inst_block58000026:
+// CHECK:STDOUT:       0:               inst58000067
+// CHECK:STDOUT:       1:               inst58000068
+// CHECK:STDOUT:       2:               inst58000069
+// CHECK:STDOUT:     inst_block58000027:
+// CHECK:STDOUT:       0:               inst58000074
+// CHECK:STDOUT:     inst_block58000028:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:     inst_block58000029:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst58000072
+// CHECK:STDOUT:       2:               inst58000073
+// CHECK:STDOUT:       3:               inst58000076
+// CHECK:STDOUT:     inst_block5800002A:
+// CHECK:STDOUT:       0:               inst58000078
+// CHECK:STDOUT:       1:               inst58000079
+// CHECK:STDOUT:     inst_block5800002B:
+// CHECK:STDOUT:       0:               inst5800007E
+// CHECK:STDOUT:       1:               inst5800007C
+// CHECK:STDOUT:     inst_block5800002C:
+// CHECK:STDOUT:       0:               inst5800007E
+// CHECK:STDOUT:     inst_block5800002D:
+// CHECK:STDOUT:       0:               inst5800007C
+// CHECK:STDOUT:     inst_block5800002E:
+// CHECK:STDOUT:       0:               inst58000082
+// CHECK:STDOUT:     inst_block5800002F:
+// CHECK:STDOUT:       0:               inst58000083
+// CHECK:STDOUT:       1:               inst58000084
+// CHECK:STDOUT:       2:               inst58000085
+// CHECK:STDOUT:       3:               inst58000086
+// CHECK:STDOUT:       4:               inst58000087
+// CHECK:STDOUT:     inst_block58000030:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst58000089
+// CHECK:STDOUT:       2:               inst5800008A
+// CHECK:STDOUT:     inst_block58000031:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst58000072
+// CHECK:STDOUT:       2:               inst5800008F
+// CHECK:STDOUT:       3:               inst5800008E
+// CHECK:STDOUT:     inst_block58000032:
+// CHECK:STDOUT:       0:               inst58000083
+// CHECK:STDOUT:     inst_block58000033:
+// CHECK:STDOUT:       0:               inst58000083
+// CHECK:STDOUT:     inst_block58000034:
+// CHECK:STDOUT:       0:               inst58000092
+// CHECK:STDOUT:       1:               inst58000093
+// CHECK:STDOUT:       2:               inst58000094
+// CHECK:STDOUT:       3:               inst58000095
+// CHECK:STDOUT:       4:               inst58000096
+// CHECK:STDOUT:       5:               inst58000097
+// CHECK:STDOUT:       6:               inst58000098
+// CHECK:STDOUT:     inst_block58000035:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst58000072
+// CHECK:STDOUT:       2:               inst58000073
+// CHECK:STDOUT:       3:               inst5800007A
+// CHECK:STDOUT:       4:               inst5800007F
+// CHECK:STDOUT:     inst_block58000036:
+// CHECK:STDOUT:       0:               inst5800009A
+// CHECK:STDOUT:     inst_block58000037:
+// CHECK:STDOUT:       0:               inst5800009D
+// CHECK:STDOUT:     inst_block58000038:
+// CHECK:STDOUT:       0:               inst5800009E
+// CHECK:STDOUT:     inst_block58000039:
+// CHECK:STDOUT:       0:               inst5800009E
+// CHECK:STDOUT:       1:               inst5800009F
+// CHECK:STDOUT:       2:               inst580000A0
+// CHECK:STDOUT:       3:               inst580000A1
+// CHECK:STDOUT:     inst_block5800003A:
+// CHECK:STDOUT:       0:               inst5800009E
+// CHECK:STDOUT:     inst_block5800003B:
+// CHECK:STDOUT:       0:               inst580000A2
+// CHECK:STDOUT:       1:               inst580000A3
+// CHECK:STDOUT:     inst_block5800003C:
+// CHECK:STDOUT:       0:               inst580000B6
+// CHECK:STDOUT:     inst_block5800003D:
+// CHECK:STDOUT:       0:               inst58000017
+// CHECK:STDOUT:       1:               inst5800001D
+// CHECK:STDOUT:       2:               inst580000B8
+// CHECK:STDOUT:     inst_block5800003E:
+// CHECK:STDOUT:       0:               inst580000B9
+// CHECK:STDOUT:     inst_block5800003F:
+// CHECK:STDOUT:       0:               inst580000BC
+// CHECK:STDOUT:     inst_block58000040:
+// CHECK:STDOUT:       0:               inst580000BD
+// CHECK:STDOUT:     inst_block58000041:
+// CHECK:STDOUT:       0:               inst580000BD
+// CHECK:STDOUT:       1:               inst580000BE
+// CHECK:STDOUT:       2:               inst580000BF
+// CHECK:STDOUT:     inst_block58000042:
+// CHECK:STDOUT:       0:               inst580000C6
+// CHECK:STDOUT:       1:               inst580000C4
+// CHECK:STDOUT:     inst_block58000043:
+// CHECK:STDOUT:       0:               inst580000C6
+// CHECK:STDOUT:     inst_block58000044:
+// CHECK:STDOUT:       0:               inst580000C4
+// CHECK:STDOUT:     inst_block58000045:
+// CHECK:STDOUT:       0:               inst580000CA
+// CHECK:STDOUT:     inst_block58000046:
+// CHECK:STDOUT:       0:               inst580000CB
+// CHECK:STDOUT:       1:               inst580000CC
+// CHECK:STDOUT:       2:               inst580000CD
+// CHECK:STDOUT:       3:               inst580000CE
+// CHECK:STDOUT:     inst_block58000047:
+// CHECK:STDOUT:       0:               inst58000017
+// CHECK:STDOUT:       1:               inst5800001D
+// CHECK:STDOUT:       2:               inst58000020
+// CHECK:STDOUT:       3:               inst580000C7
+// CHECK:STDOUT:     inst_block58000048:
+// CHECK:STDOUT:       0:               inst580000BD
+// CHECK:STDOUT:     inst_block58000049:
+// CHECK:STDOUT:       0:               inst580000CF
+// CHECK:STDOUT:       1:               inst580000D0
+// CHECK:STDOUT:       2:               inst580000D1
+// CHECK:STDOUT:     inst_block5800004A:
+// CHECK:STDOUT:       0:               inst58000072
+// CHECK:STDOUT:       1:               inst580000DD
+// CHECK:STDOUT:     inst_block5800004B:
+// CHECK:STDOUT:       0:               inst580000DF
+// CHECK:STDOUT:     inst_block5800004C:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst580000DC
+// CHECK:STDOUT:     inst_block5800004D:
+// CHECK:STDOUT:       0:               inst58000050
+// CHECK:STDOUT:       1:               inst58000050
+// CHECK:STDOUT:     inst_block5800004E:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst580000DC
+// CHECK:STDOUT:       2:               inst580000E6
+// CHECK:STDOUT:       3:               inst58000072
+// CHECK:STDOUT:       4:               inst580000DD
+// CHECK:STDOUT:       5:               inst580000DE
+// CHECK:STDOUT:       6:               inst580000E1
+// CHECK:STDOUT:     inst_block5800004F:
+// CHECK:STDOUT:       0:               inst580000E3
+// CHECK:STDOUT:       1:               inst580000E4
+// CHECK:STDOUT:     inst_block58000050:
+// CHECK:STDOUT:       0:               inst580000EB
+// CHECK:STDOUT:       1:               inst580000E9
+// CHECK:STDOUT:     inst_block58000051:
+// CHECK:STDOUT:       0:               inst580000EB
+// CHECK:STDOUT:     inst_block58000052:
+// CHECK:STDOUT:       0:               inst580000E9
+// CHECK:STDOUT:     inst_block58000053:
+// CHECK:STDOUT:       0:               inst580000EF
+// CHECK:STDOUT:       1:               inst580000F0
+// CHECK:STDOUT:     inst_block58000054:
+// CHECK:STDOUT:       0:               inst580000F2
+// CHECK:STDOUT:       1:               inst580000F4
+// CHECK:STDOUT:     inst_block58000055:
+// CHECK:STDOUT:       0:               inst580000F1
+// CHECK:STDOUT:       1:               inst580000F2
+// CHECK:STDOUT:       2:               inst580000F3
+// CHECK:STDOUT:       3:               inst580000F4
+// CHECK:STDOUT:       4:               inst580000F5
+// CHECK:STDOUT:       5:               inst580000F6
+// CHECK:STDOUT:       6:               inst580000F7
+// CHECK:STDOUT:     inst_block58000056:
+// CHECK:STDOUT:       0:               inst580000DC
+// CHECK:STDOUT:     inst_block58000057:
+// CHECK:STDOUT:       0:               inst580000DC
+// CHECK:STDOUT:       1:               inst580000F9
+// CHECK:STDOUT:       2:               inst580000FA
+// CHECK:STDOUT:     inst_block58000058:
+// CHECK:STDOUT:       0:               inst580000DC
+// CHECK:STDOUT:       1:               inst580000DD
+// CHECK:STDOUT:       2:               inst580000FF
+// CHECK:STDOUT:       3:               inst580000FE
+// CHECK:STDOUT:     inst_block58000059:
+// CHECK:STDOUT:       0:               inst580000F1
+// CHECK:STDOUT:     inst_block5800005A:
+// CHECK:STDOUT:       0:               inst580000F1
+// CHECK:STDOUT:     inst_block5800005B:
+// CHECK:STDOUT:       0:               inst580000F3
+// CHECK:STDOUT:     inst_block5800005C:
+// CHECK:STDOUT:       0:               inst580000F3
+// CHECK:STDOUT:     inst_block5800005D:
+// CHECK:STDOUT:       0:               inst58000102
+// CHECK:STDOUT:       1:               inst58000103
+// CHECK:STDOUT:       2:               inst58000104
+// CHECK:STDOUT:       3:               inst58000105
+// CHECK:STDOUT:       4:               inst58000106
+// CHECK:STDOUT:       5:               inst58000107
+// CHECK:STDOUT:       6:               inst58000108
+// CHECK:STDOUT:       7:               inst58000109
+// CHECK:STDOUT:       8:               inst5800010A
+// CHECK:STDOUT:       9:               inst5800010B
+// CHECK:STDOUT:       10:              inst5800010C
+// CHECK:STDOUT:       11:              inst5800010D
+// CHECK:STDOUT:       12:              inst5800010E
+// CHECK:STDOUT:     inst_block5800005E:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst58000072
+// CHECK:STDOUT:       2:               inst580000DC
+// CHECK:STDOUT:       3:               inst580000DD
+// CHECK:STDOUT:       4:               inst580000DE
+// CHECK:STDOUT:       5:               inst580000E7
+// CHECK:STDOUT:       6:               inst580000EC
+// CHECK:STDOUT:     inst_block5800005F:
+// CHECK:STDOUT:       0:               inst58000110
+// CHECK:STDOUT:       1:               inst5800010F
+// CHECK:STDOUT:     inst_block58000060:
+// CHECK:STDOUT:       0:               inst58000113
+// CHECK:STDOUT:       1:               inst58000114
+// CHECK:STDOUT:     inst_block58000061:
+// CHECK:STDOUT:       0:               inst58000115
+// CHECK:STDOUT:       1:               inst58000116
+// CHECK:STDOUT:     inst_block58000062:
+// CHECK:STDOUT:       0:               inst58000118
+// CHECK:STDOUT:       1:               inst58000119
+// CHECK:STDOUT:     inst_block58000063:
+// CHECK:STDOUT:       0:               inst58000115
+// CHECK:STDOUT:       1:               inst58000116
+// CHECK:STDOUT:     inst_block58000064:
+// CHECK:STDOUT:       0:               inst58000115
+// CHECK:STDOUT:       1:               inst58000116
+// CHECK:STDOUT:       2:               inst58000117
+// CHECK:STDOUT:       3:               inst58000118
+// CHECK:STDOUT:       4:               inst58000119
+// CHECK:STDOUT:       5:               inst5800011A
+// CHECK:STDOUT:       6:               inst5800011B
+// CHECK:STDOUT:     inst_block58000065:
+// CHECK:STDOUT:       0:               inst58000115
+// CHECK:STDOUT:       1:               inst58000116
+// CHECK:STDOUT:     inst_block58000066:
+// CHECK:STDOUT:       0:               inst5800011C
+// CHECK:STDOUT:       1:               inst5800011D
+// CHECK:STDOUT:     inst_block58000067:
+// CHECK:STDOUT:       0:               inst58000072
+// CHECK:STDOUT:       1:               inst580000DD
+// CHECK:STDOUT:       2:               inst58000121
+// CHECK:STDOUT:     inst_block58000068:
+// CHECK:STDOUT:       0:               inst58000123
+// CHECK:STDOUT:     inst_block58000069:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst580000DC
+// CHECK:STDOUT:       2:               inst58000120
+// CHECK:STDOUT:     inst_block5800006A:
+// CHECK:STDOUT:       0:               inst58000050
+// CHECK:STDOUT:       1:               inst58000050
+// CHECK:STDOUT:       2:               inst58000050
+// CHECK:STDOUT:     inst_block5800006B:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst580000DC
+// CHECK:STDOUT:       2:               inst58000120
+// CHECK:STDOUT:       3:               inst5800012A
+// CHECK:STDOUT:       4:               inst58000072
+// CHECK:STDOUT:       5:               inst580000DD
+// CHECK:STDOUT:       6:               inst58000121
+// CHECK:STDOUT:       7:               inst58000122
+// CHECK:STDOUT:       8:               inst58000125
+// CHECK:STDOUT:     inst_block5800006C:
+// CHECK:STDOUT:       0:               inst58000127
+// CHECK:STDOUT:       1:               inst58000128
+// CHECK:STDOUT:     inst_block5800006D:
+// CHECK:STDOUT:       0:               inst5800012F
+// CHECK:STDOUT:       1:               inst5800012D
+// CHECK:STDOUT:     inst_block5800006E:
+// CHECK:STDOUT:       0:               inst5800012F
+// CHECK:STDOUT:     inst_block5800006F:
+// CHECK:STDOUT:       0:               inst5800012D
+// CHECK:STDOUT:     inst_block58000070:
+// CHECK:STDOUT:       0:               inst58000133
+// CHECK:STDOUT:       1:               inst58000134
+// CHECK:STDOUT:       2:               inst58000135
+// CHECK:STDOUT:     inst_block58000071:
+// CHECK:STDOUT:       0:               inst58000137
+// CHECK:STDOUT:       1:               inst58000139
+// CHECK:STDOUT:       2:               inst5800013B
+// CHECK:STDOUT:     inst_block58000072:
+// CHECK:STDOUT:       0:               inst58000136
+// CHECK:STDOUT:       1:               inst58000137
+// CHECK:STDOUT:       2:               inst58000138
+// CHECK:STDOUT:       3:               inst58000139
+// CHECK:STDOUT:       4:               inst5800013A
+// CHECK:STDOUT:       5:               inst5800013B
+// CHECK:STDOUT:       6:               inst5800013C
+// CHECK:STDOUT:       7:               inst5800013D
+// CHECK:STDOUT:       8:               inst5800013E
+// CHECK:STDOUT:     inst_block58000073:
+// CHECK:STDOUT:       0:               inst58000120
+// CHECK:STDOUT:     inst_block58000074:
+// CHECK:STDOUT:       0:               inst58000120
+// CHECK:STDOUT:       1:               inst58000140
+// CHECK:STDOUT:       2:               inst58000141
+// CHECK:STDOUT:     inst_block58000075:
+// CHECK:STDOUT:       0:               inst58000120
+// CHECK:STDOUT:       1:               inst58000121
+// CHECK:STDOUT:       2:               inst58000146
+// CHECK:STDOUT:       3:               inst58000145
+// CHECK:STDOUT:     inst_block58000076:
+// CHECK:STDOUT:       0:               inst58000136
+// CHECK:STDOUT:     inst_block58000077:
+// CHECK:STDOUT:       0:               inst58000136
+// CHECK:STDOUT:     inst_block58000078:
+// CHECK:STDOUT:       0:               inst58000138
+// CHECK:STDOUT:     inst_block58000079:
+// CHECK:STDOUT:       0:               inst58000138
+// CHECK:STDOUT:     inst_block5800007A:
+// CHECK:STDOUT:       0:               inst5800013A
+// CHECK:STDOUT:     inst_block5800007B:
+// CHECK:STDOUT:       0:               inst5800013A
+// CHECK:STDOUT:     inst_block5800007C:
+// CHECK:STDOUT:       0:               inst58000149
+// CHECK:STDOUT:       1:               inst5800014A
+// CHECK:STDOUT:       2:               inst5800014B
+// CHECK:STDOUT:       3:               inst5800014C
+// CHECK:STDOUT:       4:               inst5800014D
+// CHECK:STDOUT:       5:               inst5800014E
+// CHECK:STDOUT:       6:               inst5800014F
+// CHECK:STDOUT:       7:               inst58000150
+// CHECK:STDOUT:       8:               inst58000151
+// CHECK:STDOUT:       9:               inst58000152
+// CHECK:STDOUT:       10:              inst58000153
+// CHECK:STDOUT:       11:              inst58000154
+// CHECK:STDOUT:       12:              inst58000155
+// CHECK:STDOUT:       13:              inst58000156
+// CHECK:STDOUT:       14:              inst58000157
+// CHECK:STDOUT:       15:              inst58000158
+// CHECK:STDOUT:       16:              inst58000159
+// CHECK:STDOUT:       17:              inst5800015A
+// CHECK:STDOUT:       18:              inst5800015B
+// CHECK:STDOUT:     inst_block5800007D:
+// CHECK:STDOUT:       0:               inst58000071
+// CHECK:STDOUT:       1:               inst58000072
+// CHECK:STDOUT:       2:               inst580000DC
+// CHECK:STDOUT:       3:               inst580000DD
+// CHECK:STDOUT:       4:               inst58000120
+// CHECK:STDOUT:       5:               inst58000121
+// CHECK:STDOUT:       6:               inst58000122
+// CHECK:STDOUT:       7:               inst5800012B
+// CHECK:STDOUT:       8:               inst58000130
+// CHECK:STDOUT:     inst_block5800007E:
+// CHECK:STDOUT:       0:               inst5800015E
+// CHECK:STDOUT:       1:               inst5800015D
+// CHECK:STDOUT:       2:               inst5800015C
+// CHECK:STDOUT:     inst_block5800007F:
+// CHECK:STDOUT:       0:               inst58000161
+// CHECK:STDOUT:       1:               inst58000162
+// CHECK:STDOUT:       2:               inst58000163
+// CHECK:STDOUT:     inst_block58000080:
+// CHECK:STDOUT:       0:               inst58000164
+// CHECK:STDOUT:       1:               inst58000165
+// CHECK:STDOUT:       2:               inst58000166
+// CHECK:STDOUT:     inst_block58000081:
+// CHECK:STDOUT:       0:               inst58000168
+// CHECK:STDOUT:       1:               inst58000169
+// CHECK:STDOUT:       2:               inst5800016A
+// CHECK:STDOUT:     inst_block58000082:
+// CHECK:STDOUT:       0:               inst58000164
+// CHECK:STDOUT:       1:               inst58000165
+// CHECK:STDOUT:       2:               inst58000166
+// CHECK:STDOUT:     inst_block58000083:
+// CHECK:STDOUT:       0:               inst58000164
+// CHECK:STDOUT:       1:               inst58000165
+// CHECK:STDOUT:       2:               inst58000166
+// CHECK:STDOUT:       3:               inst58000167
+// CHECK:STDOUT:       4:               inst58000168
+// CHECK:STDOUT:       5:               inst58000169
+// CHECK:STDOUT:       6:               inst5800016A
+// CHECK:STDOUT:       7:               inst5800016B
+// CHECK:STDOUT:       8:               inst5800016C
+// CHECK:STDOUT:     inst_block58000084:
+// CHECK:STDOUT:       0:               inst58000164
+// CHECK:STDOUT:       1:               inst58000165
+// CHECK:STDOUT:       2:               inst58000166
+// CHECK:STDOUT:     inst_block58000085:
+// CHECK:STDOUT:       0:               inst5800016D
+// CHECK:STDOUT:       1:               inst5800016E
+// CHECK:STDOUT:     inst_block58000086:
+// CHECK:STDOUT:       0:               inst580000C1
+// CHECK:STDOUT:       1:               inst580000C2
+// CHECK:STDOUT:       2:               inst58000042
+// CHECK:STDOUT:     inst_block58000087:
+// CHECK:STDOUT:       0:               inst58000018
+// CHECK:STDOUT:     inst_block58000088:
+// CHECK:STDOUT:       0:               inst58000172
+// CHECK:STDOUT:     inst_block58000089:
+// CHECK:STDOUT:       0:               inst58000174
+// CHECK:STDOUT:     inst_block5800008A:
+// CHECK:STDOUT:       0:               inst58000174
+// CHECK:STDOUT:       1:               inst58000175
+// CHECK:STDOUT:       2:               inst58000176
+// CHECK:STDOUT:     inst_block5800008B:
+// CHECK:STDOUT:       0:               inst58000173
+// CHECK:STDOUT:     inst_block5800008C:
+// CHECK:STDOUT:       0:               inst5800017A
+// CHECK:STDOUT:     inst_block5800008D:
+// CHECK:STDOUT:       0:               inst58000174
+// CHECK:STDOUT:       1:               inst5800001D
+// CHECK:STDOUT:       2:               inst58000020
+// CHECK:STDOUT:       3:               inst580000C7
+// CHECK:STDOUT:     inst_block5800008E:
+// CHECK:STDOUT:       0:               inst5800017A
+// CHECK:STDOUT:     inst_block5800008F:
+// CHECK:STDOUT:       0:               inst58000048
+// CHECK:STDOUT:     inst_block58000090:
+// CHECK:STDOUT:       0:               inst58000185
+// CHECK:STDOUT:       1:               inst58000188
+// CHECK:STDOUT:     inst_block58000091:
+// CHECK:STDOUT:       0:               inst58000043
+// CHECK:STDOUT:       1:               inst58000047
+// CHECK:STDOUT:       2:               inst58000171
+// CHECK:STDOUT:       3:               inst58000173
+// CHECK:STDOUT:       4:               inst5800017A
+// CHECK:STDOUT:       5:               inst5800017B
+// CHECK:STDOUT:       6:               inst5800017C
+// CHECK:STDOUT:       7:               inst5800017D
+// CHECK:STDOUT:       8:               inst58000181
+// CHECK:STDOUT:     inst_block58000092:
 // CHECK:STDOUT:       0:               instF
-// CHECK:STDOUT:       1:               inst60000010
-// CHECK:STDOUT:       2:               inst6000003E
+// CHECK:STDOUT:       1:               inst58000010
+// CHECK:STDOUT:       2:               inst5800003E
 // CHECK:STDOUT:   value_stores:
 // CHECK:STDOUT:     shared_values:
 // CHECK:STDOUT:       ints:            {}

--- a/toolchain/check/testdata/basics/raw_sem_ir/one_file_with_textual_ir.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/one_file_with_textual_ir.carbon
@@ -29,12 +29,12 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:   import_ir_insts: {}
 // CHECK:STDOUT:   clang_decls:     {}
 // CHECK:STDOUT:   name_scopes:
-// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst6000002A}}
+// CHECK:STDOUT:     name_scope0:     {inst: instF, parent_scope: name_scope<none>, has_error: false, extended_scopes: [], names: {name0: inst5000002A}}
 // CHECK:STDOUT:   entity_names:
-// CHECK:STDOUT:     entity_name60000000: {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
+// CHECK:STDOUT:     entity_name50000000: {name: name1, parent_scope: name_scope<none>, index: -1, is_template: 0, is_unused: 0, form: constant<none>}
 // CHECK:STDOUT:   cpp_global_vars: {}
 // CHECK:STDOUT:   functions:
-// CHECK:STDOUT:     function60000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block6000000C, call_params_id: inst_block6000000D, return_type_inst_id: inst60000020, return_form_inst_id: inst60000021, return_patterns_id: inst_block6000000B, body: [inst_block60000010]}
+// CHECK:STDOUT:     function50000000: {name: name0, parent_scope: name_scope0, call_param_patterns_id: inst_block5000000C, call_params_id: inst_block5000000D, return_type_inst_id: inst50000020, return_form_inst_id: inst50000021, return_patterns_id: inst_block5000000B, body: [inst_block50000010]}
 // CHECK:STDOUT:   classes:         {}
 // CHECK:STDOUT:   interfaces:      {}
 // CHECK:STDOUT:   associated_constants: {}
@@ -53,167 +53,167 @@ fn Foo(n: ()) -> ((), ()) {
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(Error)}
 // CHECK:STDOUT:     'type(inst(NamespaceType))':
 // CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     'type(inst60000010)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000010)}
-// CHECK:STDOUT:     'type(inst6000001D)':
-// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst6000001D)}
-// CHECK:STDOUT:     'type(inst6000001A)':
-// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(inst6000001D)}
-// CHECK:STDOUT:     'type(inst6000002B)':
-// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst60000010)}
+// CHECK:STDOUT:     'type(inst50000010)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000010)}
+// CHECK:STDOUT:     'type(inst5000001D)':
+// CHECK:STDOUT:       value_repr:      {kind: copy, type: type(inst5000001D)}
+// CHECK:STDOUT:     'type(inst5000001A)':
+// CHECK:STDOUT:       value_repr:      {kind: pointer, type: type(inst5000001D)}
+// CHECK:STDOUT:     'type(inst5000002B)':
+// CHECK:STDOUT:       value_repr:      {kind: none, type: type(inst50000010)}
 // CHECK:STDOUT:   facet_types:     {}
 // CHECK:STDOUT:   insts:
 // CHECK:STDOUT:     instF:           {kind: Namespace, arg0: name_scope0, arg1: inst<none>, type: type(inst(NamespaceType))}
-// CHECK:STDOUT:     inst60000010:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000011:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000012:    {kind: TupleValue, arg0: inst_block_empty, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000013:    {kind: Converted, arg0: inst60000011, arg1: inst60000010, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000014:    {kind: ValueBinding, arg0: entity_name60000000, arg1: inst60000026, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000015:    {kind: PatternType, arg0: inst60000010, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000016:    {kind: ValueBindingPattern, arg0: entity_name60000000, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000017:    {kind: ValueParamPattern, arg0: inst60000016, type: type(inst60000015)}
-// CHECK:STDOUT:     inst60000018:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000019:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst60000010)}
-// CHECK:STDOUT:     inst6000001A:    {kind: TupleType, arg0: inst_block60000008, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001B:    {kind: TupleLiteral, arg0: inst_block60000007, type: type(inst6000001A)}
-// CHECK:STDOUT:     inst6000001C:    {kind: TupleValue, arg0: inst_block60000009, type: type(inst6000001A)}
-// CHECK:STDOUT:     inst6000001D:    {kind: PointerType, arg0: inst6000001A, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001E:    {kind: Converted, arg0: inst60000012, arg1: inst60000010, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000001F:    {kind: Converted, arg0: inst60000012, arg1: inst60000010, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000020:    {kind: Converted, arg0: inst6000001B, arg1: inst6000001A, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000021:    {kind: InitForm, arg0: inst60000020, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000022:    {kind: InitForm, arg0: inst6000001A, type: type(inst(FormType))}
-// CHECK:STDOUT:     inst60000023:    {kind: PatternType, arg0: inst6000001A, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000024:    {kind: ReturnSlotPattern, arg0: inst60000020, type: type(inst60000023)}
-// CHECK:STDOUT:     inst60000025:    {kind: OutParamPattern, arg0: inst60000024, type: type(inst60000023)}
-// CHECK:STDOUT:     inst60000026:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000027:    {kind: SpliceBlock, arg0: inst_block60000005, arg1: inst60000013, type: type(TypeType)}
-// CHECK:STDOUT:     inst60000028:    {kind: OutParam, arg0: call_param1, arg1: name(ReturnSlot), type: type(inst6000001A)}
-// CHECK:STDOUT:     inst60000029:    {kind: ReturnSlot, arg0: inst6000001A, arg1: inst60000028, type: type(inst6000001A)}
-// CHECK:STDOUT:     inst6000002A:    {kind: FunctionDecl, arg0: function60000000, arg1: inst_block6000000F, type: type(inst6000002B)}
-// CHECK:STDOUT:     inst6000002B:    {kind: FunctionType, arg0: function60000000, arg1: specific<none>, type: type(TypeType)}
-// CHECK:STDOUT:     inst6000002C:    {kind: StructValue, arg0: inst_block_empty, type: type(inst6000002B)}
-// CHECK:STDOUT:     inst6000002D:    {kind: NameRef, arg0: name1, arg1: inst60000014, type: type(inst60000010)}
-// CHECK:STDOUT:     inst6000002E:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst60000010)}
-// CHECK:STDOUT:     inst6000002F:    {kind: TupleLiteral, arg0: inst_block60000011, type: type(inst6000001A)}
-// CHECK:STDOUT:     inst60000030:    {kind: TupleAccess, arg0: inst60000028, arg1: element0, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000031:    {kind: TupleInit, arg0: inst_block60000012, arg1: inst<none>, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000032:    {kind: Converted, arg0: inst6000002D, arg1: inst60000031, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000033:    {kind: TupleAccess, arg0: inst60000028, arg1: element1, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000034:    {kind: TupleInit, arg0: inst_block_empty, arg1: inst<none>, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000035:    {kind: Converted, arg0: inst6000002E, arg1: inst60000034, type: type(inst60000010)}
-// CHECK:STDOUT:     inst60000036:    {kind: TupleInit, arg0: inst_block60000013, arg1: inst60000028, type: type(inst6000001A)}
-// CHECK:STDOUT:     inst60000037:    {kind: Converted, arg0: inst6000002F, arg1: inst60000036, type: type(inst6000001A)}
-// CHECK:STDOUT:     inst60000038:    {kind: ReturnExpr, arg0: inst60000037, arg1: inst60000028}
+// CHECK:STDOUT:     inst50000010:    {kind: TupleType, arg0: inst_block_empty, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000011:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000012:    {kind: TupleValue, arg0: inst_block_empty, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000013:    {kind: Converted, arg0: inst50000011, arg1: inst50000010, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000014:    {kind: ValueBinding, arg0: entity_name50000000, arg1: inst50000026, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000015:    {kind: PatternType, arg0: inst50000010, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000016:    {kind: ValueBindingPattern, arg0: entity_name50000000, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000017:    {kind: ValueParamPattern, arg0: inst50000016, type: type(inst50000015)}
+// CHECK:STDOUT:     inst50000018:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000019:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst50000010)}
+// CHECK:STDOUT:     inst5000001A:    {kind: TupleType, arg0: inst_block50000008, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000001B:    {kind: TupleLiteral, arg0: inst_block50000007, type: type(inst5000001A)}
+// CHECK:STDOUT:     inst5000001C:    {kind: TupleValue, arg0: inst_block50000009, type: type(inst5000001A)}
+// CHECK:STDOUT:     inst5000001D:    {kind: PointerType, arg0: inst5000001A, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000001E:    {kind: Converted, arg0: inst50000012, arg1: inst50000010, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000001F:    {kind: Converted, arg0: inst50000012, arg1: inst50000010, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000020:    {kind: Converted, arg0: inst5000001B, arg1: inst5000001A, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000021:    {kind: InitForm, arg0: inst50000020, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst50000022:    {kind: InitForm, arg0: inst5000001A, type: type(inst(FormType))}
+// CHECK:STDOUT:     inst50000023:    {kind: PatternType, arg0: inst5000001A, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000024:    {kind: ReturnSlotPattern, arg0: inst50000020, type: type(inst50000023)}
+// CHECK:STDOUT:     inst50000025:    {kind: OutParamPattern, arg0: inst50000024, type: type(inst50000023)}
+// CHECK:STDOUT:     inst50000026:    {kind: ValueParam, arg0: call_param0, arg1: name1, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000027:    {kind: SpliceBlock, arg0: inst_block50000005, arg1: inst50000013, type: type(TypeType)}
+// CHECK:STDOUT:     inst50000028:    {kind: OutParam, arg0: call_param1, arg1: name(ReturnSlot), type: type(inst5000001A)}
+// CHECK:STDOUT:     inst50000029:    {kind: ReturnSlot, arg0: inst5000001A, arg1: inst50000028, type: type(inst5000001A)}
+// CHECK:STDOUT:     inst5000002A:    {kind: FunctionDecl, arg0: function50000000, arg1: inst_block5000000F, type: type(inst5000002B)}
+// CHECK:STDOUT:     inst5000002B:    {kind: FunctionType, arg0: function50000000, arg1: specific<none>, type: type(TypeType)}
+// CHECK:STDOUT:     inst5000002C:    {kind: StructValue, arg0: inst_block_empty, type: type(inst5000002B)}
+// CHECK:STDOUT:     inst5000002D:    {kind: NameRef, arg0: name1, arg1: inst50000014, type: type(inst50000010)}
+// CHECK:STDOUT:     inst5000002E:    {kind: TupleLiteral, arg0: inst_block_empty, type: type(inst50000010)}
+// CHECK:STDOUT:     inst5000002F:    {kind: TupleLiteral, arg0: inst_block50000011, type: type(inst5000001A)}
+// CHECK:STDOUT:     inst50000030:    {kind: TupleAccess, arg0: inst50000028, arg1: element0, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000031:    {kind: TupleInit, arg0: inst_block50000012, arg1: inst<none>, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000032:    {kind: Converted, arg0: inst5000002D, arg1: inst50000031, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000033:    {kind: TupleAccess, arg0: inst50000028, arg1: element1, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000034:    {kind: TupleInit, arg0: inst_block_empty, arg1: inst<none>, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000035:    {kind: Converted, arg0: inst5000002E, arg1: inst50000034, type: type(inst50000010)}
+// CHECK:STDOUT:     inst50000036:    {kind: TupleInit, arg0: inst_block50000013, arg1: inst50000028, type: type(inst5000001A)}
+// CHECK:STDOUT:     inst50000037:    {kind: Converted, arg0: inst5000002F, arg1: inst50000036, type: type(inst5000001A)}
+// CHECK:STDOUT:     inst50000038:    {kind: ReturnExpr, arg0: inst50000037, arg1: inst50000028}
 // CHECK:STDOUT:   constant_values:
 // CHECK:STDOUT:     values:
 // CHECK:STDOUT:       instF:           concrete_constant(instF)
-// CHECK:STDOUT:       inst60000010:    concrete_constant(inst60000010)
-// CHECK:STDOUT:       inst60000011:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000012:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000013:    concrete_constant(inst60000010)
-// CHECK:STDOUT:       inst60000015:    concrete_constant(inst60000015)
-// CHECK:STDOUT:       inst60000016:    concrete_constant(inst60000016)
-// CHECK:STDOUT:       inst60000017:    concrete_constant(inst60000017)
-// CHECK:STDOUT:       inst60000018:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000019:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst6000001A:    concrete_constant(inst6000001A)
-// CHECK:STDOUT:       inst6000001B:    concrete_constant(inst6000001C)
-// CHECK:STDOUT:       inst6000001C:    concrete_constant(inst6000001C)
-// CHECK:STDOUT:       inst6000001D:    concrete_constant(inst6000001D)
-// CHECK:STDOUT:       inst6000001E:    concrete_constant(inst60000010)
-// CHECK:STDOUT:       inst6000001F:    concrete_constant(inst60000010)
-// CHECK:STDOUT:       inst60000020:    concrete_constant(inst6000001A)
-// CHECK:STDOUT:       inst60000021:    concrete_constant(inst60000022)
-// CHECK:STDOUT:       inst60000022:    concrete_constant(inst60000022)
-// CHECK:STDOUT:       inst60000023:    concrete_constant(inst60000023)
-// CHECK:STDOUT:       inst60000024:    concrete_constant(inst60000024)
-// CHECK:STDOUT:       inst60000025:    concrete_constant(inst60000025)
-// CHECK:STDOUT:       inst60000027:    concrete_constant(inst60000010)
-// CHECK:STDOUT:       inst6000002A:    concrete_constant(inst6000002C)
-// CHECK:STDOUT:       inst6000002B:    concrete_constant(inst6000002B)
-// CHECK:STDOUT:       inst6000002C:    concrete_constant(inst6000002C)
-// CHECK:STDOUT:       inst6000002E:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000031:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000032:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000034:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000035:    concrete_constant(inst60000012)
-// CHECK:STDOUT:       inst60000036:    concrete_constant(inst6000001C)
-// CHECK:STDOUT:       inst60000037:    concrete_constant(inst6000001C)
+// CHECK:STDOUT:       inst50000010:    concrete_constant(inst50000010)
+// CHECK:STDOUT:       inst50000011:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000012:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000013:    concrete_constant(inst50000010)
+// CHECK:STDOUT:       inst50000015:    concrete_constant(inst50000015)
+// CHECK:STDOUT:       inst50000016:    concrete_constant(inst50000016)
+// CHECK:STDOUT:       inst50000017:    concrete_constant(inst50000017)
+// CHECK:STDOUT:       inst50000018:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000019:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst5000001A:    concrete_constant(inst5000001A)
+// CHECK:STDOUT:       inst5000001B:    concrete_constant(inst5000001C)
+// CHECK:STDOUT:       inst5000001C:    concrete_constant(inst5000001C)
+// CHECK:STDOUT:       inst5000001D:    concrete_constant(inst5000001D)
+// CHECK:STDOUT:       inst5000001E:    concrete_constant(inst50000010)
+// CHECK:STDOUT:       inst5000001F:    concrete_constant(inst50000010)
+// CHECK:STDOUT:       inst50000020:    concrete_constant(inst5000001A)
+// CHECK:STDOUT:       inst50000021:    concrete_constant(inst50000022)
+// CHECK:STDOUT:       inst50000022:    concrete_constant(inst50000022)
+// CHECK:STDOUT:       inst50000023:    concrete_constant(inst50000023)
+// CHECK:STDOUT:       inst50000024:    concrete_constant(inst50000024)
+// CHECK:STDOUT:       inst50000025:    concrete_constant(inst50000025)
+// CHECK:STDOUT:       inst50000027:    concrete_constant(inst50000010)
+// CHECK:STDOUT:       inst5000002A:    concrete_constant(inst5000002C)
+// CHECK:STDOUT:       inst5000002B:    concrete_constant(inst5000002B)
+// CHECK:STDOUT:       inst5000002C:    concrete_constant(inst5000002C)
+// CHECK:STDOUT:       inst5000002E:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000031:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000032:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000034:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000035:    concrete_constant(inst50000012)
+// CHECK:STDOUT:       inst50000036:    concrete_constant(inst5000001C)
+// CHECK:STDOUT:       inst50000037:    concrete_constant(inst5000001C)
 // CHECK:STDOUT:     symbolic_constants: {}
 // CHECK:STDOUT:   inst_blocks:
 // CHECK:STDOUT:     inst_block_empty: {}
 // CHECK:STDOUT:     exports:
-// CHECK:STDOUT:       0:               inst6000002A
+// CHECK:STDOUT:       0:               inst5000002A
 // CHECK:STDOUT:     generated:       {}
 // CHECK:STDOUT:     imports:         {}
 // CHECK:STDOUT:     global_init:     {}
-// CHECK:STDOUT:     inst_block60000005:
-// CHECK:STDOUT:       0:               inst60000011
-// CHECK:STDOUT:       1:               inst60000013
-// CHECK:STDOUT:     inst_block60000006:
-// CHECK:STDOUT:       0:               inst60000017
-// CHECK:STDOUT:     inst_block60000007:
-// CHECK:STDOUT:       0:               inst60000018
-// CHECK:STDOUT:       1:               inst60000019
-// CHECK:STDOUT:     inst_block60000008:
-// CHECK:STDOUT:       0:               inst60000010
-// CHECK:STDOUT:       1:               inst60000010
-// CHECK:STDOUT:     inst_block60000009:
-// CHECK:STDOUT:       0:               inst60000012
-// CHECK:STDOUT:       1:               inst60000012
-// CHECK:STDOUT:     inst_block6000000A:
-// CHECK:STDOUT:       0:               inst6000001E
-// CHECK:STDOUT:       1:               inst6000001F
-// CHECK:STDOUT:     inst_block6000000B:
-// CHECK:STDOUT:       0:               inst60000025
-// CHECK:STDOUT:     inst_block6000000C:
-// CHECK:STDOUT:       0:               inst60000017
-// CHECK:STDOUT:       1:               inst60000025
-// CHECK:STDOUT:     inst_block6000000D:
-// CHECK:STDOUT:       0:               inst60000026
-// CHECK:STDOUT:       1:               inst60000028
-// CHECK:STDOUT:     inst_block6000000E:
-// CHECK:STDOUT:       0:               inst60000016
-// CHECK:STDOUT:       1:               inst60000017
-// CHECK:STDOUT:       2:               inst60000024
-// CHECK:STDOUT:       3:               inst60000025
-// CHECK:STDOUT:     inst_block6000000F:
-// CHECK:STDOUT:       0:               inst60000018
-// CHECK:STDOUT:       1:               inst60000019
-// CHECK:STDOUT:       2:               inst6000001B
-// CHECK:STDOUT:       3:               inst6000001E
-// CHECK:STDOUT:       4:               inst6000001F
-// CHECK:STDOUT:       5:               inst60000020
-// CHECK:STDOUT:       6:               inst60000021
-// CHECK:STDOUT:       7:               inst60000026
-// CHECK:STDOUT:       8:               inst60000027
-// CHECK:STDOUT:       9:               inst60000014
-// CHECK:STDOUT:       10:              inst60000028
-// CHECK:STDOUT:       11:              inst60000029
-// CHECK:STDOUT:     inst_block60000010:
-// CHECK:STDOUT:       0:               inst6000002D
-// CHECK:STDOUT:       1:               inst6000002E
-// CHECK:STDOUT:       2:               inst6000002F
-// CHECK:STDOUT:       3:               inst60000030
-// CHECK:STDOUT:       4:               inst60000031
-// CHECK:STDOUT:       5:               inst60000032
-// CHECK:STDOUT:       6:               inst60000033
-// CHECK:STDOUT:       7:               inst60000034
-// CHECK:STDOUT:       8:               inst60000035
-// CHECK:STDOUT:       9:               inst60000036
-// CHECK:STDOUT:       10:              inst60000037
-// CHECK:STDOUT:       11:              inst60000038
-// CHECK:STDOUT:     inst_block60000011:
-// CHECK:STDOUT:       0:               inst6000002D
-// CHECK:STDOUT:       1:               inst6000002E
-// CHECK:STDOUT:     inst_block60000012: {}
-// CHECK:STDOUT:     inst_block60000013:
-// CHECK:STDOUT:       0:               inst60000032
-// CHECK:STDOUT:       1:               inst60000035
-// CHECK:STDOUT:     inst_block60000014:
+// CHECK:STDOUT:     inst_block50000005:
+// CHECK:STDOUT:       0:               inst50000011
+// CHECK:STDOUT:       1:               inst50000013
+// CHECK:STDOUT:     inst_block50000006:
+// CHECK:STDOUT:       0:               inst50000017
+// CHECK:STDOUT:     inst_block50000007:
+// CHECK:STDOUT:       0:               inst50000018
+// CHECK:STDOUT:       1:               inst50000019
+// CHECK:STDOUT:     inst_block50000008:
+// CHECK:STDOUT:       0:               inst50000010
+// CHECK:STDOUT:       1:               inst50000010
+// CHECK:STDOUT:     inst_block50000009:
+// CHECK:STDOUT:       0:               inst50000012
+// CHECK:STDOUT:       1:               inst50000012
+// CHECK:STDOUT:     inst_block5000000A:
+// CHECK:STDOUT:       0:               inst5000001E
+// CHECK:STDOUT:       1:               inst5000001F
+// CHECK:STDOUT:     inst_block5000000B:
+// CHECK:STDOUT:       0:               inst50000025
+// CHECK:STDOUT:     inst_block5000000C:
+// CHECK:STDOUT:       0:               inst50000017
+// CHECK:STDOUT:       1:               inst50000025
+// CHECK:STDOUT:     inst_block5000000D:
+// CHECK:STDOUT:       0:               inst50000026
+// CHECK:STDOUT:       1:               inst50000028
+// CHECK:STDOUT:     inst_block5000000E:
+// CHECK:STDOUT:       0:               inst50000016
+// CHECK:STDOUT:       1:               inst50000017
+// CHECK:STDOUT:       2:               inst50000024
+// CHECK:STDOUT:       3:               inst50000025
+// CHECK:STDOUT:     inst_block5000000F:
+// CHECK:STDOUT:       0:               inst50000018
+// CHECK:STDOUT:       1:               inst50000019
+// CHECK:STDOUT:       2:               inst5000001B
+// CHECK:STDOUT:       3:               inst5000001E
+// CHECK:STDOUT:       4:               inst5000001F
+// CHECK:STDOUT:       5:               inst50000020
+// CHECK:STDOUT:       6:               inst50000021
+// CHECK:STDOUT:       7:               inst50000026
+// CHECK:STDOUT:       8:               inst50000027
+// CHECK:STDOUT:       9:               inst50000014
+// CHECK:STDOUT:       10:              inst50000028
+// CHECK:STDOUT:       11:              inst50000029
+// CHECK:STDOUT:     inst_block50000010:
+// CHECK:STDOUT:       0:               inst5000002D
+// CHECK:STDOUT:       1:               inst5000002E
+// CHECK:STDOUT:       2:               inst5000002F
+// CHECK:STDOUT:       3:               inst50000030
+// CHECK:STDOUT:       4:               inst50000031
+// CHECK:STDOUT:       5:               inst50000032
+// CHECK:STDOUT:       6:               inst50000033
+// CHECK:STDOUT:       7:               inst50000034
+// CHECK:STDOUT:       8:               inst50000035
+// CHECK:STDOUT:       9:               inst50000036
+// CHECK:STDOUT:       10:              inst50000037
+// CHECK:STDOUT:       11:              inst50000038
+// CHECK:STDOUT:     inst_block50000011:
+// CHECK:STDOUT:       0:               inst5000002D
+// CHECK:STDOUT:       1:               inst5000002E
+// CHECK:STDOUT:     inst_block50000012: {}
+// CHECK:STDOUT:     inst_block50000013:
+// CHECK:STDOUT:       0:               inst50000032
+// CHECK:STDOUT:       1:               inst50000035
+// CHECK:STDOUT:     inst_block50000014:
 // CHECK:STDOUT:       0:               instF
-// CHECK:STDOUT:       1:               inst6000002A
+// CHECK:STDOUT:       1:               inst5000002A
 // CHECK:STDOUT:   value_stores:
 // CHECK:STDOUT:     shared_values:
 // CHECK:STDOUT:       ints:            {}

--- a/toolchain/check/testdata/eval/call.carbon
+++ b/toolchain/check/testdata/eval/call.carbon
@@ -99,7 +99,7 @@ fn UseFGenerically(X:! i32) {
   // CHECK:STDERR:   var unused v: F(X) = {};
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.Destroy` in type `<cannot stringify inst7800018B: {kind: Call, arg0: inst7800003E, arg1: inst_block78000091, type: type(TypeType)}>` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.Destroy` in type `<cannot stringify inst5C00018B: {kind: Call, arg0: inst5C00003E, arg1: inst_block5C000091, type: type(TypeType)}>` that does not implement that interface [MissingImplInMemberAccess]
   // CHECK:STDERR:   var unused v: F(X) = {};
   // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:


### PR DESCRIPTION
This is so that the last file is more likely what we're trying to compile in tests. Just splitting out the churn-y change of reordering.

Assisted-by: Google Antigravity with Gemini