### PR TITLE
Diagnose `where` clause without a designator

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -2489,16 +2489,22 @@ static auto IsSameFacetValue(Context& context, SemIR::ConstantId const_id,
 // providing a `GetConstantValue` overload for a requirement block.
 template <>
 auto TryEvalTypedInst<SemIR::WhereExpr>(EvalContext& eval_context,
-                                        SemIR::InstId inst_id, SemIR::Inst inst)
-    -> SemIR::ConstantId {
+                                        SemIR::InstId where_inst_id,
+                                        SemIR::Inst inst) -> SemIR::ConstantId {
   auto typed_inst = inst.As<SemIR::WhereExpr>();
 
   Phase phase = Phase::Concrete;
   SemIR::FacetTypeInfo info;
 
+  if (typed_inst.period_self_id == SemIR::ErrorInst::InstId) {
+    return SemIR::ErrorInst::ConstantId;
+  }
+
   // Add the constraints from the `WhereExpr` instruction into `info`.
   if (typed_inst.requirements_id.has_value()) {
     auto insts = eval_context.inst_blocks().Get(typed_inst.requirements_id);
+    // Note that these requirement instructions don't have a constant value, but
+    // they contain only canonical instructions.
     for (auto inst_id : insts) {
       if (auto base =
               eval_context.insts().TryGetAs<SemIR::RequirementBaseFacetType>(
@@ -2571,7 +2577,7 @@ auto TryEvalTypedInst<SemIR::WhereExpr>(EvalContext& eval_context,
   }
 
   auto const_info = GetConstantFacetTypeInfo(
-      eval_context, SemIR::LocId(inst_id), info, &phase);
+      eval_context, SemIR::LocId(where_inst_id), info, &phase);
   return MakeFacetTypeResult(eval_context.context(), const_info, phase);
 }
 

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -2,12 +2,14 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "toolchain/base/kind_switch.h"
 #include "toolchain/check/context.h"
 #include "toolchain/check/convert.h"
 #include "toolchain/check/facet_type.h"
 #include "toolchain/check/generic.h"
 #include "toolchain/check/handle.h"
 #include "toolchain/check/inst.h"
+#include "toolchain/check/subst.h"
 #include "toolchain/check/type.h"
 #include "toolchain/check/unused.h"
 #include "toolchain/sem_ir/facet_type_info.h"
@@ -43,6 +45,7 @@ auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
   if (auto facet_type = context.types().TryGetAs<SemIR::FacetType>(
           self_without_constraints_type_id)) {
     const auto& info = context.facet_types().Get(facet_type->facet_type_id);
+    // TODO: Missing named constraints here.
     auto stripped_info =
         SemIR::FacetTypeInfo{.extend_constraints = info.extend_constraints};
     stripped_info.Canonicalize();
@@ -185,6 +188,110 @@ auto HandleParseNode(Context& /*context*/, Parse::RequirementAndId /*node_id*/)
   return true;
 }
 
+// Returns whether a designator (`.Self` or `.MemberName`) is present in the
+// where clause.
+static auto FindDesignator(Context& context,
+                           SemIR::InstBlockId requirements_block_id) -> bool {
+  auto block = context.inst_blocks().GetOrEmpty(requirements_block_id);
+
+  llvm::SmallVector<SemIR::InstId> requirements;
+  requirements.reserve(block.size() * 2);
+
+  // These requirement instructions don't have a constant value, but they
+  // contain only canonical instructions.
+  for (auto inst_id : block) {
+    auto inst = context.insts().Get(inst_id);
+    CARBON_KIND_SWITCH(inst) {
+      case CARBON_KIND(SemIR::RequirementBaseFacetType base): {
+        requirements.push_back(base.base_type_inst_id);
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementRewrite rewrite): {
+        requirements.push_back(rewrite.lhs_id);
+        requirements.push_back(rewrite.rhs_id);
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
+        requirements.push_back(equiv.lhs_id);
+        requirements.push_back(equiv.rhs_id);
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementImpls impls): {
+        requirements.push_back(impls.lhs_id);
+        requirements.push_back(impls.rhs_id);
+        break;
+      }
+      default:
+        CARBON_CHECK(inst_id == SemIR::ErrorInst::InstId,
+                     "unexpected inst {0} in requirements", inst);
+    }
+  }
+
+  class SubstFindDesignator : public SubstInstCallbacks {
+   public:
+    explicit SubstFindDesignator(Context* context, bool* found)
+        : SubstInstCallbacks(context), found_(found) {}
+
+    auto Subst(SemIR::InstId& inst_id) -> SubstResult override {
+      if (*found_) {
+        return FullySubstituted;
+      }
+
+      // An error was diagnosed for the where clause already.
+      if (inst_id == SemIR::ErrorInst::InstId) {
+        *found_ = true;
+        return FullySubstituted;
+      }
+
+      // TypeType has type TypeType, avoid recursing on its type.
+      if (context().insts().Is<SemIR::TypeType>(inst_id)) {
+        return FullySubstituted;
+      }
+
+      // `.MemberName` is represented as an ImplWitnessAccess through `.Self` so
+      // we only need to look for `.Self` here.
+      if (auto bind =
+              context().insts().TryGetAs<SemIR::SymbolicBinding>(inst_id)) {
+        auto entity_name = context().entity_names().Get(bind->entity_name_id);
+        if (entity_name.name_id == SemIR::NameId::PeriodSelf) {
+          *found_ = true;
+          return FullySubstituted;
+        }
+      }
+      // FacetAccessType of `.Self` is evaluated to SymbolicBindingType, so we
+      // need to look for this instruction too, since we won't find a `.Self`
+      // directly in that case.
+      if (auto bind =
+              context().insts().TryGetAs<SemIR::SymbolicBindingType>(inst_id)) {
+        auto entity_name = context().entity_names().Get(bind->entity_name_id);
+        if (entity_name.name_id == SemIR::NameId::PeriodSelf) {
+          *found_ = true;
+          return FullySubstituted;
+        }
+      }
+
+      return SubstOperands;
+    }
+
+    auto Rebuild(SemIR::InstId /*orig_inst_id*/, SemIR::Inst /*new_inst*/)
+        -> SemIR::InstId override {
+      CARBON_FATAL("unexpected rebuild, no insts should change");
+    }
+
+    bool* found_;
+  };
+
+  for (auto inst_id : requirements) {
+    bool found = false;
+    SubstFindDesignator callbacks(&context, &found);
+    SubstInst(context, inst_id, callbacks);
+    if (found) {
+      return true;
+    }
+  }
+  return false;
+}
+
 auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
   context.rewrites_stack().pop_back();
   // Remove `PeriodSelf` from name lookup, undoing the `Push` done for the
@@ -193,6 +300,15 @@ auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
   SemIR::InstId period_self_id =
       context.node_stack().Pop<Parse::NodeKind::WhereOperand>();
   SemIR::InstBlockId requirements_id = context.args_type_info_stack().Pop();
+
+  if (!FindDesignator(context, requirements_id)) {
+    CARBON_DIAGNOSTIC(WhereWithoutDesignator, Error,
+                      "`where` clause without a designator; expected `.Self` "
+                      "to appear in a requirement, or a member of `.Self`");
+    context.emitter().Emit(node_id, WhereWithoutDesignator);
+    period_self_id = SemIR::ErrorInst::InstId;
+  }
+
   AddInstAndPush<SemIR::WhereExpr>(context, node_id,
                                    {.type_id = SemIR::TypeType::TypeId,
                                     .period_self_id = period_self_id,

--- a/toolchain/check/testdata/named_constraint/require.carbon
+++ b/toolchain/check/testdata/named_constraint/require.carbon
@@ -224,15 +224,15 @@ constraint Z {
 // --- fail_require_impls_incomplete_self_in_class_impls.carbon
 library "[[@TEST_NAME]]";
 
-class C;
+class C(T:! type);
 constraint Z {
   // TODO: This should be a RequireImplsReferenceCycle error since `Z` is being
   // used inside `Z`.
   // CHECK:STDERR: fail_require_impls_incomplete_self_in_class_impls.carbon:[[@LINE+4]]:17: error: semantics TODO: `facet type has constraints that we don't handle yet` [SemanticsTodo]
-  // CHECK:STDERR:   require impls type where C impls Z;
-  // CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:   require impls type where C(.Self) impls Z;
+  // CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
   // CHECK:STDERR:
-  require impls type where C impls Z;
+  require impls type where C(.Self) impls Z;
 }
 
 // --- fail_require_impls_incomplete_indirect.carbon

--- a/toolchain/check/testdata/where_expr/designator.carbon
+++ b/toolchain/check/testdata/where_expr/designator.carbon
@@ -91,35 +91,41 @@ class D {
   fn G() -> .Self { return Self; }
 }
 
-// --- todo_fail_impls_constraint_does_not_constrain_self.carbon
+// --- fail_impls_constraint_does_not_constrain_self.carbon
 library "[[@TEST_NAME]]";
 
 interface I {}
 
-// TODO: Diagnose that the `where` on `T` does not refer to `.Self` at all.
-// See https://docs.carbon-lang.dev/docs/design/generics/details.html#constraints-must-use-a-designator
+// CHECK:STDERR: fail_impls_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:27: error: `where` clause without a designator; expected `.Self` to appear in a requirement, or a member of `.Self` [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(U:! type, unused T:! type where U impls I) {}
+// CHECK:STDERR:                           ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn F(U:! type, unused T:! type where U impls I) {}
 
-// --- todo_fail_equality_constraint_does_not_constrain_self.carbon
+// --- fail_equality_constraint_does_not_constrain_self.carbon
 library "[[@TEST_NAME]]";
 
 interface I {
   let X:! type;
 }
 
-// TODO: Diagnose that the `where` on `T` does not refer to `.Self` at all.
-// See https://docs.carbon-lang.dev/docs/design/generics/details.html#constraints-must-use-a-designator
+// CHECK:STDERR: fail_equality_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:24: error: `where` clause without a designator; expected `.Self` to appear in a requirement, or a member of `.Self` [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(U:! I, unused T:! type where U.X == ()) {}
+// CHECK:STDERR:                        ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn F(U:! I, unused T:! type where U.X == ()) {}
 
-// --- todo_fail_combined_constraint_does_not_constrain_self.carbon
+// --- fail_combined_constraint_does_not_constrain_self.carbon
 library "[[@TEST_NAME]]";
 
 interface I {
   let X:! type;
 }
 
-// TODO: Diagnose that the `where` on `T` does not refer to `.Self` at all.
-// See https://docs.carbon-lang.dev/docs/design/generics/details.html#constraints-must-use-a-designator
+// CHECK:STDERR: fail_combined_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:24: error: `where` clause without a designator; expected `.Self` to appear in a requirement, or a member of `.Self` [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(U:! I, unused T:! type where U impls I and U.X == ()) {}
+// CHECK:STDERR:                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 fn F(U:! I, unused T:! type where U impls I and U.X == ()) {}
 
 // --- impls_constraint_does_constrain_self.carbon

--- a/toolchain/diagnostics/kind.def
+++ b/toolchain/diagnostics/kind.def
@@ -544,6 +544,7 @@ CARBON_DIAGNOSTIC_KIND(AliasRequiresNameRef)
 // Where operator and its requirements.
 CARBON_DIAGNOSTIC_KIND(ImplsOnNonFacetType)
 CARBON_DIAGNOSTIC_KIND(WhereOnNonFacetType)
+CARBON_DIAGNOSTIC_KIND(WhereWithoutDesignator)
 
 // Facet type resolution.
 CARBON_DIAGNOSTIC_KIND(AssociatedConstantNotConstantAfterConversion)


### PR DESCRIPTION
> We don’t allow a where constraint unless it applies a restriction to the current type. This means referring to some [designator](https://docs.carbon-lang.dev/docs/design/generics/details.html#kinds-of-where-constraints), like .MemberName, or [.Self](https://docs.carbon-lang.dev/docs/design/generics/details.html#recursive-constraints).

https://docs.carbon-lang.dev/docs/design/generics/details.html#constraints-must-use-a-designator