### PR TITLE
Fix missing include for `std::log2`

### DIFF
--- a/toolchain/lex/numeric_literal.cpp
+++ b/toolchain/lex/numeric_literal.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <cmath>
 #include <iterator>
 #include <optional>
 


### PR DESCRIPTION
Some standard libraries require this include for the code to compile.