### PR TITLE
Factor out definition merging logic.

### DIFF
--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -80,11 +80,6 @@ static auto MergeClassRedecl(Context& context, Parse::AnyClassDeclId node_id,
 
   if (new_is_definition) {
     prev_class.MergeDefinition(new_class);
-    prev_class.scope_id = new_class.scope_id;
-    prev_class.body_block_id = new_class.body_block_id;
-    prev_class.adapt_id = new_class.adapt_id;
-    prev_class.base_id = new_class.base_id;
-    prev_class.complete_type_witness_id = new_class.complete_type_witness_id;
   }
 
   if (prev_import_ir_id.has_value() ||

--- a/toolchain/check/handle_function.cpp
+++ b/toolchain/check/handle_function.cpp
@@ -169,12 +169,6 @@ static auto MergeFunctionRedecl(Context& context,
     // Track the signature from the definition, so that IDs in the body
     // match IDs in the signature.
     prev_function.MergeDefinition(new_function);
-    prev_function.call_param_patterns_id = new_function.call_param_patterns_id;
-    prev_function.call_params_id = new_function.call_params_id;
-    prev_function.return_type_inst_id = new_function.return_type_inst_id;
-    prev_function.return_form_inst_id = new_function.return_form_inst_id;
-    prev_function.return_pattern_id = new_function.return_pattern_id;
-    prev_function.self_param_id = new_function.self_param_id;
   }
   if (prev_import_ir_id.has_value()) {
     ReplacePrevInstForMerge(context, new_function.parent_scope_id,

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -107,6 +107,17 @@ struct Class : public EntityWithParamsBase,
     return complete_type_witness_id.has_value();
   }
 
+  // When merging a declaration and definition, prefer things which would point
+  // at the definition for diagnostics.
+  auto MergeDefinition(const Class& definition) -> void {
+    EntityWithParamsBase::MergeDefinition(definition);
+    scope_id = definition.scope_id;
+    body_block_id = definition.body_block_id;
+    adapt_id = definition.adapt_id;
+    base_id = definition.base_id;
+    complete_type_witness_id = definition.complete_type_witness_id;
+  }
+
   // Gets the type that this class type adapts. Returns `None` if there is no
   // such type, or if the class is not yet defined.
   auto GetAdaptedType(const File& file, SpecificId specific_id) const -> TypeId;

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -110,7 +110,7 @@ struct Class : public EntityWithParamsBase,
   // When merging a declaration and definition, prefer things which would point
   // at the definition for diagnostics.
   auto MergeDefinition(const Class& definition) -> void {
-    EntityWithParamsBase::MergeDefinition(definition);
+    EntityWithParamsBase::MergeBaseDefinition(definition);
     scope_id = definition.scope_id;
     body_block_id = definition.body_block_id;
     adapt_id = definition.adapt_id;

--- a/toolchain/sem_ir/entity_with_params_base.h
+++ b/toolchain/sem_ir/entity_with_params_base.h
@@ -41,7 +41,7 @@ struct EntityWithParamsBase {
 
   // When merging a declaration and definition, prefer things which would point
   // at the definition for diagnostics.
-  auto MergeDefinition(const EntityWithParamsBase& definition) -> void {
+  auto MergeBaseDefinition(const EntityWithParamsBase& definition) -> void {
     first_param_node_id = definition.first_param_node_id;
     last_param_node_id = definition.last_param_node_id;
     pattern_block_id = definition.pattern_block_id;

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -255,7 +255,7 @@ struct Function : public EntityWithParamsBase,
   // When merging a declaration and definition, prefer things which would point
   // at the definition for diagnostics.
   auto MergeDefinition(const Function& definition) -> void {
-    EntityWithParamsBase::MergeDefinition(definition);
+    EntityWithParamsBase::MergeBaseDefinition(definition);
     call_param_patterns_id = definition.call_param_patterns_id;
     call_params_id = definition.call_params_id;
     return_type_inst_id = definition.return_type_inst_id;

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -252,6 +252,18 @@ struct Function : public EntityWithParamsBase,
                              SpecificId specific_id = SpecificId::None) const
       -> InstId;
 
+  // When merging a declaration and definition, prefer things which would point
+  // at the definition for diagnostics.
+  auto MergeDefinition(const Function& definition) -> void {
+    EntityWithParamsBase::MergeDefinition(definition);
+    call_param_patterns_id = definition.call_param_patterns_id;
+    call_params_id = definition.call_params_id;
+    return_type_inst_id = definition.return_type_inst_id;
+    return_form_inst_id = definition.return_form_inst_id;
+    return_pattern_id = definition.return_pattern_id;
+    self_param_id = definition.self_param_id;
+  }
+
   // Sets that this function is a builtin function.
   auto SetBuiltinFunction(BuiltinFunctionKind kind) -> void {
     CARBON_CHECK(special_function_kind == SpecialFunctionKind::None);


### PR DESCRIPTION
Move logic to merge class and function definitions onto Class and Function, matching how we handle merging for EntityWithParamsBase.

Assisted-by: Gemini via Antigravity