### PR TITLE
Switch to a "manual" tags and use them more pervasively

### DIFF
--- a/bazel/cc_toolchains/carbon_bootstrapping.bzl
+++ b/bazel/cc_toolchains/carbon_bootstrapping.bzl
@@ -63,17 +63,19 @@ def filegroup_with_stage_and_exec(name, srcs, stage, tags = []):
     `filegroup_with_stage`. But when it is _enabled_, it also adds an `exec`
     config transition.
     """
+    impl_tags = tags if "manual" in tags else tags + ["manual"]
+
     filegroup_with_stage(
         name = name + "_stage_only",
         srcs = srcs,
         stage = stage,
-        tags = tags,
+        tags = impl_tags,
     )
 
     _exec_filegroup(
         name = name + "_with_exec",
         srcs = [":" + name + "_stage_only"],
-        tags = tags,
+        tags = impl_tags,
     )
 
     native.alias(
@@ -150,18 +152,20 @@ def carbon_bootstrapped_cc_toolchain(
         runtimes_cfg: The runtimes configuration to use in the toolchain.
         tags: Tags to apply to the toolchain.
     """
+    impl_tags = tags if "manual" in tags else tags + ["manual"]
+
     filegroup_with_stage_and_exec(
         name = "{}_clang_hdrs".format(name),
         srcs = clang_hdrs,
         stage = base_stage,
-        tags = tags,
+        tags = impl_tags,
     )
 
     filegroup_with_stage_and_exec(
         name = "{}_base_files".format(name),
         srcs = base_files,
         stage = base_stage,
-        tags = tags,
+        tags = impl_tags,
     )
 
     filegroup_with_stage_and_exec(
@@ -171,14 +175,14 @@ def carbon_bootstrapped_cc_toolchain(
             ":{}_clang_hdrs".format(name),
         ],
         stage = base_stage,
-        tags = tags,
+        tags = impl_tags,
     )
 
     filegroup_with_stage_and_exec(
         name = "{}_compile_files".format(name),
         srcs = [":{}_base_files".format(name)] + all_hdrs,
         stage = base_stage,
-        tags = tags,
+        tags = impl_tags,
     )
 
     # The runtimes build for this stage of the bootstrap is only compatible with
@@ -188,14 +192,7 @@ def carbon_bootstrapped_cc_toolchain(
         name = "{}_runtimes_build".format(name),
         config = runtimes_cfg,
         clang_hdrs = ["{}_clang_hdrs".format(name)],
-        tags = tags,
-        target_compatible_with = select({
-            ":is_runtimes_build": [],
-            "//conditions:default": ["@platforms//:incompatible"],
-        }) + select({
-            ":is_bootstrap_stage_{}".format(build_stage): [],
-            "//conditions:default": ["@platforms//:incompatible"],
-        }),
+        tags = impl_tags,
     )
 
     # Wrap the runtimes build in a filegroup that both sets the stage to the
@@ -207,7 +204,7 @@ def carbon_bootstrapped_cc_toolchain(
         srcs = [":{}_runtimes_build".format(name)],
         stage = build_stage,
         enable_runtimes_build = True,
-        tags = tags,
+        tags = impl_tags,
     )
 
     carbon_cc_toolchain(

--- a/bazel/cc_toolchains/carbon_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/carbon_cc_toolchain_config.bzl
@@ -263,6 +263,8 @@ def carbon_cc_toolchain(
         extra_toolchain_settings: Extra toolchain settings.
         tags: Tags to apply to the toolchain.
     """
+    impl_tags = tags if "manual" in tags else tags + ["manual"]
+
     carbon_cc_toolchain_config(
         name = "{}_runtimes_toolchain_config".format(name),
         identifier_prefix = "{}_runtimes".format(name),
@@ -276,7 +278,7 @@ def carbon_cc_toolchain(
             for os in platforms.keys()
         }),
         bins = base_files_target,
-        tags = tags,
+        tags = impl_tags,
     )
 
     cc_toolchain(
@@ -295,7 +297,7 @@ def carbon_cc_toolchain(
             for os, cpus in platforms.items()
             for cpu in cpus
         }),
-        tags = tags,
+        tags = impl_tags,
     )
 
     native.toolchain(
@@ -321,7 +323,7 @@ def carbon_cc_toolchain(
         }),
         runtimes = runtimes_target,
         bins = base_files_target,
-        tags = tags,
+        tags = impl_tags,
     )
 
     native.filegroup(
@@ -330,7 +332,7 @@ def carbon_cc_toolchain(
             base_files_target,
             runtimes_target,
         ],
-        tags = tags,
+        tags = impl_tags,
     )
 
     native.filegroup(
@@ -339,7 +341,7 @@ def carbon_cc_toolchain(
             compile_files_target,
             ":{}_linker_files".format(name),
         ],
-        tags = tags,
+        tags = impl_tags,
     )
 
     cc_toolchain(
@@ -358,7 +360,7 @@ def carbon_cc_toolchain(
             for os, cpus in platforms.items()
             for cpu in cpus
         }),
-        tags = tags,
+        tags = impl_tags,
     )
 
     native.toolchain(

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -322,7 +322,7 @@ toolchain_files(
 )
 
 toolchain_files(
-    name = "carbon_runtimes_installed",
+    name = "carbon_runtimes_bzl_installed",
     srcs = ["//toolchain/runtimes:carbon_runtimes.bzl"],
     prefix = "bazel/",
 )
@@ -353,7 +353,7 @@ filegroup(
         ":bazel_build_and_module",
         ":bazel_common_srcs",
         ":bazel_install_srcs",
-        ":carbon_runtimes_installed",
+        ":carbon_runtimes_bzl_installed",
 
         # Note that we have to put this here and not in one of the
         # `toolchain_files` because it is a generated file.


### PR DESCRIPTION
Without this, basic `bazel test //...` style wildcards would build a bunch of extra configurations because of gaps excluding things. With this, the action count of a normal build should be much more reasonable.

The switch from `target_compatible_with` to tagging is based on looking at what ends up being most idiomatic and easiest -- trying to articulate the complex and convoluted compatible with restrictions that would avoid extraneous build configurations was really painful and this seems much simpler and easier to deploy in a systematic way.

While here, also change the name of a rule that confused me to no end while debugging this -- the rule that installs a `.bzl` file that happens to be spelled `carbon_runtimes` is very different from all of the other "installed carbon runtimes" kind of things in the tree. Adding the file extension helps make that (much) more obvious.

Note that this is essentially a re-do of #7088 but now without any dependencies that can mess up the merge.

Assisted-by: Antigravity with Gemini