### PR TITLE
Reverse Interop: Nested namespace support

### DIFF
--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -395,8 +395,7 @@ auto CarbonExternalASTSource::MapInstIdToClangDecl(
 auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
     const clang::DeclContext* decl_context, clang::DeclarationName decl_name,
     const clang::DeclContext* /*OriginalDC*/) -> bool {
-  auto decl_context_inst_id =
-      scope_mapping.Lookup(const_cast<clang::DeclContext*>(decl_context));
+  auto decl_context_inst_id = scope_mapping.Lookup(decl_context);
 
   if (!decl_context_inst_id) {
     // If the context doesn't already have a mapping between C++ and Carbon,

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -348,6 +348,7 @@ class CarbonExternalASTSource : public clang::ExternalASTSource {
   auto StartTranslationUnit(clang::ASTConsumer* consumer) -> void override;
 
  private:
+  // Map a Carbon entity to a Clang NamedDecl.
   auto MapInstIdToClangDecl(clang::DeclContext& decl_context,
                             LookupResult lookup) -> clang::NamedDecl*;
 
@@ -364,7 +365,6 @@ void CarbonExternalASTSource::StartTranslationUnit(
   translation_unit.setHasExternalVisibleStorage();
 }
 
-// Map a Carbon entity to a Clang NamedDecl.
 auto CarbonExternalASTSource::MapInstIdToClangDecl(
     clang::DeclContext& decl_context, LookupResult lookup)
     -> clang::NamedDecl* {

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -348,6 +348,7 @@ class CarbonExternalASTSource : public clang::ExternalASTSource {
       const clang::DeclContext* decl_context, clang::DeclarationName decl_name,
       const clang::DeclContext* original_decl_context) -> bool override;
 
+  // See clang::ExternalASTSource.
   auto StartTranslationUnit(clang::ASTConsumer* consumer) -> void override;
 
  private:

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -383,8 +383,9 @@ auto CarbonExternalASTSource::MapInstIdToClangDecl(
     auto* namespace_decl = clang::NamespaceDecl::Create(
         *ast_context_, &decl_context, false, clang::SourceLocation(),
         clang::SourceLocation(), identifier_info, nullptr, false);
-    scope_mapping.Insert(static_cast<clang::DeclContext*>(namespace_decl),
-                         target_inst_id);
+    auto result = scope_mapping.Insert(
+        static_cast<clang::DeclContext*>(namespace_decl), target_inst_id);
+    CARBON_CHECK(result.is_inserted(), "Inserting over an existing entry.");
     namespace_decl->setHasExternalVisibleStorage();
     return namespace_decl;
   }
@@ -416,8 +417,10 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
         clang::SourceLocation(), &ast_context.Idents.get(carbon_namespace_name),
         nullptr, false);
     carbon_cpp_namespace->setHasExternalVisibleStorage();
-    scope_mapping.Insert(static_cast<clang::DeclContext*>(carbon_cpp_namespace),
-                         SemIR::Namespace::PackageInstId);
+    auto result = scope_mapping.Insert(
+        static_cast<clang::DeclContext*>(carbon_cpp_namespace),
+        SemIR::Namespace::PackageInstId);
+    CARBON_CHECK(result.is_inserted(), "Inserting over an existing entry.");
     SetExternalVisibleDeclsForName(decl_context, decl_name,
                                    {carbon_cpp_namespace});
     return true;

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -348,7 +348,8 @@ class CarbonExternalASTSource : public clang::ExternalASTSource {
   auto StartTranslationUnit(clang::ASTConsumer* consumer) -> void override;
 
  private:
-  // Map a Carbon entity to a Clang NamedDecl.
+  // Map a Carbon entity to a Clang NamedDecl. Returns null if the entity cannot
+  // currently be represented in C++.
   auto MapInstIdToClangDecl(clang::DeclContext& decl_context,
                             LookupResult lookup) -> clang::NamedDecl*;
 

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -399,6 +399,10 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
       scope_mapping.Lookup(const_cast<clang::DeclContext*>(decl_context));
 
   if (!decl_context_inst_id) {
+    // If the context doesn't already have a mapping between C++ and Carbon,
+    // check if this is the root mapping (for the "Carbon" namespace in the
+    // translation unit scope) and if so, create that mapping.
+
     if (decl_context->getDeclKind() != clang::Decl::Kind::TranslationUnit) {
       return false;
     }

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -20,6 +20,7 @@
 #include "clang/Sema/MultiplexExternalSemaSource.h"
 #include "clang/Sema/Sema.h"
 #include "common/check.h"
+#include "common/map.h"
 #include "common/raw_string_ostream.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
@@ -347,9 +348,12 @@ class CarbonExternalASTSource : public clang::ExternalASTSource {
   auto StartTranslationUnit(clang::ASTConsumer* consumer) -> void override;
 
  private:
+  auto MapInstIdToClangDecl(clang::DeclContext& decl_context,
+                            LookupResult lookup) -> clang::NamedDecl*;
+
   Check::Context* context_;
   clang::ASTContext* ast_context_;
-  clang::NamespaceDecl* carbon_cpp_namespace_ = nullptr;
+  Map<clang::DeclContext*, SemIR::InstId> scope_mapping;
 };
 
 void CarbonExternalASTSource::StartTranslationUnit(
@@ -361,24 +365,27 @@ void CarbonExternalASTSource::StartTranslationUnit(
 }
 
 // Map a Carbon entity to a Clang NamedDecl.
-static auto MapInstIdToClangDecl(Context& context,
-                                 clang::ASTContext& ast_context,
-                                 clang::DeclContext& decl_context,
-                                 LookupResult lookup) -> clang::NamedDecl* {
+auto CarbonExternalASTSource::MapInstIdToClangDecl(
+    clang::DeclContext& decl_context, LookupResult lookup)
+    -> clang::NamedDecl* {
   auto target_inst_id = lookup.scope_result.target_inst_id();
   if (auto target_inst =
-          context.insts().TryGetAs<SemIR::Namespace>(target_inst_id)) {
-    auto& name_scope = context.name_scopes().Get(target_inst->name_scope_id);
+          context_->insts().TryGetAs<SemIR::Namespace>(target_inst_id)) {
+    auto& name_scope = context_->name_scopes().Get(target_inst->name_scope_id);
     auto* identifier_info =
-        GetClangIdentifierInfo(context, name_scope.name_id());
+        GetClangIdentifierInfo(*context_, name_scope.name_id());
     // TODO: Don't immediately use the decl_context - build any intermediate
     // namespaces iteratively.
     // Eventually add a mapping and use that/populate it/keep it up to date.
     // decl_context could be prepopulated in that mapping and not passed
     // explicitly to MapInstIdToClangDecl.
-    return clang::NamespaceDecl::Create(
-        ast_context, &decl_context, false, clang::SourceLocation(),
+    auto* namespace_decl = clang::NamespaceDecl::Create(
+        *ast_context_, &decl_context, false, clang::SourceLocation(),
         clang::SourceLocation(), identifier_info, nullptr, false);
+    scope_mapping.Insert(static_cast<clang::DeclContext*>(namespace_decl),
+                         target_inst_id);
+    namespace_decl->setHasExternalVisibleStorage();
+    return namespace_decl;
   }
   return nullptr;
 }
@@ -386,7 +393,10 @@ static auto MapInstIdToClangDecl(Context& context,
 auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
     const clang::DeclContext* decl_context, clang::DeclarationName decl_name,
     const clang::DeclContext* /*OriginalDC*/) -> bool {
-  if (decl_context != carbon_cpp_namespace_) {
+  auto decl_context_inst_id =
+      scope_mapping.Lookup(const_cast<clang::DeclContext*>(decl_context));
+
+  if (!decl_context_inst_id) {
     if (decl_context->getDeclKind() != clang::Decl::Kind::TranslationUnit) {
       return false;
     }
@@ -400,13 +410,15 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
     // Build the top level 'Carbon' namespace
     auto& ast_context = decl_context->getParentASTContext();
     auto& mutable_tu_decl_context = *ast_context.getTranslationUnitDecl();
-    carbon_cpp_namespace_ = clang::NamespaceDecl::Create(
+    auto* carbon_cpp_namespace = clang::NamespaceDecl::Create(
         ast_context, &mutable_tu_decl_context, false, clang::SourceLocation(),
         clang::SourceLocation(), &ast_context.Idents.get(carbon_namespace_name),
         nullptr, false);
-    carbon_cpp_namespace_->setHasExternalVisibleStorage();
+    carbon_cpp_namespace->setHasExternalVisibleStorage();
+    scope_mapping.Insert(static_cast<clang::DeclContext*>(carbon_cpp_namespace),
+                         SemIR::Namespace::PackageInstId);
     SetExternalVisibleDeclsForName(decl_context, decl_name,
-                                   {carbon_cpp_namespace_});
+                                   {carbon_cpp_namespace});
     return true;
   }
 
@@ -418,7 +430,7 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
   // here - completeness should've been checked by clang before this point.
   if (!AppendLookupScopesForConstant(
           *context_, SemIR::LocId::None,
-          context_->constant_values().Get(SemIR::Namespace::PackageInstId),
+          context_->constant_values().Get(decl_context_inst_id.value()),
           SemIR::ConstantId::None, &lookup_scopes)) {
     return false;
   }
@@ -441,8 +453,7 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
   }
 
   // Map the found Carbon entity to a Clang NamedDecl.
-  auto* clang_decl = MapInstIdToClangDecl(*context_, *ast_context_,
-                                          *carbon_cpp_namespace_, result);
+  auto* clang_decl = MapInstIdToClangDecl(*decl_context_inst_id.key(), result);
   if (!clang_decl) {
     return false;
   }

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -355,6 +355,11 @@ class CarbonExternalASTSource : public clang::ExternalASTSource {
 
   Check::Context* context_;
   clang::ASTContext* ast_context_;
+  // The association between clang DeclContexts and the corresponding
+  // SemIR::Namespaces in Carbon.
+  // TODO: reuse the SemIR::File::ClangDeclStore to avoid duplicates, and to
+  // enable roundtripping through forward and reverse interop (once we have
+  // syntax/support for that).
   Map<clang::DeclContext*, SemIR::InstId> scope_map_;
 };
 

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -468,6 +468,7 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
   }
 
   // Map the found Carbon entity to a Clang NamedDecl.
+  // Use the key to reach the owned, mutable copy of decl_context.
   auto* clang_decl = MapInstIdToClangDecl(*decl_context_inst_id.key(), result);
   if (!clang_decl) {
     return false;

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -355,7 +355,7 @@ class CarbonExternalASTSource : public clang::ExternalASTSource {
 
   Check::Context* context_;
   clang::ASTContext* ast_context_;
-  Map<clang::DeclContext*, SemIR::InstId> scope_mapping;
+  Map<clang::DeclContext*, SemIR::InstId> scope_map_;
 };
 
 void CarbonExternalASTSource::StartTranslationUnit(
@@ -383,8 +383,8 @@ auto CarbonExternalASTSource::MapInstIdToClangDecl(
     auto* namespace_decl = clang::NamespaceDecl::Create(
         *ast_context_, &decl_context, false, clang::SourceLocation(),
         clang::SourceLocation(), identifier_info, nullptr, false);
-    auto result = scope_mapping.Insert(namespace_decl->getPrimaryContext(),
-                                       target_inst_id);
+    auto result =
+        scope_map_.Insert(namespace_decl->getPrimaryContext(), target_inst_id);
     CARBON_CHECK(result.is_inserted(), "Inserting over an existing entry.");
     namespace_decl->setHasExternalVisibleStorage();
     return namespace_decl;
@@ -396,7 +396,7 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
     const clang::DeclContext* decl_context, clang::DeclarationName decl_name,
     const clang::DeclContext* /*OriginalDC*/) -> bool {
   auto decl_context_inst_id =
-      scope_mapping.Lookup(decl_context->getPrimaryContext());
+      scope_map_.Lookup(decl_context->getPrimaryContext());
 
   if (!decl_context_inst_id) {
     // If the context doesn't already have a mapping between C++ and Carbon,
@@ -421,9 +421,8 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
         clang::SourceLocation(), &ast_context.Idents.get(carbon_namespace_name),
         nullptr, false);
     carbon_cpp_namespace->setHasExternalVisibleStorage();
-    auto result =
-        scope_mapping.Insert(carbon_cpp_namespace->getPrimaryContext(),
-                             SemIR::Namespace::PackageInstId);
+    auto result = scope_map_.Insert(carbon_cpp_namespace->getPrimaryContext(),
+                                    SemIR::Namespace::PackageInstId);
     CARBON_CHECK(result.is_inserted(), "Inserting over an existing entry.");
     SetExternalVisibleDeclsForName(decl_context, decl_name,
                                    {carbon_cpp_namespace});

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -365,6 +365,11 @@ class CarbonExternalASTSource : public clang::ExternalASTSource {
   // enable roundtripping through forward and reverse interop (once we have
   // syntax/support for that).
   Map<clang::DeclContext*, SemIR::InstId> scope_map_;
+
+  // Has the "Carbon" C++ namespace been created yet
+  // (this could be replaced with `!scope_map_.empty()` if Carbon::Map supported
+  // `empty()`)
+  bool root_scope_initialized_ = false;
 };
 
 void CarbonExternalASTSource::StartTranslationUnit(
@@ -404,15 +409,12 @@ auto CarbonExternalASTSource::MapInstIdToClangDecl(
 auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
     const clang::DeclContext* decl_context, clang::DeclarationName decl_name,
     const clang::DeclContext* /*OriginalDC*/) -> bool {
-  auto decl_context_inst_id =
-      scope_map_.Lookup(decl_context->getPrimaryContext());
-
-  if (!decl_context_inst_id) {
+  if (decl_context->getDeclKind() == clang::Decl::Kind::TranslationUnit) {
     // If the context doesn't already have a mapping between C++ and Carbon,
     // check if this is the root mapping (for the "Carbon" namespace in the
     // translation unit scope) and if so, create that mapping.
 
-    if (decl_context->getDeclKind() != clang::Decl::Kind::TranslationUnit) {
+    if (root_scope_initialized_) {
       return false;
     }
 
@@ -435,10 +437,15 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
     CARBON_CHECK(result.is_inserted(), "Inserting over an existing entry.");
     SetExternalVisibleDeclsForName(decl_context, decl_name,
                                    {carbon_cpp_namespace});
+    root_scope_initialized_ = true;
     return true;
   }
 
-  // Lookup the name in Carbon package scope
+  auto decl_context_inst_id =
+      scope_map_.Lookup(decl_context->getPrimaryContext());
+  CARBON_CHECK(
+      decl_context_inst_id,
+      "The DeclContext should already be associated with a Carbon InstId.");
 
   llvm::SmallVector<Check::LookupScope> lookup_scopes;
 

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -335,7 +335,7 @@ class ShallowCopyCompilerInvocation : public clang::CompilerInvocation {
   }
 };
 
-// Provides clang ASTs representing Carbon SemIR entities.
+// Provides clang AST nodes representing Carbon SemIR entities.
 class CarbonExternalASTSource : public clang::ExternalASTSource {
  public:
   explicit CarbonExternalASTSource(Context* context,

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -383,8 +383,8 @@ auto CarbonExternalASTSource::MapInstIdToClangDecl(
     auto* namespace_decl = clang::NamespaceDecl::Create(
         *ast_context_, &decl_context, false, clang::SourceLocation(),
         clang::SourceLocation(), identifier_info, nullptr, false);
-    auto result = scope_mapping.Insert(
-        static_cast<clang::DeclContext*>(namespace_decl), target_inst_id);
+    auto result = scope_mapping.Insert(namespace_decl->getPrimaryContext(),
+                                       target_inst_id);
     CARBON_CHECK(result.is_inserted(), "Inserting over an existing entry.");
     namespace_decl->setHasExternalVisibleStorage();
     return namespace_decl;
@@ -395,7 +395,8 @@ auto CarbonExternalASTSource::MapInstIdToClangDecl(
 auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
     const clang::DeclContext* decl_context, clang::DeclarationName decl_name,
     const clang::DeclContext* /*OriginalDC*/) -> bool {
-  auto decl_context_inst_id = scope_mapping.Lookup(decl_context);
+  auto decl_context_inst_id =
+      scope_mapping.Lookup(decl_context->getPrimaryContext());
 
   if (!decl_context_inst_id) {
     // If the context doesn't already have a mapping between C++ and Carbon,
@@ -420,9 +421,9 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
         clang::SourceLocation(), &ast_context.Idents.get(carbon_namespace_name),
         nullptr, false);
     carbon_cpp_namespace->setHasExternalVisibleStorage();
-    auto result = scope_mapping.Insert(
-        static_cast<clang::DeclContext*>(carbon_cpp_namespace),
-        SemIR::Namespace::PackageInstId);
+    auto result =
+        scope_mapping.Insert(carbon_cpp_namespace->getPrimaryContext(),
+                             SemIR::Namespace::PackageInstId);
     CARBON_CHECK(result.is_inserted(), "Inserting over an existing entry.");
     SetExternalVisibleDeclsForName(decl_context, decl_name,
                                    {carbon_cpp_namespace});

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -335,12 +335,15 @@ class ShallowCopyCompilerInvocation : public clang::CompilerInvocation {
   }
 };
 
+// Provides clang ASTs representing Carbon SemIR entities.
 class CarbonExternalASTSource : public clang::ExternalASTSource {
  public:
   explicit CarbonExternalASTSource(Context* context,
                                    clang::ASTContext* ast_context)
       : context_(context), ast_context_(ast_context) {}
 
+  // Look up decls for `decl_name` inside `decl_context`, adding the decls to
+  // `decl_context`. Returns true if any decls were added.
   auto FindExternalVisibleDeclsByName(
       const clang::DeclContext* decl_context, clang::DeclarationName decl_name,
       const clang::DeclContext* original_decl_context) -> bool override;

--- a/toolchain/check/testdata/interop/cpp/reverse/simple.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/simple.carbon
@@ -13,6 +13,7 @@
 // --- other.carbon
 package Other;
 namespace Nested;
+namespace Nested.Again;
 // --- namespace.carbon
 
 library "[[@TEST_NAME]]";
@@ -21,4 +22,5 @@ import Other;
 import Cpp inline '''
 namespace X = Carbon::Other;
 namespace Y = Carbon::Other::Nested;
+namespace Z = Carbon::Other::Nested::Again;
 ''';

--- a/toolchain/check/testdata/interop/cpp/reverse/simple.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/simple.carbon
@@ -10,23 +10,9 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/reverse/simple.carbon
 
-// --- fail_simple.carbon
-
-library "[[@TEST_NAME]]";
-
-// Demonstrate that the 'Carbon' namespace has been injected into the C++ compilation.
-
-import Cpp inline '''
-// CHECK:STDERR: fail_simple.carbon:[[@LINE+4]]:9: error: no type named 'NonExistent' in namespace 'Carbon' [CppInteropParseError]
-// CHECK:STDERR:    11 | Carbon::NonExistent v;
-// CHECK:STDERR:       | ~~~~~~~~^
-// CHECK:STDERR:
-Carbon::NonExistent v;
-''';
-
-
 // --- other.carbon
 package Other;
+namespace Nested;
 // --- namespace.carbon
 
 library "[[@TEST_NAME]]";
@@ -34,4 +20,5 @@ library "[[@TEST_NAME]]";
 import Other;
 import Cpp inline '''
 namespace X = Carbon::Other;
+namespace Y = Carbon::Other::Nested;
 ''';


### PR DESCRIPTION
Start recording the clang::DeclContext* -> InstId mapping for use in later operations.

The test update includes removing the initial fail_* test because I hadn't thought about the use of namespace aliases as a way to test for the presence of a namespace without the failure caused by not finding the thing inside the namespace.
