### PR TITLE
Return a `NewAnyPhase` result for `RequireCompleteType` with a `CompleteTypeWitness` value

### DIFF
--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -540,7 +540,7 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
                            true)) {
       return ConstantEvalResult::Error;
     }
-    return ConstantEvalResult::NewSamePhase(SemIR::CompleteTypeWitness{
+    return ConstantEvalResult::NewAnyPhase(SemIR::CompleteTypeWitness{
         .type_id = witness_type_id,
         .object_repr_type_inst_id = context.types().GetTypeInstId(
             context.types().GetObjectRepr(complete_type_id))});

--- a/toolchain/check/testdata/function/generic/resolve_used.carbon
+++ b/toolchain/check/testdata/function/generic/resolve_used.carbon
@@ -67,7 +67,6 @@ fn CallNegative() {
 // CHECK:STDOUT:   %int_0: Core.IntLiteral = int_value 0 [concrete]
 // CHECK:STDOUT:   %ErrorIfNIsZero.specific_fn: <specific function> = specific_function %ErrorIfNIsZero, @ErrorIfNIsZero(%int_0) [concrete]
 // CHECK:STDOUT:   %i0: type = class_type @Int, @Int(%int_0) [concrete]
-// CHECK:STDOUT:   %complete_type.d94: <witness> = complete_type_witness <error> [concrete]
 // CHECK:STDOUT:   %pattern_type.47b: type = pattern_type %i0 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type: type = fn_type @Destroy.Op [concrete]
 // CHECK:STDOUT:   %Destroy.Op: %Destroy.Op.type = struct_value () [concrete]
@@ -170,7 +169,7 @@ fn CallNegative() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Int.loc9_27.2 => constants.%i0
-// CHECK:STDOUT:   %require_complete => constants.%complete_type.d94
+// CHECK:STDOUT:   %require_complete => <error>
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.47b
 // CHECK:STDOUT:   %Destroy.lookup_impl_witness => constants.%custom_witness.8d7
 // CHECK:STDOUT:   %Destroy.facet => constants.%Destroy.facet.eb2


### PR DESCRIPTION
The `CompleteTypeWitness` can be concrete. This avoids making a symbolic `CompleteTypeWitness` value which itself has a concrete `CompleteTypeWitness` value with the same operands.