### PR TITLE
Remove "__cpp_thunk" from thunk name for exported functions

### DIFF
--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -465,16 +465,9 @@ static auto BuildCppToCarbonThunkBody(clang::Sema& sema,
 // callee of the Carbon thunk.)
 static auto BuildCppToCarbonThunk(Context& context, SemIR::LocId loc_id,
                                   const FunctionInfo& target,
-                                  llvm::StringRef base_name,
+                                  llvm::StringRef thunk_name,
                                   clang::FunctionDecl* carbon_function_decl)
     -> clang::FunctionDecl* {
-  // Create the thunk's name.
-  llvm::SmallString<64> thunk_name = base_name;
-  // TODO: changing the thunk name for methods hits this clang assertion:
-  // https://github.com/llvm/llvm-project/blob/058398c4ceaf/clang/lib/AST/Expr.cpp#L1720
-  if (!target.has_self()) {
-    thunk_name += "__cpp_thunk";
-  }
   auto& thunk_ident = context.ast_context().Idents.get(thunk_name);
 
   llvm::SmallVector<clang::QualType> param_types;

--- a/toolchain/check/testdata/interop/cpp/function/export/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/export/function.carbon
@@ -67,10 +67,6 @@ fn F();
 
 inline Cpp '''
 using Carbon::F;
-// CHECK:STDERR: using.carbon:[[@LINE+4]]:12: error: use of undeclared identifier 'F' [CppInteropParseError]
-// CHECK:STDERR:    10 | void G() { F(); }
-// CHECK:STDERR:       |            ^
-// CHECK:STDERR:
 void G() { F(); }
 ''';
 

--- a/toolchain/check/testdata/interop/cpp/function/export/function.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/export/function.carbon
@@ -57,6 +57,23 @@ void G() {
 }
 ''';
 
+// --- using.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+fn F();
+
+inline Cpp '''
+using Carbon::F;
+// CHECK:STDERR: using.carbon:[[@LINE+4]]:12: error: use of undeclared identifier 'F' [CppInteropParseError]
+// CHECK:STDERR:    10 | void G() { F(); }
+// CHECK:STDERR:       |            ^
+// CHECK:STDERR:
+void G() { F(); }
+''';
+
 // --- fail_todo_generic.carbon
 
 library "[[@TEST_NAME]]";

--- a/toolchain/check/testdata/interop/cpp/function/export/thunk_ast.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/export/thunk_ast.carbon
@@ -21,7 +21,7 @@ library "[[@TEST_NAME]]";
 import Cpp;
 
 fn F(i: i32) -> i32 {
-// CHECK:STDOUT: | `-FunctionDecl {{0x[a-f0-9]+}} <thunk_with_args_and_return.carbon:[[@LINE-1]]:21> col:21 used F__cpp_thunk 'int (int)' inline
+// CHECK:STDOUT: | `-FunctionDecl {{0x[a-f0-9]+}} <thunk_with_args_and_return.carbon:[[@LINE-1]]:21> col:21 used F 'int (int)' inline
 // CHECK:STDOUT: |   |-ParmVarDecl {{0x[a-f0-9]+}} <col:21> col:21 used 'int'
 // CHECK:STDOUT: |   |-CompoundStmt {{0x[a-f0-9]+}} <col:21>
 // CHECK:STDOUT: |   | |-DeclStmt {{0x[a-f0-9]+}} <col:21>
@@ -41,7 +41,7 @@ fn F(i: i32) -> i32 {
 // CHECK:STDOUT:     `-ReturnStmt {{0x[a-f0-9]+}} <line:36:3, col:21>
 // CHECK:STDOUT:       `-CallExpr {{0x[a-f0-9]+}} <col:10, col:21> 'int'
 // CHECK:STDOUT:         |-ImplicitCastExpr {{0x[a-f0-9]+}} <col:10, col:18> 'int (*)(int)' <FunctionToPointerDecay>
-// CHECK:STDOUT:         | `-DeclRefExpr {{0x[a-f0-9]+}} <col:10, col:18> 'int (int)' lvalue Function {{0x[a-f0-9]+}} 'F__cpp_thunk' 'int (int)'
+// CHECK:STDOUT:         | `-DeclRefExpr {{0x[a-f0-9]+}} <col:10, col:18> 'int (int)' lvalue Function {{0x[a-f0-9]+}} 'F' 'int (int)'
 // CHECK:STDOUT:         |   `-NestedNameSpecifier Namespace {{0x[a-f0-9]+}} 'Carbon'
 // CHECK:STDOUT:         `-ImplicitCastExpr {{0x[a-f0-9]+}} <col:20> 'int' <LValueToRValue>
 // CHECK:STDOUT:           `-DeclRefExpr {{0x[a-f0-9]+}} <col:20> 'int' lvalue ParmVar {{0x[a-f0-9]+}} 'i' 'int'

--- a/toolchain/lower/testdata/interop/cpp/reverse/class.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reverse/class.carbon
@@ -138,7 +138,7 @@ void h() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a = alloca %"class.Carbon::A", align 8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a) #3
-// CHECK:STDOUT:   call void @_ZN6CarbonL16CallA__cpp_thunkEPNS_1AE(ptr noundef %a)
+// CHECK:STDOUT:   call void @_ZN6CarbonL5CallAEPNS_1AE(ptr noundef %a)
 // CHECK:STDOUT:   call void @llvm.lifetime.end.p0(ptr %a) #3
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
@@ -147,7 +147,7 @@ void h() {
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6CarbonL16CallA__cpp_thunkEPNS_1AE(ptr noundef %0) #2 {
+// CHECK:STDOUT: define internal void @_ZN6CarbonL5CallAEPNS_1AE(ptr noundef %0) #2 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.addr = alloca ptr, align 8
 // CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8, !tbaa !11
@@ -163,13 +163,13 @@ void h() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %b = alloca %"class.Carbon::B", align 8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b) #3
-// CHECK:STDOUT:   call void @_ZN6CarbonL16CallB__cpp_thunkEPNS_1BE(ptr noundef %b)
+// CHECK:STDOUT:   call void @_ZN6CarbonL5CallBEPNS_1BE(ptr noundef %b)
 // CHECK:STDOUT:   call void @llvm.lifetime.end.p0(ptr %b) #3
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6CarbonL16CallB__cpp_thunkEPNS_1BE(ptr noundef %0) #2 {
+// CHECK:STDOUT: define internal void @_ZN6CarbonL5CallBEPNS_1BE(ptr noundef %0) #2 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.addr = alloca ptr, align 8
 // CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8, !tbaa !14
@@ -182,14 +182,14 @@ void h() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %c = alloca %"class.Carbon::C", align 8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c) #3
-// CHECK:STDOUT:   call void @_ZN6CarbonL16CallC__cpp_thunkEPNS_1CE(ptr noundef %c)
-// CHECK:STDOUT:   call void @_ZN6CarbonL16CallA__cpp_thunkEPNS_1AE(ptr noundef %c)
+// CHECK:STDOUT:   call void @_ZN6CarbonL5CallCEPNS_1CE(ptr noundef %c)
+// CHECK:STDOUT:   call void @_ZN6CarbonL5CallAEPNS_1AE(ptr noundef %c)
 // CHECK:STDOUT:   call void @llvm.lifetime.end.p0(ptr %c) #3
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6CarbonL16CallC__cpp_thunkEPNS_1CE(ptr noundef %0) #2 {
+// CHECK:STDOUT: define internal void @_ZN6CarbonL5CallCEPNS_1CE(ptr noundef %0) #2 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.addr = alloca ptr, align 8
 // CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8, !tbaa !16

--- a/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reverse/function.carbon
@@ -138,23 +138,23 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: ; Function Attrs: mustprogress uwtable
 // CHECK:STDOUT: define dso_local noundef i32 @_Z1Gv() #0 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL17NoArgs__cpp_thunkEv()
-// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL18BoolArg__cpp_thunkEb(i1 noundef zeroext true)
-// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL17IntArg__cpp_thunkEi(i32 noundef 123)
-// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL19FloatArg__cpp_thunkEf(float noundef 1.500000e+00)
-// CHECK:STDOUT:   %call = call noundef i32 @_ZN6Carbon5OtherL20IntReturn__cpp_thunkEv()
+// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL6NoArgsEv()
+// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL7BoolArgEb(i1 noundef zeroext true)
+// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL6IntArgEi(i32 noundef 123)
+// CHECK:STDOUT:   call void @_ZN6Carbon5OtherL8FloatArgEf(float noundef 1.500000e+00)
+// CHECK:STDOUT:   %call = call noundef i32 @_ZN6Carbon5OtherL9IntReturnEv()
 // CHECK:STDOUT:   ret i32 %call
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL17NoArgs__cpp_thunkEv() #1 {
+// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL6NoArgsEv() #1 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CNoArgs__carbon_thunk.Other()
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL18BoolArg__cpp_thunkEb(i1 noundef zeroext %0) #1 {
+// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL7BoolArgEb(i1 noundef zeroext %0) #1 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.addr = alloca i8, align 1
 // CHECK:STDOUT:   %storedv = zext i1 %0 to i8
@@ -164,7 +164,7 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL17IntArg__cpp_thunkEi(i32 noundef %0) #1 {
+// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL6IntArgEi(i32 noundef %0) #1 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.addr = alloca i32, align 4
 // CHECK:STDOUT:   store i32 %0, ptr %.addr, align 4, !tbaa !7
@@ -173,7 +173,7 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL19FloatArg__cpp_thunkEf(float noundef %0) #1 {
+// CHECK:STDOUT: define internal void @_ZN6Carbon5OtherL8FloatArgEf(float noundef %0) #1 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.addr = alloca float, align 4
 // CHECK:STDOUT:   store float %0, ptr %.addr, align 4, !tbaa !13
@@ -182,7 +182,7 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal noundef i32 @_ZN6Carbon5OtherL20IntReturn__cpp_thunkEv() #1 {
+// CHECK:STDOUT: define internal noundef i32 @_ZN6Carbon5OtherL9IntReturnEv() #1 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %retval = alloca i32, align 4
 // CHECK:STDOUT:   call void @_CIntReturn__carbon_thunk.Other(ptr noundef nonnull align 4 dereferenceable(4) %retval)
@@ -329,12 +329,12 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: ; Function Attrs: inlinehint mustprogress uwtable
 // CHECK:STDOUT: define linkonce_odr dso_local void @_Z2G1v() #1 comdat {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_ZN6CarbonL12F__cpp_thunkEv()
+// CHECK:STDOUT:   call void @_ZN6CarbonL1FEv()
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6CarbonL12F__cpp_thunkEv() #2 {
+// CHECK:STDOUT: define internal void @_ZN6CarbonL1FEv() #2 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CF__carbon_thunk.Main()
 // CHECK:STDOUT:   ret void

--- a/toolchain/lower/testdata/interop/cpp/reverse/method.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reverse/method.carbon
@@ -254,12 +254,12 @@ fn CallCallF() { Cpp.CallF(); }
 // CHECK:STDOUT: ; Function Attrs: mustprogress uwtable
 // CHECK:STDOUT: define dso_local void @_Z5CallFv() #0 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_ZN6Carbon1A12F__cpp_thunkEv()
+// CHECK:STDOUT:   call void @_ZN6Carbon1A1FEv()
 // CHECK:STDOUT:   ret void
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN6Carbon1A12F__cpp_thunkEv() #1 align 2 {
+// CHECK:STDOUT: define internal void @_ZN6Carbon1A1FEv() #1 align 2 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CF__carbon_thunk.A.Main()
 // CHECK:STDOUT:   ret void


### PR DESCRIPTION
This makes the behavior consistent between methods and regular functions, and fixes the behavior with `using` aliases (see new `using.carbon` test).

As requested in https://github.com/carbon-language/carbon-lang/pull/7078#discussion_r3121104954.