### PR TITLE
Recover current-package imports after import diagnostics.

### DIFF
--- a/toolchain/check/BUILD
+++ b/toolchain/check/BUILD
@@ -2,6 +2,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel/cc_rules:defs.bzl", "cc_library")
 load("//testing/fuzzing:rules.bzl", "cc_fuzz_test")
 
@@ -343,6 +344,26 @@ cc_library(
         "//toolchain/sem_ir:file",
         "//toolchain/sem_ir:stringify",
         "//toolchain/sem_ir:typed_insts",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "import_recovery_test",
+    size = "small",
+    srcs = ["import_recovery_test.cpp"],
+    deps = [
+        ":check",
+        "//common:check",
+        "//common:raw_string_ostream",
+        "//testing/base:gtest_main",
+        "//toolchain/base:shared_value_stores",
+        "//toolchain/diagnostics:emitter",
+        "//toolchain/lex",
+        "//toolchain/parse",
+        "//toolchain/parse:tree",
+        "//toolchain/source:source_buffer",
+        "@googletest//:gtest",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -100,7 +100,7 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
   const auto& packaging = unit_info.parse_tree().packaging_decl();
   PackageNameId file_package_id =
       packaging ? packaging->names.package_id : PackageNameId::None;
-  const auto import_key = GetImportKey(unit_info, file_package_id, import);
+  auto import_key = GetImportKey(unit_info, file_package_id, import);
 
   // True if the import has `Main` as the package name, even if it comes from
   // the file's packaging (diagnostics may differentiate).
@@ -110,16 +110,20 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
   // these in an order of imports that should be removed, followed by imports
   // that might be valid with syntax fixes.
   if (explicit_import_map) {
-    // Diagnose redundant imports.
-    if (auto insert_result =
-            explicit_import_map->Insert(import_key, import.node_id);
-        !insert_result.is_inserted()) {
+    auto diagnose_repeated_import = [&](Parse::NodeId first_import_id) {
       CARBON_DIAGNOSTIC(RepeatedImport, Error,
                         "library imported more than once");
       CARBON_DIAGNOSTIC(FirstImported, Note, "first import here");
       unit_info.emitter.Build(import.node_id, RepeatedImport)
-          .Note(insert_result.value(), FirstImported)
+          .Note(first_import_id, FirstImported)
           .Emit();
+    };
+
+    // Diagnose redundant imports.
+    if (auto insert_result =
+            explicit_import_map->Insert(import_key, import.node_id);
+        !insert_result.is_inserted()) {
+      diagnose_repeated_import(insert_result.value());
       return;
     }
 
@@ -174,7 +178,15 @@ static auto TrackImport(Map<ImportKey, UnitAndImports*>& api_map,
             ImportCurrentPackageByName, Error,
             "imports from the current package must omit the package name");
         unit_info.emitter.Emit(import.node_id, ImportCurrentPackageByName);
-        return;
+
+        // Recover by treating this import as if it had used the implicit
+        // current-package syntax so that later name lookup still sees the
+        // imported library.
+        auto normalized_import = import;
+        normalized_import.package_id = PackageNameId::None;
+        import = normalized_import;
+        import_key =
+            GetImportKey(unit_info, file_package_id, normalized_import);
       }
 
       // Diagnose explicit imports from `Main`.

--- a/toolchain/check/import_recovery_test.cpp
+++ b/toolchain/check/import_recovery_test.cpp
@@ -1,0 +1,135 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "common/check.h"
+#include "common/raw_string_ostream.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "toolchain/base/shared_value_stores.h"
+#include "toolchain/check/check.h"
+#include "toolchain/diagnostics/consumer.h"
+#include "toolchain/lex/lex.h"
+#include "toolchain/parse/parse.h"
+#include "toolchain/parse/tree_and_subtrees.h"
+#include "toolchain/source/source_buffer.h"
+
+namespace Carbon::Check {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::Not;
+
+struct TestUnit {
+  SharedValueStores value_stores;
+  RawStringOstream diagnostic_output;
+  Diagnostics::StreamConsumer consumer =
+      Diagnostics::StreamConsumer(&diagnostic_output);
+  llvm::LLVMContext llvm_context;
+  std::optional<SourceBuffer> source;
+  std::optional<Lex::TokenizedBuffer> tokens;
+  std::optional<Parse::Tree> tree;
+  std::optional<Parse::TreeAndSubtrees> tree_and_subtrees;
+  std::optional<SemIR::File> sem_ir;
+};
+
+static auto BuildTestUnit(TestUnit& unit, llvm::vfs::InMemoryFileSystem& fs,
+                          llvm::StringRef filename, llvm::StringRef source_text,
+                          SemIR::CheckIRId check_ir_id) -> void {
+  unit.consumer.set_include_diagnostic_kind(true);
+
+  CARBON_CHECK(
+      fs.addFile(filename, /*ModificationTime=*/0,
+                 llvm::MemoryBuffer::getMemBuffer(
+                     source_text, filename, /*RequiresNullTerminator=*/false)));
+
+  auto source = SourceBuffer::MakeFromFile(fs, filename, unit.consumer);
+  CARBON_CHECK(source.has_value());
+  unit.source = std::move(*source);
+
+  Lex::LexOptions lex_options;
+  lex_options.consumer = &unit.consumer;
+  unit.tokens.emplace(Lex::Lex(unit.value_stores, *unit.source, lex_options));
+
+  Parse::ParseOptions parse_options;
+  parse_options.consumer = &unit.consumer;
+  unit.tree.emplace(Parse::Parse(*unit.tokens, parse_options));
+
+  unit.tree_and_subtrees.emplace(*unit.tokens, *unit.tree);
+  unit.sem_ir.emplace(&*unit.tree, check_ir_id, unit.tree->packaging_decl(),
+                      unit.value_stores, filename.str());
+}
+
+TEST(ImportRecoveryTest, CurrentPackageImportByNameStillImportsLibrary) {
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> fs =
+      new llvm::vfs::InMemoryFileSystem;
+
+  constexpr int TotalIrCount = 2;
+  TestUnit unit_a;
+  BuildTestUnit(unit_a, *fs, "a.carbon",
+                "package Foo library \"a\";\n"
+                "\n"
+                "class X {}\n",
+                SemIR::CheckIRId(0));
+  TestUnit unit_b;
+  BuildTestUnit(unit_b, *fs, "b.carbon",
+                "package Foo library \"b\";\n"
+                "\n"
+                "import Foo library \"a\";\n"
+                "\n"
+                "var x: X = {};\n",
+                SemIR::CheckIRId(1));
+
+  Parse::GetTreeAndSubtreesStore tree_and_subtrees_getters =
+      Parse::GetTreeAndSubtreesStore::MakeForOverwriteWithExplicitSize(2);
+  auto get_unit_a = [&]() -> const Parse::TreeAndSubtrees& {
+    return *unit_a.tree_and_subtrees;
+  };
+  auto get_unit_b = [&]() -> const Parse::TreeAndSubtrees& {
+    return *unit_b.tree_and_subtrees;
+  };
+  tree_and_subtrees_getters.Set(SemIR::CheckIRId(0), get_unit_a);
+  tree_and_subtrees_getters.Set(SemIR::CheckIRId(1), get_unit_b);
+
+  llvm::SmallVector<Unit> units = {
+      {.consumer = &unit_a.consumer,
+       .value_stores = &unit_a.value_stores,
+       .timings = nullptr,
+       .sem_ir = &*unit_a.sem_ir,
+       .llvm_context = &unit_a.llvm_context,
+       .total_ir_count = TotalIrCount},
+      {.consumer = &unit_b.consumer,
+       .value_stores = &unit_b.value_stores,
+       .timings = nullptr,
+       .sem_ir = &*unit_b.sem_ir,
+       .llvm_context = &unit_b.llvm_context,
+       .total_ir_count = TotalIrCount},
+  };
+
+  CheckParseTrees(units, tree_and_subtrees_getters, fs,
+                  CheckParseTreesOptions(),
+                  /*clang_invocation=*/nullptr);
+
+  auto x_id = unit_b.value_stores.identifiers().Lookup("X");
+  ASSERT_TRUE(x_id.has_value());
+  EXPECT_TRUE(unit_b.sem_ir->name_scopes()
+                  .Get(SemIR::NameScopeId::Package)
+                  .Lookup(SemIR::NameId::ForIdentifier(x_id))
+                  .has_value());
+
+  auto diagnostics = unit_b.diagnostic_output.TakeStr();
+  EXPECT_THAT(diagnostics,
+              HasSubstr("imports from the current package must omit the "
+                        "package name"));
+  EXPECT_THAT(diagnostics, Not(HasSubstr("name `X`")));
+}
+
+}  // namespace
+}  // namespace Carbon::Check


### PR DESCRIPTION
Recover imports that redundantly name the current package by normalizing them to the implicit current-package form after emitting the existing diagnostic. This keeps the imported library available to later name lookup instead of dropping it entirely.

Add a toolchain/check regression test that checks the diagnostic is still emitted while lookups through the recovered import continue to work.

Closes #6898