### PR TITLE
Make Any* macros reusable

### DIFF
--- a/toolchain/base/kind_switch.h
+++ b/toolchain/base/kind_switch.h
@@ -41,10 +41,10 @@
 // - Each type passed to `CARBON_KIND_ANY` must have a macro of the form:
 //   ```
 //   #define AnyKind_CARBON_KIND_ANY_EXPAND   \
-//     CARBON_KIND_ANY_EXPAND_BEGIN CARBON_KIND_ANY_EXPAND_CASE(Kind1) \
-//     CARBON_KIND_ANY_EXPAND_SEP   CARBON_KIND_ANY_EXPAND_CASE(Kind2) \
+//     CARBON_KIND_ANY_EXPAND_BEGIN() CARBON_KIND_ANY_EXPAND_CASE(Kind1) \
+//     CARBON_KIND_ANY_EXPAND_SEP()   CARBON_KIND_ANY_EXPAND_CASE(Kind2) \
 //     ...
-//     CARBON_KIND_ANY_EXPAND_SEP   CARBON_KIND_ANY_EXPAND_CASE(KindN)
+//     CARBON_KIND_ANY_EXPAND_SEP()   CARBON_KIND_ANY_EXPAND_CASE(KindN)
 //   ```
 //   Note the prefix `,` is required.
 //
@@ -71,10 +71,10 @@
       : CARBON_KIND_INTERNAL_DECLARE(typed_variable_decl)
 
 // Macros for clients to add support for `Type_CARBON_KIND_ANY_EXPAND` (see
-// example above).
+// example above). Empty parameters are used to allow delaying macro expansion.
 #define CARBON_KIND_ANY_EXPAND_CASE(X) CARBON_KIND_INTERNAL_CASE_VALUE(X)
-#define CARBON_KIND_ANY_EXPAND_BEGIN ,
-#define CARBON_KIND_ANY_EXPAND_SEP : case
+#define CARBON_KIND_ANY_EXPAND_BEGIN() ,
+#define CARBON_KIND_ANY_EXPAND_SEP() : case
 
 // Produces a case-compatible block of code that also instantiates a local typed
 // variable. Versus `CARBON_KIND(int i)`, note this requires a comma after the

--- a/toolchain/sem_ir/inst_categories.h
+++ b/toolchain/sem_ir/inst_categories.h
@@ -39,18 +39,23 @@ struct CategoryOf {
       CARBON_INST_CATEGORY_INFO_INTERNAL_NAME, \
       CARBON_INST_CATEGORY_INFO_INTERNAL_COMMA)>
 #define CARBON_INST_CATEGORY_INFO_INTERNAL_NAME(Name) Name
-#define CARBON_INST_CATEGORY_INFO_INTERNAL_COMMA ,
+#define CARBON_INST_CATEGORY_INFO_INTERNAL_COMMA() ,
+
+// Helper for defining `AnyKind_CARBON_KIND_ANY_EXPAND`.
+#define CARBON_INST_CATEGORY_ANY_EXPAND(AnyKind)              \
+  CARBON_KIND_ANY_EXPAND_BEGIN()                              \
+  AnyKind##_CARBON_INST_CATEGORY(CARBON_KIND_ANY_EXPAND_CASE, \
+                                 CARBON_KIND_ANY_EXPAND_SEP)
 
 // clang-format off
 #define AnyAggregateAccess_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::ClassElementAccess) Sep            \
-  X(::Carbon::SemIR::StructAccess) Sep                  \
+  X(::Carbon::SemIR::ClassElementAccess) Sep()          \
+  X(::Carbon::SemIR::StructAccess) Sep()                \
   X(::Carbon::SemIR::TupleAccess)
 // clang-format on
 
-#define AnyAggregateAccess_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyAggregateAccess_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyAggregateAccess_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyAggregateAccess)
 
 // Common representation for aggregate access nodes, which access a fixed
 // element of an aggregate.
@@ -65,15 +70,14 @@ struct AnyAggregateAccess {
 
 // clang-format off
 #define AnyAggregateInit_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::ArrayInit) Sep                   \
-  X(::Carbon::SemIR::ClassInit) Sep                   \
-  X(::Carbon::SemIR::StructInit) Sep                  \
+  X(::Carbon::SemIR::ArrayInit) Sep()                 \
+  X(::Carbon::SemIR::ClassInit) Sep()                 \
+  X(::Carbon::SemIR::StructInit) Sep()                \
   X(::Carbon::SemIR::TupleInit)
 // clang-format on
 
-#define AnyAggregateInit_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyAggregateInit_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyAggregateInit_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyAggregateInit)
 
 // Common representation for all kinds of aggregate initialization.
 struct AnyAggregateInit {
@@ -87,13 +91,12 @@ struct AnyAggregateInit {
 
 // clang-format off
 #define AnyAggregateValue_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::StructValue) Sep                  \
+  X(::Carbon::SemIR::StructValue) Sep()                \
   X(::Carbon::SemIR::TupleValue)
 // clang-format on
 
-#define AnyAggregateValue_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyAggregateValue_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyAggregateValue_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyAggregateValue)
 
 // Common representation for all kinds of aggregate value.
 struct AnyAggregateValue {
@@ -106,15 +109,14 @@ struct AnyAggregateValue {
 
 // clang-format off
 #define AnyBindingPattern_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::FormBindingPattern) Sep           \
-  X(::Carbon::SemIR::RefBindingPattern) Sep            \
-  X(::Carbon::SemIR::SymbolicBindingPattern) Sep       \
+  X(::Carbon::SemIR::FormBindingPattern) Sep()         \
+  X(::Carbon::SemIR::RefBindingPattern) Sep()          \
+  X(::Carbon::SemIR::SymbolicBindingPattern) Sep()     \
   X(::Carbon::SemIR::ValueBindingPattern)
 // clang-format on
 
-#define AnyBindingPattern_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyBindingPattern_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyBindingPattern_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyBindingPattern)
 
 // Common representation for various `*binding_pattern` nodes.
 struct AnyBindingPattern {
@@ -135,16 +137,15 @@ struct AnyBindingPattern {
 
 // clang-format off
 #define AnyBinding_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::AliasBinding) Sep          \
-  X(::Carbon::SemIR::FormBinding) Sep           \
-  X(::Carbon::SemIR::RefBinding) Sep            \
-  X(::Carbon::SemIR::SymbolicBinding) Sep       \
+  X(::Carbon::SemIR::AliasBinding) Sep()        \
+  X(::Carbon::SemIR::FormBinding) Sep()         \
+  X(::Carbon::SemIR::RefBinding) Sep()          \
+  X(::Carbon::SemIR::SymbolicBinding) Sep()     \
   X(::Carbon::SemIR::ValueBinding)
 // clang-format on
 
-#define AnyBinding_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyBinding_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyBinding_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyBinding)
 
 // Common representation for various `bind*` nodes.
 struct AnyBinding {
@@ -161,18 +162,13 @@ struct AnyBinding {
 };
 
 // clang-format off
-#define AnyBindingOrExportDecl_CARBON_INST_CATEGORY(X, Sep)            \
-  X(::Carbon::SemIR::AliasBinding) Sep                                 \
-  X(::Carbon::SemIR::FormBinding) Sep                                  \
-  X(::Carbon::SemIR::RefBinding) Sep                                   \
-  X(::Carbon::SemIR::SymbolicBinding) Sep                              \
-  X(::Carbon::SemIR::ValueBinding) Sep                                 \
+#define AnyBindingOrExportDecl_CARBON_INST_CATEGORY(X, Sep) \
+  AnyBinding_CARBON_INST_CATEGORY(X, Sep) Sep()             \
   X(::Carbon::SemIR::ExportDecl)
 // clang-format on
 
-#define AnyBindingOrExportDecl_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyBindingOrExportDecl_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyBindingOrExportDecl_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyBindingOrExportDecl)
 
 // Common representation for various `bind*` nodes, and `export name`.
 struct AnyBindingOrExportDecl {
@@ -187,14 +183,13 @@ struct AnyBindingOrExportDecl {
 
 // clang-format off
 #define AnyBranch_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::Branch) Sep               \
-  X(::Carbon::SemIR::BranchIf) Sep             \
+  X(::Carbon::SemIR::Branch) Sep()             \
+  X(::Carbon::SemIR::BranchIf) Sep()           \
   X(::Carbon::SemIR::BranchWithArg)
 // clang-format on
 
-#define AnyBranch_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyBranch_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyBranch_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyBranch)
 
 // Common representation for all kinds of `Branch*` node.
 struct AnyBranch {
@@ -209,13 +204,12 @@ struct AnyBranch {
 
 // clang-format off
 #define AnyFoundationDecl_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::AdaptDecl) Sep                    \
+  X(::Carbon::SemIR::AdaptDecl) Sep()                  \
   X(::Carbon::SemIR::BaseDecl)
 // clang-format on
 
-#define AnyFoundationDecl_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyFoundationDecl_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyFoundationDecl_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyFoundationDecl)
 
 // Common representation for declarations describing the foundation type of a
 // class -- either its adapted type or its base class.
@@ -231,13 +225,12 @@ struct AnyFoundationDecl {
 
 // clang-format off
 #define AnyImportRef_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::ImportRefLoaded) Sep \
+  X(::Carbon::SemIR::ImportRefLoaded) Sep()       \
   X(::Carbon::SemIR::ImportRefUnloaded)
 // clang-format on
 
-#define AnyImportRef_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyImportRef_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyImportRef_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyImportRef)
 
 // Common representation for all kinds of `ImportRef*` node.
 struct AnyImportRef {
@@ -253,14 +246,13 @@ struct AnyImportRef {
 
 // clang-format off
 #define AnyParam_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::OutParam) Sep            \
-  X(::Carbon::SemIR::RefParam) Sep            \
+  X(::Carbon::SemIR::OutParam) Sep()          \
+  X(::Carbon::SemIR::RefParam) Sep()          \
   X(::Carbon::SemIR::ValueParam)
 // clang-format on
 
-#define AnyParam_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyParam_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyParam_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyParam)
 
 // A `Call` parameter for a function or other parameterized block.
 struct AnyParam {
@@ -278,16 +270,15 @@ struct AnyParam {
 
 // clang-format off
 #define AnyParamPattern_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::FormParamPattern) Sep           \
-  X(::Carbon::SemIR::OutParamPattern) Sep            \
-  X(::Carbon::SemIR::RefParamPattern) Sep            \
-  X(::Carbon::SemIR::ValueParamPattern) Sep          \
+  X(::Carbon::SemIR::FormParamPattern) Sep()         \
+  X(::Carbon::SemIR::OutParamPattern) Sep()          \
+  X(::Carbon::SemIR::RefParamPattern) Sep()          \
+  X(::Carbon::SemIR::ValueParamPattern) Sep()        \
   X(::Carbon::SemIR::VarParamPattern)
 // clang-format on
 
-#define AnyParamPattern_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyParamPattern_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyParamPattern_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyParamPattern)
 
 // A pattern that represents a `Call` parameter. It delegates to subpattern_id
 // in pattern matching.
@@ -304,14 +295,13 @@ struct AnyParamPattern {
 
 // clang-format off
 #define AnyPrimitiveForm_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::InitForm) Sep                    \
-  X(::Carbon::SemIR::RefForm) Sep                     \
+  X(::Carbon::SemIR::InitForm) Sep()                  \
+  X(::Carbon::SemIR::RefForm) Sep()                   \
   X(::Carbon::SemIR::ValueForm)
 // clang-format on
 
-#define AnyPrimitiveForm_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyPrimitiveForm_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyPrimitiveForm_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyPrimitiveForm)
 
 // An inst that represents a primitive form.
 struct AnyPrimitiveForm {
@@ -328,14 +318,13 @@ struct AnyPrimitiveForm {
 
 // clang-format off
 #define AnyQualifiedType_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::ConstType) Sep                   \
-  X(::Carbon::SemIR::MaybeUnformedType) Sep           \
+  X(::Carbon::SemIR::ConstType) Sep()                 \
+  X(::Carbon::SemIR::MaybeUnformedType) Sep()         \
   X(::Carbon::SemIR::PartialType)
 // clang-format on
 
-#define AnyQualifiedType_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyQualifiedType_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyQualifiedType_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyQualifiedType)
 
 // A type qualifier that wraps another type and has the same object
 // representation. Qualifiers are arranged so that adding a qualifier is
@@ -351,13 +340,12 @@ struct AnyQualifiedType {
 
 // clang-format off
 #define AnyStructType_CARBON_INST_CATEGORY(X, Sep) \
-  X(::Carbon::SemIR::CustomLayoutType) Sep         \
+  X(::Carbon::SemIR::CustomLayoutType) Sep()       \
   X(::Carbon::SemIR::StructType)
 // clang-format on
 
-#define AnyStructType_CARBON_KIND_ANY_EXPAND                       \
-  CARBON_KIND_ANY_EXPAND_BEGIN AnyStructType_CARBON_INST_CATEGORY( \
-      CARBON_KIND_ANY_EXPAND_CASE, CARBON_KIND_ANY_EXPAND_SEP)
+#define AnyStructType_CARBON_KIND_ANY_EXPAND \
+  CARBON_INST_CATEGORY_ANY_EXPAND(AnyStructType)
 
 // A struct-like type with a list of named fields.
 struct AnyStructType {


### PR DESCRIPTION
Use parens to delay macro expansion to address the comma separator case, allowing reuse in AnyBindingOrExportDecl. Also add CARBON_INST_CATEGORY_ANY_EXPAND to reduce some boilerplate.

Assisted-by: Google Antigravity with Gemini