### PR TITLE
Don't consider designators in a nested facet type as constraining the current type

### DIFF
--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -203,36 +203,92 @@ auto HandleParseNode(Context& /*context*/, Parse::RequirementAndId /*node_id*/)
 // where clause.
 static auto FindDesignator(Context& context,
                            SemIR::InstBlockId requirements_block_id) -> bool {
-  auto block = context.inst_blocks().GetOrEmpty(requirements_block_id);
-
   llvm::SmallVector<SemIR::InstId> requirements;
-  requirements.reserve(block.size() * 2);
 
-  for (auto inst_id : block) {
-    auto inst = context.insts().Get(inst_id);
-    CARBON_KIND_SWITCH(inst) {
-      case CARBON_KIND(SemIR::RequirementBaseFacetType base): {
-        requirements.push_back(base.base_type_inst_id);
-        break;
+  struct WorkItem {
+    SemIR::InstBlockId requirements_block_id;
+    bool search_rhs;
+  };
+  llvm::SmallVector<WorkItem> work = {{requirements_block_id, true}};
+
+  while (!work.empty()) {
+    auto item = work.pop_back_val();
+    auto block = context.inst_blocks().GetOrEmpty(item.requirements_block_id);
+    if (item.search_rhs) {
+      requirements.reserve(block.size() * 2);
+    }
+
+    for (auto inst_id : block) {
+      auto inst = context.insts().Get(inst_id);
+      CARBON_KIND_SWITCH(inst) {
+        case CARBON_KIND(SemIR::RequirementBaseFacetType base): {
+          requirements.push_back(base.base_type_inst_id);
+          break;
+        }
+        case CARBON_KIND(SemIR::RequirementRewrite rewrite): {
+          if (item.search_rhs) {
+            requirements.push_back(rewrite.lhs_id);
+            // The LHS of a rewrite currently always constrains the current
+            // type, so looking in the RHS is redundant.
+            //
+            // Regardless, if the RHS is a facet type, designators inside it
+            // don't constrain the current type, so we don't recurse into it.
+            auto const_rhs_id =
+                context.constant_values().GetConstantInstId(rewrite.rhs_id);
+            if (const_rhs_id.has_value() &&
+                !context.insts().Is<SemIR::FacetType>(const_rhs_id)) {
+              requirements.push_back(rewrite.rhs_id);
+            }
+          }
+          break;
+        }
+        case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
+          if (item.search_rhs) {
+            // If the instruction is a facet type, designators inside it don't
+            // constrain the current type, so we don't recurse into it.
+            auto const_lhs_id =
+                context.constant_values().GetConstantInstId(equiv.rhs_id);
+            if (const_lhs_id.has_value() &&
+                !context.insts().Is<SemIR::FacetType>(const_lhs_id)) {
+              requirements.push_back(equiv.lhs_id);
+            }
+            // If the instruction is a facet type, designators inside it don't
+            // constrain the current type, so we don't recurse into it.
+            auto const_rhs_id =
+                context.constant_values().GetConstantInstId(equiv.rhs_id);
+            if (const_rhs_id.has_value() &&
+                !context.insts().Is<SemIR::FacetType>(const_rhs_id)) {
+              requirements.push_back(equiv.rhs_id);
+            }
+          }
+          break;
+        }
+        case CARBON_KIND(SemIR::RequirementImpls impls): {
+          if (item.search_rhs) {
+            requirements.push_back(impls.lhs_id);
+
+            CARBON_KIND_SWITCH(context.insts().Get(impls.rhs_id)) {
+                // If the RHS of the `impls` contains a `where`, then it will be
+                // a WhereExpr instruction. We require a designator to be part
+                // of the constraint on the LHS of the nested `where`, so we
+                // won't search the RHS of a nested `where`.
+              case CARBON_KIND(SemIR::WhereExpr rhs_where_expr): {
+                work.push_back({rhs_where_expr.requirements_id, false});
+                break;
+              }
+                // Otherwise, it's a facet type without a `where`, so we will
+                // search that for a designator.
+              default:
+                requirements.push_back(impls.rhs_id);
+                break;
+            }
+          }
+          break;
+        }
+        default:
+          CARBON_CHECK(inst_id == SemIR::ErrorInst::InstId,
+                       "unexpected inst {0} in requirements", inst);
       }
-      case CARBON_KIND(SemIR::RequirementRewrite rewrite): {
-        requirements.push_back(rewrite.lhs_id);
-        requirements.push_back(rewrite.rhs_id);
-        break;
-      }
-      case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
-        requirements.push_back(equiv.lhs_id);
-        requirements.push_back(equiv.rhs_id);
-        break;
-      }
-      case CARBON_KIND(SemIR::RequirementImpls impls): {
-        requirements.push_back(impls.lhs_id);
-        requirements.push_back(impls.rhs_id);
-        break;
-      }
-      default:
-        CARBON_CHECK(inst_id == SemIR::ErrorInst::InstId,
-                     "unexpected inst {0} in requirements", inst);
     }
   }
 
@@ -259,13 +315,9 @@ static auto FindDesignator(Context& context,
 
       // `.MemberName` is represented as an ImplWitnessAccess through `.Self` so
       // we only need to look for `.Self` here.
-      if (auto bind =
-              context().insts().TryGetAs<SemIR::SymbolicBinding>(inst_id)) {
-        auto entity_name = context().entity_names().Get(bind->entity_name_id);
-        if (entity_name.name_id == SemIR::NameId::PeriodSelf) {
-          *found_ = true;
-          return FullySubstituted;
-        }
+      if (IsPeriodSelf(context(), inst_id)) {
+        *found_ = true;
+        return FullySubstituted;
       }
 
       return SubstOperands;
@@ -299,9 +351,11 @@ auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
 
   auto type_id = SemIR::TypeType::TypeId;
   if (!FindDesignator(context, requirements_id)) {
-    CARBON_DIAGNOSTIC(WhereWithoutDesignator, Error,
-                      "`where` clause without a designator; expected `.Self` "
-                      "to appear in a requirement, or a member of `.Self`");
+    CARBON_DIAGNOSTIC(
+        WhereWithoutDesignator, Error,
+        "`where` clause without a designator that constrains the current type; "
+        "did not find `.Self` or a member access like `.M` that refers to the "
+        "current type");
     context.emitter().Emit(node_id, WhereWithoutDesignator);
     type_id = SemIR::ErrorInst::TypeId;
   }

--- a/toolchain/check/period_self.cpp
+++ b/toolchain/check/period_self.cpp
@@ -277,11 +277,13 @@ auto SubstPeriodSelf(Context& context, SubstPeriodSelfCallbacks& callbacks,
 
 auto IsPeriodSelf(Context& context, SemIR::InstId inst_id, bool canonicalize)
     -> bool {
+  auto const_inst_id = context.constant_values().GetConstantInstId(inst_id);
+  if (!const_inst_id.has_value()) {
+    return false;
+  }
   auto query_inst_id =
-      canonicalize
-          ? GetCanonicalFacetOrTypeValue(
-                context, context.constant_values().GetConstantInstId(inst_id))
-          : inst_id;
+      canonicalize ? GetCanonicalFacetOrTypeValue(context, const_inst_id)
+                   : inst_id;
   if (auto bind =
           context.insts().TryGetAs<SemIR::SymbolicBinding>(query_inst_id)) {
     const auto& entity_name = context.entity_names().Get(bind->entity_name_id);

--- a/toolchain/check/testdata/where_expr/designator.carbon
+++ b/toolchain/check/testdata/where_expr/designator.carbon
@@ -96,7 +96,7 @@ library "[[@TEST_NAME]]";
 
 interface I {}
 
-// CHECK:STDERR: fail_impls_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:27: error: `where` clause without a designator; expected `.Self` to appear in a requirement, or a member of `.Self` [WhereWithoutDesignator]
+// CHECK:STDERR: fail_impls_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:27: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(U:! type, unused T:! type where U impls I) {}
 // CHECK:STDERR:                           ^~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -109,7 +109,7 @@ interface I {
   let X:! type;
 }
 
-// CHECK:STDERR: fail_equality_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:24: error: `where` clause without a designator; expected `.Self` to appear in a requirement, or a member of `.Self` [WhereWithoutDesignator]
+// CHECK:STDERR: fail_equality_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:24: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(U:! I, unused T:! type where U.X == ()) {}
 // CHECK:STDERR:                        ^~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -122,7 +122,7 @@ interface I {
   let X:! type;
 }
 
-// CHECK:STDERR: fail_combined_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:24: error: `where` clause without a designator; expected `.Self` to appear in a requirement, or a member of `.Self` [WhereWithoutDesignator]
+// CHECK:STDERR: fail_combined_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:24: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(U:! I, unused T:! type where U impls I and U.X == ()) {}
 // CHECK:STDERR:                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -138,6 +138,66 @@ class C(T:! type);
 fn F(unused T:! type where C(.Self) impls I(())) {}
 
 fn G(unused T:! type where C(()) impls I(.Self)) {}
+
+// --- fail_impls_with_nested_facet_type_does_not_constrain_self.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let I1:! type;
+}
+interface J(T:! type) {}
+class C;
+
+// The `.I1` satisfies constraining the "current type" of the inner nested facet
+// type `I where ...`. But it does not constrain the current type of the outer
+// facet type `type where...`. We should not consider the designator in the
+// nested where expression as making the `C impls ...` constraint valid.
+
+// CHECK:STDERR: fail_impls_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:18: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F1(unused T:! type where C impls (I where .I1 = C)) {}
+// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F1(unused T:! type where C impls (I where .I1 = C)) {}
+// CHECK:STDERR: fail_impls_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:18: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F2(unused T:! type where C impls (I where .I1 == C)) {}
+// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F2(unused T:! type where C impls (I where .I1 == C)) {}
+// CHECK:STDERR: fail_impls_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:56: error: `.Self` is ambiguous after nested `where` in `<type> impls ...` clause. [AmbiguousPeriodSelf]
+// CHECK:STDERR: fn F3(unused T:! type where C impls (I where .I1 impls J(.Self))) {}
+// CHECK:STDERR:                                                        ^~~~~~~~
+// CHECK:STDERR:
+fn F3(unused T:! type where C impls (I where .I1 impls J(.Self))) {}
+
+// --- fail_equiv_with_nested_facet_type_does_not_constrain_self.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let I1:! type;
+}
+interface J(T:! type) {}
+class C;
+
+// The `.I1` satisfies constraining the "current type" of the inner nested facet
+// type `I where ...`. But it does not constrain the current type of the outer
+// facet type `I where...`. We should not consider the designator in the nested
+// where expression as making the `C impls ...` constraint valid.
+
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 = C)) {}
+// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where C == (I where .I1 = C)) {}
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 == C)) {}
+// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where C == (I where .I1 == C)) {}
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 impls J(.Self))) {}
+// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where C == (I where .I1 impls J(.Self))) {}
 
 // CHECK:STDOUT: --- success.carbon
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/where_expr/designator.carbon
+++ b/toolchain/check/testdata/where_expr/designator.carbon
@@ -139,7 +139,45 @@ fn F(unused T:! type where C(.Self) impls I(())) {}
 
 fn G(unused T:! type where C(()) impls I(.Self)) {}
 
-// --- fail_impls_with_nested_facet_type_does_not_constrain_self.carbon
+// --- fail_impls_with_nested_facet_type_with_rewrite_does_not_constrain_self.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let I1:! type;
+}
+class C;
+
+// The `.I1` satisfies constraining the "current type" of the inner nested facet
+// type `I where ...`. But it does not constrain the current type of the outer
+// facet type `type where...`. We should not consider the designator in the
+// nested where expression as making the `C impls ...` constraint valid.
+
+// CHECK:STDERR: fail_impls_with_nested_facet_type_with_rewrite_does_not_constrain_self.carbon:[[@LINE+4]]:18: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F1(unused T:! type where C impls (I where .I1 = C)) {}
+// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F1(unused T:! type where C impls (I where .I1 = C)) {}
+
+// --- fail_impls_with_nested_facet_type_with_equiv_does_not_constrain_self.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let I1:! type;
+}
+class C;
+
+// The `.I1` satisfies constraining the "current type" of the inner nested facet
+// type `I where ...`. But it does not constrain the current type of the outer
+// facet type `type where...`. We should not consider the designator in the
+// nested where expression as making the `C impls ...` constraint valid.
+
+// CHECK:STDERR: fail_impls_with_nested_facet_type_with_equiv_does_not_constrain_self.carbon:[[@LINE+4]]:18: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F2(unused T:! type where C impls (I where .I1 == C)) {}
+// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F2(unused T:! type where C impls (I where .I1 == C)) {}
+
+// --- fail_impls_with_nested_facet_type_with_impls_does_not_constrain_self.carbon
 library "[[@TEST_NAME]]";
 
 interface I {
@@ -153,23 +191,51 @@ class C;
 // facet type `type where...`. We should not consider the designator in the
 // nested where expression as making the `C impls ...` constraint valid.
 
-// CHECK:STDERR: fail_impls_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:18: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
-// CHECK:STDERR: fn F1(unused T:! type where C impls (I where .I1 = C)) {}
-// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
-fn F1(unused T:! type where C impls (I where .I1 = C)) {}
-// CHECK:STDERR: fail_impls_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:18: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
-// CHECK:STDERR: fn F2(unused T:! type where C impls (I where .I1 == C)) {}
-// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
-fn F2(unused T:! type where C impls (I where .I1 == C)) {}
-// CHECK:STDERR: fail_impls_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:56: error: `.Self` is ambiguous after nested `where` in `<type> impls ...` clause. [AmbiguousPeriodSelf]
+// CHECK:STDERR: fail_impls_with_nested_facet_type_with_impls_does_not_constrain_self.carbon:[[@LINE+4]]:56: error: `.Self` is ambiguous after nested `where` in `<type> impls ...` clause. [AmbiguousPeriodSelf]
 // CHECK:STDERR: fn F3(unused T:! type where C impls (I where .I1 impls J(.Self))) {}
 // CHECK:STDERR:                                                        ^~~~~~~~
 // CHECK:STDERR:
 fn F3(unused T:! type where C impls (I where .I1 impls J(.Self))) {}
 
-// --- fail_equiv_with_nested_facet_type_does_not_constrain_self.carbon
+// --- fail_equiv_with_nested_facet_type_with_rewrite_does_not_constrain_self.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let I1:! type;
+}
+class C;
+
+// The `.I1` satisfies constraining the "current type" of the inner nested facet
+// type `I where ...`. But it does not constrain the current type of the outer
+// facet type `I where...`. We should not consider the designator in the nested
+// where expression as making the `C impls ...` constraint valid.
+
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_rewrite_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 = C)) {}
+// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where C == (I where .I1 = C)) {}
+
+// --- fail_equiv_with_nested_facet_type_with_equiv_does_not_constrain_self.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let I1:! type;
+}
+class C;
+
+// The `.I1` satisfies constraining the "current type" of the inner nested facet
+// type `I where ...`. But it does not constrain the current type of the outer
+// facet type `I where...`. We should not consider the designator in the nested
+// where expression as making the `C impls ...` constraint valid.
+
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_equiv_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 == C)) {}
+// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where C == (I where .I1 == C)) {}
+
+// --- fail_equiv_with_nested_facet_type_with_impls_does_not_constrain_self.carbon
 library "[[@TEST_NAME]]";
 
 interface I {
@@ -183,17 +249,7 @@ class C;
 // facet type `I where...`. We should not consider the designator in the nested
 // where expression as making the `C impls ...` constraint valid.
 
-// CHECK:STDERR: fail_equiv_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
-// CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 = C)) {}
-// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
-fn F(unused T:! type where C == (I where .I1 = C)) {}
-// CHECK:STDERR: fail_equiv_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
-// CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 == C)) {}
-// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
-fn F(unused T:! type where C == (I where .I1 == C)) {}
-// CHECK:STDERR: fail_equiv_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_impls_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 impls J(.Self))) {}
 // CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:


### PR DESCRIPTION
The design says:
> We don’t allow a where constraint unless it applies a restriction to the current type. This means referring to some [designator](https://docs.carbon-lang.dev/docs/design/generics/details.html#kinds-of-where-constraints), like .MemberName, or [.Self](https://docs.carbon-lang.dev/docs/design/generics/details.html#recursive-constraints).
-- https://docs.carbon-lang.dev/docs/design/generics/details.html#constraints-must-use-a-designator

A nested facet type in a constraint does not constrain the current type, with the exception of the LHS of a nested `where` in an impls constraint. Diagnose this appropriately by not recursing into unrelated parts of nested facet types to look for designators.

Before this change, this facet type is accepted:
```carbon
fn F(unused T:! Z where C impls (Y where .Y1 = .Y2)) {}
```

But then no calls to `F` work, since the `.Y1` and `.Y2` designators are never resolved to anything from the caller, as they do not depend on `T` in any way.
