### PR TITLE
Add syntax highlighting for SemIR.

### DIFF
--- a/utils/vscode/carbon-check-test.tmLanguage.json
+++ b/utils/vscode/carbon-check-test.tmLanguage.json
@@ -13,7 +13,7 @@
       "end": "$",
       "patterns": [
         {
-          "include": "source.semir"
+          "include": "source.carbon-semir"
         }
       ]
     }

--- a/utils/vscode/carbon-check-test.tmLanguage.json
+++ b/utils/vscode/carbon-check-test.tmLanguage.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "scopeName": "source.carbon-check-test",
+  "injectionSelector": "L:source.carbon",
+  "patterns": [
+    {
+      "begin": "^(\\s*//\\s*CHECK:STDOUT:)",
+      "beginCaptures": {
+        "1": {
+          "name": "comment.line.carbon"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "source.semir"
+        }
+      ]
+    }
+  ]
+}

--- a/utils/vscode/package.json
+++ b/utils/vscode/package.json
@@ -27,6 +27,15 @@
           ".carbon"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "semir",
+        "aliases": [
+          "SemIR"
+        ],
+        "extensions": [
+          ".semir"
+        ]
       }
     ],
     "grammars": [
@@ -34,6 +43,18 @@
         "language": "carbon",
         "scopeName": "source.carbon",
         "path": "./carbon.tmLanguage.json"
+      },
+      {
+        "language": "semir",
+        "scopeName": "source.semir",
+        "path": "./semir.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.carbon-check-test",
+        "path": "./carbon-check-test.tmLanguage.json",
+        "injectTo": [
+          "source.carbon"
+        ]
       }
     ],
     "configuration": {

--- a/utils/vscode/package.json
+++ b/utils/vscode/package.json
@@ -46,7 +46,7 @@
       },
       {
         "language": "semir",
-        "scopeName": "source.semir",
+        "scopeName": "source.carbon-semir",
         "path": "./semir.tmLanguage.json"
       },
       {

--- a/utils/vscode/semir.tmLanguage.json
+++ b/utils/vscode/semir.tmLanguage.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "semir",
-  "scopeName": "source.semir",
+  "scopeName": "source.carbon-semir",
   "fileTypes": ["semir"],
   "patterns": [
     {
@@ -44,7 +44,7 @@
       "patterns": [
         {
           "name": "entity.name.variable.semir",
-          "match": "%[a-zA-Z0-9_.]+"
+          "match": "(?:[a-zA-Z0-9_]+\\.)?%[a-zA-Z0-9_.]+"
         },
         {
           "name": "entity.name.function.semir",

--- a/utils/vscode/semir.tmLanguage.json
+++ b/utils/vscode/semir.tmLanguage.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "semir",
+  "scopeName": "source.semir",
+  "fileTypes": ["semir"],
+  "patterns": [
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#identifiers"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#numbers"
+    },
+    {
+      "include": "#labels"
+    },
+    {
+      "include": "#punctuation"
+    }
+  ],
+  "repository": {
+    "keywords": {
+      "patterns": [
+        {
+          "name": "storage.type.semir",
+          "match": "\\b(var|ref|init|out|type|val)\\b"
+        },
+        {
+          "name": "storage.modifier.semir",
+          "match": "\\b(concrete)\\b"
+        },
+        {
+          "name": "support.function.semir",
+          "match": "\\b[a-z_][a-z0-9_]+\\b"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "entity.name.variable.semir",
+          "match": "%[a-zA-Z0-9_.]+"
+        },
+        {
+          "name": "entity.name.function.semir",
+          "match": "@[a-zA-Z0-9_.]+"
+        }
+      ]
+    },
+    "labels": {
+      "patterns": [
+        {
+          "name": "entity.name.label.semir",
+          "match": "![a-zA-Z0-9_]+:"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.semir",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.semir",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.semir",
+          "match": "\\b\\d+(\\.\\d+)?\\b"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "name": "keyword.operator.semir",
+          "match": "(=>|->|=|:)"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This applies to files named *.semir, but more interestingly also to Carbon source lines starting `// CHECK:STDOUT:`.

Assisted-by: Gemini 3.1 Pro via Antigravity