### PR TITLE
Update design about use of `.Self` and ambiguity

### DIFF
--- a/docs/design/generics/appendix-rewrite-constraints.md
+++ b/docs/design/generics/appendix-rewrite-constraints.md
@@ -173,32 +173,32 @@ interface E {
 
 In a nested `where` expression, such as `T impls C where ...`, the meaning of
 `.Self` becomes ambiguous on the right-hand side of the nested `where` as it can
-refer to either `T` or the top-level value of `.Self`. And such ambiguous uses
-of `.Self` are not allowed. However implicit use of `.Self` through a designator
-always binds to the inner-most possible value of `.Self`, allowing designators
-to be used on the right-hand side of the nested `where`. Any such designators
-would be referring to `T as C`. For example in
+refer to either `T` or the top-level value of `.Self`. However designators in
+rewrite and same-type constraints are scoped to the nearest `where` expression,
+and refer to an associated entity from the interface on the left of the `where`
+keyword. For example in
 `U where T impls (C where .A = B)` the value of `T.(C.A)` is rewritten to `B`.
 
 ```carbon
 // ✅ Rewrite constraint specified directly in `impls` refers to
-// `.Self.U.(A.T)` which is `(V.(A.U)).(A.T)`.
+// `(V.(A.U)).(A.T)`.
 fn F[V:! A where .U impls (A where .T = i32)]();
 
 // ✅ Reference to `.V` in same-type constraint refers to
-// `.Self.U.(A.T)` which is `(V.(A.U)).(A.T)`.
+// `(V.(A.U)).(A.T)`.
 fn G[V:! A where .U impls (A where .T == i32)]();
 
-// ❌ Explicit use of `.Self` in `where` after `impls` is ambiguous,
-// does it refer to the top-level `V` or to the inner-most `V.U`?
-fn F[V:! A where .U impls (A where .T = .Self)]();
-
-// ✅ `.Self impls` is always allowed and refers to the value and type on the
-// left-hand side of the `where`.
-fn H[V:! type where .Self impls C]() -> V.(A.U);
+// ✅ Not specified directly, but does not result
+// in any rewrites being performed. Return type
+// is not rewritten to `i32`.
+fn H[T:! type where .Self impls C]() -> T.(A.U);
 
 // ✅ Return type is rewritten to `i32`.
 fn I[V:! C]() -> V.(A.U);
+
+// ❌ This use of `.Self` in a nested `where` after `impls` is ambiguous.
+// Does it refer to the top-level `V` or to the inner-most `V.U`?
+fn J[V:! A where .U impls (A where .T = .Self)]();
 ```
 
 ## Rewrite constraint resolution

--- a/docs/design/generics/appendix-rewrite-constraints.md
+++ b/docs/design/generics/appendix-rewrite-constraints.md
@@ -171,25 +171,34 @@ interface E {
 }
 ```
 
-The same rules apply to `where`...`impls` constraints. Note that `.T == U`
-constraints are also not allowed in this context, because the reference to `.T`
-is rewritten to `.Self.T`, and `.Self` is ambiguous.
+In a nested `where` expression, such as `T impls C where ...`, the meaning of
+`.Self` becomes ambiguous on the right-hand side of the nested `where` as it can
+refer to either `T` or the top-level value of `.Self`. And such ambiguous uses
+of `.Self` are not allowed. However implicit use of `.Self` through a designator
+always binds to the inner-most possible value of `.Self`, allowing designators
+to be used on the right-hand side of the nested `where`. Any such designators
+would be referring to `T as C`. For example in
+`U where T impls (C where .A = B)` the value of `T.(C.A)` is rewritten to `B`.
 
 ```carbon
-// ❌ Rewrite constraint specified directly in `impls`.
-fn F[T:! A where .U impls (A where .T = i32)]();
+// ✅ Rewrite constraint specified directly in `impls` refers to
+// `.Self.U.(A.T)` which is `(V.(A.U)).(A.T)`.
+fn F[V:! A where .U impls (A where .T = i32)]();
 
-// ❌ Reference to `.T` in same-type constraint is ambiguous:
-// does this mean the outer or inner `.Self.T`?
-fn G[T:! A where .U impls (A where .T == i32)]();
+// ✅ Reference to `.V` in same-type constraint refers to
+// `.Self.U.(A.T)` which is `(V.(A.U)).(A.T)`.
+fn G[V:! A where .U impls (A where .T == i32)]();
 
-// ✅ Not specified directly, but does not result
-// in any rewrites being performed. Return type
-// is not rewritten to `i32`.
-fn H[T:! type where .Self impls C]() -> T.(A.U);
+// ❌ Explicit use of `.Self` in `where` after `impls` is ambiguous,
+// does it refer to the top-level `V` or to the inner-most `V.U`?
+fn F[V:! A where .U impls (A where .T = .Self)]();
+
+// ✅ `.Self impls` is always allowed and refers to the value and type on the
+// left-hand side of the `where`.
+fn H[V:! type where .Self impls C]() -> V.(A.U);
 
 // ✅ Return type is rewritten to `i32`.
-fn I[T:! C]() -> T.(A.U);
+fn I[V:! C]() -> V.(A.U);
 ```
 
 ## Rewrite constraint resolution

--- a/docs/design/generics/appendix-rewrite-constraints.md
+++ b/docs/design/generics/appendix-rewrite-constraints.md
@@ -176,8 +176,8 @@ In a nested `where` expression, such as `T impls C where ...`, the meaning of
 refer to either `T` or the top-level value of `.Self`. However designators in
 rewrite and same-type constraints are scoped to the nearest `where` expression,
 and refer to an associated entity from the interface on the left of the `where`
-keyword. For example in
-`U where T impls (C where .A = B)` the value of `T.(C.A)` is rewritten to `B`.
+keyword. For example in `U where T impls (C where .A = B)` the value of
+`T.(C.A)` is rewritten to `B`.
 
 ```carbon
 // ✅ Rewrite constraint specified directly in `impls` refers to

--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -2697,10 +2697,7 @@ of `B`.
 The "dot followed by the name of a member" construct, like `.A`, is called a
 _designator_. The name of the designator is looked up in the constraint, and
 refers to the value of that member for whatever type is to satisfy this
-constraint.
-
-While `.A` in `T where .A = B` acts like `.Self.A` or `.Self.(T.A)`, it is not
-valid to use `.Self` to qualify a designator in a rewrite constraint.
+constraint. It may not be `.Self` or a reference to a member through `.Self`.
 
 > **Concern:** Using `=` for this use case is not consistent with other `where`
 > clauses that write a boolean expression that evaluates to `true` when the
@@ -3368,16 +3365,9 @@ its value also changes to become the value of `T`. If that `T` is not written as
 side of the `where` ambiguous as there are now two copies of `.Self` in scope:
 one for `T` and one for the abstract top-level `.Self` value.
 
-Use of an ambiguous `.Self` is an error, unless:
-
--   It is an implicit `.Self` in a designator, such as `.X`. Then `.Self` refers
-    to the inner-most possible value for `.Self`, which is the `T as X` from the
-    `impls` constraint.
--   It is `.Self impls`, the left-hand side of an implements constraint. Then
-    `.Self` also refers to the inner-most possible value for `.Self`.
-
-Any other valid use of `.Self` refers to the top-level `.Self` value
-unambiguously.
+However the `.Self` in `.Self impls` can always be disambiguated as the
+inner-most value of `.Self`, thus it can be allowed even when other use of
+`.Self` are rejected as ambiguous.
 
 ##### Implied constraints
 

--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -2699,6 +2699,9 @@ _designator_. The name of the designator is looked up in the constraint, and
 refers to the value of that member for whatever type is to satisfy this
 constraint.
 
+While `.A` in `T where .A = B` acts like `.Self.A` or `.Self.(T.A)`, it is not
+valid to use `.Self` to qualify a designator in a rewrite constraint.
+
 > **Concern:** Using `=` for this use case is not consistent with other `where`
 > clauses that write a boolean expression that evaluates to `true` when the
 > constraint is satisfied.
@@ -3357,6 +3360,24 @@ in `I where .Self impls C`. This has the same requirements as `I & C`, but that
 in `T:! I where .Self impls C`, is represented by an
 [archetype](terminology.md#archetype) that implements both `I` and `C`, but only
 [extends](terminology.md#extending-an-impl) `I`.
+
+The type of `.Self` is changed when crossing a `where`, to have the type to the
+left of the `where`. And when the `where` is nested in a `T impls X` constraint,
+its value also changes to become the value of `T`. If that `T` is not written as
+`.Self` (as in `.Self impls X`), it makes any use of `.Self` on the right-hand
+side of the `where` ambiguous as there are now two copies of `.Self` in scope:
+one for `T` and one for the abstract top-level `.Self` value.
+
+Use of an ambiguous `.Self` is an error, unless:
+
+-   It is an implicit `.Self` in a designator, such as `.X`. Then `.Self` refers
+    to the inner-most possible value for `.Self`, which is the `T as X` from the
+    `impls` constraint.
+-   It is `.Self impls`, the left-hand side of an implements constraint. Then
+    `.Self` also refers to the inner-most possible value for `.Self`.
+
+Any other valid use of `.Self` refers to the top-level `.Self` value
+unambiguously.
 
 ##### Implied constraints
 


### PR DESCRIPTION
[Proposal #2173](https://docs.carbon-lang.dev/proposals/p2173.html#rewrite-constraints) changes designators in rewrite constraints from being an implicit reference to `.Self` to being a direct reference to the self+type being modified by the `where` expression. While the toolchain implementation has a `.Self` in its modelling of a designator as an access on `.Self`, this is consistent with treating that `.Self` as the inner-most value, which the implementation does. Update the design to specify these rules and allow designators where `.Self` is ambiguous.

The proposal also explicitly disallows using `.Self` as the designator, since it is not the name of an associated member in the constraint facet type. The design now also states that you can not write `.Self` or `.Self.A` as a designator.

`.Self impls` can always be safely disambiguated to the inner-most possible value of `.Self` since it can never contain any other references to an outer `.Self` (such as through a specific), which [would lead to ambiguity](https://docs.google.com/document/d/1mjllGO3ZCL4qGt9uJHUtcxKoHAGEY7Y999ie4EtBWB8/edit?tab=t.h6lecvcwu214#heading=h.twhpk59ki1vo) with tho different `.Self` in the expression.