### PR TITLE
Fix ReadlinkSlow buffer when lstat reports zero size

### DIFF
--- a/common/filesystem.cpp
+++ b/common/filesystem.cpp
@@ -643,7 +643,7 @@ auto DirRef::ReadlinkSlow(const std::filesystem::path& path)
   if (buffer_size == 0) {
     buffer_size = MinBufferSize;
   }
-  large_buffer.resize(status.size());
+  large_buffer.resize(buffer_size);
   ssize_t result =
       readlinkat(dfd_, path.c_str(), large_buffer.data(), large_buffer.size());
   if (result == -1) {


### PR DESCRIPTION
When the symlink target length from lstat was 0, the code resized the buffer using status.size() instead of buffer_size, so the first allocation stayed empty instead of using MinBufferSize. Align the resize with the buffer_size path used for readlinkat.
