### PR TITLE
Test that a named constraint can't be used inside its definition through an alias to its name

### DIFF
--- a/toolchain/check/testdata/named_constraint/require.carbon
+++ b/toolchain/check/testdata/named_constraint/require.carbon
@@ -183,6 +183,20 @@ constraint Z {
   require impls Z;
 }
 
+// --- fail_require_impls_incomplete_self_through_alias.carbon
+library "[[@TEST_NAME]]";
+
+constraint Z;
+
+alias Y = Z;
+constraint Z {
+  // CHECK:STDERR: fail_require_impls_incomplete_self_through_alias.carbon:[[@LINE+4]]:17: error: facet type in `require` declaration refers to the named constraint `Z` from within its definition [RequireImplsReferenceCycle]
+  // CHECK:STDERR:   require impls Y;
+  // CHECK:STDERR:                 ^
+  // CHECK:STDERR:
+  require impls Y;
+}
+
 // --- fail_require_impls_incomplete_self_forward_declared.carbon
 library "[[@TEST_NAME]]";
 


### PR DESCRIPTION
We only want to allow using the named constraint through `Self`, as proposed in #6902.