### PR TITLE
Add documentation for setting up `jj b a`.

### DIFF
--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -271,10 +271,6 @@ conflict-marker-style = "git"
 # Produce Git-compatible diff format.
 format = "git"
 
-[remotes.origin]
-# Automatically track all remote bookmarks.
-auto-track-bookmarks = "*"
-
 [templates]
 # Automatically add a trailer to commits to indicate that they were AI-assisted.
 commit_trailers = '''
@@ -287,14 +283,23 @@ bookmark-advance-from = "heads(::to & bookmarks()) & ~immutable_heads()"
 bookmark-advance-to = 'heads(::@ & ~(description("") & empty() & ~merges()))'
 ```
 
-As well as this per-repository configuration (added to `.jj/config.toml`):
+As well as this per-repository configuration (added to `.jj/config.toml`)
+describing how your GitHub checkout is configured:
 
 ```toml
+[remotes.origin]
+# Automatically track all remote bookmarks.
+auto-track-bookmarks = "*"
+
 [revset-aliases]
 # Treat github.com/carbon-language/carbon-lang as immutable, but treat your fork
 # as mutable.
 "immutable_heads()" = "remote_bookmarks(*, upstream)"
 ```
+
+The above assumes that you have configured the remote name `origin` to refer to
+your fork and `upstream` to refer to `github.com/carbon-language/carbon-lang`,
+and will need to be adjusted if you use different remote names.
 
 #### AI assistants
 

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -282,7 +282,7 @@ commit_trailers = '''
 
 [revsets]
 # Make `jj bookmark advance` / `jj b a` only move bookmarks that point to
-# mutable commits, and move them to the most recent non-empty descendent.
+# mutable commits, and move them to the most recent non-empty descendant.
 bookmark-advance-from = "heads(::to & bookmarks()) & ~immutable_heads()"
 bookmark-advance-to = 'heads(::@ & ~(description("") & empty() & ~merges()))'
 ```

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -279,6 +279,21 @@ auto-track-bookmarks = "*"
 # Automatically add a trailer to commits to indicate that they were AI-assisted.
 commit_trailers = '''
 "Assisted-by: My AI Tool"'''
+
+[revsets]
+# Make `jj bookmark advance` / `jj b a` only move bookmarks that point to
+# mutable commits, and move them to the most recent non-empty descendent.
+bookmark-advance-from = "heads(::to & bookmarks()) & ~immutable_heads()"
+bookmark-advance-to = 'heads(::@ & ~(description("") & empty() & ~merges()))'
+```
+
+As well as this per-repository configuration (added to `.jj/config.toml`):
+
+```toml
+[revset-aliases]
+# Treat github.com/carbon-language/carbon-lang as immutable, but treat your fork
+# as mutable.
+"immutable_heads()" = "remote_bookmarks(*, upstream)"
 ```
 
 #### AI assistants


### PR DESCRIPTION
This gives a setup where `jj b a` / `jj bookmark advance` can reliably be used to advance a bookmark for a github pull request, without advancing other bookmarks such as `trunk` or pointing the bookmark at an empty commit.