### PR TITLE
Handle errors in form binding without crashing.

### DIFF
--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -270,6 +270,7 @@ static auto ConversionKindFor(
           context.TODO(entry.pattern_id, "Support symbolic form bindings");
           [[fallthrough]];
         case SemIR::ValueForm::Kind:
+        case SemIR::ErrorInst::Kind:
           return ConversionTarget::Value;
         default:
           CARBON_FATAL("Unexpected form kind {0}", form_kind);

--- a/toolchain/check/testdata/let/form.carbon
+++ b/toolchain/check/testdata/let/form.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/convert.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/let/form.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/let/form.carbon
+
+// --- fail_todo_form_binding.carbon
+library "[[@TEST_NAME]]";
+
+// CHECK:STDERR: fail_todo_form_binding.carbon:[[@LINE+7]]:9: error: cannot implicitly convert expression of type `()` to `Core.Form` [ConversionFailure]
+// CHECK:STDERR: let x:? () = ();
+// CHECK:STDERR:         ^~
+// CHECK:STDERR: fail_todo_form_binding.carbon:[[@LINE+4]]:9: note: type `()` does not implement interface `Core.ImplicitAs(Core.Form)` [MissingImplInMemberAccessInContext]
+// CHECK:STDERR: let x:? () = ();
+// CHECK:STDERR:         ^~
+// CHECK:STDERR:
+let x:? () = ();


### PR DESCRIPTION
Closes #6920