### PR TITLE
Fully switch to the new compilation database system

### DIFF
--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -75,10 +75,6 @@ jobs:
         if: steps.filter.outputs.has_cpp == 'true'
         run: ./scripts/create_compdb.py
 
-      - name: Build deps for clangd-tidy
-        if: steps.filter.outputs.has_cpp == 'true'
-        run: ./scripts/run_bazel.py build //scripts:deps_for_clangd_tidy
-
       - name: Install clangd-tidy
         if: steps.filter.outputs.has_cpp == 'true'
         run: pip install clangd-tidy==1.1.0.post2

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,17 +58,6 @@ register_toolchains("@bazel_cc_toolchain//:all")
 
 register_toolchains("//toolchain/install:all")
 
-# TODO: Trying out `wolfd_bazel_compile_commands`, figure out if there are
-# issues. Once people have had a chance to try and check for problems, remove
-# one or the other.
-bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
-git_override(
-    module_name = "hedron_compile_commands",
-    # HEAD as of 2026-01-28.
-    commit = "abb61a688167623088f8768cc9264798df6a9d10",
-    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
-)
-
 # Required for llvm-project.
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "34.0.bcr.1", repo_name = "com_google_protobuf")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -362,56 +362,6 @@
         "recordedRepoMappingEntries": []
       }
     },
-    "@@hedron_compile_commands+//:workspace_setup.bzl%hedron_compile_commands_extension": {
-      "general": {
-        "bzlTransitiveDigest": "GTNjt7oW5GiUBfcBtXAq5etqAZ6ue6PRd5nPaxeMoYM=",
-        "usagesDigest": "CbJ2MjubH36j9xaONhhASfhodhpi5fzvuyg/IW2f7Ds=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {},
-        "recordedRepoMappingEntries": [
-          [
-            "hedron_compile_commands+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
-    "@@hedron_compile_commands+//:workspace_setup_transitive.bzl%hedron_compile_commands_extension": {
-      "general": {
-        "bzlTransitiveDigest": "IfDf0vEa2jjQ11RNpUM0u4xftPXIs+pyM8IMVkRqVMk=",
-        "usagesDigest": "yxZQbFglJyjpn7JZ9mhIc3EhLzZivlbs6wiHWOKJ/UA=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {},
-        "recordedRepoMappingEntries": []
-      }
-    },
-    "@@hedron_compile_commands+//:workspace_setup_transitive_transitive.bzl%hedron_compile_commands_extension": {
-      "general": {
-        "bzlTransitiveDigest": "1p58k3o2Jgjt/pBE7cb8WmmkplrSguIKma/h32x7X10=",
-        "usagesDigest": "GkOuy/k8wz0dbKMeEJFKEJB3CWkMZt3DYcPgj4lALkI=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {},
-        "recordedRepoMappingEntries": []
-      }
-    },
-    "@@hedron_compile_commands+//:workspace_setup_transitive_transitive_transitive.bzl%hedron_compile_commands_extension": {
-      "general": {
-        "bzlTransitiveDigest": "arNWX4EleUjJxqkM5nCRTj+ce05Zz1gSdGH1DCKOoLs=",
-        "usagesDigest": "WZExKK/BI4lqpUZfPpv4YARDE1Y7igQB+wYGKvNoCKs=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {},
-        "recordedRepoMappingEntries": []
-      }
-    },
     "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
       "general": {
         "bzlTransitiveDigest": "pmsA+awieucfllLc2n7k8xEoPp0i5LF9Hw6mGX0cqSQ=",

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -24,7 +24,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """
 
 import argparse
-import json
 import subprocess
 import sys
 from typing import Any, Dict
@@ -78,6 +77,9 @@ def _build_generated_files(
         # We also need the Bazel C++ runfiles that aren't "generated", but are
         # not linked into place until built.
         + ["@bazel_tools//tools/cpp/runfiles:runfiles"]
+        # Also include any deps that require `_virtual_includes` to be fully
+        # populated through a special C++ rule.
+        + ["//scripts:deps_for_clangd_tidy"],
     )
 
 
@@ -95,44 +97,6 @@ def _get_config_for_entry(entry: Dict[str, Any]) -> str:
     if not obj_file.startswith("bazel-out/"):
         return "unknown"
     return str(obj_file.split("/")[1])
-
-
-def _filter_compilation_database(file_path: str) -> None:
-    """Filters out duplicate exec-config entries from the database."""
-    print("Filtering out duplicate exec-configuration entries...")
-    try:
-        with open(file_path, "r") as f:
-            commands = json.load(f)
-    except FileNotFoundError:
-        print(f"Error: The file '{file_path}' was not found.")
-        sys.exit(1)
-    except json.JSONDecodeError:
-        print(f"Error: The file '{file_path}' is not a valid JSON file.")
-        sys.exit(1)
-
-    # We want to skip compiles that were in the "exec" configuration for tools.
-    # Because we generate compile commands for every bazel cc_* target in the
-    # main configuration, even if only used by tools, their sources should be
-    # covered and the exec configuration would simply be a duplicate.
-    #
-    # Detecting this based on the `-exec-` string in the configuration name of
-    # the directory is a bit of a hack, but even using the `--notool_deps`
-    # argument, Bazel seems to sometimes include this configuration in the query
-    # that produces the compilation database.
-    filtered_commands = [
-        entry
-        for entry in commands
-        if "-exec-" not in _get_config_for_entry(entry)
-    ]
-
-    with open(file_path, "w") as f:
-        # Use indent=4 for a human-readable, pretty-printed output file
-        json.dump(filtered_commands, f, indent=4)
-    print(
-        "Filtered out "
-        f"{len(commands) - len(filtered_commands)} "
-        "duplicate entries..."
-    )
 
 
 def main() -> None:
@@ -179,16 +143,11 @@ def main() -> None:
         ]
         + args.extra_bazel_flag
         + [
-            "@hedron_compile_commands//:refresh_all",
+            "//:generate_compile_commands",
             "--",
         ]
-        + args.extra_bazel_flag
-        + [
-            "--notool_deps",
-        ]
+        + [f"--extra_aquery_arg={arg}" for arg in args.extra_bazel_flag]
     )
-
-    _filter_compilation_database("compile_commands.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This has been working really well for me, is incredibly faster than the other approach, and some commits continue to hit bugs in the old system where files that aren't even going to be run through `clangd-tidy` end up tripping up the execution. Hopefully all of that is resolved with the new version.