### PR TITLE
Add the `static` keyword to various syntax highlighting

### DIFF
--- a/utils/highlightjs/highlightjs_carbon_lang.js
+++ b/utils/highlightjs/highlightjs_carbon_lang.js
@@ -57,6 +57,7 @@ export default function (hljs) {
       'like',
       'match',
       'self',
+      'static',
       'namespace',
       'not',
       'observe',

--- a/utils/textmate/Syntaxes/carbon.tmLanguage.json
+++ b/utils/textmate/Syntaxes/carbon.tmLanguage.json
@@ -298,7 +298,7 @@
       "patterns": [
         {
           "name": "storage.modifier.carbon",
-          "match": "\\b(abstract|const|extend|extern|final|private|protected|virtual)\\b"
+          "match": "\\b(abstract|const|extend|extern|final|private|protected|static|virtual)\\b"
         },
         {
           "name": "storage.modifier.carbon",

--- a/utils/vim/syntax/carbon.vim
+++ b/utils/vim/syntax/carbon.vim
@@ -55,6 +55,7 @@ syn keyword carbonKeywordExtends extends nextgroup=carbonNominalType skipwhite
 syn keyword carbonKeywordSelf Self
 syn keyword carbonKeywordAs as
 syn keyword carbonKeywordTemplate template
+syn keyword carbonKeywordStatic static
 syn keyword carbonKeywordExternal external
 syn keyword carbonKeywordForAll forall
 syn keyword carbonKeywordAPI api
@@ -97,6 +98,7 @@ hi def link carbonKeywordExtends carbonKeyword
 hi def link carbonKeywordSelf carbonKeyword
 hi def link carbonKeywordAs carbonKeyword
 hi def link carbonKeywordTemplate carbonKeyword
+hi def link carbonKeywordStatic carbonKeyword
 hi def link carbonKeywordExternal carbonKeyword
 hi def link carbonKeywordForAll carbonKeyword
 hi def link carbonKeywordAPI Structure


### PR DESCRIPTION
This follows #7016 which suggests using `static var` for non-instance class data members.

Assisted-by: Antigravity with Gemini