### PR TITLE
Fix formatting of compound-type variable declarations in macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,3 +27,8 @@ StatementMacros: ['ABSTRACT']
 QualifierAlignment: Custom
 QualifierOrder:
   [inline, static, friend, constexpr, const, volatile, restrict, type]
+Macros:
+  # These macros can contain variable declarations, so clang-format needs to
+  # "see through" them in order to format them correctly.
+  - CARBON_ASSIGN_OR_RETURN(x)=x
+  - CARBON_KIND(x)=x

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -1111,14 +1111,14 @@ auto Lexer::LexNumericLiteral(llvm::StringRef source_text, ssize_t& position)
   position += token_size;
 
   CARBON_KIND_SWITCH(literal->ComputeValue(emitter_)) {
-    case CARBON_KIND(NumericLiteral::IntValue && value): {
+    case CARBON_KIND(NumericLiteral::IntValue&& value): {
       return LexTokenWithPayload(TokenKind::IntLiteral,
                                  buffer_.value_stores_->ints()
                                      .AddUnsigned(std::move(value.value))
                                      .AsTokenPayload(),
                                  byte_offset);
     }
-    case CARBON_KIND(NumericLiteral::RealValue && value): {
+    case CARBON_KIND(NumericLiteral::RealValue&& value): {
       auto real_id = buffer_.value_stores_->reals().Add(
           Real{.mantissa = value.mantissa,
                .exponent = value.exponent,

--- a/toolchain/sem_ir/stringify.cpp
+++ b/toolchain/sem_ir/stringify.cpp
@@ -176,7 +176,7 @@ class StepStack {
           PushSpecificNamedConstraint(specific_named_constraint);
           break;
         }
-        case CARBON_KIND(llvm::ListSeparator * sep): {
+        case CARBON_KIND(llvm::ListSeparator* sep): {
           PushString(*sep);
           break;
         }


### PR DESCRIPTION
By default clang-format interprets function-like macro invocations as function calls. E.g. the argument of `CARBON_KIND(llvm::ListSeparator* sep)` is interpreted as an expression, meaning the `*` is an infix binary operator, so it inserts a space before the `*`. This change teaches clang-format that `CARBON_KIND(x)` and `CARBON_ASSIGN_OR_RETURN(x)` rewrite to `x`, which is close enough to the truth to enable it to format them correctly. See the [clang-format docs](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#macros) for details.