### PR TITLE
Preserve ErrorInst in TryGetTypeIdForTypeConstantId

### DIFF
--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -35,7 +35,7 @@ auto TypeStore::GetTypeIdForTypeConstantId(ConstantId constant_id) const
 auto TypeStore::TryGetTypeIdForTypeConstantId(ConstantId constant_id) const
     -> TypeId {
   if (constant_id == SemIR::ErrorInst::ConstantId) {
-    return TypeId::None;
+    return SemIR::ErrorInst::TypeId;
   }
   auto type_id = file_->insts()
                      .Get(file_->constant_values().GetInstId(constant_id))


### PR DESCRIPTION
An ErrorInst::ConstantId constant can be used as a type, and should result in an ErrorInst::TypeId