### PR TITLE
Recover same-package imports after omitting the package name

### DIFF
--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -100,28 +100,22 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
   const auto& packaging = unit_info.parse_tree().packaging_decl();
   PackageNameId file_package_id =
       packaging ? packaging->names.package_id : PackageNameId::None;
-  const auto import_key = GetImportKey(unit_info, file_package_id, import);
 
   // True if the import has `Main` as the package name, even if it comes from
   // the file's packaging (diagnostics may differentiate).
-  bool is_explicit_main = import_key.first == MainPackageName;
+  bool is_explicit_main =
+      GetImportKey(unit_info, file_package_id, import).first == MainPackageName;
 
   // Explicit imports need more validation than implicit ones. We try to do
   // these in an order of imports that should be removed, followed by imports
   // that might be valid with syntax fixes.
   if (explicit_import_map) {
-    // Diagnose redundant imports.
-    if (auto insert_result =
-            explicit_import_map->Insert(import_key, import.node_id);
-        !insert_result.is_inserted()) {
-      CARBON_DIAGNOSTIC(RepeatedImport, Error,
-                        "library imported more than once");
-      CARBON_DIAGNOSTIC(FirstImported, Note, "first import here");
-      unit_info.emitter.Build(import.node_id, RepeatedImport)
-          .Note(insert_result.value(), FirstImported)
-          .Emit();
-      return;
-    }
+    CARBON_DIAGNOSTIC(
+        ImportCurrentPackageByName, Error,
+        "imports from the current package must omit the package name");
+    auto emit_import_current_package_by_name = [&] {
+      unit_info.emitter.Emit(import.node_id, ImportCurrentPackageByName);
+    };
 
     // True if the file's package is implicitly `Main` (by omitting an explicit
     // package name).
@@ -169,11 +163,11 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
     if (!is_import_implicit_current_package) {
       // Diagnose explicit imports of the same package that use the package
       // name.
-      if (is_same_package || (is_file_implicit_main && is_explicit_main)) {
-        CARBON_DIAGNOSTIC(
-            ImportCurrentPackageByName, Error,
-            "imports from the current package must omit the package name");
-        unit_info.emitter.Emit(import.node_id, ImportCurrentPackageByName);
+      if (is_same_package) {
+        emit_import_current_package_by_name();
+        import.package_id = PackageNameId::None;
+      } else if (is_file_implicit_main && is_explicit_main) {
+        emit_import_current_package_by_name();
         return;
       }
 
@@ -185,12 +179,29 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
         return;
       }
     }
+
+    // Diagnose redundant imports after any recovery so that explicit and
+    // implicit imports of the same current-package library are treated as the
+    // same import.
+    if (auto insert_result = explicit_import_map->Insert(
+            GetImportKey(unit_info, file_package_id, import), import.node_id);
+        !insert_result.is_inserted()) {
+      CARBON_DIAGNOSTIC(RepeatedImport, Error,
+                        "library imported more than once");
+      CARBON_DIAGNOSTIC(FirstImported, Note, "first import here");
+      unit_info.emitter.Build(import.node_id, RepeatedImport)
+          .Note(insert_result.value(), FirstImported)
+          .Emit();
+      return;
+    }
   } else if (is_explicit_main) {
     // An implicit import with an explicit `Main` occurs when a `package` rule
     // has bad syntax, which will have been diagnosed when building the API map.
     // As a consequence, we return silently.
     return;
   }
+
+  const auto import_key = GetImportKey(unit_info, file_package_id, import);
 
   // Get the package imports, or create them if this is the first.
   auto create_imports = [&]() -> int32_t {

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -110,10 +110,10 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
   // these in an order of imports that should be removed, followed by imports
   // that might be valid with syntax fixes.
   if (explicit_import_map) {
-    CARBON_DIAGNOSTIC(
-        ImportCurrentPackageByName, Error,
-        "imports from the current package must omit the package name");
     auto emit_import_current_package_by_name = [&] {
+      CARBON_DIAGNOSTIC(
+          ImportCurrentPackageByName, Error,
+          "imports from the current package must omit the package name");
       unit_info.emitter.Emit(import.node_id, ImportCurrentPackageByName);
     };
 

--- a/toolchain/check/testdata/packages/import_current_package_recovery.carbon
+++ b/toolchain/check/testdata/packages/import_current_package_recovery.carbon
@@ -1,0 +1,40 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
+// TODO: Add ranges and switch to "--dump-sem-ir-ranges=only".
+// EXTRA-ARGS: --dump-sem-ir-ranges=if-present
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/packages/import_current_package_recovery.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/packages/import_current_package_recovery.carbon
+// SET-CHECK-SUBSET
+
+// --- a.carbon
+
+package Foo library "a";
+
+class X {}
+
+// --- fail_b.carbon
+
+package Foo library "b";
+
+// CHECK:STDERR: fail_b.carbon:[[@LINE+4]]:1: error: imports from the current package must omit the package name [ImportCurrentPackageByName]
+// CHECK:STDERR: import Foo library "a";
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+import Foo library "a";
+
+alias Y = X;
+
+// CHECK:STDOUT: --- fail_b.carbon
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Foo.X: type = import_ref Foo//a, X, loaded [concrete = constants.%X]
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   package: <namespace> = namespace [concrete] {
+// CHECK:STDOUT:     .X = imports.%Foo.X
+// CHECK:STDOUT:   %X.ref: type = name_ref X, imports.%Foo.X [concrete = constants.%X]


### PR DESCRIPTION
Keep explicit current-package imports usable for recovery after diagnosing
`ImportCurrentPackageByName` by normalizing them to the implicit current-package
form for subsequent lookup and duplicate detection.

This preserves the existing diagnostic but stops us from dropping imports such
as `package Foo library "b"; import Foo library "a";`, so imported
declarations remain visible for unqualified lookup. It also adds a focused
regression test covering that behavior.

Closes #6898
