### PR TITLE
Don't identify sibling PRs as dependencies.

### DIFF
--- a/github_tools/check_dependent_pr.py
+++ b/github_tools/check_dependent_pr.py
@@ -333,7 +333,14 @@ def _process_pr(
         for other_pr_num, other_oids_set in pr_to_commits.items():
             if other_pr_num >= pr_number:
                 continue
-            if not (other_oids_set & current_oids_set):
+
+            # Filter out commits from PRs earlier than other_pr_num.
+            new_commits_in_other_pr = other_oids_set.copy()
+            for prev_pr_num, prev_oids_set in pr_to_commits.items():
+                if prev_pr_num < other_pr_num:
+                    new_commits_in_other_pr -= prev_oids_set
+
+            if not (new_commits_in_other_pr & current_oids_set):
                 continue
             if not (current_oids_set - other_oids_set):
                 continue

--- a/github_tools/check_dependent_pr.py
+++ b/github_tools/check_dependent_pr.py
@@ -421,7 +421,14 @@ def _process_pr(
 
         last_dep_pr_num = max(open_deps)
         last_dep_oids = pr_to_commits[last_dep_pr_num]
-        last_dep_head_oid = pr_to_head[last_dep_pr_num]
+
+        # Find the most recent commit in the current PR that is also in the
+        # last dependent PR.
+        last_dep_head_oid = None
+        for oid in reversed(current_oids):
+            if oid in last_dep_oids:
+                last_dep_head_oid = oid
+                break
 
         # Detect non-linear history: any commit in the current PR that is in
         # *some* dependency but *not* in the last dependency.

--- a/github_tools/check_dependent_pr_test.py
+++ b/github_tools/check_dependent_pr_test.py
@@ -385,7 +385,9 @@ class TestCheckDependentPR(unittest.TestCase):
         )
         calls = self.mock_client.execute.call_args_list
         variable_values = calls[1][1]["variable_values"]
-        self.assertIn(_OID9[:8], variable_values["body"])
+        self.assertIn(
+            "unable to identify starting review commit", variable_values["body"]
+        )
         self._assert_status(
             _OID2, "pending", "This PR has open dependencies: #1"
         )

--- a/github_tools/check_dependent_pr_test.py
+++ b/github_tools/check_dependent_pr_test.py
@@ -40,6 +40,36 @@ class TestCheckDependentPR(unittest.TestCase):
         self.assertEqual(kwargs["json"]["context"], "PR dependencies check")
         self.assertEqual(kwargs["json"]["description"], description)
 
+    def _process_pr(
+        self,
+        client: Any,
+        pr_number: int,
+        pr_to_commits: dict[int, list[str]],
+        open_pr_numbers: set[int],
+        label_id: str,
+        token: str,
+        dry_run: bool = False,
+        scanning: bool = False,
+        max_merged_pr: int = 10000,
+    ) -> None:
+        """Helper to call the real _process_pr with converted types."""
+        new_pr_to_commits = {k: set(v) for k, v in pr_to_commits.items()}
+        pr_to_head = {
+            k: v[-1] if v else "dummy_head" for k, v in pr_to_commits.items()
+        }
+        return check_dependent_pr._process_pr(
+            client=client,
+            pr_number=pr_number,
+            pr_to_commits=new_pr_to_commits,
+            pr_to_head=pr_to_head,
+            open_pr_numbers=open_pr_numbers,
+            label_id=label_id,
+            token=token,
+            dry_run=dry_run,
+            scanning=scanning,
+            max_merged_pr=max_merged_pr,
+        )
+
     def _make_comment(
         self,
         open_deps: list[int],
@@ -93,7 +123,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID1,
             commits=[_OID1],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=1,
             pr_to_commits={1: [_OID1]},
@@ -112,7 +142,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=2,
             pr_to_commits={1: [_OID1], 2: [_OID1, _OID2]},
@@ -136,7 +166,7 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1])],
             has_dependent_label=True,
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=3,
             pr_to_commits={3: [_OID1, _OID2]},
@@ -159,7 +189,7 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1, 2])],
             has_dependent_label=True,
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=3,
             pr_to_commits={1: [_OID1, _OID4], 3: [_OID1, _OID2]},
@@ -183,7 +213,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=10,
             pr_to_commits={10: [_OID1, _OID2], 11: [_OID1, _OID3]},
@@ -202,7 +232,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=9,
             pr_to_commits={1: [_OID2], 9: [_OID1, _OID2]},
@@ -224,7 +254,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=7,
             pr_to_commits={1: [_OID1], 7: [_OID1, _OID2]},
@@ -246,7 +276,7 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1], first_commit=_OID2)],
             has_dependent_label=True,
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=6,
             pr_to_commits={1: [_OID1], 6: [_OID1, _OID2]},
@@ -275,7 +305,7 @@ class TestCheckDependentPR(unittest.TestCase):
 
         self.assertRaises(
             json.decoder.JSONDecodeError,
-            check_dependent_pr._process_pr,
+            self._process_pr,
             self.mock_client,
             pr_number=5,
             pr_to_commits={5: [_OID1]},
@@ -298,7 +328,7 @@ class TestCheckDependentPR(unittest.TestCase):
             ],
             has_dependent_label=True,
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=14,
             pr_to_commits={1: [_OID1], 14: [_OID1, _OID2]},
@@ -321,7 +351,7 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1, 2], first_commit=_OID2)],
             has_dependent_label=True,
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=11,
             pr_to_commits={1: [_OID1], 11: [_OID1, _OID2, _OID3]},
@@ -331,8 +361,8 @@ class TestCheckDependentPR(unittest.TestCase):
         )
         calls = self.mock_client.execute.call_args_list
         variable_values = calls[1][1]["variable_values"]
-        self.assertIn(_OID2[:8], variable_values["body"])
-        self.assertNotIn(_OID1[:8], variable_values["body"])
+        # Uses the last dependency's HEAD (_OID1) instead of sticky first commit (_OID2)
+        self.assertIn(_OID1[:8], variable_values["body"])
         self._assert_status(
             _OID3, "pending", "This PR has open dependencies: #1"
         )
@@ -345,7 +375,7 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1, 2])],
             has_dependent_label=True,
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=12,
             pr_to_commits={1: [_OID9], 12: [_OID1, _OID2]},
@@ -355,7 +385,7 @@ class TestCheckDependentPR(unittest.TestCase):
         )
         calls = self.mock_client.execute.call_args_list
         variable_values = calls[1][1]["variable_values"]
-        self.assertIn(_OID1[:8], variable_values["body"])
+        self.assertIn(_OID9[:8], variable_values["body"])
         self._assert_status(
             _OID2, "pending", "This PR has open dependencies: #1"
         )
@@ -368,7 +398,7 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1, 2])],
             has_dependent_label=True,
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=13,
             pr_to_commits={1: [_OID1, _OID2], 13: [_OID1, _OID2]},
@@ -378,9 +408,8 @@ class TestCheckDependentPR(unittest.TestCase):
         )
         calls = self.mock_client.execute.call_args_list
         variable_values = calls[1][1]["variable_values"]
-        self.assertIn(
-            "unable to identify starting review commit", variable_values["body"]
-        )
+        # Uses the last dependency's HEAD even if there are no independent commits
+        self.assertIn(_OID2[:8], variable_values["body"])
         self._assert_status(
             _OID2, "pending", "This PR has open dependencies: #1"
         )
@@ -391,7 +420,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID1,
             commits=[_OID1],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=1,
             pr_to_commits={1: [_OID1], 2: [_OID1, _OID2]},
@@ -410,7 +439,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID2],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=2,
             pr_to_commits={1: [_OID1], 2: [_OID2]},
@@ -429,7 +458,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=2,
             pr_to_commits={1: [_OID1, _OID2, _OID3], 2: [_OID1, _OID2]},
@@ -448,7 +477,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID4,
             commits=[_OID1, _OID3, _OID4],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=2,
             pr_to_commits={1: [_OID1, _OID2], 2: [_OID1, _OID3, _OID4]},
@@ -469,7 +498,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID1,
             commits=[_OID1],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=1,
             pr_to_commits={1: [_OID1]},
@@ -487,7 +516,7 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        check_dependent_pr._process_pr(
+        self._process_pr(
             self.mock_client,
             pr_number=2,
             pr_to_commits={1: [_OID1], 2: [_OID1, _OID2]},
@@ -497,6 +526,39 @@ class TestCheckDependentPR(unittest.TestCase):
         )
         self._assert_status(
             _OID2, "pending", "This PR has open dependencies: #1"
+        )
+
+    def test_process_pr_sibling_prs(self) -> None:
+        # PR 1: [_OID1]
+        # PR 2: [_OID1, _OID2]
+        # PR 3: [_OID1, _OID3]
+        # PR 3 depends on PR 1, but not PR 2.
+        self.mock_client.execute.return_value = self._make_pr_response(
+            pr_id="pr_3",
+            head_ref_oid=_OID3,
+            commits=[_OID1, _OID3],
+        )
+        self._process_pr(
+            self.mock_client,
+            pr_number=3,
+            pr_to_commits={
+                1: [_OID1],
+                2: [_OID1, _OID2],
+                3: [_OID1, _OID3],
+            },
+            open_pr_numbers={1, 2, 3},
+            label_id="label_dependent",
+            token="test_token",
+        )
+        self.assertEqual(self.mock_client.execute.call_count, 3)
+        calls = self.mock_client.execute.call_args_list
+        self.assertIn("addLabelsToLabelable", calls[1][0][0])
+        # Link should only mention PR #1
+        variable_values = calls[2][1]["variable_values"]
+        self.assertIn("Depends on #1", variable_values["body"])
+        self.assertNotIn("#2", variable_values["body"])
+        self._assert_status(
+            _OID3, "pending", "This PR has open dependencies: #1"
         )
 
     def test_query_max_merged_pr_explicit_orderBy_and_first_one(self) -> None:

--- a/github_tools/check_dependent_pr_test.py
+++ b/github_tools/check_dependent_pr_test.py
@@ -40,36 +40,6 @@ class TestCheckDependentPR(unittest.TestCase):
         self.assertEqual(kwargs["json"]["context"], "PR dependencies check")
         self.assertEqual(kwargs["json"]["description"], description)
 
-    def _process_pr(
-        self,
-        client: Any,
-        pr_number: int,
-        pr_to_commits: dict[int, list[str]],
-        open_pr_numbers: set[int],
-        label_id: str,
-        token: str,
-        dry_run: bool = False,
-        scanning: bool = False,
-        max_merged_pr: int = 10000,
-    ) -> None:
-        """Helper to call the real _process_pr with converted types."""
-        new_pr_to_commits = {k: set(v) for k, v in pr_to_commits.items()}
-        pr_to_head = {
-            k: v[-1] if v else "dummy_head" for k, v in pr_to_commits.items()
-        }
-        return check_dependent_pr._process_pr(
-            client=client,
-            pr_number=pr_number,
-            pr_to_commits=new_pr_to_commits,
-            pr_to_head=pr_to_head,
-            open_pr_numbers=open_pr_numbers,
-            label_id=label_id,
-            token=token,
-            dry_run=dry_run,
-            scanning=scanning,
-            max_merged_pr=max_merged_pr,
-        )
-
     def _make_comment(
         self,
         open_deps: list[int],
@@ -123,10 +93,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID1,
             commits=[_OID1],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=1,
-            pr_to_commits={1: [_OID1]},
+            pr_to_commits={1: {_OID1}},
+            pr_to_head={1: _OID1},
             open_pr_numbers={1},
             label_id="label_id",
             token="test_token",
@@ -142,10 +113,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=2,
-            pr_to_commits={1: [_OID1], 2: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1}, 2: {_OID1, _OID2}},
+            pr_to_head={1: _OID1, 2: _OID2},
             open_pr_numbers={1, 2},
             label_id="label_dependent",
             token="test_token",
@@ -166,10 +138,11 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1])],
             has_dependent_label=True,
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=3,
-            pr_to_commits={3: [_OID1, _OID2]},
+            pr_to_commits={3: {_OID1, _OID2}},
+            pr_to_head={3: _OID2},
             open_pr_numbers={3},
             label_id="label_dependent",
             token="test_token",
@@ -189,10 +162,11 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1, 2])],
             has_dependent_label=True,
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=3,
-            pr_to_commits={1: [_OID1, _OID4], 3: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1, _OID4}, 3: {_OID1, _OID2}},
+            pr_to_head={1: _OID4, 3: _OID2},
             open_pr_numbers={1, 3},
             label_id="label_dependent",
             token="test_token",
@@ -213,10 +187,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=10,
-            pr_to_commits={10: [_OID1, _OID2], 11: [_OID1, _OID3]},
+            pr_to_commits={10: {_OID1, _OID2}, 11: {_OID1, _OID3}},
+            pr_to_head={10: _OID2, 11: _OID3},
             open_pr_numbers={10, 11},
             label_id="label_dependent",
             token="test_token",
@@ -232,10 +207,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=9,
-            pr_to_commits={1: [_OID2], 9: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID2}, 9: {_OID1, _OID2}},
+            pr_to_head={1: _OID2, 9: _OID2},
             open_pr_numbers={1, 9},
             label_id="label_dependent",
             token="test_token",
@@ -254,10 +230,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=7,
-            pr_to_commits={1: [_OID1], 7: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1}, 7: {_OID1, _OID2}},
+            pr_to_head={1: _OID1, 7: _OID2},
             open_pr_numbers={1, 7},
             label_id="label_dependent",
             token="test_token",
@@ -276,10 +253,11 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1], first_commit=_OID2)],
             has_dependent_label=True,
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=6,
-            pr_to_commits={1: [_OID1], 6: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1}, 6: {_OID1, _OID2}},
+            pr_to_head={1: _OID1, 6: _OID2},
             open_pr_numbers={1, 6},
             label_id="label_dependent",
             token="test_token",
@@ -305,10 +283,11 @@ class TestCheckDependentPR(unittest.TestCase):
 
         self.assertRaises(
             json.decoder.JSONDecodeError,
-            self._process_pr,
+            check_dependent_pr._process_pr,
             self.mock_client,
             pr_number=5,
-            pr_to_commits={5: [_OID1]},
+            pr_to_commits={5: {_OID1}},
+            pr_to_head={5: _OID1},
             open_pr_numbers={5},
             label_id="label_dependent",
             token="test_token",
@@ -328,10 +307,11 @@ class TestCheckDependentPR(unittest.TestCase):
             ],
             has_dependent_label=True,
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=14,
-            pr_to_commits={1: [_OID1], 14: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1}, 14: {_OID1, _OID2}},
+            pr_to_head={1: _OID1, 14: _OID2},
             open_pr_numbers={1, 14},
             label_id="label_dependent",
             token="test_token",
@@ -351,10 +331,11 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1, 2], first_commit=_OID2)],
             has_dependent_label=True,
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=11,
-            pr_to_commits={1: [_OID1], 11: [_OID1, _OID2, _OID3]},
+            pr_to_commits={1: {_OID1}, 11: {_OID1, _OID2, _OID3}},
+            pr_to_head={1: _OID1, 11: _OID3},
             open_pr_numbers={1, 11},
             label_id="label_dependent",
             token="test_token",
@@ -376,10 +357,11 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1, 2])],
             has_dependent_label=True,
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=12,
-            pr_to_commits={1: [_OID9], 12: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID9}, 12: {_OID1, _OID2}},
+            pr_to_head={1: _OID9, 12: _OID2},
             open_pr_numbers={1, 12},
             label_id="label_dependent",
             token="test_token",
@@ -401,10 +383,11 @@ class TestCheckDependentPR(unittest.TestCase):
             comments=[self._make_comment(open_deps=[1, 2])],
             has_dependent_label=True,
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=13,
-            pr_to_commits={1: [_OID1, _OID2], 13: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1, _OID2}, 13: {_OID1, _OID2}},
+            pr_to_head={1: _OID2, 13: _OID2},
             open_pr_numbers={1, 13},
             label_id="label_dependent",
             token="test_token",
@@ -424,10 +407,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID1,
             commits=[_OID1],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=1,
-            pr_to_commits={1: [_OID1], 2: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1}, 2: {_OID1, _OID2}},
+            pr_to_head={1: _OID1, 2: _OID2},
             open_pr_numbers={1, 2},
             label_id="label_dependent",
             token="test_token",
@@ -443,10 +427,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID2],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=2,
-            pr_to_commits={1: [_OID1], 2: [_OID2]},
+            pr_to_commits={1: {_OID1}, 2: {_OID2}},
+            pr_to_head={1: _OID1, 2: _OID2},
             open_pr_numbers={1, 2},
             label_id="label_dependent",
             token="test_token",
@@ -462,10 +447,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=2,
-            pr_to_commits={1: [_OID1, _OID2, _OID3], 2: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1, _OID2, _OID3}, 2: {_OID1, _OID2}},
+            pr_to_head={1: _OID3, 2: _OID2},
             open_pr_numbers={1, 2},
             label_id="label_dependent",
             token="test_token",
@@ -481,10 +467,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID4,
             commits=[_OID1, _OID3, _OID4],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=2,
-            pr_to_commits={1: [_OID1, _OID2], 2: [_OID1, _OID3, _OID4]},
+            pr_to_commits={1: {_OID1, _OID2}, 2: {_OID1, _OID3, _OID4}},
+            pr_to_head={1: _OID2, 2: _OID4},
             open_pr_numbers={1, 2},
             label_id="label_dependent",
             token="test_token",
@@ -502,10 +489,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID1,
             commits=[_OID1],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=1,
-            pr_to_commits={1: [_OID1]},
+            pr_to_commits={1: {_OID1}},
+            pr_to_head={1: _OID1},
             open_pr_numbers={1},
             label_id="label_id",
             token="test_token",
@@ -520,10 +508,11 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID2,
             commits=[_OID1, _OID2],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=2,
-            pr_to_commits={1: [_OID1], 2: [_OID1, _OID2]},
+            pr_to_commits={1: {_OID1}, 2: {_OID1, _OID2}},
+            pr_to_head={1: _OID1, 2: _OID2},
             open_pr_numbers={1, 2},
             label_id="label_dependent",
             token="test_token",
@@ -542,14 +531,15 @@ class TestCheckDependentPR(unittest.TestCase):
             head_ref_oid=_OID3,
             commits=[_OID1, _OID3],
         )
-        self._process_pr(
+        check_dependent_pr._process_pr(
             self.mock_client,
             pr_number=3,
             pr_to_commits={
-                1: [_OID1],
-                2: [_OID1, _OID2],
-                3: [_OID1, _OID3],
+                1: {_OID1},
+                2: {_OID1, _OID2},
+                3: {_OID1, _OID3},
             },
+            pr_to_head={1: _OID1, 2: _OID2, 3: _OID3},
             open_pr_numbers={1, 2, 3},
             label_id="label_dependent",
             token="test_token",

--- a/github_tools/check_dependent_pr_test.py
+++ b/github_tools/check_dependent_pr_test.py
@@ -361,7 +361,8 @@ class TestCheckDependentPR(unittest.TestCase):
         )
         calls = self.mock_client.execute.call_args_list
         variable_values = calls[1][1]["variable_values"]
-        # Uses the last dependency's HEAD (_OID1) instead of sticky first commit (_OID2)
+        # Uses the last dependency's HEAD (_OID1) instead of sticky first
+        # commit (_OID2)
         self.assertIn(_OID1[:8], variable_values["body"])
         self._assert_status(
             _OID3, "pending", "This PR has open dependencies: #1"
@@ -410,7 +411,8 @@ class TestCheckDependentPR(unittest.TestCase):
         )
         calls = self.mock_client.execute.call_args_list
         variable_values = calls[1][1]["variable_values"]
-        # Uses the last dependency's HEAD even if there are no independent commits
+        # Uses the last dependency's HEAD even if there are no independent
+        # commits
         self.assertIn(_OID2[:8], variable_values["body"])
         self._assert_status(
             _OID2, "pending", "This PR has open dependencies: #1"


### PR DESCRIPTION
Also, when constructing the diff link, make sure we pick a commit that's on the current PR's branch as the starting point. github wasn't able to properly process the links we were creating before, if the last dependency PR had commits that weren't on the current PR.

Fix a couple of tests that were broken by a prior change.

Assisted-by: Gemini via Antigravity