### PR TITLE
Switch to conventionally use a `name` parameter for a macro

### DIFF
--- a/bazel/check_deps/BUILD
+++ b/bazel/check_deps/BUILD
@@ -13,8 +13,8 @@ load("@rules_python//python:defs.bzl", "py_test")
 filegroup(
     name = "non_test_cc_rules",
     data = [
-        "//toolchain/install:carbon_toolchain_tar_gz_rule",
-        "//toolchain/install:carbon_toolchain_tar_rule",
+        "//toolchain/install:carbon_toolchain_tar",
+        "//toolchain/install:carbon_toolchain_tar_gz",
     ],
     tags = ["manual"],
 )

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -690,12 +690,12 @@ toolchain_pkg_filegroup(
 # This lets us use the tar file in testing as it is fast to create, but ship the
 # compressed version as a release.
 #
-# For manual tests, the tar rules are `carbon_toolchain_tar_rule` and
-# `carbon_toolchain_tar_gz_rule`.
+# For manual tests, the tar rules are `carbon_toolchain_tar` and
+# `carbon_toolchain_tar_gz`.
 pkg_tar_and_test(
+    name = "carbon_toolchain",
     srcs = [":stage1_pkg_data"],
     install_data_manifest = ":install_data_manifest.txt",
-    name_base = "carbon_toolchain",
     package_dir = "carbon_toolchain-$(version)",
     package_file_name_base = "carbon_toolchain-$(version)",
     package_variables = ":packaging_variables",
@@ -727,9 +727,9 @@ toolchain_pkg_filegroup(
 )
 
 pkg_tar_and_test(
+    name = "carbon_bootstrapped_toolchain",
     srcs = [":stage2_pkg_data"],
     install_data_manifest = ":install_data_manifest.txt",
-    name_base = "carbon_bootstrapped_toolchain",
     package_dir = "carbon_toolchain-$(version)",
     package_file_name_base = "carbon_bootstrapped_toolchain-$(version)",
     package_variables = ":packaging_variables",

--- a/toolchain/install/pkg_helpers.bzl
+++ b/toolchain/install/pkg_helpers.bzl
@@ -25,13 +25,13 @@ pkg_naming_variables = rule(
     attrs = VERSION_ATTRS,
 )
 
-def pkg_tar_and_test(name_base, package_file_name_base, install_data_manifest, tags = [], **kwargs):
+def pkg_tar_and_test(name, package_file_name_base, install_data_manifest, tags = [], **kwargs):
     """Create a `pkg_tar` and a test for both `.tar` and `.tar.gz` extensions.
 
     Args:
-        name_base:
+        name:
             The base name of the rules and tests. Will have `tar` or `tar_gz` added
-            and then `_rule` for the `pkg_tar` and `_test` for the test.
+            for the `pkg_tar` rule, and additionally `_test` for the test.
         package_file_name_base:
             The base of the `package_file_name` attribute to `pkg_tar`. The file
             extensions will be appended after a `.`.
@@ -44,7 +44,7 @@ def pkg_tar_and_test(name_base, package_file_name_base, install_data_manifest, t
     """
     for file_ext in ["tar", "tar.gz"]:
         target_ext = file_ext.replace(".", "_")
-        tar_target = name_base + "_" + target_ext + "_rule"
+        tar_target = name + "_" + target_ext
         pkg_tar(
             name = tar_target,
             extension = file_ext,
@@ -55,7 +55,7 @@ def pkg_tar_and_test(name_base, package_file_name_base, install_data_manifest, t
         )
 
         py_test(
-            name = name_base + "_" + target_ext + "_test",
+            name = name + "_" + target_ext + "_test",
             size = "small",
             srcs = ["toolchain_tar_test.py"],
             data = [":" + tar_target, install_data_manifest],


### PR DESCRIPTION
This is important to allow tools like buildozer to manipulate macro
invocation.