### PR TITLE
Fix ValueStore::GetRawIndex DCHECK to use id.index in diagnostic

### DIFF
--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -232,7 +232,7 @@ class ValueStore
 
   auto GetIdTag() const -> IdTagType { return tag_; }
   auto GetRawIndex(IdT id) const -> int32_t {
-    CARBON_DCHECK(id.index >= 0, "{0}", index);
+    CARBON_DCHECK(id.index >= 0, "{0}", id.index);
     auto index = tag_.Remove(id);
 #ifndef NDEBUG
     if (index >= size_) {


### PR DESCRIPTION
## Summary

`ValueStore::GetRawIndex` formatted the first `CARBON_DCHECK` with `index` before the local `index` is declared. Use `id.index` so the diagnostic matches the condition being checked.

## Test plan

- `bazelisk build //toolchain/base:base` (or `//toolchain/...` as appropriate)