### PR TITLE
Remove TODO in impl lookup for discarding unused witnesses

### DIFF
--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -991,10 +991,6 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
                              req_impl.specific_interface)) {
       // At least one queried interface in the facet type has no witness for the
       // given type, we can stop looking for more.
-      //
-      // TODO: The LookupImplWitness won't be used. We should find a way to
-      // discard it, which would remove it from the generic eval block if the
-      // lookup is within a generic context.
       break;
     }
 


### PR DESCRIPTION
In #6972 we stopped finishing instructions added just for EvalOrAddInst, which prevents adding the instruction to the containing generic eval block.