### PR TITLE
consistently uses the caller's specific to get the callee's pattern type id

### DIFF
--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -632,7 +632,7 @@ auto MatchContext::DoVarPreWorkImpl(State state, SemIR::InstId scrutinee_id,
       break;
     }
     case CARBON_KIND(CallerState* caller): {
-      auto specific_type_id = SemIR::GetTypeOfInstInSpecific(
+      auto specific_pattern_type_id = SemIR::GetTypeOfInstInSpecific(
           context_.sem_ir(), caller->callee_specific_id, entry.pattern_id);
       storage_id = AddInst<SemIR::TemporaryStorage>(
           context_, SemIR::LocId(entry.pattern_id),

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -180,11 +180,11 @@ class MatchContext {
     return value_id;
   }
 
-  // Performs the core logic of matching a variable pattern whose type is
-  // `entry.pattern_id`, but returns the scrutinee that its subpattern should be
-  // matched with, rather than pushing it onto the worklist. This is factored
-  // out so it can be reused when handling a `FormBindingPattern` or
-  // `FormParamPattern` with an initializing form.
+  // Performs the core logic of matching a variable pattern, returning the
+  // scrutinee that its subpattern should be matched with, rather than pushing
+  // it onto the worklist. This is factored out so it can be reused when
+  // handling a `FormBindingPattern` or `FormParamPattern` with an initializing
+  // form.
   auto DoVarPreWorkImpl(State state, SemIR::InstId scrutinee_id,
                         WorkItem entry) const -> SemIR::InstId;
 

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -636,8 +636,8 @@ auto MatchContext::DoVarPreWorkImpl(State state, SemIR::InstId scrutinee_id,
           context_.sem_ir(), caller->callee_specific_id, entry.pattern_id);
       storage_id = AddInst<SemIR::TemporaryStorage>(
           context_, SemIR::LocId(entry.pattern_id),
-          {.type_id =
-               ExtractScrutineeType(context_.sem_ir(), specific_type_id)});
+          {.type_id = ExtractScrutineeType(context_.sem_ir(),
+                                           specific_pattern_type_id)});
       CARBON_CHECK(scrutinee_id.has_value());
       break;
     }

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -181,13 +181,12 @@ class MatchContext {
   }
 
   // Performs the core logic of matching a variable pattern whose type is
-  // `pattern_type_id`, but returns the scrutinee that its subpattern should be
+  // `entry.pattern_id`, but returns the scrutinee that its subpattern should be
   // matched with, rather than pushing it onto the worklist. This is factored
   // out so it can be reused when handling a `FormBindingPattern` or
   // `FormParamPattern` with an initializing form.
-  auto DoVarPreWorkImpl(State state, SemIR::TypeId pattern_type_id,
-                        SemIR::InstId scrutinee_id, WorkItem entry) const
-      -> SemIR::InstId;
+  auto DoVarPreWorkImpl(State state, SemIR::InstId scrutinee_id,
+                        WorkItem entry) const -> SemIR::InstId;
 
   // The stack of work to be processed.
   llvm::SmallVector<WorkItem> stack_;
@@ -462,8 +461,7 @@ auto MatchContext::DoPreWork(State state, SemIR::AnyParamPattern param_pattern,
       [[fallthrough]];
     }
     case SemIR::VarParamPattern::Kind: {
-      scrutinee_id =
-          DoVarPreWorkImpl(state, param_pattern.type_id, scrutinee_id, entry);
+      scrutinee_id = DoVarPreWorkImpl(state, scrutinee_id, entry);
       entry.allow_unmarked_ref = true;
       break;
     }
@@ -603,8 +601,7 @@ auto MatchContext::DoPostWork(State state,
 auto MatchContext::DoPreWork(State state, SemIR::VarPattern var_pattern,
                              SemIR::InstId scrutinee_id, WorkItem entry)
     -> void {
-  auto new_scrutinee_id =
-      DoVarPreWorkImpl(state, var_pattern.type_id, scrutinee_id, entry);
+  auto new_scrutinee_id = DoVarPreWorkImpl(state, scrutinee_id, entry);
   if (need_subpattern_results()) {
     AddAsPostWork(entry);
   }
@@ -613,8 +610,7 @@ auto MatchContext::DoPreWork(State state, SemIR::VarPattern var_pattern,
            .allow_unmarked_ref = true});
 }
 
-auto MatchContext::DoVarPreWorkImpl(State state, SemIR::TypeId pattern_type_id,
-                                    SemIR::InstId scrutinee_id,
+auto MatchContext::DoVarPreWorkImpl(State state, SemIR::InstId scrutinee_id,
                                     WorkItem entry) const -> SemIR::InstId {
   auto storage_id = SemIR::InstId::None;
   CARBON_KIND_SWITCH(state) {
@@ -635,11 +631,13 @@ auto MatchContext::DoVarPreWorkImpl(State state, SemIR::TypeId pattern_type_id,
       storage_id = lookup_result.value();
       break;
     }
-    case CARBON_KIND(CallerState* _): {
+    case CARBON_KIND(CallerState* caller): {
+      auto specific_type_id = SemIR::GetTypeOfInstInSpecific(
+          context_.sem_ir(), caller->callee_specific_id, entry.pattern_id);
       storage_id = AddInst<SemIR::TemporaryStorage>(
           context_, SemIR::LocId(entry.pattern_id),
           {.type_id =
-               ExtractScrutineeType(context_.sem_ir(), pattern_type_id)});
+               ExtractScrutineeType(context_.sem_ir(), specific_type_id)});
       CARBON_CHECK(scrutinee_id.has_value());
       break;
     }

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -19,6 +19,7 @@
 #include "toolchain/check/type.h"
 #include "toolchain/diagnostics/format_providers.h"
 #include "toolchain/sem_ir/expr_info.h"
+#include "toolchain/sem_ir/inst_kind.h"
 #include "toolchain/sem_ir/pattern.h"
 
 namespace Carbon::Check {
@@ -185,8 +186,15 @@ class MatchContext {
   // it onto the worklist. This is factored out so it can be reused when
   // handling a `FormBindingPattern` or `FormParamPattern` with an initializing
   // form.
-  auto DoVarPreWorkImpl(State state, SemIR::InstId scrutinee_id,
-                        WorkItem entry) const -> SemIR::InstId;
+  auto DoVarPreWorkImpl(State state, SemIR::TypeId pattern_type_id,
+                        SemIR::InstId scrutinee_id, WorkItem entry) const
+      -> SemIR::InstId;
+
+  // Returns the scrutinee type from `pattern_id` when passed a `CallerState`,
+  // and `param_pattern_type_id` otherwise.
+  auto GetSpecificPatternTypeId(State state, SemIR::InstId pattern_id,
+                                SemIR::TypeId param_pattern_type_id)
+      -> SemIR::TypeId;
 
   // The stack of work to be processed.
   llvm::SmallVector<WorkItem> stack_;
@@ -443,10 +451,28 @@ static auto ParamKindFor(Context& context, SemIR::Inst param_pattern,
   }
 }
 
+auto MatchContext::GetSpecificPatternTypeId(State state,
+                                            SemIR::InstId pattern_id,
+                                            SemIR::TypeId param_pattern_type_id)
+    -> SemIR::TypeId {
+  CARBON_KIND_SWITCH(state) {
+    case CARBON_KIND(CallerState* caller): {
+      auto& sem_ir = context_.sem_ir();
+      return ExtractScrutineeType(
+          sem_ir, SemIR::GetTypeOfInstInSpecific(
+                      sem_ir, caller->callee_specific_id, pattern_id));
+    }
+    default:
+      return param_pattern_type_id;
+  }
+}
+
 auto MatchContext::DoPreWork(State state, SemIR::AnyParamPattern param_pattern,
                              SemIR::InstId scrutinee_id, WorkItem entry)
     -> void {
   AddAsPostWork(entry);
+  auto pattern_type_id =
+      GetSpecificPatternTypeId(state, entry.pattern_id, param_pattern.type_id);
 
   // If `param_pattern` has initializing form, match it as a `VarPattern`
   // before matching it as a parameter pattern.
@@ -461,7 +487,8 @@ auto MatchContext::DoPreWork(State state, SemIR::AnyParamPattern param_pattern,
       [[fallthrough]];
     }
     case SemIR::VarParamPattern::Kind: {
-      scrutinee_id = DoVarPreWorkImpl(state, scrutinee_id, entry);
+      scrutinee_id =
+          DoVarPreWorkImpl(state, pattern_type_id, scrutinee_id, entry);
       entry.allow_unmarked_ref = true;
       break;
     }
@@ -475,15 +502,10 @@ auto MatchContext::DoPreWork(State state, SemIR::AnyParamPattern param_pattern,
       if (scrutinee_id == SemIR::ErrorInst::InstId) {
         caller_state->call_args.push_back(SemIR::ErrorInst::InstId);
       } else {
-        auto scrutinee_type_id = ExtractScrutineeType(
-            context_.sem_ir(),
-            SemIR::GetTypeOfInstInSpecific(context_.sem_ir(),
-                                           caller_state->callee_specific_id,
-                                           entry.pattern_id));
         caller_state->call_args.push_back(
             Convert(context_, SemIR::LocId(scrutinee_id), scrutinee_id,
                     {.kind = ConversionKindFor(context_, param_pattern, entry),
-                     .type_id = scrutinee_type_id}));
+                     .type_id = pattern_type_id}));
       }
       // Do not traverse farther or schedule PostWork, because the caller side
       // of the pattern ends here.
@@ -601,7 +623,10 @@ auto MatchContext::DoPostWork(State state,
 auto MatchContext::DoPreWork(State state, SemIR::VarPattern var_pattern,
                              SemIR::InstId scrutinee_id, WorkItem entry)
     -> void {
-  auto new_scrutinee_id = DoVarPreWorkImpl(state, scrutinee_id, entry);
+  auto pattern_type_id =
+      GetSpecificPatternTypeId(state, entry.pattern_id, var_pattern.type_id);
+  auto new_scrutinee_id =
+      DoVarPreWorkImpl(state, pattern_type_id, scrutinee_id, entry);
   if (need_subpattern_results()) {
     AddAsPostWork(entry);
   }
@@ -610,7 +635,8 @@ auto MatchContext::DoPreWork(State state, SemIR::VarPattern var_pattern,
            .allow_unmarked_ref = true});
 }
 
-auto MatchContext::DoVarPreWorkImpl(State state, SemIR::InstId scrutinee_id,
+auto MatchContext::DoVarPreWorkImpl(State state, SemIR::TypeId pattern_type_id,
+                                    SemIR::InstId scrutinee_id,
                                     WorkItem entry) const -> SemIR::InstId {
   auto storage_id = SemIR::InstId::None;
   CARBON_KIND_SWITCH(state) {
@@ -631,13 +657,10 @@ auto MatchContext::DoVarPreWorkImpl(State state, SemIR::InstId scrutinee_id,
       storage_id = lookup_result.value();
       break;
     }
-    case CARBON_KIND(CallerState* caller): {
-      auto specific_pattern_type_id = SemIR::GetTypeOfInstInSpecific(
-          context_.sem_ir(), caller->callee_specific_id, entry.pattern_id);
+    case CARBON_KIND(CallerState* _): {
       storage_id = AddInst<SemIR::TemporaryStorage>(
           context_, SemIR::LocId(entry.pattern_id),
-          {.type_id = ExtractScrutineeType(context_.sem_ir(),
-                                           specific_pattern_type_id)});
+          {.type_id = pattern_type_id});
       CARBON_CHECK(scrutinee_id.has_value());
       break;
     }

--- a/toolchain/check/testdata/generic/var_param.carbon
+++ b/toolchain/check/testdata/generic/var_param.carbon
@@ -1,0 +1,147 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/generic/var_param.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/generic/var_param.carbon
+
+interface I {
+  fn Op[self: Self]();
+}
+
+impl i32 as I {
+  fn Op[unused self: Self]() {}
+}
+
+//@dump-sem-ir-begin
+fn TestOp[T:! I](unused var x: T) {}
+//@dump-sem-ir-end
+
+fn Test(x: i32) {
+  //@dump-sem-ir-begin
+  TestOp(x);
+  //@dump-sem-ir-end
+}
+
+// CHECK:STDOUT: --- var_param.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %I.type: type = facet_type <@I> [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %N: Core.IntLiteral = symbolic_binding N, 0 [symbolic]
+// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness @i32.as.I.impl.%I.impl_witness_table [concrete]
+// CHECK:STDOUT:   %pattern_type.7ce: type = pattern_type %i32 [concrete]
+// CHECK:STDOUT:   %I.facet: %I.type = facet_value %i32, (%I.impl_witness) [concrete]
+// CHECK:STDOUT:   %i32.builtin: type = int_type signed, %int_32 [concrete]
+// CHECK:STDOUT:   %complete_type.f8a: <witness> = complete_type_witness %i32.builtin [concrete]
+// CHECK:STDOUT:   %pattern_type.9d9: type = pattern_type %I.type [concrete]
+// CHECK:STDOUT:   %T.651: %I.type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %T.binding.as_type.3af: type = symbolic_binding_type T, 0, %T.651 [symbolic]
+// CHECK:STDOUT:   %pattern_type.422: type = pattern_type %T.binding.as_type.3af [symbolic]
+// CHECK:STDOUT:   %TestOp.type: type = fn_type @TestOp [concrete]
+// CHECK:STDOUT:   %TestOp: %TestOp.type = struct_value () [concrete]
+// CHECK:STDOUT:   %require_complete.2b8: <witness> = require_complete_type %T.binding.as_type.3af [symbolic]
+// CHECK:STDOUT:   %TestOp.specific_fn: <specific function> = specific_function %TestOp, @TestOp(%I.facet) [concrete]
+// CHECK:STDOUT:   %Copy.type: type = facet_type <@Copy> [concrete]
+// CHECK:STDOUT:   %Int.as.Copy.impl.Op.type.824: type = fn_type @Int.as.Copy.impl.Op, @Int.as.Copy.impl(%N) [symbolic]
+// CHECK:STDOUT:   %Int.as.Copy.impl.Op.9b9: %Int.as.Copy.impl.Op.type.824 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Copy.impl_witness.f17: <witness> = impl_witness imports.%Copy.impl_witness_table.e76, @Int.as.Copy.impl(%int_32) [concrete]
+// CHECK:STDOUT:   %Int.as.Copy.impl.Op.type.546: type = fn_type @Int.as.Copy.impl.Op, @Int.as.Copy.impl(%int_32) [concrete]
+// CHECK:STDOUT:   %Int.as.Copy.impl.Op.664: %Int.as.Copy.impl.Op.type.546 = struct_value () [concrete]
+// CHECK:STDOUT:   %Copy.facet: %Copy.type = facet_value %i32, (%Copy.impl_witness.f17) [concrete]
+// CHECK:STDOUT:   %Copy.WithSelf.Op.type.081: type = fn_type @Copy.WithSelf.Op, @Copy.WithSelf(%Copy.facet) [concrete]
+// CHECK:STDOUT:   %.8e2: type = fn_type_with_self_type %Copy.WithSelf.Op.type.081, %Copy.facet [concrete]
+// CHECK:STDOUT:   %Int.as.Copy.impl.Op.specific_fn: <specific function> = specific_function %Int.as.Copy.impl.Op.664, @Int.as.Copy.impl.Op(%int_32) [concrete]
+// CHECK:STDOUT:   %Destroy.Op.type.bae255.2: type = fn_type @Destroy.Op.loc22_25.2 [concrete]
+// CHECK:STDOUT:   %Destroy.Op.651ba6.2: %Destroy.Op.type.bae255.2 = struct_value () [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core.import_ref.18d: @Int.as.Copy.impl.%Int.as.Copy.impl.Op.type (%Int.as.Copy.impl.Op.type.824) = import_ref Core//prelude/parts/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.Copy.impl.%Int.as.Copy.impl.Op (constants.%Int.as.Copy.impl.Op.9b9)]
+// CHECK:STDOUT:   %Copy.impl_witness_table.e76 = impl_witness_table (%Core.import_ref.18d), @Int.as.Copy.impl [concrete]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   %TestOp.decl: %TestOp.type = fn_decl @TestOp [concrete = constants.%TestOp] {
+// CHECK:STDOUT:     %T.patt: %pattern_type.9d9 = symbolic_binding_pattern T, 0 [concrete]
+// CHECK:STDOUT:     %x.patt: @TestOp.%pattern_type (%pattern_type.422) = ref_binding_pattern x [concrete]
+// CHECK:STDOUT:     %x.param_patt: @TestOp.%pattern_type (%pattern_type.422) = var_param_pattern %x.patt [concrete]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.loc22_15: type = splice_block %I.ref [concrete = constants.%I.type] {
+// CHECK:STDOUT:       <elided>
+// CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %T.loc22_12.2: %I.type = symbolic_binding T, 0 [symbolic = %T.loc22_12.1 (constants.%T.651)]
+// CHECK:STDOUT:     %x.param: ref @TestOp.%T.binding.as_type (%T.binding.as_type.3af) = ref_param call_param0
+// CHECK:STDOUT:     %.loc22_32.1: type = splice_block %.loc22_32.2 [symbolic = %T.binding.as_type (constants.%T.binding.as_type.3af)] {
+// CHECK:STDOUT:       %T.ref: %I.type = name_ref T, %T.loc22_12.2 [symbolic = %T.loc22_12.1 (constants.%T.651)]
+// CHECK:STDOUT:       %T.as_type: type = facet_access_type %T.ref [symbolic = %T.binding.as_type (constants.%T.binding.as_type.3af)]
+// CHECK:STDOUT:       %.loc22_32.2: type = converted %T.ref, %T.as_type [symbolic = %T.binding.as_type (constants.%T.binding.as_type.3af)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %x: ref @TestOp.%T.binding.as_type (%T.binding.as_type.3af) = ref_binding x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @TestOp(%T.loc22_12.2: %I.type) {
+// CHECK:STDOUT:   %T.loc22_12.1: %I.type = symbolic_binding T, 0 [symbolic = %T.loc22_12.1 (constants.%T.651)]
+// CHECK:STDOUT:   %T.binding.as_type: type = symbolic_binding_type T, 0, %T.loc22_12.1 [symbolic = %T.binding.as_type (constants.%T.binding.as_type.3af)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.binding.as_type [symbolic = %pattern_type (constants.%pattern_type.422)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.binding.as_type [symbolic = %require_complete (constants.%require_complete.2b8)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param: ref @TestOp.%T.binding.as_type (%T.binding.as_type.3af)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Test(%x.param: %i32) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %TestOp.ref: %TestOp.type = name_ref TestOp, file.%TestOp.decl [concrete = constants.%TestOp]
+// CHECK:STDOUT:   %x.ref: %i32 = name_ref x, %x
+// CHECK:STDOUT:   %I.facet: %I.type = facet_value constants.%i32, (constants.%I.impl_witness) [concrete = constants.%I.facet]
+// CHECK:STDOUT:   %.loc27: %I.type = converted constants.%i32, %I.facet [concrete = constants.%I.facet]
+// CHECK:STDOUT:   %TestOp.specific_fn: <specific function> = specific_function %TestOp.ref, @TestOp(constants.%I.facet) [concrete = constants.%TestOp.specific_fn]
+// CHECK:STDOUT:   %.loc22_25.1: ref %i32 = temporary_storage
+// CHECK:STDOUT:   %impl.elem0: %.8e2 = impl_witness_access constants.%Copy.impl_witness.f17, element0 [concrete = constants.%Int.as.Copy.impl.Op.664]
+// CHECK:STDOUT:   %bound_method.loc27_10.1: <bound method> = bound_method %x.ref, %impl.elem0
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Int.as.Copy.impl.Op(constants.%int_32) [concrete = constants.%Int.as.Copy.impl.Op.specific_fn]
+// CHECK:STDOUT:   %bound_method.loc27_10.2: <bound method> = bound_method %x.ref, %specific_fn
+// CHECK:STDOUT:   %Int.as.Copy.impl.Op.call: init %i32 = call %bound_method.loc27_10.2(%x.ref)
+// CHECK:STDOUT:   %.loc22_25.2: ref %i32 = temporary %.loc22_25.1, %Int.as.Copy.impl.Op.call
+// CHECK:STDOUT:   %TestOp.call: init %empty_tuple.type = call %TestOp.specific_fn(%.loc22_25.2)
+// CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc22_25.2, constants.%Destroy.Op.651ba6.2
+// CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc22_25.2)
+// CHECK:STDOUT:   <elided>
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Destroy.Op.loc22_25.1(%self.param: ref %i32.builtin) = "no_op";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Destroy.Op.loc22_25.2(%self.param: ref %i32) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @TestOp(constants.%T.651) {
+// CHECK:STDOUT:   %T.loc22_12.1 => constants.%T.651
+// CHECK:STDOUT:   %T.binding.as_type => constants.%T.binding.as_type.3af
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.422
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @TestOp(constants.%I.facet) {
+// CHECK:STDOUT:   %T.loc22_12.1 => constants.%I.facet
+// CHECK:STDOUT:   %T.binding.as_type => constants.%i32
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.7ce
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
+// CHECK:STDOUT: }
+// CHECK:STDOUT:


### PR DESCRIPTION
`DoVarPreWorkImpl` was provided an incorrect pattern type while trying to match `var` parameters, which caused the toolchain to crash in `Convert`. This commit changes `DoVarPreWorkImpl`'s API so it derives the pattern type from the work item's pattern ID, rather than relying on an external source.