### PR TITLE
Support constexpr pointers

### DIFF
--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -85,8 +85,8 @@ static auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
 }
 
 auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
-                          const clang::APValue& ap_value, clang::QualType type)
-    -> SemIR::ConstantId {
+                          const clang::APValue& ap_value, clang::QualType type,
+                          bool is_lvalue) -> SemIR::ConstantId {
   SemIR::TypeId type_id = ImportCppType(context, loc_id, type).type_id;
   if (!type_id.has_value()) {
     return SemIR::ConstantId::NotConstant;
@@ -108,7 +108,7 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
     FloatId float_id = context.floats().Add(ap_value.getFloat());
     return TryEvalInst(
         context, SemIR::FloatValue{.type_id = type_id, .float_id = float_id});
-  } else if (ap_value.isLValue()) {
+  } else if (is_lvalue) {
     auto const_id = MapLValueToConstant(context, loc_id, ap_value, type);
     if (type->isPointerType()) {
       auto inst_id = AddInst<SemIR::AddrOf>(
@@ -223,8 +223,11 @@ auto EvalCppCall(Context& context, SemIR::LocId loc_id,
                            function_decl->isConsteval());
     return SemIR::ErrorInst::ConstantId;
   }
+
+  // TODO
+  bool is_lvalue = eval_result.Val.isLValue();
   return MapAPValueToConstant(context, loc_id, eval_result.Val,
-                              function_decl->getCallResultType());
+                              function_decl->getCallResultType(), is_lvalue);
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -8,6 +8,7 @@
 #include "toolchain/check/cpp/type_mapping.h"
 #include "toolchain/check/eval.h"
 #include "toolchain/check/member_access.h"
+#include "toolchain/check/type.h"
 #include "toolchain/check/type_completion.h"
 #include "toolchain/diagnostics/format_providers.h"
 
@@ -95,6 +96,13 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
 
   if (is_lvalue) {
     return MapLValueToConstant(context, loc_id, ap_value, type);
+  } else if (type->isPointerType()) {
+    auto const_id = MapLValueToConstant(context, loc_id, ap_value, type);
+    auto inst_id = AddInst<SemIR::AddrOf>(
+        context, loc_id,
+        {.type_id = type_id,
+         .lvalue_id = context.constant_values().GetInstId(const_id)});
+    return context.constant_values().Get(inst_id);
   } else if (ap_value.isInt()) {
     if (type->isBooleanType()) {
       auto value = SemIR::BoolValue::From(!ap_value.getInt().isZero());

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -111,7 +111,9 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
         context, SemIR::FloatValue{.type_id = type_id, .float_id = float_id});
   } else {
     // TODO: support other types.
-    return SemIR::ConstantId::NotConstant;
+    context.TODO(loc_id, "unsupported conversion to constant from APValue " +
+                             ap_value.getAsString(context.ast_context(), type));
+    return SemIR::ErrorInst::ConstantId;
   }
 }
 

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -13,7 +13,6 @@
 namespace Carbon::Check {
 
 // TODO: call from MapAPValueToConstant and make `static`.
-// TODO: update error messages.
 auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
                          const clang::APValue& ap_value, clang::QualType type)
     -> SemIR::ConstantId {
@@ -23,12 +22,12 @@ auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
       ap_value.getLValueBase().get<const clang::ValueDecl*>();
 
   if (!ap_value.hasLValuePath()) {
-    context.TODO(loc_id, "Macro expanded to lvalue with no path");
+    context.TODO(loc_id, "lvalue has no path");
     return SemIR::ErrorInst::ConstantId;
   }
 
   if (ap_value.isLValueOnePastTheEnd()) {
-    context.TODO(loc_id, "Macro expanded to a one-past-the-end lvalue");
+    context.TODO(loc_id, "one-past-the-end lvalue");
     return SemIR::ErrorInst::ConstantId;
   }
 
@@ -51,14 +50,14 @@ auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
   clang::QualType qual_type = ap_value.getLValueBase().getType();
   for (const auto& entry : ap_value.getLValuePath()) {
     if (qual_type->isArrayType()) {
-      context.TODO(loc_id, "Macro expanded to array type");
+      context.TODO(loc_id, "lvalue path contains an array type");
     } else {
       const auto* decl =
           cast<clang::Decl>(entry.getAsBaseOrMember().getPointer());
 
       const auto* field_decl = dyn_cast<clang::FieldDecl>(decl);
       if (!field_decl) {
-        context.TODO(loc_id, "Macro expanded to a base class subobject");
+        context.TODO(loc_id, "lvalue path contains a base class subobject");
         return SemIR::ErrorInst::ConstantId;
       }
 
@@ -69,7 +68,7 @@ auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
 
       if (field_inst_id == SemIR::ErrorInst::InstId) {
         context.TODO(loc_id,
-                     "Unsupported field in macro expansion: " +
+                     "unsupported field in lvalue path: " +
                          ap_value.getAsString(context.ast_context(), type));
         return SemIR::ErrorInst::ConstantId;
       }

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -6,9 +6,85 @@
 
 #include "toolchain/check/cpp/import.h"
 #include "toolchain/check/eval.h"
+#include "toolchain/check/member_access.h"
+#include "toolchain/check/type_completion.h"
 #include "toolchain/diagnostics/format_providers.h"
 
 namespace Carbon::Check {
+
+// TODO: call from MapAPValueToConstant and make `static`.
+// TODO: update error messages.
+auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
+                         const clang::APValue& ap_value, clang::QualType type)
+    -> SemIR::ConstantId {
+  CARBON_CHECK(ap_value.isLValue(), "not an LValue");
+
+  const auto* value_decl =
+      ap_value.getLValueBase().get<const clang::ValueDecl*>();
+
+  if (!ap_value.hasLValuePath()) {
+    context.TODO(loc_id, "Macro expanded to lvalue with no path");
+    return SemIR::ErrorInst::ConstantId;
+  }
+
+  if (ap_value.isLValueOnePastTheEnd()) {
+    context.TODO(loc_id, "Macro expanded to a one-past-the-end lvalue");
+    return SemIR::ErrorInst::ConstantId;
+  }
+
+  auto key = SemIR::ClangDeclKey::ForNonFunctionDecl(
+      // TODO: can this const_cast be avoided?
+      const_cast<clang::ValueDecl*>(value_decl));
+
+  auto inst_id = ImportCppDecl(context, loc_id, key);
+  if (ap_value.getLValuePath().size() == 0) {
+    return context.constant_values().Get(inst_id);
+  }
+
+  // Import the base type so that its fields can be accessed.
+  auto var_storage = context.insts().GetAs<SemIR::VarStorage>(inst_id);
+  // TODO: currently an error isn't reachable here because incomplete
+  // array types can't be imported. Once that changes, switch to
+  // `RequireCompleteType` and handle the error.
+  CompleteTypeOrCheckFail(context, var_storage.type_id);
+
+  clang::QualType qual_type = ap_value.getLValueBase().getType();
+  for (const auto& entry : ap_value.getLValuePath()) {
+    if (qual_type->isArrayType()) {
+      context.TODO(loc_id, "Macro expanded to array type");
+    } else {
+      const auto* decl =
+          cast<clang::Decl>(entry.getAsBaseOrMember().getPointer());
+
+      const auto* field_decl = dyn_cast<clang::FieldDecl>(decl);
+      if (!field_decl) {
+        context.TODO(loc_id, "Macro expanded to a base class subobject");
+        return SemIR::ErrorInst::ConstantId;
+      }
+
+      auto field_inst_id =
+          ImportCppDecl(context, loc_id,
+                        SemIR::ClangDeclKey::ForNonFunctionDecl(
+                            const_cast<clang::FieldDecl*>(field_decl)));
+
+      if (field_inst_id == SemIR::ErrorInst::InstId) {
+        context.TODO(loc_id,
+                     "Unsupported field in macro expansion: " +
+                         ap_value.getAsString(context.ast_context(), type));
+        return SemIR::ErrorInst::ConstantId;
+      }
+
+      const SemIR::FieldDecl& field_decl_inst =
+          context.insts().GetAs<SemIR::FieldDecl>(field_inst_id);
+
+      qual_type = field_decl->getType();
+      inst_id = PerformMemberAccess(context, loc_id, inst_id,
+                                    field_decl_inst.name_id);
+    }
+  }
+
+  return context.constant_values().Get(inst_id);
+}
 
 auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
                           const clang::APValue& ap_value, clang::QualType type)

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -133,8 +133,11 @@ static auto MapAPValueToConstantForConstexpr(Context& context,
                                              const clang::APValue& ap_value,
                                              clang::QualType type)
     -> SemIR::ConstantId {
-  // TODO
-  bool is_lvalue = ap_value.isLValue();
+  bool is_lvalue = false;
+  if (type->isReferenceType()) {
+    is_lvalue = true;
+    type = type.getNonReferenceType();
+  }
   return MapAPValueToConstant(context, loc_id, ap_value, type, is_lvalue);
 }
 

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/check/cpp/constant.h"
 
 #include "toolchain/check/cpp/import.h"
+#include "toolchain/check/cpp/type_mapping.h"
 #include "toolchain/check/eval.h"
 #include "toolchain/check/member_access.h"
 #include "toolchain/check/type_completion.h"
@@ -125,6 +126,28 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
                              ap_value.getAsString(context.ast_context(), type));
     return SemIR::ErrorInst::ConstantId;
   }
+}
+
+auto EvalCppVarDecl(Context& context, SemIR::LocId loc_id,
+                    const clang::VarDecl* var_decl, SemIR::TypeId type_id)
+    -> SemIR::ConstantId {
+  // If the C++ global is constant, map it to a Carbon constant.
+  if (var_decl->isUsableInConstantExpressions(context.ast_context())) {
+    if (const auto* ap_value = var_decl->getEvaluatedValue()) {
+      auto clang_type = MapToCppType(context, type_id);
+      if (clang_type.isNull()) {
+        context.TODO(loc_id, "failed to map C++ type to Carbon");
+        return SemIR::ErrorInst::ConstantId;
+      }
+
+      // TODO
+      bool is_lvalue = ap_value->isLValue();
+      return MapAPValueToConstant(context, loc_id, *ap_value, clang_type,
+                                  is_lvalue);
+    }
+  }
+
+  return SemIR::ConstantId::NotConstant;
 }
 
 static auto ConvertConstantToAPValue(Context& context,

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -93,7 +93,18 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
     return SemIR::ConstantId::NotConstant;
   }
 
-  if (ap_value.isInt()) {
+  if (is_lvalue) {
+    auto const_id = MapLValueToConstant(context, loc_id, ap_value, type);
+    if (type->isPointerType()) {
+      auto inst_id = AddInst<SemIR::AddrOf>(
+          context, loc_id,
+          {.type_id = type_id,
+           .lvalue_id = context.constant_values().GetInstId(const_id)});
+      return context.constant_values().Get(inst_id);
+    }
+    return const_id;
+
+  } else if (ap_value.isInt()) {
     if (type->isBooleanType()) {
       auto value = SemIR::BoolValue::From(!ap_value.getInt().isZero());
       return TryEvalInst(
@@ -109,17 +120,6 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
     FloatId float_id = context.floats().Add(ap_value.getFloat());
     return TryEvalInst(
         context, SemIR::FloatValue{.type_id = type_id, .float_id = float_id});
-  } else if (is_lvalue) {
-    auto const_id = MapLValueToConstant(context, loc_id, ap_value, type);
-    if (type->isPointerType()) {
-      auto inst_id = AddInst<SemIR::AddrOf>(
-          context, loc_id,
-          {.type_id = type_id,
-           .lvalue_id = context.constant_values().GetInstId(const_id)});
-      return context.constant_values().Get(inst_id);
-    }
-    return const_id;
-
   } else {
     // TODO: support other types.
     context.TODO(loc_id, "unsupported conversion to constant from APValue " +

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -94,16 +94,7 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
   }
 
   if (is_lvalue) {
-    auto const_id = MapLValueToConstant(context, loc_id, ap_value, type);
-    if (type->isPointerType()) {
-      auto inst_id = AddInst<SemIR::AddrOf>(
-          context, loc_id,
-          {.type_id = type_id,
-           .lvalue_id = context.constant_values().GetInstId(const_id)});
-      return context.constant_values().Get(inst_id);
-    }
-    return const_id;
-
+    return MapLValueToConstant(context, loc_id, ap_value, type);
   } else if (ap_value.isInt()) {
     if (type->isBooleanType()) {
       auto value = SemIR::BoolValue::From(!ap_value.getInt().isZero());

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -12,10 +12,9 @@
 
 namespace Carbon::Check {
 
-// TODO: call from MapAPValueToConstant and make `static`.
-auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
-                         const clang::APValue& ap_value, clang::QualType type)
-    -> SemIR::ConstantId {
+static auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
+                                const clang::APValue& ap_value,
+                                clang::QualType type) -> SemIR::ConstantId {
   CARBON_CHECK(ap_value.isLValue(), "not an LValue");
 
   const auto* value_decl =
@@ -109,6 +108,17 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
     FloatId float_id = context.floats().Add(ap_value.getFloat());
     return TryEvalInst(
         context, SemIR::FloatValue{.type_id = type_id, .float_id = float_id});
+  } else if (ap_value.isLValue()) {
+    auto const_id = MapLValueToConstant(context, loc_id, ap_value, type);
+    if (type->isPointerType()) {
+      auto inst_id = AddInst<SemIR::AddrOf>(
+          context, loc_id,
+          {.type_id = type_id,
+           .lvalue_id = context.constant_values().GetInstId(const_id)});
+      return context.constant_values().Get(inst_id);
+    }
+    return const_id;
+
   } else {
     // TODO: support other types.
     context.TODO(loc_id, "unsupported conversion to constant from APValue " +

--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -128,6 +128,16 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
   }
 }
 
+static auto MapAPValueToConstantForConstexpr(Context& context,
+                                             SemIR::LocId loc_id,
+                                             const clang::APValue& ap_value,
+                                             clang::QualType type)
+    -> SemIR::ConstantId {
+  // TODO
+  bool is_lvalue = ap_value.isLValue();
+  return MapAPValueToConstant(context, loc_id, ap_value, type, is_lvalue);
+}
+
 auto EvalCppVarDecl(Context& context, SemIR::LocId loc_id,
                     const clang::VarDecl* var_decl, SemIR::TypeId type_id)
     -> SemIR::ConstantId {
@@ -140,10 +150,8 @@ auto EvalCppVarDecl(Context& context, SemIR::LocId loc_id,
         return SemIR::ErrorInst::ConstantId;
       }
 
-      // TODO
-      bool is_lvalue = ap_value->isLValue();
-      return MapAPValueToConstant(context, loc_id, *ap_value, clang_type,
-                                  is_lvalue);
+      return MapAPValueToConstantForConstexpr(context, loc_id, *ap_value,
+                                              clang_type);
     }
   }
 
@@ -247,10 +255,8 @@ auto EvalCppCall(Context& context, SemIR::LocId loc_id,
     return SemIR::ErrorInst::ConstantId;
   }
 
-  // TODO
-  bool is_lvalue = eval_result.Val.isLValue();
-  return MapAPValueToConstant(context, loc_id, eval_result.Val,
-                              function_decl->getCallResultType(), is_lvalue);
+  return MapAPValueToConstantForConstexpr(context, loc_id, eval_result.Val,
+                                          function_decl->getCallResultType());
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/cpp/constant.h
+++ b/toolchain/check/cpp/constant.h
@@ -11,6 +11,11 @@
 
 namespace Carbon::Check {
 
+// Converts an LValue `APValue` to a Carbon `ConstantId`.
+auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
+                         const clang::APValue& ap_value, clang::QualType type)
+    -> SemIR::ConstantId;
+
 // Converts an `APValue` to a Carbon `ConstantId`.
 auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
                           const clang::APValue& ap_value, clang::QualType type)

--- a/toolchain/check/cpp/constant.h
+++ b/toolchain/check/cpp/constant.h
@@ -16,6 +16,11 @@ auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
                           const clang::APValue& ap_value, clang::QualType type,
                           bool is_lvalue) -> SemIR::ConstantId;
 
+// Attempt to evaluate a C++ constexpr variable as a Carbon constant.
+auto EvalCppVarDecl(Context& context, SemIR::LocId loc_id,
+                    const clang::VarDecl* var_decl, SemIR::TypeId type_id)
+    -> SemIR::ConstantId;
+
 // Attempt to evaluate a call to a C++ constexpr/consteval function as a
 // Carbon constant.
 auto EvalCppCall(Context& context, SemIR::LocId loc_id,

--- a/toolchain/check/cpp/constant.h
+++ b/toolchain/check/cpp/constant.h
@@ -11,11 +11,6 @@
 
 namespace Carbon::Check {
 
-// Converts an LValue `APValue` to a Carbon `ConstantId`.
-auto MapLValueToConstant(Context& context, SemIR::LocId loc_id,
-                         const clang::APValue& ap_value, clang::QualType type)
-    -> SemIR::ConstantId;
-
 // Converts an `APValue` to a Carbon `ConstantId`.
 auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
                           const clang::APValue& ap_value, clang::QualType type)

--- a/toolchain/check/cpp/constant.h
+++ b/toolchain/check/cpp/constant.h
@@ -13,8 +13,8 @@ namespace Carbon::Check {
 
 // Converts an `APValue` to a Carbon `ConstantId`.
 auto MapAPValueToConstant(Context& context, SemIR::LocId loc_id,
-                          const clang::APValue& ap_value, clang::QualType type)
-    -> SemIR::ConstantId;
+                          const clang::APValue& ap_value, clang::QualType type,
+                          bool is_lvalue) -> SemIR::ConstantId;
 
 // Attempt to evaluate a call to a C++ constexpr/consteval function as a
 // Carbon constant.

--- a/toolchain/check/cpp/macros.cpp
+++ b/toolchain/check/cpp/macros.cpp
@@ -107,24 +107,16 @@ auto TryEvaluateMacro(Context& context, SemIR::LocId loc_id,
     CARBON_FATAL("failed to evaluate macro as constant expression");
   }
 
-  clang::APValue ap_value = evaluated_result.Val;
-  // TODO: Add support for other types.
-  if (result_expr->isGLValue()) {
-    auto const_id =
-        MapLValueToConstant(context, loc_id, ap_value, result_expr->getType());
-    return context.constant_values().GetInstId(const_id);
-  } else {
-    auto const_id =
-        MapAPValueToConstant(context, loc_id, ap_value, result_expr->getType());
-    if (const_id == SemIR::ConstantId::NotConstant) {
-      context.TODO(loc_id,
-                   "Unsupported: macro evaluated to a constant of type: " +
-                       result_expr->getType().getAsString());
-      return SemIR::ErrorInst::InstId;
-    }
-
-    return context.constant_values().GetInstId(const_id);
+  auto const_id = MapAPValueToConstant(context, loc_id, evaluated_result.Val,
+                                       result_expr->getType());
+  if (const_id == SemIR::ConstantId::NotConstant) {
+    context.TODO(loc_id,
+                 "Unsupported: macro evaluated to a constant of type: " +
+                     result_expr->getType().getAsString());
+    return SemIR::ErrorInst::InstId;
   }
+
+  return context.constant_values().GetInstId(const_id);
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/cpp/macros.cpp
+++ b/toolchain/check/cpp/macros.cpp
@@ -108,7 +108,8 @@ auto TryEvaluateMacro(Context& context, SemIR::LocId loc_id,
   }
 
   auto const_id = MapAPValueToConstant(context, loc_id, evaluated_result.Val,
-                                       result_expr->getType());
+                                       result_expr->getType(),
+                                       /*is_lvalue=*/result_expr->isGLValue());
   if (const_id == SemIR::ConstantId::NotConstant) {
     context.TODO(loc_id,
                  "Unsupported: macro evaluated to a constant of type: " +

--- a/toolchain/check/cpp/macros.cpp
+++ b/toolchain/check/cpp/macros.cpp
@@ -12,8 +12,6 @@
 #include "toolchain/check/cpp/constant.h"
 #include "toolchain/check/cpp/import.h"
 #include "toolchain/check/literal.h"
-#include "toolchain/check/member_access.h"
-#include "toolchain/check/type_completion.h"
 
 namespace Carbon::Check {
 
@@ -112,72 +110,9 @@ auto TryEvaluateMacro(Context& context, SemIR::LocId loc_id,
   clang::APValue ap_value = evaluated_result.Val;
   // TODO: Add support for other types.
   if (result_expr->isGLValue()) {
-    const auto* value_decl =
-        ap_value.getLValueBase().get<const clang::ValueDecl*>();
-
-    if (!ap_value.hasLValuePath()) {
-      context.TODO(loc_id, "Macro expanded to lvalue with no path");
-      return SemIR::ErrorInst::InstId;
-    }
-
-    if (ap_value.isLValueOnePastTheEnd()) {
-      context.TODO(loc_id, "Macro expanded to a one-past-the-end lvalue");
-      return SemIR::ErrorInst::InstId;
-    }
-
-    auto key = SemIR::ClangDeclKey::ForNonFunctionDecl(
-        // TODO: can this const_cast be avoided?
-        const_cast<clang::ValueDecl*>(value_decl));
-
-    auto inst_id = ImportCppDecl(context, loc_id, key);
-    if (ap_value.getLValuePath().size() == 0) {
-      return inst_id;
-    }
-
-    // Import the base type so that its fields can be accessed.
-    auto var_storage = context.insts().GetAs<SemIR::VarStorage>(inst_id);
-    // TODO: currently an error isn't reachable here because incomplete
-    // array types can't be imported. Once that changes, switch to
-    // `RequireCompleteType` and handle the error.
-    CompleteTypeOrCheckFail(context, var_storage.type_id);
-
-    clang::QualType qual_type = ap_value.getLValueBase().getType();
-    for (const auto& entry : ap_value.getLValuePath()) {
-      if (qual_type->isArrayType()) {
-        context.TODO(loc_id, "Macro expanded to array type");
-      } else {
-        const auto* decl =
-            cast<clang::Decl>(entry.getAsBaseOrMember().getPointer());
-
-        const auto* field_decl = dyn_cast<clang::FieldDecl>(decl);
-        if (!field_decl) {
-          context.TODO(loc_id, "Macro expanded to a base class subobject");
-          return SemIR::ErrorInst::InstId;
-        }
-
-        auto field_inst_id =
-            ImportCppDecl(context, loc_id,
-                          SemIR::ClangDeclKey::ForNonFunctionDecl(
-                              const_cast<clang::FieldDecl*>(field_decl)));
-
-        if (field_inst_id == SemIR::ErrorInst::InstId) {
-          context.TODO(loc_id,
-                       "Unsupported field in macro expansion: " +
-                           ap_value.getAsString(context.ast_context(),
-                                                result_expr->getType()));
-          return SemIR::ErrorInst::InstId;
-        }
-
-        const SemIR::FieldDecl& field_decl_inst =
-            context.insts().GetAs<SemIR::FieldDecl>(field_inst_id);
-
-        qual_type = field_decl->getType();
-        inst_id = PerformMemberAccess(context, loc_id, inst_id,
-                                      field_decl_inst.name_id);
-      }
-    }
-
-    return inst_id;
+    auto const_id =
+        MapLValueToConstant(context, loc_id, ap_value, result_expr->getType());
+    return context.constant_values().GetInstId(const_id);
   } else {
     auto const_id =
         MapAPValueToConstant(context, loc_id, ap_value, result_expr->getType());

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -128,22 +128,10 @@ auto EvalConstantInst(Context& /*context*/, SemIR::ValueBinding /*inst*/)
 auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
                       SemIR::AcquireValue inst) -> ConstantEvalResult {
   if (const auto* var_decl = GetAsClangVarDecl(context, inst.value_id)) {
-    // If the C++ global is constant, map it to a Carbon constant.
-    if (var_decl->isUsableInConstantExpressions(context.ast_context())) {
-      if (const auto* ap_value = var_decl->getEvaluatedValue()) {
-        auto clang_type = MapToCppType(context, inst.type_id);
-        if (clang_type.isNull()) {
-          return ConstantEvalResult::TODO;
-        }
-
-        // TODO
-        bool is_lvalue = ap_value->isLValue();
-        auto const_id = MapAPValueToConstant(context, SemIR::LocId(inst_id),
-                                             *ap_value, clang_type, is_lvalue);
-        if (const_id.has_value() && const_id.is_constant()) {
-          return ConstantEvalResult::Existing(const_id);
-        }
-      }
+    auto const_id =
+        EvalCppVarDecl(context, SemIR::LocId(inst_id), var_decl, inst.type_id);
+    if (const_id.has_value() && const_id.is_constant()) {
+      return ConstantEvalResult::Existing(const_id);
     }
 
     return ConstantEvalResult::NotConstant;

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -136,8 +136,10 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
           return ConstantEvalResult::TODO;
         }
 
+        // TODO
+        bool is_lvalue = ap_value->isLValue();
         auto const_id = MapAPValueToConstant(context, SemIR::LocId(inst_id),
-                                             *ap_value, clang_type);
+                                             *ap_value, clang_type, is_lvalue);
         if (const_id.has_value() && const_id.is_constant()) {
           return ConstantEvalResult::Existing(const_id);
         }

--- a/toolchain/check/testdata/interop/cpp/constexpr.carbon
+++ b/toolchain/check/testdata/interop/cpp/constexpr.carbon
@@ -56,7 +56,7 @@ constexpr int* _Nonnull ptr = &i;
 ''';
 
 class C(V:! i32*) {}
-// CHECK:STDERR: pointer.carbon:[[@LINE+7]]:11: error: argument for generic parameter is not a compile-time constant [CompTimeArgumentNotConstant]
+// CHECK:STDERR: pointer.carbon:[[@LINE+7]]:11: error: semantics TODO: `unsupported conversion to constant from APValue &i` [SemanticsTodo]
 // CHECK:STDERR: fn F() -> C(Cpp.ptr);
 // CHECK:STDERR:           ^~~~~~~~~~
 // CHECK:STDERR: pointer.carbon:[[@LINE-4]]:9: note: initializing generic parameter `V` declared here [InitializingGenericParam]

--- a/toolchain/check/testdata/interop/cpp/constexpr.carbon
+++ b/toolchain/check/testdata/interop/cpp/constexpr.carbon
@@ -46,6 +46,26 @@ class C(V:! f32) {}
 fn F() -> C(Cpp.flt);
 let x: C(123.5) = F();
 
+// --- pointer.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp inline '''
+int i = 123;
+constexpr int* _Nonnull ptr = &i;
+''';
+
+class C(V:! i32*) {}
+// CHECK:STDERR: pointer.carbon:[[@LINE+7]]:11: error: argument for generic parameter is not a compile-time constant [CompTimeArgumentNotConstant]
+// CHECK:STDERR: fn F() -> C(Cpp.ptr);
+// CHECK:STDERR:           ^~~~~~~~~~
+// CHECK:STDERR: pointer.carbon:[[@LINE-4]]:9: note: initializing generic parameter `V` declared here [InitializingGenericParam]
+// CHECK:STDERR: class C(V:! i32*) {}
+// CHECK:STDERR:         ^
+// CHECK:STDERR:
+fn F() -> C(Cpp.ptr);
+let x: C(&Cpp.i) = F();
+
 // --- function.carbon
 
 library "[[@TEST_NAME]]";

--- a/toolchain/check/testdata/interop/cpp/constexpr.carbon
+++ b/toolchain/check/testdata/interop/cpp/constexpr.carbon
@@ -56,13 +56,6 @@ constexpr int* _Nonnull ptr = &i;
 ''';
 
 class C(V:! i32*) {}
-// CHECK:STDERR: pointer.carbon:[[@LINE+7]]:11: error: semantics TODO: `unsupported conversion to constant from APValue &i` [SemanticsTodo]
-// CHECK:STDERR: fn F() -> C(Cpp.ptr);
-// CHECK:STDERR:           ^~~~~~~~~~
-// CHECK:STDERR: pointer.carbon:[[@LINE-4]]:9: note: initializing generic parameter `V` declared here [InitializingGenericParam]
-// CHECK:STDERR: class C(V:! i32*) {}
-// CHECK:STDERR:         ^
-// CHECK:STDERR:
 fn F() -> C(Cpp.ptr);
 let x: C(&Cpp.i) = F();
 

--- a/toolchain/check/testdata/interop/cpp/constexpr.carbon
+++ b/toolchain/check/testdata/interop/cpp/constexpr.carbon
@@ -56,6 +56,13 @@ constexpr int* _Nonnull ptr = &i;
 ''';
 
 class C(V:! i32*) {}
+// CHECK:STDERR: pointer.carbon:[[@LINE+7]]:11: error: semantics TODO: `unsupported conversion to constant from APValue &i` [SemanticsTodo]
+// CHECK:STDERR: fn F() -> C(Cpp.ptr);
+// CHECK:STDERR:           ^~~~~~~~~~
+// CHECK:STDERR: pointer.carbon:[[@LINE-4]]:9: note: initializing generic parameter `V` declared here [InitializingGenericParam]
+// CHECK:STDERR: class C(V:! i32*) {}
+// CHECK:STDERR:         ^
+// CHECK:STDERR:
 fn F() -> C(Cpp.ptr);
 let x: C(&Cpp.i) = F();
 

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -2101,7 +2101,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
-// CHECK:STDOUT:     .m = @F.%.loc17_6.2
+// CHECK:STDOUT:     .m = constants.%.59e
 // CHECK:STDOUT:     import Cpp//...
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.patt: %pattern_type.9de = ref_binding_pattern a [concrete]
@@ -2118,7 +2118,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc17_6.1: ref %B = class_element_access imports.%a.var, element0 [concrete = constants.%.1b7]
 // CHECK:STDOUT:   %c.ref: %B.elem = name_ref c, @B.%.1 [concrete = @B.%.1]
 // CHECK:STDOUT:   %.loc17_6.2: ref %i32 = class_element_access %.loc17_6.1, element0 [concrete = constants.%.59e]
-// CHECK:STDOUT:   %m.ref: ref %i32 = name_ref m, %.loc17_6.2 [concrete = constants.%.59e]
+// CHECK:STDOUT:   %m.ref: ref %i32 = name_ref m, constants.%.59e [concrete = constants.%.59e]
 // CHECK:STDOUT:   %int_2: Core.IntLiteral = int_value 2 [concrete = constants.%int_2.ecc]
 // CHECK:STDOUT:   %impl.elem0: %.545 = impl_witness_access constants.%ImplicitAs.impl_witness.6bc, element0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.0b5]
 // CHECK:STDOUT:   %bound_method.loc17_9.1: <bound method> = bound_method %int_2, %impl.elem0 [concrete = constants.%Core.IntLiteral.as.ImplicitAs.impl.Convert.bound]

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -890,16 +890,9 @@ int v = 1;
 ''';
 
 fn F() {
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+11]]:5: error: semantics TODO: `unsupported conversion to constant from APValue &v` [SemanticsTodo]
+  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+4]]:4: error: cannot dereference operand of non-pointer type `Core.Optional(i32* as Core.OptionalStorage)` [DerefOfNonPointer]
   // CHECK:STDERR:   (*Cpp.m) = 2;
-  // CHECK:STDERR:     ^~~~~
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+8]]:5: note: in `Cpp` name lookup for `m` [InCppNameLookup]
-  // CHECK:STDERR:   (*Cpp.m) = 2;
-  // CHECK:STDERR:     ^~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+4]]:5: error: member name `m` not found in `Cpp` [MemberNameNotFoundInInstScope]
-  // CHECK:STDERR:   (*Cpp.m) = 2;
-  // CHECK:STDERR:     ^~~~~
+  // CHECK:STDERR:    ^
   // CHECK:STDERR:
   (*Cpp.m) = 2;
 }

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -881,7 +881,7 @@ fn F() {
   Cpp.q = &n;
 }
 
-// --- fail_todo_assign_through_pointer.carbon
+// --- assign_through_pointer.carbon
 library "[[@TEST_NAME]]";
 
 import Cpp inline '''
@@ -890,11 +890,7 @@ int v = 1;
 ''';
 
 fn F() {
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+4]]:4: error: cannot dereference operand of non-pointer type `Core.Optional(i32* as Core.OptionalStorage)` [DerefOfNonPointer]
-  // CHECK:STDERR:   (*Cpp.m) = 2;
-  // CHECK:STDERR:    ^
-  // CHECK:STDERR:
-  (*Cpp.m) = 2;
+  *Cpp.m.Get() = 2;
 }
 
 // --- assign_subobject.carbon

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -932,7 +932,7 @@ fn F() {
   // CHECK:STDERR:   Cpp.m = 2;
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_assign_array.carbon:[[@LINE+11]]:3: error: semantics TODO: `Unsupported field in macro expansion: &s.arr[1]` [SemanticsTodo]
+  // CHECK:STDERR: fail_todo_assign_array.carbon:[[@LINE+11]]:3: error: semantics TODO: `unsupported field in lvalue path: &s.arr[1]` [SemanticsTodo]
   // CHECK:STDERR:   Cpp.m = 2;
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_todo_assign_array.carbon:[[@LINE+8]]:3: note: in `Cpp` name lookup for `m` [InCppNameLookup]
@@ -959,7 +959,7 @@ struct B : A {} b;
 ''';
 
 fn F() {
-  // CHECK:STDERR: fail_todo_assign_base_class_member.carbon:[[@LINE+11]]:3: error: semantics TODO: `Macro expanded to a base class subobject` [SemanticsTodo]
+  // CHECK:STDERR: fail_todo_assign_base_class_member.carbon:[[@LINE+11]]:3: error: semantics TODO: `lvalue path contains a base class subobject` [SemanticsTodo]
   // CHECK:STDERR:   Cpp.m = 2;
   // CHECK:STDERR:   ^~~~~
   // CHECK:STDERR: fail_todo_assign_base_class_member.carbon:[[@LINE+8]]:3: note: in `Cpp` name lookup for `m` [InCppNameLookup]

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -877,16 +877,9 @@ int v = 1;
 ''';
 
 fn F() {
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+11]]:5: error: semantics TODO: `unsupported conversion to constant from APValue &v` [SemanticsTodo]
+  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+4]]:4: error: cannot dereference operand of non-pointer type `Core.Optional(i32* as Core.OptionalStorage)` [DerefOfNonPointer]
   // CHECK:STDERR:   (*Cpp.m) = 2;
-  // CHECK:STDERR:     ^~~~~
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+8]]:5: note: in `Cpp` name lookup for `m` [InCppNameLookup]
-  // CHECK:STDERR:   (*Cpp.m) = 2;
-  // CHECK:STDERR:     ^~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+4]]:5: error: member name `m` not found in `Cpp` [MemberNameNotFoundInInstScope]
-  // CHECK:STDERR:   (*Cpp.m) = 2;
-  // CHECK:STDERR:     ^~~~~
+  // CHECK:STDERR:    ^
   // CHECK:STDERR:
   (*Cpp.m) = 2;
 }
@@ -2073,12 +2066,12 @@ fn F() {
 // CHECK:STDOUT: --- assign_subobject.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
 // CHECK:STDOUT:   %A: type = class_type @A [concrete]
 // CHECK:STDOUT:   %pattern_type.9de: type = pattern_type %A [concrete]
 // CHECK:STDOUT:   %B: type = class_type @B [concrete]
 // CHECK:STDOUT:   %A.elem: type = unbound_element_type %A, %B [concrete]
-// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
-// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
 // CHECK:STDOUT:   %B.elem: type = unbound_element_type %B, %i32 [concrete]
 // CHECK:STDOUT:   %.1b7: ref %B = class_element_access imports.%a.var, element0 [concrete]
 // CHECK:STDOUT:   %.59e: ref %i32 = class_element_access %.1b7, element0 [concrete]
@@ -2114,6 +2107,7 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %b.ref: %A.elem = name_ref b, @A.%.1 [concrete = @A.%.1]
 // CHECK:STDOUT:   %.loc17_6.1: ref %B = class_element_access imports.%a.var, element0 [concrete = constants.%.1b7]
 // CHECK:STDOUT:   %c.ref: %B.elem = name_ref c, @B.%.1 [concrete = @B.%.1]

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -868,6 +868,23 @@ fn F() {
   //@dump-sem-ir-end
 }
 
+// --- assign_pointer.carbon
+library "[[@TEST_NAME]]";
+
+import Cpp inline '''
+int *p;
+#define q p
+''';
+
+var n: i32;
+fn F() {
+  // CHECK:STDERR: assign_pointer.carbon:[[@LINE+4]]:3: error: expression is not assignable [AssignmentToNonAssignable]
+  // CHECK:STDERR:   Cpp.q = &n;
+  // CHECK:STDERR:   ^~~~~
+  // CHECK:STDERR:
+  Cpp.q = &n;
+}
+
 // --- fail_todo_assign_through_pointer.carbon
 library "[[@TEST_NAME]]";
 

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -878,10 +878,6 @@ int *p;
 
 var n: i32;
 fn F() {
-  // CHECK:STDERR: assign_pointer.carbon:[[@LINE+4]]:3: error: expression is not assignable [AssignmentToNonAssignable]
-  // CHECK:STDERR:   Cpp.q = &n;
-  // CHECK:STDERR:   ^~~~~
-  // CHECK:STDERR:
   Cpp.q = &n;
 }
 

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -894,9 +894,16 @@ int v = 1;
 ''';
 
 fn F() {
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+4]]:4: error: cannot dereference operand of non-pointer type `Core.Optional(i32* as Core.OptionalStorage)` [DerefOfNonPointer]
+  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+11]]:5: error: semantics TODO: `unsupported conversion to constant from APValue &v` [SemanticsTodo]
   // CHECK:STDERR:   (*Cpp.m) = 2;
-  // CHECK:STDERR:    ^
+  // CHECK:STDERR:     ^~~~~
+  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+8]]:5: note: in `Cpp` name lookup for `m` [InCppNameLookup]
+  // CHECK:STDERR:   (*Cpp.m) = 2;
+  // CHECK:STDERR:     ^~~~~
+  // CHECK:STDERR:
+  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+4]]:5: error: member name `m` not found in `Cpp` [MemberNameNotFoundInInstScope]
+  // CHECK:STDERR:   (*Cpp.m) = 2;
+  // CHECK:STDERR:     ^~~~~
   // CHECK:STDERR:
   (*Cpp.m) = 2;
 }

--- a/toolchain/check/testdata/interop/cpp/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros.carbon
@@ -877,7 +877,7 @@ int v = 1;
 ''';
 
 fn F() {
-  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+11]]:5: error: semantics TODO: `Unsupported: macro evaluated to a constant of type: int *` [SemanticsTodo]
+  // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+11]]:5: error: semantics TODO: `unsupported conversion to constant from APValue &v` [SemanticsTodo]
   // CHECK:STDERR:   (*Cpp.m) = 2;
   // CHECK:STDERR:     ^~~~~
   // CHECK:STDERR: fail_todo_assign_through_pointer.carbon:[[@LINE+8]]:5: note: in `Cpp` name lookup for `m` [InCppNameLookup]

--- a/toolchain/check/testdata/interop/cpp/var/global.carbon
+++ b/toolchain/check/testdata/interop/cpp/var/global.carbon
@@ -32,6 +32,10 @@ import Cpp library "global_scope.h";
 fn MyF() {
   let unused local: Cpp.C = Cpp.global;
   let unused local_ptr: Cpp.C* = Cpp.global_ptr;
+  // CHECK:STDERR: import_global_scope.carbon:[[@LINE+4]]:34: error: semantics TODO: `unsupported conversion to constant from APValue &global` [SemanticsTodo]
+  // CHECK:STDERR:   let unused local_ref: Cpp.C* = Cpp.global_ref;
+  // CHECK:STDERR:                                  ^~~~~~~~~~~~~~
+  // CHECK:STDERR:
   let unused local_ref: Cpp.C* = Cpp.global_ref;
 }
 
@@ -83,7 +87,6 @@ fn MyF() {
 // CHECK:STDOUT:   %const: type = const_type %ptr.d9e [concrete]
 // CHECK:STDOUT:   %pattern_type.8ca: type = pattern_type %const [concrete]
 // CHECK:STDOUT:   %global_ref.var: ref %ptr.d9e = var imports.%global_ref.var_patt [concrete]
-// CHECK:STDOUT:   %addr: %ptr.d9e = addr_of imports.%global.var [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -160,18 +163,17 @@ fn MyF() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %local_ref.patt: %pattern_type.a31 = value_binding_pattern local_ref [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %Cpp.ref.loc9_34: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %Cpp.ref.loc13_34: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %global_ref.ref: ref %const = name_ref global_ref, imports.%global_ref.var [concrete = imports.%global_ref.var]
-// CHECK:STDOUT:   %.loc9_30: type = splice_block %ptr.loc9 [concrete = constants.%ptr.d9e] {
-// CHECK:STDOUT:     %Cpp.ref.loc9_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, imports.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:     %ptr.loc9: type = ptr_type %C.ref.loc9 [concrete = constants.%ptr.d9e]
+// CHECK:STDOUT:   %.loc13_30: type = splice_block %ptr.loc13 [concrete = constants.%ptr.d9e] {
+// CHECK:STDOUT:     %Cpp.ref.loc13_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, imports.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %ptr.loc13: type = ptr_type %C.ref.loc13 [concrete = constants.%ptr.d9e]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc9_37.1: ref %ptr.d9e = as_compatible %global_ref.ref [concrete = constants.%global_ref.var]
-// CHECK:STDOUT:   %.loc9_37.2: ref %ptr.d9e = converted %global_ref.ref, %.loc9_37.1 [concrete = constants.%global_ref.var]
-// CHECK:STDOUT:   %addr: %ptr.d9e = addr_of imports.%global.var [concrete = constants.%addr]
-// CHECK:STDOUT:   %.loc9_37.3: %ptr.d9e = acquire_value %.loc9_37.2 [concrete = constants.%addr]
-// CHECK:STDOUT:   %local_ref: %ptr.d9e = value_binding local_ref, %.loc9_37.3
+// CHECK:STDOUT:   %.loc13_37.1: ref %ptr.d9e = as_compatible %global_ref.ref [concrete = constants.%global_ref.var]
+// CHECK:STDOUT:   %.loc13_37.2: ref %ptr.d9e = converted %global_ref.ref, %.loc13_37.1 [concrete = constants.%global_ref.var]
+// CHECK:STDOUT:   %.loc13_37.3: %ptr.d9e = acquire_value %.loc13_37.2 [concrete = <error>]
+// CHECK:STDOUT:   %local_ref: %ptr.d9e = value_binding local_ref, %.loc13_37.3 [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/var/global.carbon
+++ b/toolchain/check/testdata/interop/cpp/var/global.carbon
@@ -32,6 +32,10 @@ import Cpp library "global_scope.h";
 fn MyF() {
   let unused local: Cpp.C = Cpp.global;
   let unused local_ptr: Cpp.C* = Cpp.global_ptr;
+  // CHECK:STDERR: import_global_scope.carbon:[[@LINE+4]]:34: error: semantics TODO: `unsupported conversion to constant from APValue &global` [SemanticsTodo]
+  // CHECK:STDERR:   let unused local_ref: Cpp.C* = Cpp.global_ref;
+  // CHECK:STDERR:                                  ^~~~~~~~~~~~~~
+  // CHECK:STDERR:
   let unused local_ref: Cpp.C* = Cpp.global_ref;
 }
 
@@ -159,17 +163,17 @@ fn MyF() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %local_ref.patt: %pattern_type.a31 = value_binding_pattern local_ref [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %Cpp.ref.loc9_34: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %Cpp.ref.loc13_34: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %global_ref.ref: ref %const = name_ref global_ref, imports.%global_ref.var [concrete = imports.%global_ref.var]
-// CHECK:STDOUT:   %.loc9_30: type = splice_block %ptr.loc9 [concrete = constants.%ptr.d9e] {
-// CHECK:STDOUT:     %Cpp.ref.loc9_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, imports.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:     %ptr.loc9: type = ptr_type %C.ref.loc9 [concrete = constants.%ptr.d9e]
+// CHECK:STDOUT:   %.loc13_30: type = splice_block %ptr.loc13 [concrete = constants.%ptr.d9e] {
+// CHECK:STDOUT:     %Cpp.ref.loc13_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, imports.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %ptr.loc13: type = ptr_type %C.ref.loc13 [concrete = constants.%ptr.d9e]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc9_37.1: ref %ptr.d9e = as_compatible %global_ref.ref [concrete = constants.%global_ref.var]
-// CHECK:STDOUT:   %.loc9_37.2: ref %ptr.d9e = converted %global_ref.ref, %.loc9_37.1 [concrete = constants.%global_ref.var]
-// CHECK:STDOUT:   %.loc9_37.3: %ptr.d9e = acquire_value %.loc9_37.2
-// CHECK:STDOUT:   %local_ref: %ptr.d9e = value_binding local_ref, %.loc9_37.3
+// CHECK:STDOUT:   %.loc13_37.1: ref %ptr.d9e = as_compatible %global_ref.ref [concrete = constants.%global_ref.var]
+// CHECK:STDOUT:   %.loc13_37.2: ref %ptr.d9e = converted %global_ref.ref, %.loc13_37.1 [concrete = constants.%global_ref.var]
+// CHECK:STDOUT:   %.loc13_37.3: %ptr.d9e = acquire_value %.loc13_37.2 [concrete = <error>]
+// CHECK:STDOUT:   %local_ref: %ptr.d9e = value_binding local_ref, %.loc13_37.3 [concrete = <error>]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/var/global.carbon
+++ b/toolchain/check/testdata/interop/cpp/var/global.carbon
@@ -32,10 +32,6 @@ import Cpp library "global_scope.h";
 fn MyF() {
   let unused local: Cpp.C = Cpp.global;
   let unused local_ptr: Cpp.C* = Cpp.global_ptr;
-  // CHECK:STDERR: import_global_scope.carbon:[[@LINE+4]]:34: error: semantics TODO: `unsupported conversion to constant from APValue &global` [SemanticsTodo]
-  // CHECK:STDERR:   let unused local_ref: Cpp.C* = Cpp.global_ref;
-  // CHECK:STDERR:                                  ^~~~~~~~~~~~~~
-  // CHECK:STDERR:
   let unused local_ref: Cpp.C* = Cpp.global_ref;
 }
 
@@ -87,6 +83,7 @@ fn MyF() {
 // CHECK:STDOUT:   %const: type = const_type %ptr.d9e [concrete]
 // CHECK:STDOUT:   %pattern_type.8ca: type = pattern_type %const [concrete]
 // CHECK:STDOUT:   %global_ref.var: ref %ptr.d9e = var imports.%global_ref.var_patt [concrete]
+// CHECK:STDOUT:   %addr: %ptr.d9e = addr_of imports.%global.var [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -163,17 +160,18 @@ fn MyF() {
 // CHECK:STDOUT:   name_binding_decl {
 // CHECK:STDOUT:     %local_ref.patt: %pattern_type.a31 = value_binding_pattern local_ref [concrete]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %Cpp.ref.loc13_34: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %Cpp.ref.loc9_34: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %global_ref.ref: ref %const = name_ref global_ref, imports.%global_ref.var [concrete = imports.%global_ref.var]
-// CHECK:STDOUT:   %.loc13_30: type = splice_block %ptr.loc13 [concrete = constants.%ptr.d9e] {
-// CHECK:STDOUT:     %Cpp.ref.loc13_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:     %C.ref.loc13: type = name_ref C, imports.%C.decl [concrete = constants.%C]
-// CHECK:STDOUT:     %ptr.loc13: type = ptr_type %C.ref.loc13 [concrete = constants.%ptr.d9e]
+// CHECK:STDOUT:   %.loc9_30: type = splice_block %ptr.loc9 [concrete = constants.%ptr.d9e] {
+// CHECK:STDOUT:     %Cpp.ref.loc9_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %C.ref.loc9: type = name_ref C, imports.%C.decl [concrete = constants.%C]
+// CHECK:STDOUT:     %ptr.loc9: type = ptr_type %C.ref.loc9 [concrete = constants.%ptr.d9e]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc13_37.1: ref %ptr.d9e = as_compatible %global_ref.ref [concrete = constants.%global_ref.var]
-// CHECK:STDOUT:   %.loc13_37.2: ref %ptr.d9e = converted %global_ref.ref, %.loc13_37.1 [concrete = constants.%global_ref.var]
-// CHECK:STDOUT:   %.loc13_37.3: %ptr.d9e = acquire_value %.loc13_37.2 [concrete = <error>]
-// CHECK:STDOUT:   %local_ref: %ptr.d9e = value_binding local_ref, %.loc13_37.3 [concrete = <error>]
+// CHECK:STDOUT:   %.loc9_37.1: ref %ptr.d9e = as_compatible %global_ref.ref [concrete = constants.%global_ref.var]
+// CHECK:STDOUT:   %.loc9_37.2: ref %ptr.d9e = converted %global_ref.ref, %.loc9_37.1 [concrete = constants.%global_ref.var]
+// CHECK:STDOUT:   %addr: %ptr.d9e = addr_of imports.%global.var [concrete = constants.%addr]
+// CHECK:STDOUT:   %.loc9_37.3: %ptr.d9e = acquire_value %.loc9_37.2 [concrete = constants.%addr]
+// CHECK:STDOUT:   %local_ref: %ptr.d9e = value_binding local_ref, %.loc9_37.3
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
This moves the LValue path code from macros.cpp to constant.cpp, so that it can be called from `MapAPValueToConstant`. TODO messages are updated accordingly to avoid referring to macros. Added a constexpr pointer test to `constexpr.carbon` to show the result of this change.