### PR TITLE
Make choice to replace only implicit `.Self` or all into a parameter of SubstPeriodSelfCallbacks

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -2617,67 +2617,46 @@ static auto AddRequirementImpls(Context& context, SemIR::LocId loc_id,
     // Impls constraints are written as `T impls X` where `T` is a facet and `X`
     // is a facet type. The `T` can be `.Self`.
     //
-    // What's important here is that since `X` is a facet type, it can contain a
-    // `where` expression, and the value of `.Self` changes across a `where`
-    // expression. This can create ambiguous `.Self` references where on the RHS
-    // they refer to a different facet (`T`) than on the LHS, which is diagnosed
-    // as an error.
+    // A value for `.Self` is not known here, so we do not replace them
+    // generally. However in `T impls X where ...` the value of `.Self` on the
+    // RHS of the `where` refers to the `T`. Generally this would make the
+    // `.Self` be ambiguous, but any explicit use of an ambiguous `.Self` is
+    // diagnosed before we get here. So any explicit `.Self` left over are known
+    // to be non-ambiguous and refer to the top level value for `.Self`.
     //
-    // TODO: For now we do this diagnosis here, but we should diagnose this
-    // during name lookup of `.Self` instead, in order to properly allow only
-    // implicit `.Self` references when it would be ambiguous. Then use
-    // `should_replace_implicit_only` in all cases.
-    //
-    // Implicit `.Self` references can't be avoided when referencing members of
-    // the facet's type such as with `.Member`. As such, we replace implicit
-    // `.Self` references on the RHS of a nested `where` with the inner-most
-    // facet that it could possibly refer to, the `T as X` from the `impls`
-    // constraint, which eliminates any ambiguity in the resulting facet type.
+    // However, implicit references to `.Self`, via designators, are bound to
+    // the innermost possible value, which makes them bound to the `T` on the
+    // RHS of the nested `where`. We need to replace those implicit `.Self`
+    // references here so that we are left with a facet type where all `.Self`
+    // references are to the same top-level value for `.Self` and can all be
+    // replaced together later.
 
-    class SubstPeriodSelfImplicitOnlyCallbacks
-        : public SubstPeriodSelfCallbacks {
-     public:
-      explicit SubstPeriodSelfImplicitOnlyCallbacks(
-          Context* context, SemIR::LocId loc_id,
-          SemIR::ConstantId period_self_replacement_id)
-          : SubstPeriodSelfCallbacks(context, loc_id,
-                                     period_self_replacement_id) {}
-
-      // TODO: Replace this callback with a SubstPeriodSelf parameter saying
-      // what to replace (as a bool or an enum). Then this subclass can go away.
-      auto ShouldReplace(bool implicit) -> bool override { return implicit; }
-    };
-    SubstPeriodSelfImplicitOnlyCallbacks callbacks_should_replace_implicit_only(
-        &context, loc_id, context.constant_values().Get(lhs_facet_or_type));
+    SubstPeriodSelfCallbacks callbacks(
+        &context, loc_id, context.constant_values().Get(lhs_facet_or_type),
+        SubstPeriodSelfCallbacks::Behaviour::ImplicitOnly);
 
     auto self_impls_interface = [&](SemIR::SpecificInterface si) {
-      return SubstPeriodSelf(context, callbacks_should_replace_implicit_only,
-                             si);
+      return SubstPeriodSelf(context, callbacks, si);
     };
     auto self_impls_constraint = [&](SemIR::SpecificNamedConstraint sc) {
-      return SubstPeriodSelf(context, callbacks_should_replace_implicit_only,
-                             sc);
+      return SubstPeriodSelf(context, callbacks, sc);
     };
     auto type_impls_interface =
         [&](SemIR::FacetTypeInfo::TypeImplsInterface impls)
         -> SemIR::FacetTypeInfo::TypeImplsInterface {
-      auto self =
-          SubstPeriodSelf(context, callbacks_should_replace_implicit_only,
-                          context.constant_values().Get(impls.self_type));
+      auto self = SubstPeriodSelf(
+          context, callbacks, context.constant_values().Get(impls.self_type));
       auto interface =
-          SubstPeriodSelf(context, callbacks_should_replace_implicit_only,
-                          impls.specific_interface);
+          SubstPeriodSelf(context, callbacks, impls.specific_interface);
       return {context.constant_values().GetInstId(self), interface};
     };
     auto type_impls_constraint =
         [&](SemIR::FacetTypeInfo::TypeImplsNamedConstraint impls)
         -> SemIR::FacetTypeInfo::TypeImplsNamedConstraint {
-      auto self =
-          SubstPeriodSelf(context, callbacks_should_replace_implicit_only,
-                          context.constant_values().Get(impls.self_type));
+      auto self = SubstPeriodSelf(
+          context, callbacks, context.constant_values().Get(impls.self_type));
       auto constraint =
-          SubstPeriodSelf(context, callbacks_should_replace_implicit_only,
-                          impls.specific_named_constraint);
+          SubstPeriodSelf(context, callbacks, impls.specific_named_constraint);
       return {context.constant_values().GetInstId(self), constraint};
     };
 
@@ -2694,22 +2673,13 @@ static auto AddRequirementImpls(Context& context, SemIR::LocId loc_id,
                        llvm::map_range(rhs.type_impls_named_constraints,
                                        type_impls_constraint));
 
-    // TODO: We have to pass explicit `.Self` along unchanged in rewrites. A
-    // rewrite of the form `M(.Self) where .M0 = {}` is an access into `.Self as
-    // M(.Self)`. The first `.Self` is implicit and should be replaced. The
-    // second is explicit but refers to the outer-most facet and should not be
-    // replaced. In the future when we diagnose ambiguous `.Self` in name
-    // lookup, we will replace all implicit `.Self` and leave all explicit
-    // `.Self` alone since they won't be ambiguous.
     auto rewrite_constraint =
         [&](SemIR::FacetTypeInfo::RewriteConstraint rewrite)
         -> SemIR::FacetTypeInfo::RewriteConstraint {
-      auto lhs_id =
-          SubstPeriodSelf(context, callbacks_should_replace_implicit_only,
-                          context.constant_values().Get(rewrite.lhs_id));
-      auto rhs_id =
-          SubstPeriodSelf(context, callbacks_should_replace_implicit_only,
-                          context.constant_values().Get(rewrite.rhs_id));
+      auto lhs_id = SubstPeriodSelf(
+          context, callbacks, context.constant_values().Get(rewrite.lhs_id));
+      auto rhs_id = SubstPeriodSelf(
+          context, callbacks, context.constant_values().Get(rewrite.rhs_id));
       return {context.constant_values().GetInstId(lhs_id),
               context.constant_values().GetInstId(rhs_id)};
     };

--- a/toolchain/check/period_self.cpp
+++ b/toolchain/check/period_self.cpp
@@ -41,10 +41,11 @@ auto MakePeriodSelfFacetValue(Context& context, SemIR::TypeId self_type_id)
 
 SubstPeriodSelfCallbacks::SubstPeriodSelfCallbacks(
     Context* context, SemIR::LocId loc_id,
-    SemIR::ConstantId period_self_replacement_id)
+    SemIR::ConstantId period_self_replacement_id, Behaviour behaviour)
     : SubstInstCallbacks(context),
       loc_id_(loc_id),
-      period_self_replacement_id_(period_self_replacement_id) {}
+      period_self_replacement_id_(period_self_replacement_id),
+      behaviour_(behaviour) {}
 
 auto SubstPeriodSelfCallbacks::Subst(SemIR::InstId& inst_id) -> SubstResult {
   // FacetTypes are concrete even if they have `.Self` inside them, but we
@@ -59,51 +60,45 @@ auto SubstPeriodSelfCallbacks::Subst(SemIR::InstId& inst_id) -> SubstResult {
     return FullySubstituted;
   }
 
-  // For `.X` (which is `.Self.X`) replace the `.Self` in the query self
-  // position, and report it as `implicit`. Any `.Self` references in the
-  // specific interface would be replaced later and not treated as `implicit`.
-  //
-  // TODO: This all goes away when eval doesn't need to know about implicit
-  // .Self for diagnostics, once we diagnose invalid `.Self` in name lookup.
+  // Look for implicit use of `.Self` in designators: `.X` is really `.Self.X`.
   if (auto access =
           context().insts().TryGetAs<SemIR::ImplWitnessAccess>(inst_id)) {
     if (auto witness = context().insts().TryGetAs<SemIR::LookupImplWitness>(
             access->witness_id)) {
-      if (auto bind = context().insts().TryGetAs<SemIR::SymbolicBinding>(
-              witness->query_self_inst_id)) {
-        const auto& entity_name =
-            context().entity_names().Get(bind->entity_name_id);
-        if (entity_name.name_id == SemIR::NameId::PeriodSelf) {
-          auto replacement_id =
-              GetReplacement(witness->query_self_inst_id, true);
-          auto new_witness =
-              Rebuild(access->witness_id,
-                      SemIR::LookupImplWitness{
-                          .type_id = witness->type_id,
-                          .query_self_inst_id = replacement_id,
-                          // Don't replace `.Self` in the interface specific
-                          // here. That is an explicit `.Self` use. We'll
-                          // revisit the instruction for that.
-                          .query_specific_interface_id =
-                              witness->query_specific_interface_id,
-                      });
-          auto new_access = Rebuild(inst_id, SemIR::ImplWitnessAccess{
-                                                 .type_id = access->type_id,
-                                                 .witness_id = new_witness,
-                                                 .index = access->index,
-                                             });
-          inst_id = new_access;
-          return SubstAgain;
-        }
+      // Canonicalization not necessary; We are working with the constant
+      // value already, and the query self in a witness is already
+      // canonicalized.
+      if (IsPeriodSelf(context(), witness->query_self_inst_id,
+                       /*canonicalize=*/false)) {
+        auto replacement_id = GetReplacement(witness->query_self_inst_id);
+        auto new_witness =
+            Rebuild(access->witness_id,
+                    SemIR::LookupImplWitness{
+                        .type_id = witness->type_id,
+                        .query_self_inst_id = replacement_id,
+                        // Don't replace `.Self` in the interface specific
+                        // here. That is an explicit `.Self` use. We'll
+                        // revisit the instruction for that.
+                        .query_specific_interface_id =
+                            witness->query_specific_interface_id,
+                    });
+        auto new_access = Rebuild(inst_id, SemIR::ImplWitnessAccess{
+                                               .type_id = access->type_id,
+                                               .witness_id = new_witness,
+                                               .index = access->index,
+                                           });
+        inst_id = new_access;
+        return SubstAgain;
       }
     }
   }
 
-  if (auto bind = context().insts().TryGetAs<SemIR::SymbolicBinding>(inst_id)) {
-    const auto& entity_name =
-        context().entity_names().Get(bind->entity_name_id);
-    if (entity_name.name_id == SemIR::NameId::PeriodSelf) {
-      inst_id = GetReplacement(inst_id, false);
+  // Look for explicit use of `.Self`.
+  if (behaviour_ == Behaviour::All) {
+    // Canonicalization not necessary; Subst will recurse anyway, so avoid
+    // extra work for non-matches.
+    if (IsPeriodSelf(context(), inst_id, /*canonicalize=*/false)) {
+      inst_id = GetReplacement(inst_id);
       return FullySubstituted;
     }
   }
@@ -116,12 +111,8 @@ auto SubstPeriodSelfCallbacks::Rebuild(SemIR::InstId orig_inst_id,
   return RebuildNewInst(SemIR::LocId(orig_inst_id), new_inst);
 }
 
-auto SubstPeriodSelfCallbacks::GetReplacement(SemIR::InstId period_self,
-                                              bool implicit) -> SemIR::InstId {
-  if (!ShouldReplace(implicit)) {
-    return period_self;
-  }
-
+auto SubstPeriodSelfCallbacks::GetReplacement(SemIR::InstId period_self)
+    -> SemIR::InstId {
   auto period_self_type_id = context().insts().Get(period_self).type_id();
   CARBON_CHECK(context().types().Is<SemIR::FacetType>(period_self_type_id));
 

--- a/toolchain/check/period_self.h
+++ b/toolchain/check/period_self.h
@@ -23,14 +23,18 @@ auto MakePeriodSelfFacetValue(Context& context, SemIR::TypeId self_type_id)
 
 class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
  public:
+  enum Behaviour {
+    ImplicitOnly,
+    All,
+  };
+
   explicit SubstPeriodSelfCallbacks(
       Context* context, SemIR::LocId loc_id,
-      SemIR::ConstantId period_self_replacement_id);
+      SemIR::ConstantId period_self_replacement_id,
+      Behaviour behaviour = Behaviour::All);
   auto Subst(SemIR::InstId& inst_id) -> SubstResult override;
   auto Rebuild(SemIR::InstId orig_inst_id, SemIR::Inst new_inst)
       -> SemIR::InstId override;
-
-  virtual auto ShouldReplace(bool /*implicit*/) -> bool { return true; }
 
   auto loc_id() const -> SemIR::LocId { return loc_id_; }
   auto period_self_replacement_id() const -> SemIR::ConstantId {
@@ -38,14 +42,14 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
   }
 
  private:
-  auto GetReplacement(SemIR::InstId period_self, bool implicit)
-      -> SemIR::InstId;
+  auto GetReplacement(SemIR::InstId period_self) -> SemIR::InstId;
   auto ConvertReplacement(SemIR::InstId replacement_self_inst_id,
                           SemIR::TypeId replacement_type_id,
                           SemIR::TypeId period_self_type_id) -> SemIR::InstId;
 
   SemIR::LocId loc_id_;
   SemIR::ConstantId period_self_replacement_id_;
+  Behaviour behaviour_;
 
   // The last output of GetReplacement().
   SemIR::InstId cached_replacement_id_ = SemIR::InstId::None;


### PR DESCRIPTION
This avoids the need for a virtual method, and a class overriding it in eval.