### PR TITLE
Support C++ calling Carbon functions with non-`()` return type

### DIFF
--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -280,11 +280,16 @@ auto PerformCallToFunction(Context& context, SemIR::LocId loc_id,
           BuildNameRef(context, loc_id, callee.name_id, callee.thunk_decl_id(),
                        callee_function.enclosing_specific_id);
 
+      auto param_pattern_ids =
+          context.inst_blocks().Get(context.functions()
+                                        .Get(callee_function.function_id)
+                                        .param_patterns_id);
+
       // This recurses back into `PerformCall`. However, we never form a thunk
       // to a thunk, so we only recurse once.
-      return PerformThunkCall(context, loc_id, callee_function.function_id,
-                              context.inst_blocks().Get(converted_args_id),
-                              thunk_ref_id);
+      return PerformThunkCall(
+          context, loc_id, callee_function.function_id, param_pattern_ids,
+          context.inst_blocks().Get(converted_args_id), thunk_ref_id);
     }
 
     case SemIR::Function::SpecialFunctionKind::HasCppThunk: {

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -254,7 +254,7 @@ static auto BuildCppToCarbonThunkDecl(
 
   auto ext_proto_info = clang::FunctionProtoType::ExtProtoInfo();
   clang::QualType thunk_function_type = ast_context.getFunctionType(
-      ast_context.VoidTy, thunk_param_types, ext_proto_info);
+      cpp_return_type, thunk_param_types, ext_proto_info);
 
   auto* tinfo =
       ast_context.getTrivialTypeSourceInfo(thunk_function_type, clang_loc);
@@ -308,6 +308,31 @@ static auto BuildCppToCarbonThunkBody(clang::Sema& sema,
     -> clang::StmtResult {
   clang::SourceLocation clang_loc = function_decl->getLocation();
 
+  llvm::SmallVector<clang::Stmt*> stmts;
+
+  // Create return storage if the target function returns non-void.
+  const bool has_return_value = !function_decl->getReturnType()->isVoidType();
+  clang::ExprResult return_storage_expr;
+  if (has_return_value) {
+    auto& return_storage_ident =
+        sema.getASTContext().Idents.get("return_storage");
+    auto* return_storage_var_decl =
+        clang::VarDecl::Create(sema.getASTContext(), function_decl,
+                               /*StartLoc=*/clang_loc,
+                               /*IdLoc=*/clang_loc, &return_storage_ident,
+                               function_decl->getReturnType(),
+                               /*TInfo=*/nullptr, clang::SC_None);
+    return_storage_expr = sema.BuildDeclRefExpr(
+        return_storage_var_decl, return_storage_var_decl->getType(),
+        clang::VK_LValue, clang_loc);
+
+    auto decl_group_ref = clang::DeclGroupRef(return_storage_var_decl);
+    auto decl_stmt =
+        sema.ActOnDeclStmt(clang::Sema::DeclGroupPtrTy::make(decl_group_ref),
+                           clang_loc, clang_loc);
+    stmts.push_back(decl_stmt.get());
+  }
+
   clang::ExprResult callee = sema.BuildDeclRefExpr(
       callee_function_decl, callee_function_decl->getType(), clang::VK_PRValue,
       clang_loc);
@@ -319,11 +344,26 @@ static auto BuildCppToCarbonThunkBody(clang::Sema& sema,
                               clang::VK_LValue, clang_loc);
     call_args.push_back(call_arg);
   }
+
+  // If the target function returns non-void, the Carbon thunk takes an
+  // extra output parameter referencing the return storage.
+  if (has_return_value) {
+    call_args.push_back(return_storage_expr.get());
+  }
+
   clang::ExprResult call = sema.BuildCallExpr(nullptr, callee.get(), clang_loc,
                                               call_args, clang_loc);
   CARBON_CHECK(call.isUsable());
+  stmts.push_back(call.get());
 
-  return call.get();
+  if (has_return_value) {
+    stmts.push_back(
+        sema.BuildReturnStmt(clang_loc, return_storage_expr.get()).get());
+  }
+
+  return clang::CompoundStmt::Create(sema.getASTContext(), stmts,
+                                     clang::FPOptionsOverride(), clang_loc,
+                                     clang_loc);
 }
 
 // Create a C++ thunk that calls the Carbon thunk. The C++ thunk's

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -324,6 +324,7 @@ static auto BuildCppToCarbonThunkBody(clang::Sema& sema,
                                /*IdLoc=*/clang_loc, &return_storage_ident,
                                function_decl->getReturnType(),
                                /*TInfo=*/nullptr, clang::SC_None);
+    return_storage_var_decl->setNRVOVariable(true);
     return_storage_expr = sema.BuildDeclRefExpr(
         return_storage_var_decl, return_storage_var_decl->getType(),
         clang::VK_LValue, clang_loc);

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -233,10 +233,22 @@ static auto BuildCppFunctionDeclForCarbonFn(Context& context,
 static auto BuildCppToCarbonThunkDecl(
     Context& context, SemIR::LocId loc_id, clang::DeclContext* decl_context,
     clang::DeclarationName thunk_name,
-    llvm::ArrayRef<clang::QualType> thunk_param_types) -> clang::FunctionDecl* {
+    llvm::ArrayRef<clang::QualType> thunk_param_types,
+    SemIR::TypeId return_type_id) -> clang::FunctionDecl* {
   clang::ASTContext& ast_context = context.ast_context();
 
   auto clang_loc = GetCppLocation(context, loc_id);
+
+  // Get the C++ return type (this corresponds to the return type of the
+  // target Carbon function).
+  clang::QualType cpp_return_type = context.ast_context().VoidTy;
+  if (return_type_id != SemIR::TypeId::None) {
+    cpp_return_type = MapToCppType(context, return_type_id);
+    if (cpp_return_type.isNull()) {
+      context.TODO(loc_id, "failed to map Carbon return type to C++ type");
+      return nullptr;
+    }
+  }
 
   clang::DeclarationNameInfo name_info(thunk_name, clang_loc);
 
@@ -321,8 +333,8 @@ static auto BuildCppToCarbonThunkBody(clang::Sema& sema,
 static auto BuildCppToCarbonThunk(
     Context& context, SemIR::LocId loc_id, clang::DeclContext* decl_context,
     llvm::StringRef base_name, clang::FunctionDecl* carbon_function_decl,
-    llvm::ArrayRef<SemIR::TypeId> callee_param_type_ids)
-    -> clang::FunctionDecl* {
+    llvm::ArrayRef<SemIR::TypeId> callee_param_type_ids,
+    SemIR::TypeId return_type_id) -> clang::FunctionDecl* {
   // Create the thunk's name.
   llvm::SmallString<64> thunk_name = base_name;
   thunk_name += "__cpp_thunk";
@@ -339,7 +351,7 @@ static auto BuildCppToCarbonThunk(
   }
 
   auto* thunk_function_decl = BuildCppToCarbonThunkDecl(
-      context, loc_id, decl_context, &thunk_ident, param_types);
+      context, loc_id, decl_context, &thunk_ident, param_types, return_type_id);
 
   // Build the thunk function body.
   clang::Sema& sema = context.clang_sema();
@@ -440,7 +452,8 @@ auto ExportFunctionToCpp(Context& context, SemIR::LocId loc_id,
   // Create a C++ thunk that calls the Carbon thunk.
   return BuildCppToCarbonThunk(context, loc_id, decl_context,
                                context.names().GetFormatted(callee.name_id),
-                               carbon_function_decl, callee_param_type_ids);
+                               carbon_function_decl, callee_param_type_ids,
+                               callee.GetDeclaredReturnType(context.sem_ir()));
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -314,11 +314,12 @@ static auto BuildCppToCarbonThunkBody(clang::Sema& sema,
 
   // Create return storage if the target function returns non-void.
   const bool has_return_value = !function_decl->getReturnType()->isVoidType();
+  clang::VarDecl* return_storage_var_decl = nullptr;
   clang::ExprResult return_storage_expr;
   if (has_return_value) {
     auto& return_storage_ident =
         sema.getASTContext().Idents.get("return_storage");
-    auto* return_storage_var_decl =
+    return_storage_var_decl =
         clang::VarDecl::Create(sema.getASTContext(), function_decl,
                                /*StartLoc=*/clang_loc,
                                /*IdLoc=*/clang_loc, &return_storage_ident,
@@ -360,8 +361,10 @@ static auto BuildCppToCarbonThunkBody(clang::Sema& sema,
   stmts.push_back(call.get());
 
   if (has_return_value) {
-    stmts.push_back(
-        sema.BuildReturnStmt(clang_loc, return_storage_expr.get()).get());
+    auto* return_stmt = clang::ReturnStmt::Create(
+        sema.getASTContext(), clang_loc, return_storage_expr.get(),
+        return_storage_var_decl);
+    stmts.push_back(return_stmt);
   }
 
   return clang::CompoundStmt::Create(sema.getASTContext(), stmts,

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -410,7 +410,8 @@ static auto BuildCppToCarbonThunk(
 // Create a Carbon thunk that calls `callee`. The thunk's parameters are
 // all references to the callee parameter type.
 static auto BuildCarbonToCarbonThunk(
-    Context& context, SemIR::LocId loc_id, const SemIR::Function& callee,
+    Context& context, SemIR::LocId loc_id, SemIR::FunctionId callee_function_id,
+    const SemIR::Function& callee,
     llvm::ArrayRef<SemIR::TypeId> callee_param_type_ids) -> SemIR::FunctionId {
   // Create the thunk's name.
   llvm::SmallString<64> thunk_name =
@@ -420,16 +421,27 @@ static auto BuildCarbonToCarbonThunk(
   auto thunk_name_id =
       SemIR::NameId::ForIdentifier(context.identifiers().Add(ident.getName()));
 
+  // Get the thunk's parameters. These match the callee parameters, with
+  // the addition of an output parameter for the callee's return value
+  // (if it has one).
+  llvm::SmallVector<SemIR::TypeId> thunk_param_type_ids(callee_param_type_ids);
+  auto callee_return_type_id = callee.GetDeclaredReturnType(context.sem_ir());
+  if (callee_return_type_id != SemIR::TypeId::None) {
+    thunk_param_type_ids.push_back(callee_return_type_id);
+  }
+
   auto carbon_thunk_function_id =
       MakeGeneratedFunctionDecl(context, loc_id,
                                 {.parent_scope_id = callee.parent_scope_id,
                                  .name_id = thunk_name_id,
-                                 .param_type_ids = callee_param_type_ids,
+                                 .param_type_ids = thunk_param_type_ids,
                                  .params_are_refs = true})
           .second;
-  BuildThunkDefinition(context, carbon_thunk_function_id,
-                       carbon_thunk_function_id, callee.first_decl_id(),
-                       callee.first_decl_id());
+
+  BuildThunkDefinitionForExport(
+      context, carbon_thunk_function_id, callee_function_id,
+      context.functions().Get(carbon_thunk_function_id).first_decl_id(),
+      callee.first_decl_id());
 
   return carbon_thunk_function_id;
 }
@@ -467,9 +479,13 @@ auto ExportFunctionToCpp(Context& context, SemIR::LocId loc_id,
     return nullptr;
   }
 
-  // Get the parameter types of the Carbon function being called.
+  // Get the parameter types of the Carbon function being
+  // called. Exclude return params, if present.
   auto callee_function_params =
       context.inst_blocks().Get(callee.call_param_patterns_id);
+  callee_function_params =
+      callee_function_params.drop_back(callee.call_param_ranges.return_size());
+
   llvm::SmallVector<SemIR::TypeId> callee_param_type_ids;
   for (auto callee_param_inst_id : callee_function_params) {
     auto scrutinee_type_id = ExtractScrutineeType(
@@ -479,8 +495,8 @@ auto ExportFunctionToCpp(Context& context, SemIR::LocId loc_id,
 
   // Create a Carbon thunk that calls the callee. The thunk's parameters
   // are all references so that the ABI is compatible with C++ callers.
-  auto carbon_thunk_function_id =
-      BuildCarbonToCarbonThunk(context, loc_id, callee, callee_param_type_ids);
+  auto carbon_thunk_function_id = BuildCarbonToCarbonThunk(
+      context, loc_id, callee_function_id, callee, callee_param_type_ids);
 
   // Create a `clang::FunctionDecl` that can be used to call the Carbon thunk.
   auto* carbon_function_decl = BuildCppFunctionDeclForCarbonFn(

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -78,6 +78,7 @@ auto ExportNameScopeToCpp(Context& context, SemIR::LocId loc_id,
       auto* namespace_decl = clang::NamespaceDecl::Create(
           context.ast_context(), decl_context, false, clang::SourceLocation(),
           clang::SourceLocation(), identifier_info, nullptr, false);
+      decl_context->addHiddenDecl(namespace_decl);
       decl_context = namespace_decl;
     } else if (inst.Is<SemIR::ClassDecl>()) {
       // TODO: Provide a source location.
@@ -90,6 +91,7 @@ auto ExportNameScopeToCpp(Context& context, SemIR::LocId loc_id,
         record_decl->setAccess(clang::AS_public);
       }
 
+      decl_context->addHiddenDecl(record_decl);
       decl_context = record_decl;
       decl_context->setHasExternalLexicalStorage();
     } else {

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -451,13 +451,6 @@ auto ExportFunctionToCpp(Context& context, SemIR::LocId loc_id,
     -> clang::FunctionDecl* {
   const SemIR::Function& callee = context.functions().Get(callee_function_id);
 
-  if (callee.return_type_inst_id != SemIR::TypeInstId::None) {
-    context.TODO(loc_id,
-                 "unsupported: C++ calling a Carbon function with "
-                 "return type other than `()`");
-    return nullptr;
-  }
-
   if (callee.generic_id.has_value()) {
     context.TODO(loc_id,
                  "unsupported: C++ calling a Carbon function with "

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -186,7 +186,7 @@ static auto BuildCppFunctionDeclForCarbonFn(Context& context,
         context.sem_ir(), context.insts().Get(param_inst_id).type_id());
     auto cpp_type = MapToCppType(context, scrutinee_type_id);
     if (cpp_type.isNull()) {
-      context.TODO(loc_id, "failed to map C++ type to Carbon");
+      context.TODO(loc_id, "failed to map Carbon type to C++");
       return nullptr;
     }
     auto ref_type = context.ast_context().getLValueReferenceType(cpp_type);

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -934,7 +934,7 @@ auto CalleePatternMatch(Context& context,
 }
 
 auto ThunkPatternMatch(Context& context, SemIR::InstId self_pattern_id,
-                       SemIR::InstBlockId param_patterns_id,
+                       llvm::ArrayRef<SemIR::InstId> param_pattern_ids,
                        llvm::ArrayRef<SemIR::InstId> outer_call_args)
     -> ThunkPatternMatchResults {
   ThunkState state = {.outer_call_args = outer_call_args};
@@ -950,13 +950,11 @@ auto ThunkPatternMatch(Context& context, SemIR::InstId self_pattern_id,
          .work = MatchContext::PreWork{.scrutinee_id = SemIR::InstId::None}}));
   }
 
-  if (param_patterns_id.has_value()) {
-    for (SemIR::InstId inst_id : context.inst_blocks().Get(param_patterns_id)) {
-      inner_args.push_back(match.MatchWithResult(
-          &state, {.pattern_id = inst_id,
-                   .work = MatchContext::PreWork{.scrutinee_id =
-                                                     SemIR::InstId::None}}));
-    }
+  for (SemIR::InstId inst_id : param_pattern_ids) {
+    inner_args.push_back(match.MatchWithResult(
+        &state,
+        {.pattern_id = inst_id,
+         .work = MatchContext::PreWork{.scrutinee_id = SemIR::InstId::None}}));
   }
 
   return {.syntactic_args = std::move(inner_args),

--- a/toolchain/check/pattern_match.h
+++ b/toolchain/check/pattern_match.h
@@ -58,7 +58,7 @@ struct ThunkPatternMatchResults {
 // computes the corresponding syntactic argument list, suitable for passing to
 // the inner part of the thunked function call.
 auto ThunkPatternMatch(Context& context, SemIR::InstId self_pattern_id,
-                       SemIR::InstBlockId param_patterns_id,
+                       llvm::ArrayRef<SemIR::InstId> param_patterns,
                        llvm::ArrayRef<SemIR::InstId> outer_call_args)
     -> ThunkPatternMatchResults;
 

--- a/toolchain/check/pattern_match.h
+++ b/toolchain/check/pattern_match.h
@@ -58,7 +58,7 @@ struct ThunkPatternMatchResults {
 // computes the corresponding syntactic argument list, suitable for passing to
 // the inner part of the thunked function call.
 auto ThunkPatternMatch(Context& context, SemIR::InstId self_pattern_id,
-                       llvm::ArrayRef<SemIR::InstId> param_patterns,
+                       llvm::ArrayRef<SemIR::InstId> param_pattern_ids,
                        llvm::ArrayRef<SemIR::InstId> outer_call_args)
     -> ThunkPatternMatchResults;
 

--- a/toolchain/check/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/function.carbon
@@ -35,22 +35,13 @@ void G() {
 }
 ''';
 
-// --- fail_todo_return_int.carbon
+// --- return_int.carbon
 
 library "[[@TEST_NAME]]";
 
-// CHECK:STDERR: fail_todo_return_int.carbon:[[@LINE+5]]:1: in import [InImport]
-// CHECK:STDERR: other.carbon:4:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with return type other than `()`` [SemanticsTodo]
-// CHECK:STDERR: fn F2() -> i32 { return 0; }
-// CHECK:STDERR: ^~~~~~~~~~~~~~~~
-// CHECK:STDERR:
 import Other;
 import Cpp inline '''
 int G() {
-  // CHECK:STDERR: fail_todo_return_int.carbon:[[@LINE+4]]:25: error: no member named 'F2' in namespace 'Carbon::Other' [CppInteropParseError]
-  // CHECK:STDERR:    16 |   return Carbon::Other::F2();
-  // CHECK:STDERR:       |                         ^~
-  // CHECK:STDERR:
   return Carbon::Other::F2();
 }
 ''';

--- a/toolchain/check/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/function.carbon
@@ -35,23 +35,23 @@ void G() {
 }
 ''';
 
-// --- fail_todo_non_void.carbon
+// --- fail_todo_return_int.carbon
 
 library "[[@TEST_NAME]]";
 
-// CHECK:STDERR: fail_todo_non_void.carbon:[[@LINE+5]]:1: in import [InImport]
+// CHECK:STDERR: fail_todo_return_int.carbon:[[@LINE+5]]:1: in import [InImport]
 // CHECK:STDERR: other.carbon:4:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with return type other than `()`` [SemanticsTodo]
 // CHECK:STDERR: fn F2() -> i32 { return 0; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Other;
 import Cpp inline '''
-void G() {
-  // CHECK:STDERR: fail_todo_non_void.carbon:[[@LINE+4]]:18: error: no member named 'F2' in namespace 'Carbon::Other' [CppInteropParseError]
-  // CHECK:STDERR:    16 |   Carbon::Other::F2();
-  // CHECK:STDERR:       |                  ^~
+int G() {
+  // CHECK:STDERR: fail_todo_return_int.carbon:[[@LINE+4]]:25: error: no member named 'F2' in namespace 'Carbon::Other' [CppInteropParseError]
+  // CHECK:STDERR:    16 |   return Carbon::Other::F2();
+  // CHECK:STDERR:       |                         ^~
   // CHECK:STDERR:
-  Carbon::Other::F2();
+  return Carbon::Other::F2();
 }
 ''';
 

--- a/toolchain/check/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/function.carbon
@@ -42,9 +42,9 @@ library "[[@TEST_NAME]]";
 import Other;
 import Cpp inline '''
 void G() {
-// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <function.carbon:[[@LINE-1]]:1, line:31:1> line:6:6 G 'void ()'
-// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:31:1>
-// CHECK:STDOUT:     `-CallExpr {{0x[a-f0-9]+}} <line:30:3, col:21> 'void'
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <function.carbon:[[@LINE-1]]:1, line:30:1> line:6:6 G 'void ()'
+// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:30:1>
+// CHECK:STDOUT:     `-CallExpr {{0x[a-f0-9]+}} <line:29:3, col:21> 'void'
 // CHECK:STDOUT:       `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void (*)()' <FunctionToPointerDecay>
 // CHECK:STDOUT:         `-DeclRefExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void ()' lvalue Function {{0x[a-f0-9]+}} 'F1__cpp_thunk' 'void ()'
 // CHECK:STDOUT:           `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Other'
@@ -60,9 +60,8 @@ void G() {
 // CHECK:STDOUT: |     | | |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:16> 'void (*)(int &)' <FunctionToPointerDecay>
 // CHECK:STDOUT: |     | | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'void (int &)' Function {{0x[a-f0-9]+}} 'F2__carbon_thunk' 'void (int &)'
 // CHECK:STDOUT: |     | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
-// CHECK:STDOUT: |     | `-ReturnStmt {{0x[a-f0-9]+}} <col:16>
-// CHECK:STDOUT: |     |   `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:16> 'int' <LValueToRValue>
-// CHECK:STDOUT: |     |     `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
+// CHECK:STDOUT: |     | `-ReturnStmt {{0x[a-f0-9]+}} <col:16> nrvo_candidate(Var {{0x[a-f0-9]+}} 'return_storage' 'int')
+// CHECK:STDOUT: |     |   `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
 // CHECK:STDOUT: |     |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
 // CHECK:STDOUT: |     `-InternalLinkageAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit
   Carbon::Other::F1();

--- a/toolchain/check/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/function.carbon
@@ -55,7 +55,7 @@ void G() {
 // CHECK:STDOUT: |   `-FunctionDecl {{0x[a-f0-9]+}} <other.carbon:11:16> col:16 used F2__cpp_thunk 'int ()' inline
 // CHECK:STDOUT: |     |-CompoundStmt {{0x[a-f0-9]+}} <col:16>
 // CHECK:STDOUT: |     | |-DeclStmt {{0x[a-f0-9]+}} <col:16>
-// CHECK:STDOUT: |     | | `-VarDecl {{0x[a-f0-9]+}} <col:16> col:16 used return_storage 'int'
+// CHECK:STDOUT: |     | | `-VarDecl {{0x[a-f0-9]+}} <col:16> col:16 used return_storage 'int' nrvo
 // CHECK:STDOUT: |     | |-CallExpr {{0x[a-f0-9]+}} <col:16> 'void'
 // CHECK:STDOUT: |     | | |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:16> 'void (*)(int &)' <FunctionToPointerDecay>
 // CHECK:STDOUT: |     | | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'void (int &)' Function {{0x[a-f0-9]+}} 'F2__carbon_thunk' 'void (int &)'

--- a/toolchain/check/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/function.carbon
@@ -3,17 +3,28 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+// EXTRA-ARGS: --dump-cpp-ast
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/reverse/function.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/reverse/function.carbon
+// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
+// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
 
 // --- other.carbon
 
 package Other;
 fn F1() {}
+// CHECK:STDOUT: |   `-FunctionDecl {{0x[a-f0-9]+}} <other.carbon:[[@LINE-1]]:9> col:9 used F1__cpp_thunk 'void ()' inline
+// CHECK:STDOUT: |     |-CompoundStmt {{0x[a-f0-9]+}} <col:9>
+// CHECK:STDOUT: |     | `-CallExpr {{0x[a-f0-9]+}} <col:9> 'void'
+// CHECK:STDOUT: |     |   `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:9> 'void (*)()' <FunctionToPointerDecay>
+// CHECK:STDOUT: |     |     `-DeclRefExpr {{0x[a-f0-9]+}} <col:9> 'void ()' Function {{0x[a-f0-9]+}} 'F1__carbon_thunk' 'void ()'
+// CHECK:STDOUT: |     |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
+// CHECK:STDOUT: |     `-InternalLinkageAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit
 fn F2() -> i32 { return 0; }
 fn F3(_: i32) {}
 
@@ -31,6 +42,29 @@ library "[[@TEST_NAME]]";
 import Other;
 import Cpp inline '''
 void G() {
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <function.carbon:[[@LINE-1]]:1, line:31:1> line:6:6 G 'void ()'
+// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:31:1>
+// CHECK:STDOUT:     `-CallExpr {{0x[a-f0-9]+}} <line:30:3, col:21> 'void'
+// CHECK:STDOUT:       `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void (*)()' <FunctionToPointerDecay>
+// CHECK:STDOUT:         `-DeclRefExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void ()' lvalue Function {{0x[a-f0-9]+}} 'F1__cpp_thunk' 'void ()'
+// CHECK:STDOUT:           `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Other'
+// CHECK:STDOUT:             `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Carbon'
+// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
+// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
+// CHECK:STDOUT: |   `-FunctionDecl {{0x[a-f0-9]+}} <other.carbon:11:16> col:16 used F2__cpp_thunk 'int ()' inline
+// CHECK:STDOUT: |     |-CompoundStmt {{0x[a-f0-9]+}} <col:16>
+// CHECK:STDOUT: |     | |-DeclStmt {{0x[a-f0-9]+}} <col:16>
+// CHECK:STDOUT: |     | | `-VarDecl {{0x[a-f0-9]+}} <col:16> col:16 used return_storage 'int'
+// CHECK:STDOUT: |     | |-CallExpr {{0x[a-f0-9]+}} <col:16> 'void'
+// CHECK:STDOUT: |     | | |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:16> 'void (*)(int &)' <FunctionToPointerDecay>
+// CHECK:STDOUT: |     | | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'void (int &)' Function {{0x[a-f0-9]+}} 'F2__carbon_thunk' 'void (int &)'
+// CHECK:STDOUT: |     | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
+// CHECK:STDOUT: |     | `-ReturnStmt {{0x[a-f0-9]+}} <col:16>
+// CHECK:STDOUT: |     |   `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:16> 'int' <LValueToRValue>
+// CHECK:STDOUT: |     |     `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
+// CHECK:STDOUT: |     |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
+// CHECK:STDOUT: |     `-InternalLinkageAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit
   Carbon::Other::F1();
 }
 ''';
@@ -42,6 +76,26 @@ library "[[@TEST_NAME]]";
 import Other;
 import Cpp inline '''
 int G() {
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <return_int.carbon:[[@LINE-1]]:1, line:28:1> line:6:5 G 'int ()'
+// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:9, line:28:1>
+// CHECK:STDOUT:     `-ReturnStmt {{0x[a-f0-9]+}} <line:27:3, col:28>
+// CHECK:STDOUT:       `-CallExpr {{0x[a-f0-9]+}} <col:10, col:28> 'int'
+// CHECK:STDOUT:         `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:10, col:25> 'int (*)()' <FunctionToPointerDecay>
+// CHECK:STDOUT:           `-DeclRefExpr {{0x[a-f0-9]+}} <col:10, col:25> 'int ()' lvalue Function {{0x[a-f0-9]+}} 'F2__cpp_thunk' 'int ()'
+// CHECK:STDOUT:             `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Other'
+// CHECK:STDOUT:               `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Carbon'
+// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
+// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
+// CHECK:STDOUT: |   `-FunctionDecl {{0x[a-f0-9]+}} <other.carbon:12:15> col:15 used F3__cpp_thunk 'void (int)' inline
+// CHECK:STDOUT: |     |-ParmVarDecl {{0x[a-f0-9]+}} <col:15> col:15 used 'int'
+// CHECK:STDOUT: |     |-CompoundStmt {{0x[a-f0-9]+}} <col:15>
+// CHECK:STDOUT: |     | `-CallExpr {{0x[a-f0-9]+}} <col:15> 'void'
+// CHECK:STDOUT: |     |   |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:15> 'void (*)(int &)' <FunctionToPointerDecay>
+// CHECK:STDOUT: |     |   | `-DeclRefExpr {{0x[a-f0-9]+}} <col:15> 'void (int &)' Function {{0x[a-f0-9]+}} 'F3__carbon_thunk' 'void (int &)'
+// CHECK:STDOUT: |     |   `-DeclRefExpr {{0x[a-f0-9]+}} <col:15> 'int' lvalue ParmVar {{0x[a-f0-9]+}} depth 0 index 0 'int'
+// CHECK:STDOUT: |     |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
+// CHECK:STDOUT: |     `-InternalLinkageAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit
   return Carbon::Other::F2();
 }
 ''';
@@ -53,6 +107,17 @@ library "[[@TEST_NAME]]";
 import Other;
 import Cpp inline '''
 void G() {
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <args.carbon:[[@LINE-1]]:1, line:19:1> line:6:6 G 'void ()'
+// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:19:1>
+// CHECK:STDOUT:     `-CallExpr {{0x[a-f0-9]+}} <line:18:3, col:24> 'void'
+// CHECK:STDOUT:       |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void (*)(int)' <FunctionToPointerDecay>
+// CHECK:STDOUT:       | `-DeclRefExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void (int)' lvalue Function {{0x[a-f0-9]+}} 'F3__cpp_thunk' 'void (int)'
+// CHECK:STDOUT:       |   `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Other'
+// CHECK:STDOUT:       |     `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Carbon'
+// CHECK:STDOUT:       `-IntegerLiteral {{0x[a-f0-9]+}} <col:21> 'int' 123
+// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
+// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
   Carbon::Other::F3(123);
 }
 ''';
@@ -62,19 +127,24 @@ void G() {
 library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+5]]:1: in import [InImport]
-// CHECK:STDERR: other.carbon:7:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with generic parameters` [SemanticsTodo]
+// CHECK:STDERR: other.carbon:14:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with generic parameters` [SemanticsTodo]
 // CHECK:STDERR: fn HasGenericArg(T:! type, a: T) { a; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Other;
 import Cpp inline '''
 void G() {
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <fail_todo_generic.carbon:[[@LINE-1]]:1, line:26:1> line:11:6 G 'void ()'
+// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:26:1>
+// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
+// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
   // CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+8]]:18: error: no member named 'HasGenericArg' in namespace 'Carbon::Other' [CppInteropParseError]
-  // CHECK:STDERR:    20 |   Carbon::Other::HasGenericArg<int>(123);
+  // CHECK:STDERR:    25 |   Carbon::Other::HasGenericArg<int>(123);
   // CHECK:STDERR:       |                  ^~~~~~~~~~~~~
   // CHECK:STDERR:
   // CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+4]]:35: error: expected '(' for function-style cast or type construction [CppInteropParseError]
-  // CHECK:STDERR:    20 |   Carbon::Other::HasGenericArg<int>(123);
+  // CHECK:STDERR:    25 |   Carbon::Other::HasGenericArg<int>(123);
   // CHECK:STDERR:       |                                ~~~^
   // CHECK:STDERR:
   Carbon::Other::HasGenericArg<int>(123);
@@ -86,15 +156,20 @@ void G() {
 library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_todo_deduced.carbon:[[@LINE+5]]:1: in import [InImport]
-// CHECK:STDERR: other.carbon:8:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with generic parameters` [SemanticsTodo]
+// CHECK:STDERR: other.carbon:15:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with generic parameters` [SemanticsTodo]
 // CHECK:STDERR: fn HasDeducedArg[T:! type](a: T) { a; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Other;
 import Cpp inline '''
 void G() {
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <fail_todo_deduced.carbon:[[@LINE-1]]:1, line:22:1> line:11:6 G 'void ()'
+// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:22:1>
+// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
+// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
   // CHECK:STDERR: fail_todo_deduced.carbon:[[@LINE+4]]:18: error: no member named 'HasDeducedArg' in namespace 'Carbon::Other' [CppInteropParseError]
-  // CHECK:STDERR:    16 |   Carbon::Other::HasDeducedArg(123);
+  // CHECK:STDERR:    21 |   Carbon::Other::HasDeducedArg(123);
   // CHECK:STDERR:       |                  ^~~~~~~~~~~~~
   // CHECK:STDERR:
   Carbon::Other::HasDeducedArg(123);
@@ -106,15 +181,20 @@ void G() {
 library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_todo_method.carbon:[[@LINE+5]]:1: in import [InImport]
-// CHECK:STDERR: other.carbon:11:3: error: semantics TODO: `unsupported: C++ calling a Carbon function with an implicit parameter` [SemanticsTodo]
+// CHECK:STDERR: other.carbon:18:3: error: semantics TODO: `unsupported: C++ calling a Carbon function with an implicit parameter` [SemanticsTodo]
 // CHECK:STDERR:   fn Method[self: Self]() { self; }
 // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Other;
 import Cpp inline '''
 void G() {
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <fail_todo_method.carbon:[[@LINE-1]]:1, line:22:1> line:11:6 G 'void ()'
+// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:22:1>
+// CHECK:STDOUT:     `-CallExpr {{0x[a-f0-9]+}} <line:21:3, col:29> '<dependent type>' contains-errors
+// CHECK:STDOUT:       `-RecoveryExpr {{0x[a-f0-9]+}} <col:3, col:22> '<dependent type>' contains-errors lvalue
+// CHECK:STDOUT:         `-CXXTemporaryObjectExpr {{0x[a-f0-9]+}} <col:3, col:20> 'Carbon::Other::C' 'void () noexcept' zeroing
   // CHECK:STDERR: fail_todo_method.carbon:[[@LINE+4]]:22: error: no member named 'Method' in 'Carbon::Other::C' [CppInteropParseError]
-  // CHECK:STDERR:    16 |   Carbon::Other::C().Method();
+  // CHECK:STDERR:    21 |   Carbon::Other::C().Method();
   // CHECK:STDERR:       |   ~~~~~~~~~~~~~~~~~~ ^
   // CHECK:STDERR:
   Carbon::Other::C().Method();

--- a/toolchain/check/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/function.carbon
@@ -3,28 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
-// EXTRA-ARGS: --dump-cpp-ast
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/reverse/function.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/reverse/function.carbon
-// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
-// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
 
 // --- other.carbon
 
 package Other;
 fn F1() {}
-// CHECK:STDOUT: |   `-FunctionDecl {{0x[a-f0-9]+}} <other.carbon:[[@LINE-1]]:9> col:9 used F1__cpp_thunk 'void ()' inline
-// CHECK:STDOUT: |     |-CompoundStmt {{0x[a-f0-9]+}} <col:9>
-// CHECK:STDOUT: |     | `-CallExpr {{0x[a-f0-9]+}} <col:9> 'void'
-// CHECK:STDOUT: |     |   `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:9> 'void (*)()' <FunctionToPointerDecay>
-// CHECK:STDOUT: |     |     `-DeclRefExpr {{0x[a-f0-9]+}} <col:9> 'void ()' Function {{0x[a-f0-9]+}} 'F1__carbon_thunk' 'void ()'
-// CHECK:STDOUT: |     |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
-// CHECK:STDOUT: |     `-InternalLinkageAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit
 fn F2() -> i32 { return 0; }
 fn F3(_: i32) {}
 
@@ -42,28 +31,6 @@ library "[[@TEST_NAME]]";
 import Other;
 import Cpp inline '''
 void G() {
-// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <function.carbon:[[@LINE-1]]:1, line:30:1> line:6:6 G 'void ()'
-// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:30:1>
-// CHECK:STDOUT:     `-CallExpr {{0x[a-f0-9]+}} <line:29:3, col:21> 'void'
-// CHECK:STDOUT:       `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void (*)()' <FunctionToPointerDecay>
-// CHECK:STDOUT:         `-DeclRefExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void ()' lvalue Function {{0x[a-f0-9]+}} 'F1__cpp_thunk' 'void ()'
-// CHECK:STDOUT:           `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Other'
-// CHECK:STDOUT:             `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Carbon'
-// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
-// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
-// CHECK:STDOUT: |   `-FunctionDecl {{0x[a-f0-9]+}} <other.carbon:11:16> col:16 used F2__cpp_thunk 'int ()' inline
-// CHECK:STDOUT: |     |-CompoundStmt {{0x[a-f0-9]+}} <col:16>
-// CHECK:STDOUT: |     | |-DeclStmt {{0x[a-f0-9]+}} <col:16>
-// CHECK:STDOUT: |     | | `-VarDecl {{0x[a-f0-9]+}} <col:16> col:16 used return_storage 'int' nrvo
-// CHECK:STDOUT: |     | |-CallExpr {{0x[a-f0-9]+}} <col:16> 'void'
-// CHECK:STDOUT: |     | | |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:16> 'void (*)(int &)' <FunctionToPointerDecay>
-// CHECK:STDOUT: |     | | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'void (int &)' Function {{0x[a-f0-9]+}} 'F2__carbon_thunk' 'void (int &)'
-// CHECK:STDOUT: |     | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
-// CHECK:STDOUT: |     | `-ReturnStmt {{0x[a-f0-9]+}} <col:16> nrvo_candidate(Var {{0x[a-f0-9]+}} 'return_storage' 'int')
-// CHECK:STDOUT: |     |   `-DeclRefExpr {{0x[a-f0-9]+}} <col:16> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
-// CHECK:STDOUT: |     |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
-// CHECK:STDOUT: |     `-InternalLinkageAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit
   Carbon::Other::F1();
 }
 ''';
@@ -75,26 +42,6 @@ library "[[@TEST_NAME]]";
 import Other;
 import Cpp inline '''
 int G() {
-// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <return_int.carbon:[[@LINE-1]]:1, line:28:1> line:6:5 G 'int ()'
-// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:9, line:28:1>
-// CHECK:STDOUT:     `-ReturnStmt {{0x[a-f0-9]+}} <line:27:3, col:28>
-// CHECK:STDOUT:       `-CallExpr {{0x[a-f0-9]+}} <col:10, col:28> 'int'
-// CHECK:STDOUT:         `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:10, col:25> 'int (*)()' <FunctionToPointerDecay>
-// CHECK:STDOUT:           `-DeclRefExpr {{0x[a-f0-9]+}} <col:10, col:25> 'int ()' lvalue Function {{0x[a-f0-9]+}} 'F2__cpp_thunk' 'int ()'
-// CHECK:STDOUT:             `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Other'
-// CHECK:STDOUT:               `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Carbon'
-// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
-// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
-// CHECK:STDOUT: |   `-FunctionDecl {{0x[a-f0-9]+}} <other.carbon:12:15> col:15 used F3__cpp_thunk 'void (int)' inline
-// CHECK:STDOUT: |     |-ParmVarDecl {{0x[a-f0-9]+}} <col:15> col:15 used 'int'
-// CHECK:STDOUT: |     |-CompoundStmt {{0x[a-f0-9]+}} <col:15>
-// CHECK:STDOUT: |     | `-CallExpr {{0x[a-f0-9]+}} <col:15> 'void'
-// CHECK:STDOUT: |     |   |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:15> 'void (*)(int &)' <FunctionToPointerDecay>
-// CHECK:STDOUT: |     |   | `-DeclRefExpr {{0x[a-f0-9]+}} <col:15> 'void (int &)' Function {{0x[a-f0-9]+}} 'F3__carbon_thunk' 'void (int &)'
-// CHECK:STDOUT: |     |   `-DeclRefExpr {{0x[a-f0-9]+}} <col:15> 'int' lvalue ParmVar {{0x[a-f0-9]+}} depth 0 index 0 'int'
-// CHECK:STDOUT: |     |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
-// CHECK:STDOUT: |     `-InternalLinkageAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit
   return Carbon::Other::F2();
 }
 ''';
@@ -106,17 +53,6 @@ library "[[@TEST_NAME]]";
 import Other;
 import Cpp inline '''
 void G() {
-// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <args.carbon:[[@LINE-1]]:1, line:19:1> line:6:6 G 'void ()'
-// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:19:1>
-// CHECK:STDOUT:     `-CallExpr {{0x[a-f0-9]+}} <line:18:3, col:24> 'void'
-// CHECK:STDOUT:       |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void (*)(int)' <FunctionToPointerDecay>
-// CHECK:STDOUT:       | `-DeclRefExpr {{0x[a-f0-9]+}} <col:3, col:18> 'void (int)' lvalue Function {{0x[a-f0-9]+}} 'F3__cpp_thunk' 'void (int)'
-// CHECK:STDOUT:       |   `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Other'
-// CHECK:STDOUT:       |     `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Carbon'
-// CHECK:STDOUT:       `-IntegerLiteral {{0x[a-f0-9]+}} <col:21> 'int' 123
-// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
-// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
   Carbon::Other::F3(123);
 }
 ''';
@@ -126,24 +62,19 @@ void G() {
 library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+5]]:1: in import [InImport]
-// CHECK:STDERR: other.carbon:14:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with generic parameters` [SemanticsTodo]
+// CHECK:STDERR: other.carbon:7:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with generic parameters` [SemanticsTodo]
 // CHECK:STDERR: fn HasGenericArg(T:! type, a: T) { a; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Other;
 import Cpp inline '''
 void G() {
-// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <fail_todo_generic.carbon:[[@LINE-1]]:1, line:26:1> line:11:6 G 'void ()'
-// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:26:1>
-// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
-// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
   // CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+8]]:18: error: no member named 'HasGenericArg' in namespace 'Carbon::Other' [CppInteropParseError]
-  // CHECK:STDERR:    25 |   Carbon::Other::HasGenericArg<int>(123);
+  // CHECK:STDERR:    20 |   Carbon::Other::HasGenericArg<int>(123);
   // CHECK:STDERR:       |                  ^~~~~~~~~~~~~
   // CHECK:STDERR:
   // CHECK:STDERR: fail_todo_generic.carbon:[[@LINE+4]]:35: error: expected '(' for function-style cast or type construction [CppInteropParseError]
-  // CHECK:STDERR:    25 |   Carbon::Other::HasGenericArg<int>(123);
+  // CHECK:STDERR:    20 |   Carbon::Other::HasGenericArg<int>(123);
   // CHECK:STDERR:       |                                ~~~^
   // CHECK:STDERR:
   Carbon::Other::HasGenericArg<int>(123);
@@ -155,20 +86,15 @@ void G() {
 library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_todo_deduced.carbon:[[@LINE+5]]:1: in import [InImport]
-// CHECK:STDERR: other.carbon:15:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with generic parameters` [SemanticsTodo]
+// CHECK:STDERR: other.carbon:8:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with generic parameters` [SemanticsTodo]
 // CHECK:STDERR: fn HasDeducedArg[T:! type](a: T) { a; }
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Other;
 import Cpp inline '''
 void G() {
-// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <fail_todo_deduced.carbon:[[@LINE-1]]:1, line:22:1> line:11:6 G 'void ()'
-// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:22:1>
-// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
-// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
-// CHECK:STDOUT: | `-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Other
   // CHECK:STDERR: fail_todo_deduced.carbon:[[@LINE+4]]:18: error: no member named 'HasDeducedArg' in namespace 'Carbon::Other' [CppInteropParseError]
-  // CHECK:STDERR:    21 |   Carbon::Other::HasDeducedArg(123);
+  // CHECK:STDERR:    16 |   Carbon::Other::HasDeducedArg(123);
   // CHECK:STDERR:       |                  ^~~~~~~~~~~~~
   // CHECK:STDERR:
   Carbon::Other::HasDeducedArg(123);
@@ -180,20 +106,15 @@ void G() {
 library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_todo_method.carbon:[[@LINE+5]]:1: in import [InImport]
-// CHECK:STDERR: other.carbon:18:3: error: semantics TODO: `unsupported: C++ calling a Carbon function with an implicit parameter` [SemanticsTodo]
+// CHECK:STDERR: other.carbon:11:3: error: semantics TODO: `unsupported: C++ calling a Carbon function with an implicit parameter` [SemanticsTodo]
 // CHECK:STDERR:   fn Method[self: Self]() { self; }
 // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 import Other;
 import Cpp inline '''
 void G() {
-// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <fail_todo_method.carbon:[[@LINE-1]]:1, line:22:1> line:11:6 G 'void ()'
-// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:10, line:22:1>
-// CHECK:STDOUT:     `-CallExpr {{0x[a-f0-9]+}} <line:21:3, col:29> '<dependent type>' contains-errors
-// CHECK:STDOUT:       `-RecoveryExpr {{0x[a-f0-9]+}} <col:3, col:22> '<dependent type>' contains-errors lvalue
-// CHECK:STDOUT:         `-CXXTemporaryObjectExpr {{0x[a-f0-9]+}} <col:3, col:20> 'Carbon::Other::C' 'void () noexcept' zeroing
   // CHECK:STDERR: fail_todo_method.carbon:[[@LINE+4]]:22: error: no member named 'Method' in 'Carbon::Other::C' [CppInteropParseError]
-  // CHECK:STDERR:    21 |   Carbon::Other::C().Method();
+  // CHECK:STDERR:    16 |   Carbon::Other::C().Method();
   // CHECK:STDERR:       |   ~~~~~~~~~~~~~~~~~~ ^
   // CHECK:STDERR:
   Carbon::Other::C().Method();

--- a/toolchain/check/testdata/interop/cpp/reverse/thunk_ast.carbon
+++ b/toolchain/check/testdata/interop/cpp/reverse/thunk_ast.carbon
@@ -1,0 +1,55 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+// EXTRA-ARGS: --dump-cpp-ast
+// SET-CHECK-SUBSET
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/reverse/thunk_ast.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/reverse/thunk_ast.carbon
+// CHECK:STDOUT: TranslationUnitDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc>
+// CHECK:STDOUT: |-NamespaceDecl {{0x[a-f0-9]+}} <<invalid sloc>> <invalid sloc> Carbon
+
+// --- thunk_with_args_and_return.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn F(i: i32) -> i32 {
+// CHECK:STDOUT: | `-FunctionDecl {{0x[a-f0-9]+}} <thunk_with_args_and_return.carbon:[[@LINE-1]]:21> col:21 used F__cpp_thunk 'int (int)' inline
+// CHECK:STDOUT: |   |-ParmVarDecl {{0x[a-f0-9]+}} <col:21> col:21 used 'int'
+// CHECK:STDOUT: |   |-CompoundStmt {{0x[a-f0-9]+}} <col:21>
+// CHECK:STDOUT: |   | |-DeclStmt {{0x[a-f0-9]+}} <col:21>
+// CHECK:STDOUT: |   | | `-VarDecl {{0x[a-f0-9]+}} <col:21> col:21 used return_storage 'int' nrvo
+// CHECK:STDOUT: |   | |-CallExpr {{0x[a-f0-9]+}} <col:21> 'void'
+// CHECK:STDOUT: |   | | |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:21> 'void (*)(int &, int &)' <FunctionToPointerDecay>
+// CHECK:STDOUT: |   | | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:21> 'void (int &, int &)' Function {{0x[a-f0-9]+}} 'F__carbon_thunk' 'void (int &, int &)'
+// CHECK:STDOUT: |   | | |-DeclRefExpr {{0x[a-f0-9]+}} <col:21> 'int' lvalue ParmVar {{0x[a-f0-9]+}} depth 0 index 0 'int'
+// CHECK:STDOUT: |   | | `-DeclRefExpr {{0x[a-f0-9]+}} <col:21> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
+// CHECK:STDOUT: |   | `-ReturnStmt {{0x[a-f0-9]+}} <col:21> nrvo_candidate(Var {{0x[a-f0-9]+}} 'return_storage' 'int')
+// CHECK:STDOUT: |   |   `-DeclRefExpr {{0x[a-f0-9]+}} <col:21> 'int' lvalue Var {{0x[a-f0-9]+}} 'return_storage' 'int'
+// CHECK:STDOUT: |   |-AlwaysInlineAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit always_inline
+// CHECK:STDOUT: |   `-InternalLinkageAttr {{0x[a-f0-9]+}} <<invalid sloc>> Implicit
+// CHECK:STDOUT: `-FunctionDecl {{0x[a-f0-9]+}} <line:35:1, line:37:1> line:35:5 G 'int (int)'
+// CHECK:STDOUT:   |-ParmVarDecl {{0x[a-f0-9]+}} <col:7, col:11> col:11 used i 'int'
+// CHECK:STDOUT:   `-CompoundStmt {{0x[a-f0-9]+}} <col:14, line:37:1>
+// CHECK:STDOUT:     `-ReturnStmt {{0x[a-f0-9]+}} <line:36:3, col:21>
+// CHECK:STDOUT:       `-CallExpr {{0x[a-f0-9]+}} <col:10, col:21> 'int'
+// CHECK:STDOUT:         |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:10, col:18> 'int (*)(int)' <FunctionToPointerDecay>
+// CHECK:STDOUT:         | `-DeclRefExpr {{0x[a-f0-9]+}} <col:10, col:18> 'int (int)' lvalue Function {{0x[a-f0-9]+}} 'F__cpp_thunk' 'int (int)'
+// CHECK:STDOUT:         |   `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Carbon'
+// CHECK:STDOUT:         `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:20> 'int' <LValueToRValue>
+// CHECK:STDOUT:           `-DeclRefExpr {{0x[a-f0-9]+}} <col:20> 'int' lvalue ParmVar {{0x[a-f0-9]+}} 'i' 'int'
+  return i;
+}
+
+inline Cpp '''
+int G(int i) {
+  return Carbon::F(i);
+}
+''';

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -396,10 +396,14 @@ auto BuildThunkDefinitionForExport(Context& context,
   if (thunk_has_return_param) {
     auto out_param_id =
         context.inst_blocks().Get(thunk_function.call_params_id).back();
-    AddInst(context, SemIR::LocId(out_param_id),
+
+    SemIR::LocId loc_id(out_param_id);
+    auto init_id =
+        Initialize(context, loc_id, out_param_id, call_id, /*for_return=*/true);
+    AddInst(context, loc_id,
             SemIR::Assign{
                 .lhs_id = out_param_id,
-                .rhs_id = call_id,
+                .rhs_id = init_id,
             });
   } else {
     DiscardExpr(context, call_id);

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -320,9 +320,13 @@ static auto StartThunkFunctionDefinition(Context& context,
   StartFunctionDefinition(context, thunk_id, function_id);
 }
 
-auto BuildThunkDefinition(Context& context, SemIR::FunctionId signature_id,
-                          SemIR::FunctionId function_id, SemIR::InstId thunk_id,
-                          SemIR::InstId callee_id) -> void {
+// Given a declaration of a thunk and the function that it should call, build
+// the thunk body.
+static auto BuildThunkDefinition(Context& context,
+                                 SemIR::FunctionId signature_id,
+                                 SemIR::FunctionId function_id,
+                                 SemIR::InstId thunk_id,
+                                 SemIR::InstId callee_id) -> void {
   // TODO: Improve the diagnostics produced here. Specifically, it would likely
   // be better for the primary error message to be that we tried to produce a
   // thunk because of a type mismatch, but couldn't, with notes explaining

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -261,13 +261,13 @@ static auto HasDeclaredReturnType(Context& context,
 
 auto PerformThunkCall(Context& context, SemIR::LocId loc_id,
                       SemIR::FunctionId function_id,
+                      llvm::ArrayRef<SemIR::InstId> param_pattern_ids,
                       llvm::ArrayRef<SemIR::InstId> call_arg_ids,
                       SemIR::InstId callee_id) -> SemIR::InstId {
   auto& function = context.functions().Get(function_id);
 
-  auto [args_vec, ignored_call_args] =
-      ThunkPatternMatch(context, function.self_param_id,
-                        function.param_patterns_id, call_arg_ids);
+  auto [args_vec, ignored_call_args] = ThunkPatternMatch(
+      context, function.self_param_id, param_pattern_ids, call_arg_ids);
   llvm::ArrayRef<SemIR::InstId> args = args_vec;
 
   // If we have a self parameter, form `self.<callee_id>` if needed.
@@ -287,7 +287,10 @@ auto PerformThunkCall(Context& context, SemIR::LocId loc_id,
 // Build a call to a function that forwards the arguments of the enclosing
 // function, for use when constructing a thunk.
 static auto BuildThunkCall(Context& context, SemIR::FunctionId function_id,
-                           SemIR::InstId callee_id) -> SemIR::InstId {
+                           SemIR::InstId callee_id,
+                           llvm::ArrayRef<SemIR::InstId> param_pattern_ids,
+                           llvm::ArrayRef<SemIR::InstId> call_arg_ids)
+    -> SemIR::InstId {
   auto& function = context.functions().Get(function_id);
 
   // Build a `NameRef` naming the callee, and a `SpecificConstant` if needed.
@@ -297,8 +300,8 @@ static auto BuildThunkCall(Context& context, SemIR::FunctionId function_id,
   callee_id = BuildNameRef(context, loc_id, function.name_id, callee_id,
                            callee_type.specific_id);
 
-  auto call_params = context.inst_blocks().Get(function.call_params_id);
-  return PerformThunkCall(context, loc_id, function_id, call_params, callee_id);
+  return PerformThunkCall(context, loc_id, function_id, param_pattern_ids,
+                          call_arg_ids, callee_id);
 }
 
 static auto StartThunkFunctionDefinition(Context& context,
@@ -339,7 +342,15 @@ auto BuildThunkDefinition(Context& context, SemIR::FunctionId signature_id,
                      ThunkSignature);
       });
 
-  auto call_id = BuildThunkCall(context, function_id, callee_id);
+  const auto& function = context.functions().Get(function_id);
+  llvm::ArrayRef<SemIR::InstId> param_pattern_ids;
+  if (function.param_patterns_id.has_value()) {
+    param_pattern_ids = context.inst_blocks().Get(function.param_patterns_id);
+  }
+  auto call_param_ids = context.inst_blocks().Get(function.call_params_id);
+
+  auto call_id = BuildThunkCall(context, function_id, callee_id,
+                                param_pattern_ids, call_param_ids);
   if (HasDeclaredReturnType(context, function_id)) {
     BuildReturnWithExpr(context, SemIR::LocId(callee_id), call_id);
   } else {

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -361,6 +361,51 @@ auto BuildThunkDefinition(Context& context, SemIR::FunctionId signature_id,
   FinishFunctionDefinition(context, function_id);
 }
 
+auto BuildThunkDefinitionForExport(Context& context,
+                                   SemIR::FunctionId thunk_function_id,
+                                   SemIR::FunctionId callee_function_id,
+                                   SemIR::InstId thunk_id,
+                                   SemIR::InstId callee_id) -> void {
+  auto& thunk_function = context.functions().Get(thunk_function_id);
+  auto& callee_function = context.functions().Get(callee_function_id);
+
+  StartThunkFunctionDefinition(context, thunk_function_id, thunk_id, callee_id);
+
+  const bool thunk_has_return_param =
+      callee_function.return_type_inst_id != SemIR::TypeInstId::None;
+
+  llvm::ArrayRef<SemIR::InstId> param_pattern_ids;
+  if (thunk_function.param_patterns_id.has_value()) {
+    param_pattern_ids =
+        context.inst_blocks().Get(thunk_function.param_patterns_id);
+  }
+  auto call_param_ids =
+      context.inst_blocks().Get(thunk_function.call_params_id);
+
+  if (thunk_has_return_param) {
+    param_pattern_ids = param_pattern_ids.drop_back();
+    call_param_ids = call_param_ids.drop_back();
+  }
+
+  auto call_id = BuildThunkCall(context, thunk_function_id, callee_id,
+                                param_pattern_ids, call_param_ids);
+  if (thunk_has_return_param) {
+    auto out_param_id =
+        context.inst_blocks().Get(thunk_function.call_params_id).back();
+    AddInst(context, SemIR::LocId(out_param_id),
+            SemIR::Assign{
+                .lhs_id = out_param_id,
+                .rhs_id = call_id,
+            });
+  } else {
+    DiscardExpr(context, call_id);
+  }
+
+  BuildReturnWithNoExpr(context, SemIR::LocId(callee_id));
+
+  FinishFunctionDefinition(context, thunk_function_id);
+}
+
 auto BuildThunkDefinition(Context& context,
                           DeferredDefinitionWorklist::DefineThunk&& task)
     -> void {

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -301,6 +301,22 @@ static auto BuildThunkCall(Context& context, SemIR::FunctionId function_id,
   return PerformThunkCall(context, loc_id, function_id, call_params, callee_id);
 }
 
+static auto StartThunkFunctionDefinition(Context& context,
+                                         SemIR::FunctionId function_id,
+                                         SemIR::InstId thunk_id,
+                                         SemIR::InstId callee_id) {
+  // The check below produces diagnostics referring to the signature, so also
+  // note the callee.
+  Diagnostics::AnnotationScope annot_scope(
+      &context.emitter(), [&](DiagnosticBuilder& builder) {
+        CARBON_DIAGNOSTIC(ThunkCallee, Note,
+                          "while building thunk calling this function");
+        builder.Note(callee_id, ThunkCallee);
+      });
+
+  StartFunctionDefinition(context, thunk_id, function_id);
+}
+
 auto BuildThunkDefinition(Context& context, SemIR::FunctionId signature_id,
                           SemIR::FunctionId function_id, SemIR::InstId thunk_id,
                           SemIR::InstId callee_id) -> void {
@@ -310,18 +326,7 @@ auto BuildThunkDefinition(Context& context, SemIR::FunctionId signature_id,
   // why, rather than the primary error message being whatever went wrong
   // building the thunk.
 
-  {
-    // The check below produces diagnostics referring to the signature, so also
-    // note the callee.
-    Diagnostics::AnnotationScope annot_scope(
-        &context.emitter(), [&](DiagnosticBuilder& builder) {
-          CARBON_DIAGNOSTIC(ThunkCallee, Note,
-                            "while building thunk calling this function");
-          builder.Note(callee_id, ThunkCallee);
-        });
-
-    StartFunctionDefinition(context, thunk_id, function_id);
-  }
+  StartThunkFunctionDefinition(context, function_id, thunk_id, callee_id);
 
   // The checks below produce diagnostics pointing at the callee, so also note
   // the signature.

--- a/toolchain/check/thunk.h
+++ b/toolchain/check/thunk.h
@@ -17,6 +17,15 @@ auto BuildThunkDefinition(Context& context, SemIR::FunctionId signature_id,
                           SemIR::FunctionId function_id, SemIR::InstId thunk_id,
                           SemIR::InstId callee_id) -> void;
 
+// Similar to `BuildThunkDefinition`, but modified for reverse
+// interop. If the callee has a return value, the thunk returns it
+// through an explicit output parameter at the end of the parameter list.
+auto BuildThunkDefinitionForExport(Context& context,
+                                   SemIR::FunctionId thunk_function_id,
+                                   SemIR::FunctionId callee_function_id,
+                                   SemIR::InstId thunk_id,
+                                   SemIR::InstId callee_id) -> void;
+
 // Given a function signature and a callee function, build a thunk that matches
 // the given signature and calls the specified callee. Returns the callee
 // unchanged if it can be used directly.

--- a/toolchain/check/thunk.h
+++ b/toolchain/check/thunk.h
@@ -35,9 +35,11 @@ auto BuildThunkDefinition(Context& context,
                           DeferredDefinitionWorklist::DefineThunk&& task)
     -> void;
 
-// Similar to `BuildThunkDefinition`, but modified for reverse
-// interop. If the callee has a return value, the thunk returns it
-// through an explicit output parameter at the end of the parameter list.
+// Given a declaration of a thunk and the function that it should call,
+// build a thunk body for calling a Carbon function from a C++
+// function. If the callee has a return value, the thunk returns it
+// through an explicit output parameter at the end of the parameter
+// list.
 auto BuildThunkDefinitionForExport(Context& context,
                                    SemIR::FunctionId thunk_function_id,
                                    SemIR::FunctionId callee_function_id,

--- a/toolchain/check/thunk.h
+++ b/toolchain/check/thunk.h
@@ -31,6 +31,7 @@ auto BuildThunk(Context& context, SemIR::FunctionId signature_id,
 // of call arguments for `function_id`, not a syntactic argument list.
 auto PerformThunkCall(Context& context, SemIR::LocId loc_id,
                       SemIR::FunctionId function_id,
+                      llvm::ArrayRef<SemIR::InstId> param_pattern_ids,
                       llvm::ArrayRef<SemIR::InstId> call_arg_ids,
                       SemIR::InstId callee_id) -> SemIR::InstId;
 

--- a/toolchain/check/thunk.h
+++ b/toolchain/check/thunk.h
@@ -11,21 +11,6 @@
 
 namespace Carbon::Check {
 
-// Given a declaration of a thunk and the function that it should call, build
-// the thunk body.
-auto BuildThunkDefinition(Context& context, SemIR::FunctionId signature_id,
-                          SemIR::FunctionId function_id, SemIR::InstId thunk_id,
-                          SemIR::InstId callee_id) -> void;
-
-// Similar to `BuildThunkDefinition`, but modified for reverse
-// interop. If the callee has a return value, the thunk returns it
-// through an explicit output parameter at the end of the parameter list.
-auto BuildThunkDefinitionForExport(Context& context,
-                                   SemIR::FunctionId thunk_function_id,
-                                   SemIR::FunctionId callee_function_id,
-                                   SemIR::InstId thunk_id,
-                                   SemIR::InstId callee_id) -> void;
-
 // Given a function signature and a callee function, build a thunk that matches
 // the given signature and calls the specified callee. Returns the callee
 // unchanged if it can be used directly.
@@ -49,6 +34,15 @@ auto PerformThunkCall(Context& context, SemIR::LocId loc_id,
 auto BuildThunkDefinition(Context& context,
                           DeferredDefinitionWorklist::DefineThunk&& task)
     -> void;
+
+// Similar to `BuildThunkDefinition`, but modified for reverse
+// interop. If the callee has a return value, the thunk returns it
+// through an explicit output parameter at the end of the parameter list.
+auto BuildThunkDefinitionForExport(Context& context,
+                                   SemIR::FunctionId thunk_function_id,
+                                   SemIR::FunctionId callee_function_id,
+                                   SemIR::InstId thunk_id,
+                                   SemIR::InstId callee_id) -> void;
 
 }  // namespace Carbon::Check
 

--- a/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
@@ -22,17 +22,30 @@ fn IntArg(a: i32) {
 fn FloatArg(a: f32) {
   a;
 }
+fn IntReturn() -> i32 {
+  return 123;
+}
 // --- function.carbon
 
 library "[[@TEST_NAME]]";
 
+// CHECK:STDERR: function.carbon:[[@LINE+5]]:1: in import [InImport]
+// CHECK:STDERR: other.carbon:12:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with return type other than `()`` [SemanticsTodo]
+// CHECK:STDERR: fn IntReturn() -> i32 {
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
 import Other;
 import Cpp inline '''
-void G() {
+int G() {
   Carbon::Other::NoArgs();
   Carbon::Other::BoolArg(true);
   Carbon::Other::IntArg(123);
   Carbon::Other::FloatArg(1.5);
+  // CHECK:STDERR: function.carbon:[[@LINE+4]]:25: error: no member named 'IntReturn' in namespace 'Carbon::Other' [CppInteropParseError]
+  // CHECK:STDERR:    20 |   return Carbon::Other::IntReturn();
+  // CHECK:STDERR:       |                         ^~~~~~~~~
+  // CHECK:STDERR:
+  return Carbon::Other::IntReturn();
 }
 ''';
 
@@ -58,275 +71,3 @@ inline void G2() {
 
 fn H() { Cpp.G2(); }
 
-// CHECK:STDOUT: ; ModuleID = 'other.carbon'
-// CHECK:STDOUT: source_filename = "other.carbon"
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CNoArgs.Other() #0 !dbg !4 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !7
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CBoolArg.Other(i1 %a) #0 !dbg !8 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !14
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CIntArg.Other(i32 %a) #0 !dbg !15 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !21
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CFloatArg.Other(float %a) #0 !dbg !22 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !25
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: attributes #0 = { nounwind }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
-// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
-// CHECK:STDOUT:
-// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
-// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !3 = !DIFile(filename: "other.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoArgs", linkageName: "_CNoArgs.Other", scope: null, file: !3, line: 2, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 2, column: 1, scope: !4)
-// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "BoolArg", linkageName: "_CBoolArg.Other", scope: null, file: !3, line: 3, type: !9, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !12)
-// CHECK:STDOUT: !9 = !DISubroutineType(types: !10)
-// CHECK:STDOUT: !10 = !{null, !11}
-// CHECK:STDOUT: !11 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
-// CHECK:STDOUT: !12 = !{!13}
-// CHECK:STDOUT: !13 = !DILocalVariable(arg: 1, scope: !8, type: !11)
-// CHECK:STDOUT: !14 = !DILocation(line: 3, column: 1, scope: !8)
-// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "IntArg", linkageName: "_CIntArg.Other", scope: null, file: !3, line: 6, type: !16, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !19)
-// CHECK:STDOUT: !16 = !DISubroutineType(types: !17)
-// CHECK:STDOUT: !17 = !{null, !18}
-// CHECK:STDOUT: !18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !19 = !{!20}
-// CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !15, type: !18)
-// CHECK:STDOUT: !21 = !DILocation(line: 6, column: 1, scope: !15)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "FloatArg", linkageName: "_CFloatArg.Other", scope: null, file: !3, line: 9, type: !9, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !23)
-// CHECK:STDOUT: !23 = !{!24}
-// CHECK:STDOUT: !24 = !DILocalVariable(arg: 1, scope: !22, type: !11)
-// CHECK:STDOUT: !25 = !DILocation(line: 9, column: 1, scope: !22)
-// CHECK:STDOUT: ; ModuleID = 'function.carbon'
-// CHECK:STDOUT: source_filename = "function.carbon"
-// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: mustprogress uwtable
-// CHECK:STDOUT: define dso_local void @_Z1Gv() #0 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL17NoArgs__cpp_thunkEv()
-// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL18BoolArg__cpp_thunkEb(i1 noundef zeroext true)
-// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL17IntArg__cpp_thunkEi(i32 noundef 123)
-// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL19FloatArg__cpp_thunkEf(float noundef 1.500000e+00)
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL17NoArgs__cpp_thunkEv() #1 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CNoArgs__carbon_thunk.Other()
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL18BoolArg__cpp_thunkEb(i1 noundef zeroext %0) #1 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.addr = alloca i8, align 1
-// CHECK:STDOUT:   %storedv = zext i1 %0 to i8
-// CHECK:STDOUT:   store i8 %storedv, ptr %.addr, align 1, !tbaa !11
-// CHECK:STDOUT:   call void @_CBoolArg__carbon_thunk.Other(ptr noundef nonnull align 1 dereferenceable(1) %.addr)
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL17IntArg__cpp_thunkEi(i32 noundef %0) #1 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.addr = alloca i32, align 4
-// CHECK:STDOUT:   store i32 %0, ptr %.addr, align 4, !tbaa !7
-// CHECK:STDOUT:   call void @_CIntArg__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %.addr)
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL19FloatArg__cpp_thunkEf(float noundef %0) #1 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.addr = alloca float, align 4
-// CHECK:STDOUT:   store float %0, ptr %.addr, align 4, !tbaa !13
-// CHECK:STDOUT:   call void @_CFloatArg__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %.addr)
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_CNoArgs.Other()
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CNoArgs__carbon_thunk.Other() #2 !dbg !15 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CNoArgs.Other(), !dbg !19
-// CHECK:STDOUT:   ret void, !dbg !19
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_CBoolArg.Other(i1)
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CBoolArg__carbon_thunk.Other(ptr %_) #2 !dbg !20 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.1 = load i8, ptr %_, align 1, !dbg !26
-// CHECK:STDOUT:   %.11 = trunc i8 %.1 to i1, !dbg !26
-// CHECK:STDOUT:   call void @_CBoolArg.Other(i1 %.11), !dbg !26
-// CHECK:STDOUT:   ret void, !dbg !26
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_CIntArg.Other(i32)
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CIntArg__carbon_thunk.Other(ptr %_) #2 !dbg !27 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.1 = load i32, ptr %_, align 4, !dbg !33
-// CHECK:STDOUT:   call void @_CIntArg.Other(i32 %.1), !dbg !33
-// CHECK:STDOUT:   ret void, !dbg !33
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_CFloatArg.Other(float)
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CFloatArg__carbon_thunk.Other(ptr %_) #2 !dbg !34 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.1 = load float, ptr %_, align 4, !dbg !37
-// CHECK:STDOUT:   call void @_CFloatArg.Other(float %.1), !dbg !37
-// CHECK:STDOUT:   ret void, !dbg !37
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: attributes #0 = { mustprogress uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:STDOUT: attributes #2 = { nounwind }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
-// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
-// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
-// CHECK:STDOUT:
-// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
-// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
-// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
-// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
-// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !6 = !DIFile(filename: "function.carbon", directory: "")
-// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
-// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
-// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
-// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
-// CHECK:STDOUT: !11 = !{!12, !12, i64 0}
-// CHECK:STDOUT: !12 = !{!"bool", !9, i64 0}
-// CHECK:STDOUT: !13 = !{!14, !14, i64 0}
-// CHECK:STDOUT: !14 = !{!"float", !9, i64 0}
-// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "NoArgs__carbon_thunk", linkageName: "_CNoArgs__carbon_thunk.Other", scope: null, file: !16, line: 2, type: !17, spFlags: DISPFlagDefinition, unit: !5)
-// CHECK:STDOUT: !16 = !DIFile(filename: "other.carbon", directory: "")
-// CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
-// CHECK:STDOUT: !18 = !{null}
-// CHECK:STDOUT: !19 = !DILocation(line: 2, column: 1, scope: !15)
-// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "BoolArg__carbon_thunk", linkageName: "_CBoolArg__carbon_thunk.Other", scope: null, file: !16, line: 3, type: !21, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !24)
-// CHECK:STDOUT: !21 = !DISubroutineType(types: !22)
-// CHECK:STDOUT: !22 = !{null, !23}
-// CHECK:STDOUT: !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
-// CHECK:STDOUT: !24 = !{!25}
-// CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !20, type: !23)
-// CHECK:STDOUT: !26 = !DILocation(line: 3, column: 1, scope: !20)
-// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "IntArg__carbon_thunk", linkageName: "_CIntArg__carbon_thunk.Other", scope: null, file: !16, line: 6, type: !28, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !31)
-// CHECK:STDOUT: !28 = !DISubroutineType(types: !29)
-// CHECK:STDOUT: !29 = !{null, !30}
-// CHECK:STDOUT: !30 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !31 = !{!32}
-// CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !27, type: !30)
-// CHECK:STDOUT: !33 = !DILocation(line: 6, column: 1, scope: !27)
-// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "FloatArg__carbon_thunk", linkageName: "_CFloatArg__carbon_thunk.Other", scope: null, file: !16, line: 9, type: !21, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !35)
-// CHECK:STDOUT: !35 = !{!36}
-// CHECK:STDOUT: !36 = !DILocalVariable(arg: 1, scope: !34, type: !23)
-// CHECK:STDOUT: !37 = !DILocation(line: 9, column: 1, scope: !34)
-// CHECK:STDOUT: ; ModuleID = 'single_file.carbon'
-// CHECK:STDOUT: source_filename = "single_file.carbon"
-// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
-// CHECK:STDOUT:
-// CHECK:STDOUT: $_Z2G2v = comdat any
-// CHECK:STDOUT:
-// CHECK:STDOUT: $_Z2G1v = comdat any
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CF.Main() #0 !dbg !11 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !14
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CF__carbon_thunk.Main() #0 !dbg !15 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CF.Main(), !dbg !16
-// CHECK:STDOUT:   ret void, !dbg !16
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CH.Main() #0 !dbg !17 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_Z2G2v(), !dbg !18
-// CHECK:STDOUT:   ret void, !dbg !19
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: inlinehint mustprogress uwtable
-// CHECK:STDOUT: define linkonce_odr dso_local void @_Z2G2v() #1 comdat {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_Z2G1v()
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: inlinehint mustprogress uwtable
-// CHECK:STDOUT: define linkonce_odr dso_local void @_Z2G1v() #1 comdat {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_ZN6CarbonL12F__cpp_thunkEv()
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6CarbonL12F__cpp_thunkEv() #2 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CF__carbon_thunk.Main()
-// CHECK:STDOUT:   ret void
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: attributes #0 = { nounwind }
-// CHECK:STDOUT: attributes #1 = { inlinehint mustprogress uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:STDOUT: attributes #2 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
-// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
-// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
-// CHECK:STDOUT:
-// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
-// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
-// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
-// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
-// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !6 = !DIFile(filename: "single_file.carbon", directory: "")
-// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
-// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
-// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
-// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !6, line: 6, type: !12, spFlags: DISPFlagDefinition, unit: !5)
-// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
-// CHECK:STDOUT: !13 = !{null}
-// CHECK:STDOUT: !14 = !DILocation(line: 6, column: 1, scope: !11)
-// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "F__carbon_thunk", linkageName: "_CF__carbon_thunk.Main", scope: null, file: !6, line: 6, type: !12, spFlags: DISPFlagDefinition, unit: !5)
-// CHECK:STDOUT: !16 = !DILocation(line: 6, column: 1, scope: !15)
-// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main", scope: null, file: !6, line: 20, type: !12, spFlags: DISPFlagDefinition, unit: !5)
-// CHECK:STDOUT: !18 = !DILocation(line: 20, column: 10, scope: !17)
-// CHECK:STDOUT: !19 = !DILocation(line: 20, column: 1, scope: !17)

--- a/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
@@ -184,11 +184,9 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
 // CHECK:STDOUT: define internal noundef i32 @_ZN6Carbon5OtherL20IntReturn__cpp_thunkEv() #1 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %return_storage = alloca i32, align 4
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %return_storage) #2
-// CHECK:STDOUT:   call void @_CIntReturn__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %return_storage)
-// CHECK:STDOUT:   %0 = load i32, ptr %return_storage, align 4, !tbaa !7
-// CHECK:STDOUT:   call void @llvm.lifetime.end.p0(ptr %return_storage) #2
+// CHECK:STDOUT:   %retval = alloca i32, align 4
+// CHECK:STDOUT:   call void @_CIntReturn__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %retval)
+// CHECK:STDOUT:   %0 = load i32, ptr %retval, align 4, !tbaa !7
 // CHECK:STDOUT:   ret i32 %0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -242,16 +240,9 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT:   ret void, !dbg !41
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #3
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-// CHECK:STDOUT: declare void @llvm.lifetime.end.p0(ptr captures(none)) #3
-// CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { mustprogress uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 // CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 // CHECK:STDOUT: attributes #2 = { nounwind }
-// CHECK:STDOUT: attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!5}

--- a/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
@@ -29,11 +29,6 @@ fn IntReturn() -> i32 {
 
 library "[[@TEST_NAME]]";
 
-// CHECK:STDERR: function.carbon:[[@LINE+5]]:1: in import [InImport]
-// CHECK:STDERR: other.carbon:12:1: error: semantics TODO: `unsupported: C++ calling a Carbon function with return type other than `()`` [SemanticsTodo]
-// CHECK:STDERR: fn IntReturn() -> i32 {
-// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
 import Other;
 import Cpp inline '''
 int G() {
@@ -41,10 +36,6 @@ int G() {
   Carbon::Other::BoolArg(true);
   Carbon::Other::IntArg(123);
   Carbon::Other::FloatArg(1.5);
-  // CHECK:STDERR: function.carbon:[[@LINE+4]]:25: error: no member named 'IntReturn' in namespace 'Carbon::Other' [CppInteropParseError]
-  // CHECK:STDERR:    20 |   return Carbon::Other::IntReturn();
-  // CHECK:STDERR:       |                         ^~~~~~~~~
-  // CHECK:STDERR:
   return Carbon::Other::IntReturn();
 }
 ''';
@@ -71,3 +62,318 @@ inline void G2() {
 
 fn H() { Cpp.G2(); }
 
+// CHECK:STDOUT: ; ModuleID = 'other.carbon'
+// CHECK:STDOUT: source_filename = "other.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CNoArgs.Other() #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !7
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CBoolArg.Other(i1 %a) #0 !dbg !8 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CIntArg.Other(i32 %a) #0 !dbg !15 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !21
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CFloatArg.Other(float %a) #0 !dbg !22 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !25
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define i32 @_CIntReturn.Other() #0 !dbg !26 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret i32 123, !dbg !29
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "other.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoArgs", linkageName: "_CNoArgs.Other", scope: null, file: !3, line: 2, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{null}
+// CHECK:STDOUT: !7 = !DILocation(line: 2, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "BoolArg", linkageName: "_CBoolArg.Other", scope: null, file: !3, line: 3, type: !9, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !12)
+// CHECK:STDOUT: !9 = !DISubroutineType(types: !10)
+// CHECK:STDOUT: !10 = !{null, !11}
+// CHECK:STDOUT: !11 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !12 = !{!13}
+// CHECK:STDOUT: !13 = !DILocalVariable(arg: 1, scope: !8, type: !11)
+// CHECK:STDOUT: !14 = !DILocation(line: 3, column: 1, scope: !8)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "IntArg", linkageName: "_CIntArg.Other", scope: null, file: !3, line: 6, type: !16, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !19)
+// CHECK:STDOUT: !16 = !DISubroutineType(types: !17)
+// CHECK:STDOUT: !17 = !{null, !18}
+// CHECK:STDOUT: !18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !19 = !{!20}
+// CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !15, type: !18)
+// CHECK:STDOUT: !21 = !DILocation(line: 6, column: 1, scope: !15)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "FloatArg", linkageName: "_CFloatArg.Other", scope: null, file: !3, line: 9, type: !9, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !23)
+// CHECK:STDOUT: !23 = !{!24}
+// CHECK:STDOUT: !24 = !DILocalVariable(arg: 1, scope: !22, type: !11)
+// CHECK:STDOUT: !25 = !DILocation(line: 9, column: 1, scope: !22)
+// CHECK:STDOUT: !26 = distinct !DISubprogram(name: "IntReturn", linkageName: "_CIntReturn.Other", scope: null, file: !3, line: 12, type: !27, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !27 = !DISubroutineType(types: !28)
+// CHECK:STDOUT: !28 = !{!18}
+// CHECK:STDOUT: !29 = !DILocation(line: 13, column: 3, scope: !26)
+// CHECK:STDOUT: ; ModuleID = 'function.carbon'
+// CHECK:STDOUT: source_filename = "function.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: mustprogress uwtable
+// CHECK:STDOUT: define dso_local noundef i32 @_Z1Gv() #0 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL17NoArgs__cpp_thunkEv()
+// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL18BoolArg__cpp_thunkEb(i1 noundef zeroext true)
+// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL17IntArg__cpp_thunkEi(i32 noundef 123)
+// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL19FloatArg__cpp_thunkEf(float noundef 1.500000e+00)
+// CHECK:STDOUT:   %call = call noundef i32 @_ZN6Carbon5OtherL20IntReturn__cpp_thunkEv()
+// CHECK:STDOUT:   ret i32 %call
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL17NoArgs__cpp_thunkEv() #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CNoArgs__carbon_thunk.Other()
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL18BoolArg__cpp_thunkEb(i1 noundef zeroext %0) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca i8, align 1
+// CHECK:STDOUT:   %storedv = zext i1 %0 to i8
+// CHECK:STDOUT:   store i8 %storedv, ptr %.addr, align 1, !tbaa !11
+// CHECK:STDOUT:   call void @_CBoolArg__carbon_thunk.Other(ptr noundef nonnull align 1 dereferenceable(1) %.addr)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL17IntArg__cpp_thunkEi(i32 noundef %0) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca i32, align 4
+// CHECK:STDOUT:   store i32 %0, ptr %.addr, align 4, !tbaa !7
+// CHECK:STDOUT:   call void @_CIntArg__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %.addr)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL19FloatArg__cpp_thunkEf(float noundef %0) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca float, align 4
+// CHECK:STDOUT:   store float %0, ptr %.addr, align 4, !tbaa !13
+// CHECK:STDOUT:   call void @_CFloatArg__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %.addr)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal noundef i32 @_ZN6Carbon5OtherL20IntReturn__cpp_thunkEv() #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return_storage = alloca i32, align 4
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %return_storage) #2
+// CHECK:STDOUT:   call void @_CIntReturn__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %return_storage)
+// CHECK:STDOUT:   %0 = load i32, ptr %return_storage, align 4, !tbaa !7
+// CHECK:STDOUT:   call void @llvm.lifetime.end.p0(ptr %return_storage) #2
+// CHECK:STDOUT:   ret i32 %0
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CNoArgs.Other()
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CNoArgs__carbon_thunk.Other() #2 !dbg !15 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CNoArgs.Other(), !dbg !19
+// CHECK:STDOUT:   ret void, !dbg !19
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CBoolArg.Other(i1)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CBoolArg__carbon_thunk.Other(ptr %_) #2 !dbg !20 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.1 = load i8, ptr %_, align 1, !dbg !26
+// CHECK:STDOUT:   %.11 = trunc i8 %.1 to i1, !dbg !26
+// CHECK:STDOUT:   call void @_CBoolArg.Other(i1 %.11), !dbg !26
+// CHECK:STDOUT:   ret void, !dbg !26
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CIntArg.Other(i32)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CIntArg__carbon_thunk.Other(ptr %_) #2 !dbg !27 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.1 = load i32, ptr %_, align 4, !dbg !33
+// CHECK:STDOUT:   call void @_CIntArg.Other(i32 %.1), !dbg !33
+// CHECK:STDOUT:   ret void, !dbg !33
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CFloatArg.Other(float)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CFloatArg__carbon_thunk.Other(ptr %_) #2 !dbg !34 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.1 = load float, ptr %_, align 4, !dbg !37
+// CHECK:STDOUT:   call void @_CFloatArg.Other(float %.1), !dbg !37
+// CHECK:STDOUT:   ret void, !dbg !37
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare i32 @_CIntReturn.Other()
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CIntReturn__carbon_thunk.Other(ptr %_) #2 !dbg !38 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %IntReturn.call = call i32 @_CIntReturn.Other(), !dbg !41
+// CHECK:STDOUT:   store i32 %IntReturn.call, ptr %_, align 4, !dbg !41
+// CHECK:STDOUT:   ret void, !dbg !41
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.end.p0(ptr captures(none)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { mustprogress uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #2 = { nounwind }
+// CHECK:STDOUT: attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "function.carbon", directory: "")
+// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
+// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !11 = !{!12, !12, i64 0}
+// CHECK:STDOUT: !12 = !{!"bool", !9, i64 0}
+// CHECK:STDOUT: !13 = !{!14, !14, i64 0}
+// CHECK:STDOUT: !14 = !{!"float", !9, i64 0}
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "NoArgs__carbon_thunk", linkageName: "_CNoArgs__carbon_thunk.Other", scope: null, file: !16, line: 2, type: !17, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !16 = !DIFile(filename: "other.carbon", directory: "")
+// CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
+// CHECK:STDOUT: !18 = !{null}
+// CHECK:STDOUT: !19 = !DILocation(line: 2, column: 1, scope: !15)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "BoolArg__carbon_thunk", linkageName: "_CBoolArg__carbon_thunk.Other", scope: null, file: !16, line: 3, type: !21, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !24)
+// CHECK:STDOUT: !21 = !DISubroutineType(types: !22)
+// CHECK:STDOUT: !22 = !{null, !23}
+// CHECK:STDOUT: !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !24 = !{!25}
+// CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !20, type: !23)
+// CHECK:STDOUT: !26 = !DILocation(line: 3, column: 1, scope: !20)
+// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "IntArg__carbon_thunk", linkageName: "_CIntArg__carbon_thunk.Other", scope: null, file: !16, line: 6, type: !28, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !31)
+// CHECK:STDOUT: !28 = !DISubroutineType(types: !29)
+// CHECK:STDOUT: !29 = !{null, !30}
+// CHECK:STDOUT: !30 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !31 = !{!32}
+// CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !27, type: !30)
+// CHECK:STDOUT: !33 = !DILocation(line: 6, column: 1, scope: !27)
+// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "FloatArg__carbon_thunk", linkageName: "_CFloatArg__carbon_thunk.Other", scope: null, file: !16, line: 9, type: !21, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !35)
+// CHECK:STDOUT: !35 = !{!36}
+// CHECK:STDOUT: !36 = !DILocalVariable(arg: 1, scope: !34, type: !23)
+// CHECK:STDOUT: !37 = !DILocation(line: 9, column: 1, scope: !34)
+// CHECK:STDOUT: !38 = distinct !DISubprogram(name: "IntReturn__carbon_thunk", linkageName: "_CIntReturn__carbon_thunk.Other", scope: null, file: !16, line: 12, type: !28, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !39)
+// CHECK:STDOUT: !39 = !{!40}
+// CHECK:STDOUT: !40 = !DILocalVariable(arg: 1, scope: !38, type: !30)
+// CHECK:STDOUT: !41 = !DILocation(line: 12, column: 1, scope: !38)
+// CHECK:STDOUT: ; ModuleID = 'single_file.carbon'
+// CHECK:STDOUT: source_filename = "single_file.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: $_Z2G2v = comdat any
+// CHECK:STDOUT:
+// CHECK:STDOUT: $_Z2G1v = comdat any
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CF.Main() #0 !dbg !11 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CF__carbon_thunk.Main() #0 !dbg !15 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CF.Main(), !dbg !16
+// CHECK:STDOUT:   ret void, !dbg !16
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CH.Main() #0 !dbg !17 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_Z2G2v(), !dbg !18
+// CHECK:STDOUT:   ret void, !dbg !19
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: inlinehint mustprogress uwtable
+// CHECK:STDOUT: define linkonce_odr dso_local void @_Z2G2v() #1 comdat {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_Z2G1v()
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: inlinehint mustprogress uwtable
+// CHECK:STDOUT: define linkonce_odr dso_local void @_Z2G1v() #1 comdat {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN6CarbonL12F__cpp_thunkEv()
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN6CarbonL12F__cpp_thunkEv() #2 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CF__carbon_thunk.Main()
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { inlinehint mustprogress uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #2 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "single_file.carbon", directory: "")
+// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
+// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !6, line: 6, type: !12, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
+// CHECK:STDOUT: !13 = !{null}
+// CHECK:STDOUT: !14 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "F__carbon_thunk", linkageName: "_CF__carbon_thunk.Main", scope: null, file: !6, line: 6, type: !12, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !16 = !DILocation(line: 6, column: 1, scope: !15)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main", scope: null, file: !6, line: 20, type: !12, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !18 = !DILocation(line: 20, column: 10, scope: !17)
+// CHECK:STDOUT: !19 = !DILocation(line: 20, column: 1, scope: !17)

--- a/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
@@ -186,7 +186,7 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %retval = alloca i32, align 4
 // CHECK:STDOUT:   call void @_CIntReturn__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %retval)
-// CHECK:STDOUT:   %0 = load i32, ptr %retval, align 4, !tbaa !7
+// CHECK:STDOUT:   %0 = load i32, ptr %retval, align 4
 // CHECK:STDOUT:   ret i32 %0
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
For calling non-`()` functions, the Carbon->Carbon thunk now takes an extra reference parameter and writes the target function's return value out to that parameter. (At the SemIR level this is how returns already work, but adding this extra reference parameter is needed so that the function is lowered correctly.) The C++ thunk now creates a local variable to be initialized by the Carbon thunk, and then returns that value to the original C++ caller.
