### PR TITLE
Remove ASan from the default build mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -87,12 +87,12 @@ common --define=absl=1
 # Enable TCMalloc on Linux in optimized builds.
 common --custom_malloc=//bazel/malloc:tcmalloc_if_linux_opt
 
-# Configuration for enabling Address Sanitizer. Note that this is enabled by
-# default for fastbuild. The config is provided to enable ASan even in
-# optimized or other build configurations. Note that ASan and TCMalloc are
+# Configuration for enabling Address Sanitizer. Note that ASan and TCMalloc are
 # incompatible so this explicitly forces the system malloc.
 common:asan --features=asan
 common:asan --custom_malloc=@bazel_tools//tools/cpp:malloc
+# Also double the test timeouts for ASan to improve their consistency.
+test:asan --test_timeout=120,600,1800,-1
 
 # Configuration for enabling LibFuzzer (along with ASan).
 common:fuzzer --features=fuzzer

--- a/bazel/cc_toolchains/cc_toolchain_carbon_project_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_carbon_project_features.bzl
@@ -27,10 +27,9 @@ carbon_project_fastbuild_feature = feature(
     enabled = True,
     requires = [feature_set(["fastbuild"])],
     implies = [
-        "asan",
-        "asan_min_size",
         "minimal_optimization_flags",
         "minimal_debug_info_flags",
+        "preserve_call_stacks",
     ],
 )
 

--- a/bazel/cc_toolchains/cc_toolchain_optimization.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_optimization.bzl
@@ -26,7 +26,7 @@ minimal_optimization_flags = feature(
     name = "minimal_optimization_flags",
     flag_sets = [flag_set(
         actions = codegen_compile_actions,
-        flag_groups = [flag_group(flags = ["-O1"])],
+        flag_groups = [flag_group(flags = ["-Og"])],
     )],
 )
 default_optimization_flags = feature(

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -24,6 +24,7 @@ contributions.
     -   [Optional tools](#optional-tools)
         -   [Jujutsu (`jj`)](#jujutsu-jj)
         -   [AI assistants](#ai-assistants)
+    -   [Running tests with AddressSanitizer (ASan)](#running-tests-with-addresssanitizer-asan)
     -   [Manually building Clang and LLVM (not recommended)](#manually-building-clang-and-llvm-not-recommended)
 -   [Troubleshooting build issues](#troubleshooting-build-issues)
     -   [`bazel clean`](#bazel-clean)
@@ -309,6 +310,20 @@ git log
 git show
 git status
 ```
+
+### Running tests with AddressSanitizer (ASan)
+
+By default, the Bazel build mode for the toolchain does not enable
+AddressSanitizer (ASan). If you wish to enable ASan for local testing, you must
+pass the `--config=asan` flag explicitly:
+
+```shell
+bazelisk test --config=asan //...
+```
+
+Note that our Continuous Integration (CI) infrastructure runs a separate
+configuration for ASan to ensure test coverage without slowing down the default
+test cycle.
 
 ### Manually building Clang and LLVM (not recommended)
 


### PR DESCRIPTION
Also increases the default optimization to `-Og` which is likely to give faster turn-around time which is what we want to optimize for here. This should also _substantially_ shrink binary sizes, etc.

ASan is still available via `--config=asan`, and is added to the CI infrastructure. However, my current thought is to only run it after push rather than in PRs and in the merge queue.