### PR TITLE
Add ASan to post-merge CI and improve the action structure for GitHub

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,13 +22,30 @@ concurrency:
 
 jobs:
   test:
+    name:
+      Testing ${{ matrix.config.name != 'Default' && format('({0})',
+      matrix.config.name) || '' }} (${{ matrix.runner }})
     strategy:
       matrix:
         # Test a recent version of each supported OS.
         runner: ['ubuntu-22.04', 'macos-14']
-        build_mode: [fastbuild, opt]
+        # Create a synthetic matrix dimension with the event name for filtering.
+        event: ['${{ github.event_name }}']
+        config:
+          - name: 'Default'
+            flags: ''
+          - name: 'Opt'
+            flags: '-c opt'
+          - name: 'ASan'
+            flags: '--config=asan'
+        exclude:
+          - runner: 'macos-14'
+            config: { name: 'ASan', flags: '--config=asan' }
+          - event: 'pull_request'
+            config: { name: 'ASan', flags: '--config=asan' }
+          - event: 'merge_group'
+            config: { name: 'ASan', flags: '--config=asan' }
     runs-on: ${{ matrix.runner }}
-
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
@@ -74,7 +91,7 @@ jobs:
           targets_file: ${{ runner.temp }}/targets
 
       # Build and run just the tests impacted by the PR or merge group.
-      - name: Test (${{ matrix.build_mode }})
+      - name: Test (${{ matrix.config.name }})
         if: steps.test-setup.outputs.has_code == 'true'
         shell: bash
         env:
@@ -89,7 +106,7 @@ jobs:
           # skip thim as-if we were using `//...` style wild card patterns.
           ./scripts/run_bazel.py \
             --attempts=5 --jobs-on-last-attempt=4 \
-            test -c ${{ matrix.build_mode }} \
+            test ${{ matrix.config.flags }} \
             --target_pattern_file=$TARGETS_FILE
 
       # See "Disk space before build" in `test-setup`.


### PR DESCRIPTION
Note that this will require changing the branch protections to use new names for all of the checks and be somewhat disruptive. There aren't any really good ways I could find of fixing this. Some options that I explored:

- Have a single `pre-merge` workflow file that contains all of the other workflows, splitting as much of the logic as we can into re-usable files. This would basically merge testing, `pre-commit`, and `clangd-tidy` checking into a single workflow file. However, it would also delay the pre-commit suggestions action to only run once _all_ of these finish, rather than as soon as pre-commit finishes.

- Serialize `pre-commit` and the rest of `pre-merge` to get the effect of the above option but without the downside. Instead, the downside would be serializing some of our actions. 

- Have a single `pre-merge` workflow that triggers whenever any of the other workflows completes, and have it check whether all the others have completed. It will fail until it reaches that point. This requires passing in GitHub keys to the workflow so that it can check the status of other checks, and documentation online seems to indicate it is sometimes flaky, I assume because of racing triggers of events or check-status not being guaranteed consistent in the queries.

- Have a single `pre-merge` workflow that polls, waiting for all the other workflows to finish using some Python logic. This requires building and maintaining code to poll GitHub, keys to authorize that polling, and handling all of the failure modes of a polling operation -- timeouts, network issues, etc.

Maybe there are others, but not sure what they look like. Suggestions welcome here.

I'm hesitant to either delay the pre-commit suggestions or serialize pre-commit execution. And the complexity or flakiness of the other two options seem worse than having to re-work the branch protections each time the naming here changes. But interested if folks think a different direction would be better.

Assisted-by: Antigravity with Gemini