### PR TITLE
Improve vscode line number display for test files.

### DIFF
--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -10,9 +10,15 @@
 
 import {
   workspace,
+  window,
   ExtensionContext,
   commands,
   WorkspaceConfiguration,
+  TextEditor,
+  Range,
+  DecorationOptions,
+  ThemeColor,
+  TextDocumentChangeEvent,
 } from 'vscode';
 
 import {
@@ -22,6 +28,58 @@ import {
 } from 'vscode-languageclient/node';
 
 let client: LanguageClient;
+
+const splitLineNumberDecorationType = window.createTextEditorDecorationType({});
+
+function updateSplitLineNumbers(editor: TextEditor | undefined) {
+  if (!editor) {
+    return;
+  }
+  const document = editor.document;
+  if (!document.fileName.includes('/testdata/')) {
+    return;
+  }
+
+  const decorations: DecorationOptions[] = [];
+
+  // Find all splits
+  const splitStarts: number[] = [];
+  for (let i = 0; i < document.lineCount; i++) {
+    if (document.lineAt(i).text.startsWith('// ---')) {
+      splitStarts.push(i);
+    }
+  }
+
+  // Iterate through each split
+  for (let s = 0; s < splitStarts.length; s++) {
+    const startLine = splitStarts[s];
+    const endLine = s + 1 < splitStarts.length ? splitStarts[s + 1] : document.lineCount;
+    const splitLength = endLine - startLine - 1;
+    if (splitLength <= 0) {
+      continue;
+    }
+
+    const maxDigits = splitLength.toString().length;
+    const widthStr = `${maxDigits}ch`;
+
+    for (let i = startLine + 1; i < endLine; i++) {
+      const splitLineNum = i - startLine;
+      decorations.push({
+        range: new Range(i, 0, i, 0),
+        renderOptions: {
+          before: {
+            contentText: splitLineNum.toString().padStart(maxDigits, ' '),
+            color: new ThemeColor('editorLineNumber.foreground'),
+            width: widthStr,
+            margin: '0 2ch 0 0',
+          }
+        }
+      });
+    }
+  }
+
+  editor.setDecorations(splitLineNumberDecorationType, decorations);
+}
 
 /**
  * Splits a CLI-style quoted string.
@@ -136,6 +194,27 @@ export function activate(context: ExtensionContext) {
       client.restart();
     })
   );
+
+  // Update split line numbers when the active editor changes
+  context.subscriptions.push(
+    window.onDidChangeActiveTextEditor((editor: TextEditor | undefined) => {
+      updateSplitLineNumbers(editor);
+    })
+  );
+
+  // Update split line numbers when the document changes
+  context.subscriptions.push(
+    workspace.onDidChangeTextDocument((event: TextDocumentChangeEvent) => {
+      if (window.activeTextEditor && event.document === window.activeTextEditor.document) {
+        updateSplitLineNumbers(window.activeTextEditor);
+      }
+    })
+  );
+
+  // Initial update
+  if (window.activeTextEditor) {
+    updateSplitLineNumbers(window.activeTextEditor);
+  }
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -68,10 +68,11 @@ function updateSplitLineNumbers(editor: TextEditor | undefined) {
         range: new Range(i, 0, i, 0),
         renderOptions: {
           before: {
-            contentText: splitLineNum.toString().padStart(maxDigits, ' '),
+            contentText: splitLineNum.toString(),
             color: new ThemeColor('editorLineNumber.foreground'),
             width: widthStr,
             margin: '0 2ch 0 0',
+            textDecoration: 'none; text-align: right;',
           }
         }
       });


### PR DESCRIPTION
In the Carbon vscode extension, in /testdata/ files with file splits, add a line number column within the split next to the line number column for the overall file line number.

Assisted-by: Gemini 3.1 Pro via Antigravity