### PR TITLE
Update LLVM (again) to pick up a workaround crashes the compiler when building with ASan

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,8 +86,8 @@ git_override(
     build_file_content = "# empty",
     # We pin to specific upstream commits and try to track top-of-tree
     # reasonably closely rather than pinning to a specific release.
-    # HEAD as of 2026-03-31.
-    commit = "0e0a0458ce3aeccb27c677b15abe02e72cf18a50",
+    # HEAD as of 2026-04-01.
+    commit = "b71eacea7687f68c11299e3bda5654fbbaa1e20e",
     patch_cmds = ["echo \"module(name='llvm-raw')\" > MODULE.bazel"],
     patch_strip = 1,
     patches = [


### PR DESCRIPTION

Assisted-by: Antigravity with Gemini

