### PR TITLE
Avoid crashing if a C++ type was used to look for an IntFitsIn witness

### DIFF
--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -99,12 +99,32 @@ auto GetDeclForCoreInterface(Context& context, SemIR::LocId loc_id,
   }
 }
 
+static auto CoreInterfaceIsCarbonOnly(CoreInterface core_interface) -> bool {
+  switch (core_interface) {
+    case CoreInterface::Copy:
+    case CoreInterface::Destroy:
+    case CoreInterface::CppUnsafeDeref:
+      return false;
+
+    // IntFitsIn is for carbon integer types only.
+    case CoreInterface::IntFitsIn:
+      return true;
+
+    case CoreInterface::Unknown:
+      CARBON_FATAL("unexpected CoreInterface `{0}`", core_interface);
+  }
+}
+
 auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
                    CoreInterface core_interface,
                    SemIR::ConstantId query_self_const_id,
                    SemIR::SpecificInterfaceId query_specific_interface_id,
                    const TypeStructure* best_impl_type_structure,
                    SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
+  if (CoreInterfaceIsCarbonOnly(core_interface)) {
+    return SemIR::InstId::None;
+  }
+
   // TODO: This should provide `Destroy` for enums and other trivially
   // destructible types.
   auto* class_decl = TypeAsClassDecl(context, query_self_const_id);

--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -49,10 +49,15 @@ static auto TypeAsClassDecl(Context& context,
       context.clang_decls().Get(decl_id).key.decl);
 }
 
+namespace {
 struct DeclInfo {
-  clang::NamedDecl* decl;
+  // If null, no C++ decl was found and no witness can be created.
+  clang::NamedDecl* decl = nullptr;
   SemIR::ClangDeclKey::Signature signature;
+  // If true, an error was diagnosed and the witness will be an ErrorInst.
+  bool error = false;
 };
+}  // namespace
 
 // Given a DeclInfo of the C++ function to call that will act as an impl for a
 // specific interface, construct a custom witness for that function.
@@ -62,6 +67,11 @@ static auto BuildWitnessForDeclInfo(
     SemIR::SpecificInterfaceId query_specific_interface_id,
     const TypeStructure* best_impl_type_structure,
     SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
+  if (decl_info.error) {
+    // An error was diagnosed.
+    return SemIR::ErrorInst::InstId;
+  }
+
   if (!decl_info.decl) {
     // The C++ type is not able to implement the interface.
     return SemIR::InstId::None;
@@ -92,54 +102,85 @@ static auto BuildWitnessForDeclInfo(
                             query_specific_interface_id, {fn_id});
 }
 
+auto LookupCopyConstructor(Context& context,
+                           SemIR::ConstantId query_self_const_id) -> DeclInfo {
+  auto& clang_sema = context.clang_sema();
+
+  // TODO: This should provide `Copy` for enums and other trivially copyable
+  // types.
+  auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
+  if (!class_decl) {
+    return {};
+  }
+  return {.decl = clang_sema.LookupCopyingConstructor(class_decl,
+                                                      clang::Qualifiers::Const),
+          .signature = {.num_params = 1}};
+}
+
+auto LookupDestructor(Context& context, SemIR::ConstantId query_self_const_id)
+    -> DeclInfo {
+  auto& clang_sema = context.clang_sema();
+
+  // TODO: This should provide `Destroy` for enums and other trivially
+  // destructible types.
+  auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
+  if (!class_decl) {
+    return {};
+  }
+  return {.decl = clang_sema.LookupDestructor(class_decl),
+          .signature = {.num_params = 0}};
+}
+
+auto LookupUnsafeDeref(Context& context, SemIR::LocId loc_id,
+                       SemIR::ConstantId query_self_const_id) -> DeclInfo {
+  auto& clang_sema = context.clang_sema();
+
+  auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
+  if (!class_decl) {
+    return {};
+  }
+  auto candidates = class_decl->lookup(
+      clang_sema.getASTContext().DeclarationNames.getCXXOperatorName(
+          clang::OO_Star));
+  if (candidates.empty()) {
+    return {};
+  }
+  if (!candidates.isSingleResult()) {
+    context.TODO(loc_id, "operator* overload sets not implemented yet");
+    return {.error = true};
+  }
+  return {.decl = *candidates.begin(), .signature = {.num_params = 0}};
+}
+
 auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
                    CoreInterface core_interface,
                    SemIR::ConstantId query_self_const_id,
                    SemIR::SpecificInterfaceId query_specific_interface_id,
                    const TypeStructure* best_impl_type_structure,
                    SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
-  auto& clang_sema = context.clang_sema();
-
-  auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
-
-  DeclInfo decl_info;
   switch (core_interface) {
     case CoreInterface::Copy: {
-      // TODO: This should provide `Copy` for enums and other trivially copyable
-      // types.
-      if (!class_decl) {
-        return SemIR::InstId::None;
-      }
-      decl_info = {.decl = clang_sema.LookupCopyingConstructor(
-                       class_decl, clang::Qualifiers::Const),
-                   .signature = {.num_params = 1}};
+      auto decl_info = LookupCopyConstructor(context, query_self_const_id);
+      return BuildWitnessForDeclInfo(
+          context, loc_id, decl_info, query_self_const_id,
+          query_specific_interface_id, best_impl_type_structure,
+          best_impl_loc_id);
       break;
     }
-
     case CoreInterface::Destroy: {
-      // TODO: This should provide `Destroy` for enums and other trivially
-      // destructible types.
-      if (!class_decl) {
-        return SemIR::InstId::None;
-      }
-      decl_info = {.decl = clang_sema.LookupDestructor(class_decl),
-                   .signature = {.num_params = 0}};
+      auto decl_info = LookupDestructor(context, query_self_const_id);
+      return BuildWitnessForDeclInfo(
+          context, loc_id, decl_info, query_self_const_id,
+          query_specific_interface_id, best_impl_type_structure,
+          best_impl_loc_id);
       break;
     }
-
     case CoreInterface::CppUnsafeDeref: {
-      auto candidates = class_decl->lookup(
-          clang_sema.getASTContext().DeclarationNames.getCXXOperatorName(
-              clang::OO_Star));
-      clang::NamedDecl* decl = nullptr;
-      if (!candidates.empty()) {
-        if (!candidates.isSingleResult()) {
-          context.TODO(loc_id, "operator* overload sets not implemented yet");
-          return SemIR::ErrorInst::InstId;
-        }
-        decl = *candidates.begin();
-      }
-      decl_info = {.decl = decl, .signature = {.num_params = 0}};
+      auto decl_info = LookupUnsafeDeref(context, loc_id, query_self_const_id);
+      return BuildWitnessForDeclInfo(
+          context, loc_id, decl_info, query_self_const_id,
+          query_specific_interface_id, best_impl_type_structure,
+          best_impl_loc_id);
       break;
     }
 
@@ -150,10 +191,6 @@ auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
     case CoreInterface::Unknown:
       CARBON_FATAL("unexpected CoreInterface `{0}`", core_interface);
   }
-
-  return BuildWitnessForDeclInfo(
-      context, loc_id, decl_info, query_self_const_id,
-      query_specific_interface_id, best_impl_type_structure, best_impl_loc_id);
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -54,8 +54,6 @@ struct DeclInfo {
   // If null, no C++ decl was found and no witness can be created.
   clang::NamedDecl* decl = nullptr;
   SemIR::ClangDeclKey::Signature signature;
-  // If true, an error was diagnosed and the witness will be an ErrorInst.
-  bool error = false;
 };
 }  // namespace
 
@@ -67,11 +65,6 @@ static auto BuildWitnessForDeclInfo(
     SemIR::SpecificInterfaceId query_specific_interface_id,
     const TypeStructure* best_impl_type_structure,
     SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
-  if (decl_info.error) {
-    // An error was diagnosed.
-    return SemIR::ErrorInst::InstId;
-  }
-
   if (!decl_info.decl) {
     // The C++ type is not able to implement the interface.
     return SemIR::InstId::None;
@@ -102,54 +95,76 @@ static auto BuildWitnessForDeclInfo(
                             query_specific_interface_id, {fn_id});
 }
 
-auto LookupCopyConstructor(Context& context,
-                           SemIR::ConstantId query_self_const_id) -> DeclInfo {
+static auto BuildCopyWitness(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::ConstantId query_self_const_id,
+    SemIR::SpecificInterfaceId query_specific_interface_id,
+    const TypeStructure* best_impl_type_structure,
+    SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
   auto& clang_sema = context.clang_sema();
 
   // TODO: This should provide `Copy` for enums and other trivially copyable
   // types.
   auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
   if (!class_decl) {
-    return {};
+    return SemIR::InstId::None;
   }
-  return {.decl = clang_sema.LookupCopyingConstructor(class_decl,
-                                                      clang::Qualifiers::Const),
-          .signature = {.num_params = 1}};
+  auto decl_info = DeclInfo{.decl = clang_sema.LookupCopyingConstructor(
+                                class_decl, clang::Qualifiers::Const),
+                            .signature = {.num_params = 1}};
+  return BuildWitnessForDeclInfo(
+      context, loc_id, decl_info, query_self_const_id,
+      query_specific_interface_id, best_impl_type_structure, best_impl_loc_id);
 }
 
-auto LookupDestructor(Context& context, SemIR::ConstantId query_self_const_id)
-    -> DeclInfo {
+static auto BuildDestroyWitness(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::ConstantId query_self_const_id,
+    SemIR::SpecificInterfaceId query_specific_interface_id,
+    const TypeStructure* best_impl_type_structure,
+    SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
   auto& clang_sema = context.clang_sema();
 
   // TODO: This should provide `Destroy` for enums and other trivially
   // destructible types.
   auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
   if (!class_decl) {
-    return {};
+    return SemIR::InstId::None;
   }
-  return {.decl = clang_sema.LookupDestructor(class_decl),
-          .signature = {.num_params = 0}};
+  auto decl_info = DeclInfo{.decl = clang_sema.LookupDestructor(class_decl),
+                            .signature = {.num_params = 0}};
+  return BuildWitnessForDeclInfo(
+      context, loc_id, decl_info, query_self_const_id,
+      query_specific_interface_id, best_impl_type_structure, best_impl_loc_id);
 }
 
-auto LookupUnsafeDeref(Context& context, SemIR::LocId loc_id,
-                       SemIR::ConstantId query_self_const_id) -> DeclInfo {
+static auto BuildCppUnsafeDerefWitness(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::ConstantId query_self_const_id,
+    SemIR::SpecificInterfaceId query_specific_interface_id,
+    const TypeStructure* best_impl_type_structure,
+    SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
   auto& clang_sema = context.clang_sema();
 
   auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
   if (!class_decl) {
-    return {};
+    return SemIR::InstId::None;
   }
   auto candidates = class_decl->lookup(
       clang_sema.getASTContext().DeclarationNames.getCXXOperatorName(
           clang::OO_Star));
   if (candidates.empty()) {
-    return {};
+    return SemIR::InstId::None;
   }
   if (!candidates.isSingleResult()) {
     context.TODO(loc_id, "operator* overload sets not implemented yet");
-    return {.error = true};
+    return SemIR::ErrorInst::InstId;
   }
-  return {.decl = *candidates.begin(), .signature = {.num_params = 0}};
+  auto decl_info =
+      DeclInfo{.decl = *candidates.begin(), .signature = {.num_params = 0}};
+  return BuildWitnessForDeclInfo(
+      context, loc_id, decl_info, query_self_const_id,
+      query_specific_interface_id, best_impl_type_structure, best_impl_loc_id);
 }
 
 auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
@@ -159,30 +174,18 @@ auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
                    const TypeStructure* best_impl_type_structure,
                    SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
   switch (core_interface) {
-    case CoreInterface::Copy: {
-      auto decl_info = LookupCopyConstructor(context, query_self_const_id);
-      return BuildWitnessForDeclInfo(
-          context, loc_id, decl_info, query_self_const_id,
-          query_specific_interface_id, best_impl_type_structure,
-          best_impl_loc_id);
-      break;
-    }
-    case CoreInterface::Destroy: {
-      auto decl_info = LookupDestructor(context, query_self_const_id);
-      return BuildWitnessForDeclInfo(
-          context, loc_id, decl_info, query_self_const_id,
-          query_specific_interface_id, best_impl_type_structure,
-          best_impl_loc_id);
-      break;
-    }
-    case CoreInterface::CppUnsafeDeref: {
-      auto decl_info = LookupUnsafeDeref(context, loc_id, query_self_const_id);
-      return BuildWitnessForDeclInfo(
-          context, loc_id, decl_info, query_self_const_id,
-          query_specific_interface_id, best_impl_type_structure,
-          best_impl_loc_id);
-      break;
-    }
+    case CoreInterface::Copy:
+      return BuildCopyWitness(context, loc_id, query_self_const_id,
+                              query_specific_interface_id,
+                              best_impl_type_structure, best_impl_loc_id);
+    case CoreInterface::Destroy:
+      return BuildDestroyWitness(context, loc_id, query_self_const_id,
+                                 query_specific_interface_id,
+                                 best_impl_type_structure, best_impl_loc_id);
+    case CoreInterface::CppUnsafeDeref:
+      return BuildCppUnsafeDerefWitness(
+          context, loc_id, query_self_const_id, query_specific_interface_id,
+          best_impl_type_structure, best_impl_loc_id);
 
     // IntFitsIn is for Carbon integer types only.
     case CoreInterface::IntFitsIn:

--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -122,8 +122,8 @@ auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
       if (!class_decl) {
         return SemIR::InstId::None;
       }
-      decl_info = DeclInfo{.decl = clang_sema.LookupDestructor(class_decl),
-                           .signature = {.num_params = 0}};
+      decl_info = {.decl = clang_sema.LookupDestructor(class_decl),
+                   .signature = {.num_params = 0}};
       break;
     }
 

--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -106,7 +106,7 @@ static auto CoreInterfaceIsCarbonOnly(CoreInterface core_interface) -> bool {
     case CoreInterface::CppUnsafeDeref:
       return false;
 
-    // IntFitsIn is for carbon integer types only.
+    // IntFitsIn is for Carbon integer types only.
     case CoreInterface::IntFitsIn:
       return true;
 

--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -49,101 +49,25 @@ static auto TypeAsClassDecl(Context& context,
       context.clang_decls().Get(decl_id).key.decl);
 }
 
-namespace {
-// See `GetDeclForCoreInterface`.
 struct DeclInfo {
   clang::NamedDecl* decl;
   SemIR::ClangDeclKey::Signature signature;
 };
-}  // namespace
 
-// Retrieves a `core_interface`'s corresponding `NamedDecl`, also with the
-// expected number of parameters. May return a null decl to indicate nothing was
-// found, or nullopt to indicate `SemIR::ErrInst::InstId` should be propagated.
-auto GetDeclForCoreInterface(Context& context, SemIR::LocId loc_id,
-                             CoreInterface core_interface,
-                             clang::CXXRecordDecl* class_decl)
-    -> std::optional<DeclInfo> {
-  auto& clang_sema = context.clang_sema();
-  CARBON_CHECK(class_decl != nullptr);
-
-  // TODO: Handle other interfaces.
-
-  switch (core_interface) {
-    case CoreInterface::Copy:
-      return DeclInfo{.decl = clang_sema.LookupCopyingConstructor(
-                          class_decl, clang::Qualifiers::Const),
-                      .signature = {.num_params = 1}};
-    case CoreInterface::Destroy:
-      return DeclInfo{.decl = clang_sema.LookupDestructor(class_decl),
-                      .signature = {.num_params = 0}};
-    case CoreInterface::CppUnsafeDeref: {
-      auto candidates = class_decl->lookup(
-          clang_sema.getASTContext().DeclarationNames.getCXXOperatorName(
-              clang::OO_Star));
-      if (candidates.empty()) {
-        return DeclInfo{};
-      }
-
-      if (!candidates.isSingleResult()) {
-        context.TODO(loc_id, "operator* overload sets not implemented yet");
-        return std::nullopt;
-      }
-
-      return DeclInfo{.decl = *candidates.begin(),
-                      .signature = {.num_params = 0}};
-    }
-    case CoreInterface::IntFitsIn:
-    case CoreInterface::Unknown:
-      CARBON_FATAL("shouldn't be called with `{}`", core_interface);
-  }
-}
-
-static auto CoreInterfaceIsCarbonOnly(CoreInterface core_interface) -> bool {
-  switch (core_interface) {
-    case CoreInterface::Copy:
-    case CoreInterface::Destroy:
-    case CoreInterface::CppUnsafeDeref:
-      return false;
-
-    // IntFitsIn is for Carbon integer types only.
-    case CoreInterface::IntFitsIn:
-      return true;
-
-    case CoreInterface::Unknown:
-      CARBON_FATAL("unexpected CoreInterface `{0}`", core_interface);
-  }
-}
-
-auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
-                   CoreInterface core_interface,
-                   SemIR::ConstantId query_self_const_id,
-                   SemIR::SpecificInterfaceId query_specific_interface_id,
-                   const TypeStructure* best_impl_type_structure,
-                   SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
-  if (CoreInterfaceIsCarbonOnly(core_interface)) {
+// Given a DeclInfo of the C++ function to call that will act as an impl for a
+// specific interface, construct a custom witness for that function.
+static auto BuildWitnessForDeclInfo(
+    Context& context, SemIR::LocId loc_id, DeclInfo decl_info,
+    SemIR::ConstantId query_self_const_id,
+    SemIR::SpecificInterfaceId query_specific_interface_id,
+    const TypeStructure* best_impl_type_structure,
+    SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
+  if (!decl_info.decl) {
+    // The C++ type is not able to implement the interface.
     return SemIR::InstId::None;
   }
 
-  // TODO: This should provide `Destroy` for enums and other trivially
-  // destructible types.
-  auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
-  if (!class_decl) {
-    return SemIR::InstId::None;
-  }
-
-  auto decl_info =
-      GetDeclForCoreInterface(context, loc_id, core_interface, class_decl);
-  if (!decl_info.has_value()) {
-    return SemIR::ErrorInst::InstId;
-  }
-
-  if (!decl_info->decl) {
-    // TODO: If the impl lookup failure is an error, we should produce a
-    // diagnostic explaining why the class does not satisfy the core interface.
-    return SemIR::InstId::None;
-  }
-  auto* cpp_fn = cast<clang::FunctionDecl>(decl_info->decl);
+  auto* cpp_fn = cast<clang::FunctionDecl>(decl_info.decl);
 
   if (context.clang_sema().DiagnoseUseOfOverloadedDecl(
           cpp_fn, GetCppLocation(context, loc_id))) {
@@ -151,7 +75,7 @@ auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
   }
 
   auto fn_id =
-      ImportCppFunctionDecl(context, loc_id, cpp_fn, decl_info->signature);
+      ImportCppFunctionDecl(context, loc_id, cpp_fn, decl_info.signature);
   if (fn_id == SemIR::ErrorInst::InstId) {
     return SemIR::ErrorInst::InstId;
   }
@@ -166,6 +90,70 @@ auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
 
   return BuildCustomWitness(context, loc_id, query_self_const_id,
                             query_specific_interface_id, {fn_id});
+}
+
+auto LookupCppImpl(Context& context, SemIR::LocId loc_id,
+                   CoreInterface core_interface,
+                   SemIR::ConstantId query_self_const_id,
+                   SemIR::SpecificInterfaceId query_specific_interface_id,
+                   const TypeStructure* best_impl_type_structure,
+                   SemIR::LocId best_impl_loc_id) -> SemIR::InstId {
+  auto& clang_sema = context.clang_sema();
+
+  auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
+
+  DeclInfo decl_info;
+  switch (core_interface) {
+    case CoreInterface::Copy: {
+      // TODO: This should provide `Copy` for enums and other trivially copyable
+      // types.
+      if (!class_decl) {
+        return SemIR::InstId::None;
+      }
+      decl_info = {.decl = clang_sema.LookupCopyingConstructor(
+                       class_decl, clang::Qualifiers::Const),
+                   .signature = {.num_params = 1}};
+      break;
+    }
+
+    case CoreInterface::Destroy: {
+      // TODO: This should provide `Destroy` for enums and other trivially
+      // destructible types.
+      if (!class_decl) {
+        return SemIR::InstId::None;
+      }
+      decl_info = DeclInfo{.decl = clang_sema.LookupDestructor(class_decl),
+                           .signature = {.num_params = 0}};
+      break;
+    }
+
+    case CoreInterface::CppUnsafeDeref: {
+      auto candidates = class_decl->lookup(
+          clang_sema.getASTContext().DeclarationNames.getCXXOperatorName(
+              clang::OO_Star));
+      clang::NamedDecl* decl = nullptr;
+      if (!candidates.empty()) {
+        if (!candidates.isSingleResult()) {
+          context.TODO(loc_id, "operator* overload sets not implemented yet");
+          return SemIR::ErrorInst::InstId;
+        }
+        decl = *candidates.begin();
+      }
+      decl_info = {.decl = decl, .signature = {.num_params = 0}};
+      break;
+    }
+
+    // IntFitsIn is for Carbon integer types only.
+    case CoreInterface::IntFitsIn:
+      return SemIR::InstId::None;
+
+    case CoreInterface::Unknown:
+      CARBON_FATAL("unexpected CoreInterface `{0}`", core_interface);
+  }
+
+  return BuildWitnessForDeclInfo(
+      context, loc_id, decl_info, query_self_const_id,
+      query_specific_interface_id, best_impl_type_structure, best_impl_loc_id);
 }
 
 }  // namespace Carbon::Check


### PR DESCRIPTION
Originally this was handled in LookupCppImpl in the switch on the CoreInterface, but in subsequent refactorings it was lost, and we now assume we are always looking for a C++ witness and CHECK that the interface is not `IntFitsIn`.

Refactor LookupCppImpl to have a single switch up front on the CoreInterface enum, instead of multiple. It's a quick early out for `IntFitsIn` and delegates work to helper functions specific to each other CoreInterface value.