### PR TITLE
Use a 'pending' rather than 'failed' status for PRs with the dependent label.

### DIFF
--- a/.github/workflows/check_dependent.yaml
+++ b/.github/workflows/check_dependent.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   check_label:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
@@ -21,9 +23,19 @@ jobs:
             api.github.com:443
 
       - name: Check for 'dependent' label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'dependent') }}" == "true" ]]; then
-            echo "PR has 'dependent' label. Blocking merge."
-            exit 1
+            echo "PR has 'dependent' label. Setting status to pending."
+            gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+              -f state=pending \
+              -f context="Waiting for dependency PRs to be merged" \
+              -f description="PR has 'dependent' label. Blocking merge."
+            exit 0
           fi
-          echo "PR does not have 'dependent' label."
+          echo "PR does not have 'dependent' label. Setting status to success."
+          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+            -f state=success \
+            -f context="Waiting for dependency PRs to be merged" \
+            -f description="No 'dependent' label."


### PR DESCRIPTION
Assisted-by: Gemini via Antigravity