### PR TITLE
Make ImplWitnessAccess inst have constant kind Conditional

### DIFF
--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -12,6 +12,7 @@
 #include "toolchain/check/generic.h"
 #include "toolchain/check/inst.h"
 #include "toolchain/check/literal.h"
+#include "toolchain/check/subst.h"
 #include "toolchain/check/type.h"
 #include "toolchain/diagnostics/emitter.h"
 #include "toolchain/diagnostics/format_providers.h"
@@ -328,6 +329,10 @@ class TypeCompleter {
 
   auto BuildInfoForInst(SemIR::TypeId /*type_id*/,
                         SemIR::ImplWitnessAssociatedConstant inst) const
+      -> SemIR::CompleteTypeInfo;
+
+  auto BuildInfoForInst(SemIR::TypeId /*type_id*/,
+                        SemIR::ImplWitnessAccess inst) const
       -> SemIR::CompleteTypeInfo;
 
   template <typename InstT>
@@ -826,6 +831,16 @@ auto TypeCompleter::BuildInfoForInst(
     SemIR::TypeId /*type_id*/, SemIR::ImplWitnessAssociatedConstant inst) const
     -> SemIR::CompleteTypeInfo {
   return GetNestedInfo(inst.type_id);
+}
+
+auto TypeCompleter::BuildInfoForInst(SemIR::TypeId type_id,
+                                     SemIR::ImplWitnessAccess /*inst*/) const
+    -> SemIR::CompleteTypeInfo {
+  // An ImplWitnessAccess is typically symbolic. But even if the witness is
+  // replaced by a concrete one, which does not provide a value for the
+  // ImplWitnessAcess to use, then it is still a dependent value, as the actual
+  // value remains unknown.
+  return MakeDependentTypeInfo(type_id);
 }
 
 // Builds and returns the value representation for the given type. All nested

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -1314,6 +1314,12 @@ static auto BuildTypeForInst(FileContext& context, SemIR::IntType inst)
                                         : llvm::dwarf::DW_ATE_unsigned)};
 }
 
+static auto BuildTypeForInst(FileContext& /*context*/,
+                             SemIR::ImplWitnessAccess /*inst*/)
+    -> FileContext::LoweredTypes {
+  CARBON_FATAL("Unexpected ImplWitnessAccess in lowering");
+}
+
 static auto BuildTypeForInst(FileContext& context, SemIR::PointerType /*inst*/)
     -> FileContext::LoweredTypes {
   return {llvm::PointerType::get(context.llvm_context(), /*AddressSpace=*/0),

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -944,7 +944,7 @@ struct ImplWitnessAccess {
       InstKind::ImplWitnessAccess.Define<Parse::NodeId>(
           {.ir_name = "impl_witness_access",
            .is_type = InstIsType::Maybe,
-           .constant_kind = InstConstantKind::SymbolicOnly,
+           .constant_kind = InstConstantKind::Conditional,
            .constant_needs_inst_id =
                InstConstantNeedsInstIdKind::DuringEvaluation,
            .is_lowered = false});


### PR DESCRIPTION
ImplWitnessAccess can contain a LookupImplWitness instruction as an operand, which used to be SymbolicOnly but has now become Conditional in #6915. This opens up the possibility for LookupImplWitness to have a concrete value, without resolving to a different instruction kind. If this occurs when it's the operand of an ImplWitnessAccess, and the access is unable to find a different value to resolve to through the witness' self type, then the ImplWitnessAccess can also become concrete.

This can happen in particular when:
- You have an ImplWitnessAccess into a `.Self` symbolic in a facet type.
- You convert a concrete type to the facet type.
- The `.Self` is replaced by a concrete type, causing the impl lookup to be on that concrete type.
- The (now concrete) impl lookup fails to find any impl witness, so it remains a concrete LookupImplWitness

This results in a diagnostic, as the incoming type does not satisfy the facet type, but in the meantime we have a concrete ImplWitnessAccess, which we do not want to crash.

For example in this test:
```carbon
interface I {
  let I1:! type;
}
interface J {}

fn F(T:! I where .I1 impls J) {}

fn G() {
  class C;

  // This identifies `C as (I where .I1 impls J)`, which replaces `.Self.I1`
  // with `C.(I.I1)`. This is a concrete lookup since C and I are both concrete,
  // but it doesn't find anything as there is no impl.
  //
  // As such, the call to F fails to deduce a value for T.
  F(C);
}
```

This PR splits out the change to ImplWitnessAccess from the larger change of replacing `.Self` in identified facet types (and comparisons with identified facet types).