### PR TITLE
Fix crash if an inst in a pending block needs a cleanup.

### DIFF
--- a/toolchain/check/pending_block.h
+++ b/toolchain/check/pending_block.h
@@ -7,6 +7,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/check/context.h"
+#include "toolchain/check/control_flow.h"
 #include "toolchain/check/inst.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
@@ -31,16 +32,24 @@ class PendingBlock {
     // If `block` is not null, enters the scope. If `block` is null, this object
     // has no effect.
     explicit DiscardUnusedInstsScope(PendingBlock* block)
-        : block_(block), size_(block ? block->insts_.size() : 0) {}
+        : block_(block),
+          size_(block ? block->insts_.size() : 0),
+          cleanups_size_(block ? block->cleanups_.size() : 0) {}
     ~DiscardUnusedInstsScope() {
-      if (block_ && block_->insts_.size() > size_) {
-        block_->insts_.truncate(size_);
+      if (block_) {
+        if (block_->insts_.size() > size_) {
+          block_->insts_.truncate(size_);
+        }
+        if (block_->cleanups_.size() > cleanups_size_) {
+          block_->cleanups_.truncate(cleanups_size_);
+        }
       }
     }
 
    private:
     PendingBlock* block_;
     size_t size_;
+    size_t cleanups_size_;
   };
 
   template <typename InstT, typename LocT>
@@ -54,8 +63,10 @@ class PendingBlock {
   template <typename InstT, typename LocT>
     requires(std::convertible_to<LocT, SemIR::LocId>)
   auto AddInstWithCleanup(LocT loc_id, InstT inst) -> SemIR::InstId {
-    auto inst_id = AddInstWithCleanupInNoBlock(*context_, loc_id, inst);
+    auto inst_id =
+        AddInstInNoBlock(*context_, SemIR::LocIdAndInst(loc_id, inst));
     insts_.push_back(inst_id);
+    cleanups_.push_back(inst_id);
     return inst_id;
   }
 
@@ -65,6 +76,7 @@ class PendingBlock {
       context_->inst_block_stack().AddInstId(id);
     }
     insts_.clear();
+    AddPendingCleanups();
   }
 
   // Replace the instruction at target_id with the instructions in this block.
@@ -91,6 +103,13 @@ class PendingBlock {
       // The block is {value_id}. Replace `target_id` with the instruction
       // referred to by `value_id`. This is intended to be the common case.
       result_id = target_id;
+
+      // If this instruction needed a cleanup, the instruction that now needs a
+      // cleanup is `target_id`.
+      CARBON_CHECK(cleanups_.size() <= 1);
+      if (cleanups_.size() == 1 && cleanups_[0] == value_id) {
+        cleanups_[0] = target_id;
+      }
     } else {
       // Anything else: splice it into the IR, replacing `target_id`. This
       // includes empty blocks, which `Add` handles.
@@ -101,15 +120,23 @@ class PendingBlock {
     }
 
     ReplaceLocIdAndInstBeforeConstantUse(*context_, target_id, value);
-
-    // Prepare to stash more pending instructions.
     insts_.clear();
+
+    AddPendingCleanups();
     return result_id;
   }
 
  private:
+  auto AddPendingCleanups() -> void {
+    for (auto id : cleanups_) {
+      MaybeAddCleanupForInst(*context_, id);
+    }
+    cleanups_.clear();
+  }
+
   Context* context_;
   llvm::SmallVector<SemIR::InstId> insts_;
+  llvm::SmallVector<SemIR::InstId> cleanups_;
 };
 
 }  // namespace Carbon::Check

--- a/toolchain/check/testdata/var/var_pattern.carbon
+++ b/toolchain/check/testdata/var/var_pattern.carbon
@@ -1020,8 +1020,8 @@ fn Call() {
 // CHECK:STDOUT:   %MakeInit.call: init %X to %a.var = call %MakeInit.ref()
 // CHECK:STDOUT:   assign %a.var, %MakeInit.call
 // CHECK:STDOUT:   %TakeVar.call: init %empty_tuple.type = call %TakeVar.ref(%a.var)
-// CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method <unexpected>.inst{{[0-9A-F]+}}.loc7_12, constants.%Destroy.Op.651ba6.2
-// CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(<unexpected>.inst{{[0-9A-F]+}}.loc7_12)
+// CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %a.var, constants.%Destroy.Op.651ba6.2
+// CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%a.var)
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/var/param.carbon
+++ b/toolchain/lower/testdata/var/param.carbon
@@ -1,0 +1,91 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/var/param.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/var/param.carbon
+
+// --- with_cleanup.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+inline Cpp '''c++
+struct X { ~X(); };
+''';
+
+fn F(var x: Cpp.X);
+
+fn G() {
+  F(Cpp.X.X());
+}
+
+// CHECK:STDOUT: ; ModuleID = 'with_cleanup.carbon'
+// CHECK:STDOUT: source_filename = "with_cleanup.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CF.Main(ptr)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CG.Main() #0 !dbg !11 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !14
+// CHECK:STDOUT:   call void @_ZN1XC1Ev.carbon_thunk(ptr %x.var), !dbg !15
+// CHECK:STDOUT:   call void @_CF.Main(ptr %x.var), !dbg !16
+// CHECK:STDOUT:   call void @_ZN1XD1Ev(ptr %x.var), !dbg !14
+// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN1XC1Ev.carbon_thunk(ptr noundef %return) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8, !tbaa !18
+// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8, !tbaa !18
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: declare void @_ZN1XD1Ev(ptr noundef nonnull align 1 dereferenceable(1)) unnamed_addr #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #2 = { nounwind "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "with_cleanup.carbon", directory: "")
+// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
+// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main", scope: null, file: !6, line: 12, type: !12, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
+// CHECK:STDOUT: !13 = !{null}
+// CHECK:STDOUT: !14 = !DILocation(line: 10, column: 6, scope: !11)
+// CHECK:STDOUT: !15 = !DILocation(line: 13, column: 5, scope: !11)
+// CHECK:STDOUT: !16 = !DILocation(line: 13, column: 3, scope: !11)
+// CHECK:STDOUT: !17 = !DILocation(line: 12, column: 1, scope: !11)
+// CHECK:STDOUT: !18 = !{!19, !19, i64 0}
+// CHECK:STDOUT: !19 = !{!"p1 _ZTS1X", !20, i64 0}
+// CHECK:STDOUT: !20 = !{!"any pointer", !9, i64 0}

--- a/toolchain/lower/testdata/var/param.carbon
+++ b/toolchain/lower/testdata/var/param.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/destroy.carbon
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -14,78 +14,71 @@
 
 library "[[@TEST_NAME]]";
 
-import Cpp;
+class C {
+  // TODO: Change to Core.Destructor when possible.
+  impl as Core.Destroy {
+    fn Op[ref self: Self]();
+  }
 
-inline Cpp '''c++
-struct X { ~X(); };
-''';
+  fn Make() -> Self;
+}
 
-fn F(var x: Cpp.X);
+fn F(var c: C);
 
 fn G() {
-  F(Cpp.X.X());
+  F(C.Make());
 }
 
 // CHECK:STDOUT: ; ModuleID = 'with_cleanup.carbon'
 // CHECK:STDOUT: source_filename = "with_cleanup.carbon"
-// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @"_COp.C.Main:Destroy.Core"(ptr)
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CMake.C.Main(ptr sret({}))
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_CF.Main(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @_CG.Main() #0 !dbg !11 {
+// CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !14
-// CHECK:STDOUT:   call void @_ZN1XC1Ev.carbon_thunk(ptr %x.var), !dbg !15
-// CHECK:STDOUT:   call void @_CF.Main(ptr %x.var), !dbg !16
-// CHECK:STDOUT:   call void @_ZN1XD1Ev(ptr %x.var), !dbg !14
-// CHECK:STDOUT:   ret void, !dbg !17
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
-// CHECK:STDOUT: define internal void @_ZN1XC1Ev.carbon_thunk(ptr noundef %return) #1 {
-// CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
-// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8, !tbaa !18
-// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8, !tbaa !18
-// CHECK:STDOUT:   ret void
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !7
+// CHECK:STDOUT:   call void @_CMake.C.Main(ptr %c.var), !dbg !8
+// CHECK:STDOUT:   call void @_CF.Main(ptr %c.var), !dbg !9
+// CHECK:STDOUT:   call void @"_COp.71e25083d63c4d6c:core.Destroy.Core"(ptr %c.var), !dbg !7
+// CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: declare void @_ZN1XD1Ev(ptr noundef nonnull align 1 dereferenceable(1)) unnamed_addr #2
+// CHECK:STDOUT: define weak_odr void @"_COp.71e25083d63c4d6c:core.Destroy.Core"(ptr %self) #0 !dbg !11 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #3
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
-// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:STDOUT: attributes #2 = { nounwind "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
-// CHECK:STDOUT: attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT:
-// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
-// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
-// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
 // CHECK:STDOUT:
 // CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
-// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
-// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
-// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !6 = !DIFile(filename: "with_cleanup.carbon", directory: "")
-// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
-// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
-// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
-// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main", scope: null, file: !6, line: 12, type: !12, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "with_cleanup.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main", scope: null, file: !3, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{null}
+// CHECK:STDOUT: !7 = !DILocation(line: 13, column: 6, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 16, column: 5, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 15, column: 1, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Op", linkageName: "_COp.71e25083d63c4d6c:core.Destroy.Core", scope: null, file: !3, line: 13, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !15)
 // CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
-// CHECK:STDOUT: !13 = !{null}
-// CHECK:STDOUT: !14 = !DILocation(line: 10, column: 6, scope: !11)
-// CHECK:STDOUT: !15 = !DILocation(line: 13, column: 5, scope: !11)
-// CHECK:STDOUT: !16 = !DILocation(line: 13, column: 3, scope: !11)
-// CHECK:STDOUT: !17 = !DILocation(line: 12, column: 1, scope: !11)
-// CHECK:STDOUT: !18 = !{!19, !19, i64 0}
-// CHECK:STDOUT: !19 = !{!"p1 _ZTS1X", !20, i64 0}
-// CHECK:STDOUT: !20 = !{!"any pointer", !9, i64 0}
+// CHECK:STDOUT: !13 = !{null, !14}
+// CHECK:STDOUT: !14 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !15 = !{!16}
+// CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !11, type: !14)
+// CHECK:STDOUT: !17 = !DILocation(line: 13, column: 6, scope: !11)


### PR DESCRIPTION
Insert the cleanup if and when the pending block is inserted, not eagerly. And if the pending block is inserted by overwriting an existing instruction, create a cleanup for that instruction rather than for the instruction in the pending block that we are discarding.

Assisted-by: Gemini via Antigravity