### PR TITLE
Suppress some clang-tidy false positives

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,6 +35,7 @@ Checks:
   - '-readability-make-member-function-const'
   - '-readability-math-missing-parentheses'
   - '-readability-static-definition-in-anonymous-namespace'
+  - '-readability-trailing-comma'
   - '-readability-use-anyofallof'
 
   # Warns when we have multiple empty cases in switches, which we do for comment
@@ -94,6 +95,10 @@ Checks:
   # Warns on `= {}` which is also used to indicate which fields do not need to
   # be explicitly initialized in aggregate initialization.
   - '-readability-redundant-member-init'
+  # Broken, wants to remove parens from `*(p + 1)` and `("Foo" + s).str()`.
+  # TODO: Re-enable once https://github.com/llvm/llvm-project/issues/192435 and
+  # related bugs are fixed.
+  - '-readability-redundant-parentheses'
   # Warns when callers use similar names as different parameters.
   - '-readability-suspicious-call-argument'
 

--- a/toolchain/base/kind_switch.h
+++ b/toolchain/base/kind_switch.h
@@ -308,15 +308,21 @@ auto Cast(SwitchT&& kind_switch_value) -> decltype(auto) {
 //
 // This uses `if` to scope the variable, and provides a dangling `else` in order
 // to prevent accidental `else` use. The label allows `:` to follow the macro
-// name, making it look more like a typical `case`.
+// name, making it look more like a typical `case`. We use an unbraced `if` body
+// to avoid lint warnings that the `else` is unbraced. Braces are required after
+// the `:`, but we don't have a good way to enforce that.
+//
+// TODO: Replace the `;` with `{}` if
+// https://github.com/llvm/llvm-project/issues/194694 is fixed.
 #define CARBON_KIND_INTERNAL_DECLARE(typed_variable_decl)                \
   if (typed_variable_decl =                                              \
           ::Carbon::Internal::Kind::Cast<CARBON_KIND_INTERNAL_WRAP_TYPE( \
               typed_variable_decl)>(                                     \
               std::forward<decltype(carbon_internal_kind_switch_value)>( \
                   carbon_internal_kind_switch_value));                   \
-      false) {                                                           \
-  } else [[maybe_unused]]                                                \
+      false)                                                             \
+    ;                                                                    \
+  else [[maybe_unused]]                                                  \
     CARBON_INTERNAL_KIND_LABEL(__LINE__)
 
 // Helper for `CARBON_KIND_ANY` that expands the now-suffixed macro.


### PR DESCRIPTION
This gets us back to being mostly clang-tidy clean. This turns out to be important for agentic coding agents, which otherwise sometimes try to "fix" these false-positive lints.

Assisted-by: Gemini via Antigravity