### PR TITLE
Update the name of the bazel target to build the nightly tarball

### DIFF
--- a/.github/workflows/nightly_release.yaml
+++ b/.github/workflows/nightly_release.yaml
@@ -93,7 +93,7 @@ jobs:
             test -c opt --stamp --remote_download_toplevel \
             --pre_release=nightly --nightly_date=${{ env.nightly_date }} \
             //toolchain \
-            //toolchain/install:carbon_toolchain_tar_gz_rule \
+            //toolchain/install:carbon_toolchain_tar_gz \
             //toolchain/install:carbon_toolchain_tar_gz_test
 
       - name: Extract the release version


### PR DESCRIPTION
The target was renamed in `82fad290285baf9763132a13b1f73de1e7919074` from `//toolchain/install:carbon_toolchain_tar_gz_rule` to `//toolchain/install:carbon_toolchain_tar_gz`