### PR TITLE
Refactor Bazel toolchain to use `rules_cc` action groups

### DIFF
--- a/bazel/cc_toolchains/carbon_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/carbon_cc_toolchain_config.bzl
@@ -5,7 +5,7 @@
 """Starlark cc_toolchain configuration rules for using the Carbon toolchain"""
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "action_config",
@@ -29,8 +29,6 @@ load(
 load(
     "cc_toolchain_actions.bzl",
     "all_c_compile_actions",
-    "all_cpp_compile_actions",
-    "all_link_actions",
 )
 load("cc_toolchain_carbon_project_features.bzl", "carbon_project_features")
 load("cc_toolchain_features.bzl", "clang_cc_toolchain_features")
@@ -57,7 +55,7 @@ def _make_action_configs(tools, runtimes_path = None):
             enabled = True,
             tools = [tools.clangpp],
         )
-        for name in all_cpp_compile_actions
+        for name in ACTION_NAME_GROUPS.all_cpp_compile_actions
     ] + [
         action_config(
             action_name = name,
@@ -74,7 +72,7 @@ def _make_action_configs(tools, runtimes_path = None):
                 "--",
             ])])],
         )
-        for name in all_link_actions
+        for name in ACTION_NAME_GROUPS.all_cc_link_actions
     ] + [
         action_config(
             action_name = name,

--- a/bazel/cc_toolchains/cc_toolchain_actions.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_actions.bzl
@@ -4,44 +4,18 @@
 
 """Useful sets of actions for defining `cc_toolchain_config` features."""
 
-load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "ACTION_NAME_GROUPS")
 
+# all_c_compile_actions includes actions that compile C or assembly.
 all_c_compile_actions = [
-    ACTION_NAMES.c_compile,
-    ACTION_NAMES.assemble,
-    ACTION_NAMES.preprocess_assemble,
+    x
+    for x in ACTION_NAME_GROUPS.all_cc_compile_actions
+    if x not in ACTION_NAME_GROUPS.all_cpp_compile_actions
 ]
 
-all_cpp_compile_actions = [
-    ACTION_NAMES.cpp_compile,
-    ACTION_NAMES.linkstamp_compile,
-    ACTION_NAMES.cpp_header_parsing,
-    ACTION_NAMES.cpp_module_compile,
-    ACTION_NAMES.cpp_module_codegen,
-]
-
-all_compile_actions = all_c_compile_actions + all_cpp_compile_actions
-
+# preprocessor_compile_actions includes actions that run the preprocessor.
 preprocessor_compile_actions = [
-    ACTION_NAMES.c_compile,
-    ACTION_NAMES.cpp_compile,
-    ACTION_NAMES.linkstamp_compile,
-    ACTION_NAMES.preprocess_assemble,
-    ACTION_NAMES.cpp_header_parsing,
-    ACTION_NAMES.cpp_module_compile,
-]
-
-codegen_compile_actions = [
-    ACTION_NAMES.c_compile,
-    ACTION_NAMES.cpp_compile,
-    ACTION_NAMES.linkstamp_compile,
-    ACTION_NAMES.assemble,
-    ACTION_NAMES.preprocess_assemble,
-    ACTION_NAMES.cpp_module_codegen,
-]
-
-all_link_actions = [
-    ACTION_NAMES.cpp_link_executable,
-    ACTION_NAMES.cpp_link_dynamic_library,
-    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+    x
+    for x in ACTION_NAME_GROUPS.all_cc_compile_actions
+    if x not in [ACTION_NAMES.assemble, ACTION_NAMES.cpp_module_codegen]
 ]

--- a/bazel/cc_toolchains/cc_toolchain_base_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_base_features.bzl
@@ -4,18 +4,13 @@
 
 """Definitions used for the base features of a `cc_toolchain_config`."""
 
-load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "feature",
     "feature_set",
     "flag_group",
     "flag_set",
-)
-load(
-    ":cc_toolchain_actions.bzl",
-    "all_compile_actions",
-    "all_link_actions",
 )
 
 # Declare features that are used by Bazel to model specific build modes.
@@ -44,7 +39,7 @@ user_flags_feature = feature(
     enabled = True,
     flag_sets = [
         flag_set(
-            actions = all_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
             flag_groups = [flag_group(
                 expand_if_available = "user_compile_flags",
                 flags = ["%{user_compile_flags}"],
@@ -52,7 +47,7 @@ user_flags_feature = feature(
             )],
         ),
         flag_set(
-            actions = all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [flag_group(
                 expand_if_available = "user_link_flags",
                 flags = ["%{user_link_flags}"],
@@ -69,7 +64,7 @@ output_flags_feature = feature(
     enabled = True,
     flag_sets = [
         flag_set(
-            actions = all_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
             flag_groups = [
                 # For compile actions we have a single source and so put it at
                 # the end next to the output.
@@ -84,7 +79,7 @@ output_flags_feature = feature(
             ],
         ),
         flag_set(
-            actions = all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [flag_group(
                 expand_if_available = "output_execpath",
                 flags = ["-o", "%{output_execpath}"],

--- a/bazel/cc_toolchains/cc_toolchain_carbon_project_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_carbon_project_features.bzl
@@ -4,7 +4,7 @@
 
 """Defines `cc_toolchain_config` features specific to the Carbon project."""
 
-load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "feature",
@@ -15,7 +15,6 @@ load(
 )
 load(
     ":cc_toolchain_actions.bzl",
-    "all_compile_actions",
     "preprocessor_compile_actions",
 )
 
@@ -39,7 +38,7 @@ def carbon_project_features(cache_key):
         enabled = True,
         flag_sets = [
             flag_set(
-                actions = all_compile_actions,
+                actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
                 flag_groups = [flag_group(flags = [
                     # Don't warn on external code as we can't
                     # necessarily patch it easily. Note that these have

--- a/bazel/cc_toolchains/cc_toolchain_cpp_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_cpp_features.bzl
@@ -4,7 +4,7 @@
 
 """Definitions of general C++ `cc_toolchain_config` features."""
 
-load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "feature",
@@ -14,10 +14,6 @@ load(
 )
 load(
     ":cc_toolchain_actions.bzl",
-    "all_compile_actions",
-    "all_cpp_compile_actions",
-    "all_link_actions",
-    "codegen_compile_actions",
     "preprocessor_compile_actions",
 )
 
@@ -26,7 +22,7 @@ clang_feature = feature(
     enabled = True,
     flag_sets = [
         flag_set(
-            actions = all_compile_actions + all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [
                 flag_group(flags = [
                     "-no-canonical-prefixes",
@@ -39,7 +35,7 @@ clang_feature = feature(
             ],
         ),
         flag_set(
-            actions = all_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
             flag_groups = [
                 flag_group(flags = [
                     # Compile actions shouldn't link anything.
@@ -68,20 +64,20 @@ clang_feature = feature(
         ),
         flag_set(
             # Flags specific to compiling C++ sources.
-            actions = all_cpp_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cpp_compile_actions,
             flag_groups = [flag_group(flags = [
                 "-std=c++20",
             ])],
         ),
         flag_set(
-            actions = codegen_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
             flag_groups = [flag_group(flags = [
                 "-ffunction-sections",
                 "-fdata-sections",
             ])],
         ),
         flag_set(
-            actions = codegen_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
             flag_groups = [flag_group(
                 expand_if_available = "pic",
                 flags = ["-fPIC"],
@@ -129,7 +125,7 @@ clang_feature = feature(
             flag_groups = [flag_group(flags = ["-shared"])],
         ),
         flag_set(
-            actions = all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [
                 flag_group(
                     expand_if_available = "strip_debug_symbols",
@@ -151,7 +147,7 @@ clang_feature = feature(
             ],
         ),
         flag_set(
-            actions = all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [
                 flag_group(
                     flags = [
@@ -199,7 +195,7 @@ clang_warnings_feature = feature(
     name = "clang_warnings",
     enabled = True,
     flag_sets = [flag_set(
-        actions = all_compile_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
         flag_groups = [flag_group(flags = [
             "-Werror",
             "-Wall",
@@ -263,7 +259,7 @@ def libcxx_feature(llvm_bindir = None, clang_bindir = None):
         enabled = True,
         flag_sets = [
             flag_set(
-                actions = all_cpp_compile_actions + all_link_actions,
+                actions = ACTION_NAME_GROUPS.all_cpp_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
                 flag_groups = [flag_group(flags = [
                     "-stdlib=libc++",
                 ])],
@@ -273,17 +269,17 @@ def libcxx_feature(llvm_bindir = None, clang_bindir = None):
                 ],
             ),
             flag_set(
-                actions = all_cpp_compile_actions,
+                actions = ACTION_NAME_GROUPS.all_cpp_compile_actions,
                 flag_groups = [flag_group(flags = _libcpp_debug_flags)],
                 with_features = [with_feature_set(not_features = ["opt"])],
             ),
             flag_set(
-                actions = all_cpp_compile_actions,
+                actions = ACTION_NAME_GROUPS.all_cpp_compile_actions,
                 flag_groups = [flag_group(flags = _libcpp_release_flags)],
                 with_features = [with_feature_set(features = ["opt"])],
             ),
             flag_set(
-                actions = all_link_actions,
+                actions = ACTION_NAME_GROUPS.all_cc_link_actions,
                 flag_groups = [flag_group(flags = [
                     "-unwindlib=libunwind",
                 ])],
@@ -293,7 +289,7 @@ def libcxx_feature(llvm_bindir = None, clang_bindir = None):
                 ],
             ),
             flag_set(
-                actions = all_link_actions,
+                actions = ACTION_NAME_GROUPS.all_cc_link_actions,
                 flag_groups = [flag_group(flags = extra_link_flags + [
                     # Force linking the static libc++abi archive here. This
                     # *should* be linked automatically, but not every release of

--- a/bazel/cc_toolchains/cc_toolchain_debugging.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_debugging.bzl
@@ -4,17 +4,13 @@
 
 """Definitions of debugging related features used in a `cc_toolchain_config`."""
 
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "feature",
     "feature_set",
     "flag_group",
     "flag_set",
-)
-load(
-    ":cc_toolchain_actions.bzl",
-    "all_link_actions",
-    "codegen_compile_actions",
 )
 
 # Handle different levels and forms of debug info emission with individual
@@ -24,7 +20,7 @@ minimal_debug_info_flags = feature(
     name = "minimal_debug_info_flags",
     implies = ["debug_info_compression_flags"],
     flag_sets = [flag_set(
-        actions = codegen_compile_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
         flag_groups = [flag_group(flags = ["-gmlt"])],
     )],
 )
@@ -32,7 +28,7 @@ debug_info_flags = feature(
     name = "debug_info_flags",
     implies = ["debug_info_compression_flags"],
     flag_sets = [flag_set(
-        actions = codegen_compile_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
         flag_groups = [
             flag_group(flags = ["-g"]),
             flag_group(
@@ -45,7 +41,7 @@ debug_info_flags = feature(
 debug_info_compression_flags = feature(
     name = "debug_info_compression_flags",
     flag_sets = [flag_set(
-        actions = codegen_compile_actions + all_link_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
         flag_groups = [flag_group(flags = ["-gz"])],
     )],
 )
@@ -60,7 +56,7 @@ lldb_flags = feature(
     requires = [feature_set(features = ["debug_info_flags"])],
     provides = ["debugger_flags"],
     flag_sets = [flag_set(
-        actions = codegen_compile_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
         flag_groups = [flag_group(flags = [
             "-glldb",
             "-gpubnames",
@@ -75,14 +71,14 @@ gdb_flags = feature(
     provides = ["debugger_flags"],
     flag_sets = [
         flag_set(
-            actions = codegen_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
             flag_groups = [flag_group(flags = [
                 "-ggdb",
                 "-ggnu-pubnames",
             ])],
         ),
         flag_set(
-            actions = all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [flag_group(flags = ["-Wl,--gdb-index"])],
         ),
     ],
@@ -93,7 +89,7 @@ gdb_flags = feature(
 preserve_call_stacks = feature(
     name = "preserve_call_stacks",
     flag_sets = [flag_set(
-        actions = codegen_compile_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
         flag_groups = [flag_group(flags = [
             # Ensure good backtraces by preserving frame pointers and
             # disabling tail call elimination.

--- a/bazel/cc_toolchains/cc_toolchain_linking.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_linking.bzl
@@ -4,7 +4,7 @@
 
 """Definitions of linking related features used in a `cc_toolchain_config`."""
 
-load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "feature",
@@ -13,17 +13,13 @@ load(
     "variable_with_value",
     "with_feature_set",
 )
-load(
-    ":cc_toolchain_actions.bzl",
-    "all_link_actions",
-)
 
 link_libraries_feature = feature(
     name = "link_libraries",
     enabled = True,
     flag_sets = [
         flag_set(
-            actions = all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [
                 flag_group(
                     expand_if_available = "linkstamp_paths",
@@ -111,7 +107,7 @@ link_libraries_feature = feature(
             with_features = [with_feature_set(not_features = ["macos_target"])],
         ),
         flag_set(
-            actions = all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [
                 flag_group(
                     expand_if_available = "linkstamp_paths",

--- a/bazel/cc_toolchains/cc_toolchain_optimization.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_optimization.bzl
@@ -4,6 +4,7 @@
 
 """Definitions of optimization `cc_toolchain_config` features."""
 
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "feature",
@@ -12,12 +13,6 @@ load(
     "flag_set",
     "with_feature_set",
 )
-load(
-    ":cc_toolchain_actions.bzl",
-    "all_compile_actions",
-    "all_link_actions",
-    "codegen_compile_actions",
-)
 
 # Handle different levels of optimization with individual features so that
 # they can be ordered and the defaults can override the minimal settings if
@@ -25,7 +20,7 @@ load(
 minimal_optimization_flags = feature(
     name = "minimal_optimization_flags",
     flag_sets = [flag_set(
-        actions = codegen_compile_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
         flag_groups = [flag_group(flags = ["-Og"])],
     )],
 )
@@ -35,11 +30,11 @@ default_optimization_flags = feature(
     requires = [feature_set(["opt"])],
     flag_sets = [
         flag_set(
-            actions = all_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
             flag_groups = [flag_group(flags = ["-DNDEBUG"])],
         ),
         flag_set(
-            actions = codegen_compile_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions,
             flag_groups = [flag_group(flags = ["-O3"])],
         ),
     ],
@@ -50,12 +45,12 @@ cpu_flags = feature(
     enabled = True,
     flag_sets = [
         flag_set(
-            actions = all_compile_actions + all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [flag_group(flags = ["-march=armv8.2-a"])],
             with_features = [with_feature_set(["aarch64_target"])],
         ),
         flag_set(
-            actions = all_compile_actions + all_link_actions,
+            actions = ACTION_NAME_GROUPS.all_cc_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
             flag_groups = [flag_group(flags = ["-march=x86-64-v2"])],
             with_features = [with_feature_set(["x86_64_target"])],
         ),

--- a/bazel/cc_toolchains/cc_toolchain_sanitizer_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_sanitizer_features.bzl
@@ -4,6 +4,7 @@
 
 """Definitions of sanitizer-related `cc_toolchain_config` features."""
 
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "feature",
@@ -12,17 +13,12 @@ load(
     "flag_set",
     "with_feature_set",
 )
-load(
-    ":cc_toolchain_actions.bzl",
-    "all_compile_actions",
-    "all_link_actions",
-)
 
 sanitizer_common_flags = feature(
     name = "sanitizer_common_flags",
     implies = ["minimal_debug_info_flags", "preserve_call_stacks"],
     flag_sets = [flag_set(
-        actions = all_link_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_link_actions,
         flag_groups = [flag_group(flags = ["-static-libsan"])],
         with_features = [
             with_feature_set(["linux_target"]),
@@ -35,7 +31,7 @@ asan = feature(
     name = "asan",
     implies = ["sanitizer_common_flags"],
     flag_sets = [flag_set(
-        actions = all_compile_actions + all_link_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
         flag_groups = [flag_group(flags = [
             "-fsanitize=address,undefined,nullability",
             "-fsanitize-address-use-after-scope",
@@ -65,7 +61,7 @@ asan_min_size = feature(
     name = "asan_min_size",
     requires = [feature_set(["asan"])],
     flag_sets = [flag_set(
-        actions = all_compile_actions + all_link_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
         flag_groups = [flag_group(flags = [
             # Force two UBSan checks that have especially large code size
             # cost to use the minimal branch to a trapping instruction model
@@ -78,7 +74,7 @@ asan_min_size = feature(
 fuzzer = feature(
     name = "fuzzer",
     flag_sets = [flag_set(
-        actions = all_compile_actions + all_link_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
         flag_groups = [flag_group(flags = [
             "-fsanitize=fuzzer-no-link",
         ])],
@@ -90,7 +86,7 @@ sanitizer_workarounds = feature(
     enabled = True,
     requires = [feature_set(["asan"])],
     flag_sets = [flag_set(
-        actions = all_compile_actions + all_link_actions,
+        actions = ACTION_NAME_GROUPS.all_cc_compile_actions + ACTION_NAME_GROUPS.all_cc_link_actions,
         flag_groups = [flag_group(flags = [
             # Likely due to being unable to use the static-linked and up-to-date
             # sanitizer runtimes, we have to disable this sanitizer on macOS.

--- a/bazel/cc_toolchains/cc_toolchain_tools.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_tools.bzl
@@ -10,7 +10,7 @@ They presume an LLVM and Clang toolchain's tools, but support both a single
 installation and installations that split the LLVM tools and Clang tools apart.
 """
 
-load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "ACTION_NAME_GROUPS")
 load(
     "@rules_cc//cc:cc_toolchain_config_lib.bzl",
     "action_config",
@@ -20,8 +20,6 @@ load(
 load(
     ":cc_toolchain_actions.bzl",
     "all_c_compile_actions",
-    "all_cpp_compile_actions",
-    "all_link_actions",
 )
 
 def llvm_tool_paths(llvm_bindir, clang_bindir = None):
@@ -56,14 +54,14 @@ def llvm_action_configs(llvm_bindir, clang_bindir = None):
             enabled = True,
             tools = [tool(path = clang_bindir + "/clang++")],
         )
-        for name in all_cpp_compile_actions
+        for name in ACTION_NAME_GROUPS.all_cpp_compile_actions
     ] + [
         action_config(
             action_name = name,
             enabled = True,
             tools = [tool(path = clang_bindir + "/clang++")],
         )
-        for name in all_link_actions
+        for name in ACTION_NAME_GROUPS.all_cc_link_actions
     ] + [
         action_config(
             action_name = name,


### PR DESCRIPTION
Rather than defining our own action groups, work to re-use the `rules_cc` ones, as they are (much) more comprehensive. Also, completely eliminate the `codegen` action group as it was not well used. For example, `-march` flags and `-O` flags change the preprocessor macros defined. There isn't a really great "codegen" heuristic, so just pass those flags to all compiles which is simpler anyways.

I'm tempted to do the same with preprocessor actions, but maybe it makes sense to have that one stay separate.

Assisted-by: Antigravity with Gemini