### PR TITLE
Add a colon to the dump output for IdentifiedFacetType

### DIFF
--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -309,7 +309,7 @@ LLVM_DUMP_METHOD auto Dump(const File& file,
        llvm::enumerate(identified_facet_type.required_impls())) {
     auto [self, req_interface] = req_impl;
     out << "\n  - self: " << DumpConstantSummary(file, self);
-    out << "\n    impls "
+    out << "\n    impls: "
         << DumpInterfaceSummary(file, req_interface.interface_id);
     if (req_interface.specific_id.has_value()) {
       out << "; " << DumpSpecificSummary(file, req_interface.specific_id);


### PR DESCRIPTION
Put a colon after `impls` to make it a bit easier to read.

Before:
```
identified_facet_type50000000
  - self: concrete_constant(inst50000023): {kind: ClassType, arg0: class50000004, arg1: specific<none>, type: type(TypeType)}
    impls interface50000000: {name: name0, parent_scope: name_scope0, require_impls_block_id: require_block_empty} `Z`
```

After:
```
identified_facet_type50000000
  - self: concrete_constant(inst50000023): {kind: ClassType, arg0: class50000004, arg1: specific<none>, type: type(TypeType)}
    impls: interface50000000: {name: name0, parent_scope: name_scope0, require_impls_block_id: require_block_empty} `Z`
```