### PR TITLE
Remove uses of `-Oz` flag

### DIFF
--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -865,7 +865,7 @@ static auto GetLLVMOptimizationLevel(Lower::OptimizationLevel opt_level)
     case Lower::OptimizationLevel::Debug:
       return llvm::OptimizationLevel::O1;
     case Lower::OptimizationLevel::Size:
-      return llvm::OptimizationLevel::Oz;
+      return llvm::OptimizationLevel::O2;
     case Lower::OptimizationLevel::Speed:
       return llvm::OptimizationLevel::O3;
   }
@@ -880,7 +880,7 @@ static auto GetClangOptimizationFlag(Lower::OptimizationLevel opt_level)
     case Lower::OptimizationLevel::Debug:
       return "-O1";
     case Lower::OptimizationLevel::Size:
-      return "-Oz";
+      return "-O2";
     case Lower::OptimizationLevel::Speed:
       return "-O3";
   }

--- a/toolchain/driver/testdata/compile/optimize/fail_clang_forward_optimize_size.carbon
+++ b/toolchain/driver/testdata/compile/optimize/fail_clang_forward_optimize_size.carbon
@@ -11,6 +11,6 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/driver/testdata/compile/optimize/fail_clang_forward_optimize_size.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/compile/optimize/fail_clang_forward_optimize_size.carbon
-// CHECK:STDERR:  "{{.*}}/toolchain/install/llvm/bin/clang" "-cc1" {{.*}} "-Oz" {{.*}}
+// CHECK:STDERR:  "{{.*}}/toolchain/install/llvm/bin/clang" "-cc1" {{.*}} "-O2" {{.*}}
 
 // --- fail_foo.carbon


### PR DESCRIPTION
The `-Oz` flag has been [removed from LLVM](https://github.com/llvm/llvm-project/pull/191363). The documented replacement is to use `-O2` in conjunction with the `optsize` or `minsize` attributes, which we already apply in lowering.

