### PR TITLE
Fix FacetTypeInfo::Print guard for self impls named constraints

### DIFF
--- a/toolchain/sem_ir/facet_type_info.cpp
+++ b/toolchain/sem_ir/facet_type_info.cpp
@@ -193,7 +193,7 @@ auto FacetTypeInfo::Print(llvm::raw_ostream& out) const -> void {
     }
   }
 
-  if (!self_impls_constraints.empty()) {
+  if (!self_impls_named_constraints.empty()) {
     out << outer_sep << "self impls named constraint: ";
     llvm::ListSeparator sep;
     for (auto self_impls : self_impls_named_constraints) {


### PR DESCRIPTION
## Summary

Fixes a copy-paste bug in `FacetTypeInfo::Print`: the "self impls named constraint" section was gated on `self_impls_constraints.empty()` instead of `self_impls_named_constraints.empty()`.

## Test plan

- `bazelisk build //toolchain/sem_ir:sem_ir` (not run in this environment; no Bazel installed)