### PR TITLE
clang-format: Turn off trailing commas in braced lists lint.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,7 @@ DerivePointerAlignment: 'false'
 ExperimentalAutoDetectBinPacking: 'false'
 FixNamespaceComments: 'true'
 InsertBraces: 'true'
+InsertTrailingCommas: None
 PointerAlignment: Left
 # We abuse control macros for formatting other kinds of macros.
 SpaceBeforeParens: ControlStatementsExceptControlMacros


### PR DESCRIPTION
Our codebase does not conform to this rule, and it's causing havoc for automated tooling that tries to "fix" it.