### PR TITLE
Disable precommit checks for package-lock.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -257,6 +257,7 @@ repos:
 exclude: |
   (?x)^(
       MODULE.bazel.lock|
+      .*package-lock\.json|
       bazel/bazel_clang_tidy/.*\.patch|
       bazel/google_benchmark/.*\.patch|
       bazel/libpfm/.*\.patch|


### PR DESCRIPTION
This file contains base64 hashes that sometimes contain word-shaped sequences like ...+nD+... that generate precommit false positives from codespell.

MODULE.bazel.lock was already excluded from all precommit checks; it seems consistent to do the same for package-lock.json too.

Assisted-by: Gemini via Antigravity