### PR TITLE
Fix skill file to parse correctly.

### DIFF
--- a/.agents/skills/summarize_testdata_changes/SKILL.md
+++ b/.agents/skills/summarize_testdata_changes/SKILL.md
@@ -5,13 +5,13 @@ description:
     (`toolchain/*/testdata`).
 ---
 
+# Summarize testdata changes
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# Summarize testdata changes
 
 This skill provides instructions for creating a comprehensive report summarizing
 changes to Carbon testdata files (`toolchain/*/testdata`) and associating them

--- a/.agents/skills/summarize_testdata_changes/SKILL.md
+++ b/.agents/skills/summarize_testdata_changes/SKILL.md
@@ -1,15 +1,15 @@
+---
+name: Summarize testdata changes
+description:
+    Instructions for summarizing changes to Carbon testdata files
+    (`toolchain/*/testdata`).
+---
+
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
 Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
----
-
-name: Summarize testdata changes description: Instructions for summarizing
-changes to Carbon testdata files (`toolchain/*/testdata`).
-
----
 
 # Summarize testdata changes
 


### PR DESCRIPTION
The license header needs to go after the YAML in order for it to parse.