### PR TITLE
Improve vscode extension ownership

### DIFF
--- a/scripts/sync_repos.sh
+++ b/scripts/sync_repos.sh
@@ -18,7 +18,7 @@ $(git diff --summary "${COMMIT_SHA}^!")
 
 # Setup global git configuration.
 GIT_USERNAME="CarbonInfraBot"
-git config --global user.email "carbon-external-infra@google.com"
+git config --global user.email "infra-role@carbon-lang.dev"
 git config --global user.name "$GIT_USERNAME"
 
 declare -A MIRRORS

--- a/utils/vscode/README.md
+++ b/utils/vscode/README.md
@@ -36,7 +36,7 @@ path to the `carbon` binary. This looks like:
 See Carbon's
 [collaboration systems](https://github.com/carbon-language/carbon-lang/blob/trunk/CONTRIBUTING.md#collaboration-systems).
 We're most active on [Discord](https://discord.gg/ZjVdShJDAs) and have a
-#editor-integrations channel. We'll also respond to questions on
+`#editor-integrations` channel. We'll also respond to questions on
 [GitHub Discussions](https://github.com/carbon-language/carbon-lang/discussions).
 
 ## Documentation

--- a/utils/vscode/development.md
+++ b/utils/vscode/development.md
@@ -48,6 +48,9 @@ This installs `vsce` and `ovsx` to `/usr/local/bin`. Ensure that
 
     1. `npm install && vsce package -o carbon.vsix && realpath carbon.vsix`
     2. Go to https://marketplace.visualstudio.com/manage/publishers/carbon-lang
+        - We use `infra-role@carbon-lang.dev` for publishing; the GitHub account
+          `CarbonInfraBot` can also be used for login. Contact leads if you
+          require access.
     3. Next to the extension name, click the "..." and select "Update".
     4. Select the `carbon.vsix` file.
 


### PR DESCRIPTION
Updates the way to access vscode marketplace for publishing. I've adjusted CarbonInfraBot's attached email to match.

The `#editor-integrations` change is for inconsistent markdown handling by MS... https://marketplace.visualstudio.com/items?itemName=carbon-lang.carbon-vscode looks fine at the moment, but I was seeing rendering as a title -- maybe a bug that won't be rolled out, but backticks seem fair here.

Assisted-by: Google Antigravity with Gemini