### PR TITLE
Fix lowering of imported globals.

### DIFF
--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -11,6 +11,7 @@
 #include "toolchain/sem_ir/expr_info.h"
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/generic.h"
+#include "toolchain/sem_ir/import_ir.h"
 
 namespace Carbon::Lower {
 
@@ -175,7 +176,12 @@ auto FunctionContext::GetValue(SemIR::InstId inst_id) -> llvm::Value* {
     return result.value();
   }
 
-  if (auto result = file_context_->global_variables().Lookup(inst_id)) {
+  // Look up global variables (local or imported).
+  auto [current_sem_ir, current_inst_id] =
+      SemIR::GetCanonicalFileAndInstId(&sem_ir(), inst_id);
+  auto& defining_file_context = GetFileContext(current_sem_ir);
+  if (auto result =
+          defining_file_context.global_variables().Lookup(current_inst_id)) {
     return result.value();
   }
 

--- a/toolchain/lower/testdata/impl/import_thunk.carbon
+++ b/toolchain/lower/testdata/impl/import_thunk.carbon
@@ -335,6 +335,14 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #2
 // CHECK:STDOUT:
+// CHECK:STDOUT: declare void @"_CF.61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }), ptr)
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @"_CF:thunk.61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }), ptr)
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr)
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @"_COp.3d608d0372c8fc08:core.Destroy.Core"(ptr)
+// CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
 // CHECK:STDOUT: uselistorder ptr @"_COp.301c2cde953858ec:core.Destroy.Core", { 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 1, 0 }

--- a/toolchain/lower/testdata/var/import_ref.carbon
+++ b/toolchain/lower/testdata/var/import_ref.carbon
@@ -1,0 +1,82 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/var/import_ref.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/var/import_ref.carbon
+
+// --- a.carbon
+
+library "[[@TEST_NAME]]";
+
+var v: i32 = 42;
+
+// --- b.carbon
+
+library "[[@TEST_NAME]]";
+
+import library "a";
+
+fn Run() -> i32 {
+  return v;
+}
+
+// CHECK:STDOUT: ; ModuleID = 'a.carbon'
+// CHECK:STDOUT: source_filename = "a.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @_Cv.Main = global i32 0
+// CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @_C__global_init.Main, ptr null }]
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define internal void @_C__global_init.Main() #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   store i32 42, ptr @_Cv.Main, align 4, !dbg !7
+// CHECK:STDOUT:   ret void, !dbg !8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "a.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !3, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{null}
+// CHECK:STDOUT: !7 = !DILocation(line: 4, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT: ; ModuleID = 'b.carbon'
+// CHECK:STDOUT: source_filename = "b.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @_Cv.Main = external global i32
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc7 = load i32, ptr @_Cv.Main, align 4, !dbg !8
+// CHECK:STDOUT:   ret i32 %.loc7, !dbg !9
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "b.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 6, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 7, column: 10, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 7, column: 3, scope: !4)


### PR DESCRIPTION
When lowering an instruction that represents a reference to an imported global variable, look for the global variable in the right `FileContext`.

Assisted-by: Gemini via Antigravity