### PR TITLE
Update tree_sitter for the new `self` syntax and `static var`

### DIFF
--- a/utils/tree_sitter/README.md
+++ b/utils/tree_sitter/README.md
@@ -17,6 +17,27 @@ To install tree-sitter, run:
 npm install -g tree-sitter-cli
 ```
 
+### Building and Testing
+
+To build and test changes to the grammar using Bazel, provide specific flags to
+allow the build to access the system `tree-sitter` binary and environment.
+
+```bash
+bazel test //utils/tree_sitter:string_tests \
+  --strategy=Genrule=local \
+  --action_env=PATH \
+  --action_env=HOME
+```
+
+-   `--strategy=Genrule=local`: Disables sandboxing for the genrule that runs
+    `tree-sitter generate`, allowing it to find the system-installed binary.
+-   `--action_env=PATH`: Passes your current `PATH` to the build actions,
+    ensuring `tree-sitter` can be found. If `tree-sitter` is not in your default
+    PATH, you can specify it explicitly, for example:
+    `--action_env=PATH=/path/to/tree-sitter/bin:$PATH`.
+-   `--action_env=HOME`: Passes your `HOME` environment variable, which
+    `tree-sitter` may need to locate its configuration or cache.
+
 ## Editor Installation
 
 ### Helix

--- a/utils/tree_sitter/grammar.js
+++ b/utils/tree_sitter/grammar.js
@@ -46,6 +46,7 @@ module.exports = grammar({
   conflicts: ($) => [
     [$.paren_pattern, $.paren_expression],
     [$.struct_literal, $.struct_type_literal],
+    [$._pattern_without_expression, $._simple_expression],
   ],
 
   extras: ($) => [/\s/, $.comment],
@@ -163,6 +164,7 @@ module.exports = grammar({
     _pattern_without_expression: ($) =>
       choice(
         'auto',
+        seq(optional('ref'), 'self', optional(seq(':', $._expression))),
         seq($.binding_lhs, ':', $._expression),
         seq($.binding_lhs, ':!', $._expression),
         seq('template', $.binding_lhs, ':!', $._expression),
@@ -316,7 +318,7 @@ module.exports = grammar({
 
     var_declaration: ($) =>
       seq(
-        'var',
+        seq(optional('static'), 'var'),
         $._pattern_without_expression,
         optional(seq('=', $._expression)),
         ';'
@@ -379,11 +381,7 @@ module.exports = grammar({
     generic_binding: ($) =>
       seq(optional('template'), $.ident, ':!', $._expression),
 
-    deduced_param: ($) =>
-      choice(
-        $.generic_binding,
-        seq(optional('addr'), 'self', ':', $._expression)
-      ),
+    deduced_param: ($) => $.generic_binding,
 
     deduced_params: ($) => seq('[', comma_sep($.deduced_param), ']'),
 

--- a/utils/tree_sitter/testdata/string/self_parameter.carbon
+++ b/utils/tree_sitter/testdata/string/self_parameter.carbon
@@ -1,0 +1,11 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+class Point {
+  var x: i32;
+
+  fn GetX(self: Point) -> i32 { return self.x; }
+  fn GetY(self) -> i32 { return 0; }
+  fn SetX(ref self, new_x: i32) {}
+}

--- a/utils/tree_sitter/testdata/string/static_var.carbon
+++ b/utils/tree_sitter/testdata/string/static_var.carbon
@@ -1,0 +1,7 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+class Widget {
+  static var count: i32;
+}


### PR DESCRIPTION
This implements p7016 for tree_sitter. It also updates the build and source file to allow this to build successfully and documents how to successfully run these tests with Bazel given that it is fundamentally not hermetic.

Assisted-by: Antigravity with Gemini