### PR TITLE
Update LLVM and fix a couple of API usages

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -84,8 +84,8 @@ git_override(
     build_file_content = "# empty",
     # We pin to specific upstream commits and try to track top-of-tree
     # reasonably closely rather than pinning to a specific release.
-    # HEAD as of 2026-03-09.
-    commit = "d8474abfc1e7c3856b85b088f1133ae2e90da3d0",
+    # HEAD as of 2026-03-31.
+    commit = "0e0a0458ce3aeccb27c677b15abe02e72cf18a50",
     patch_cmds = ["echo \"module(name='llvm-raw')\" > MODULE.bazel"],
     patch_strip = 1,
     patches = [

--- a/toolchain/check/cpp/call.cpp
+++ b/toolchain/check/cpp/call.cpp
@@ -223,7 +223,8 @@ static auto ConvertArgToTemplateArg(
     }
 
     // TODO: provide a better location.
-    auto template_loc = clang::TemplateArgumentLocInfo();
+    auto template_loc = clang::TemplateArgumentLocInfo(context.ast_context(),
+                                                       clang::SourceLocation());
 
     auto const_inst_id =
         context.constant_values().GetConstantInstId(converted_inst_id);

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -999,7 +999,7 @@ auto FileContext::BuildFunctionBody(SemIR::FunctionId function_id,
   if (entry_block->hasNPredecessorsOrMore(1)) {
     auto* new_entry_block = llvm::BasicBlock::Create(
         llvm_context(), "entry", function_info->llvm_function, entry_block);
-    llvm::BranchInst::Create(entry_block, new_entry_block);
+    llvm::UncondBrInst::Create(entry_block, new_entry_block);
   }
 
   // Emit fingerprint accumulated inside the function context.


### PR DESCRIPTION
The `TemplateArgLocInfo` change is more interesting than usual as this isn't enforced in the type system, and only shows up as a crash.