### PR TITLE
Search all facets in the impl lookup query for witnesses

### DIFF
--- a/toolchain/base/kind_switch.h
+++ b/toolchain/base/kind_switch.h
@@ -210,6 +210,12 @@ CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
                               15, 16, 17, 18, 19, 20, 21, 22);
 CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
                               15, 16, 17, 18, 19, 20, 21, 22, 23);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18, 19, 20, 21, 22, 23, 24);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25);
+CARBON_INTERNAL_KIND_TYPE_MAP(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                              15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26);
 
 #undef CARBON_INTERNAL_KIND_IDENTIFIER
 #undef CARBON_INTERNAL_KIND_IDENTIFIERS

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -780,7 +780,7 @@ static auto IndexOfImplWitnessInIdentifiedFacetType(
     SemIR::SpecificInterface query_specific_interface) -> IndexInFacetValue {
   // The self in the identified facet type is a canonicalized facet value, so we
   // canonicalize the query for comparison.
-  auto canonical_self =
+  auto canonical_query_self_const_id =
       GetCanonicalFacetOrTypeValue(context, query_self_const_id);
 
   const auto& identified =
@@ -788,7 +788,7 @@ static auto IndexOfImplWitnessInIdentifiedFacetType(
   auto facet_type_req_impls = llvm::enumerate(identified.required_impls());
   auto it = llvm::find_if(facet_type_req_impls, [&](auto e) {
     auto [req_self, req_specific_interface] = e.value();
-    return req_self == canonical_self &&
+    return req_self == canonical_query_self_const_id &&
            req_specific_interface == query_specific_interface;
   });
   if (it == facet_type_req_impls.end()) {

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -342,11 +342,11 @@ static auto TryGetSpecificWitnessIdForImpl(
 struct FacetWitnessSource {
   // A facet, of type FacetType. If this is a FacetValue, we may be able to get
   // a concrete witness out of it.
-  SemIR::ConstantId facet;
+  SemIR::ConstantId facet_const_id;
   // The set of witnesses this facet provides at least symbolically. Encodes
   // the order of the witnesses for looking for a concrete witness in `facet`
   // if it's a FacetValue.
-  SemIR::IdentifiedFacetTypeId identified;
+  SemIR::IdentifiedFacetTypeId identified_facet_type_id;
 };
 
 // Collect witnesses from facets in the query. The facets' types in the query
@@ -372,11 +372,12 @@ static auto CollectFacetWitnessSources(
     }
     auto facet_const_id = context.constant_values().Get(facet);
     auto facet_type = context.types().GetAs<SemIR::FacetType>(type_id);
-    auto identified =
+    auto identified_id =
         TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
                                allow_partially_identified);
-    if (identified.has_value()) {
-      witnesses.push_back({.facet = facet_const_id, .identified = identified});
+    if (identified_id.has_value()) {
+      witnesses.push_back({.facet_const_id = facet_const_id,
+                           .identified_facet_type_id = identified_id});
     }
   };
 

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -339,23 +339,92 @@ static auto TryGetSpecificWitnessIdForImpl(
                                            impl.witness_id);
 }
 
-// Identify the facet type of the query self. It is allowed to be partially
-// identified.
-static auto IdentifyQuerySelfFacetType(Context& context, SemIR::LocId loc_id,
-                                       SemIR::ConstantId query_self_const_id)
-    -> SemIR::IdentifiedFacetTypeId {
+struct FacetWitnessSource {
+  // A facet, of type FacetType. If this is a FacetValue, we may be able to get
+  // a concrete witness out of it.
+  SemIR::ConstantId facet;
+  // The set of witnesses this facet provides at least symbolically. Encodes
+  // the order of the witnesses for looking for a concrete witness in `facet`
+  // if it's a FacetValue.
+  SemIR::IdentifiedFacetTypeId identified;
+};
+
+// Collect witnesses from facets in the query. The facets' types in the query
+// self are allowed to be partially identified to support the use of `Self`
+// inside a named constraint, which can appear anywhere in the query self, e.g.
+// as `Self` or as `C(Self)`.
+static auto CollectFacetWitnessSources(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::ConstantId query_self_const_id,
+    SemIR::ConstantId query_facet_type_const_id)
+    -> llvm::SmallVector<FacetWitnessSource> {
   auto query_self_inst_id =
       context.constant_values().GetInstId(query_self_const_id);
+  auto query_facet_type_inst_id =
+      context.constant_values().GetInstId(query_facet_type_const_id);
 
-  auto facet_type = context.types().TryGetAs<SemIR::FacetType>(
-      context.insts().Get(query_self_inst_id).type_id());
-  if (!facet_type) {
-    return SemIR::IdentifiedFacetTypeId::None;
+  llvm::SmallVector<FacetWitnessSource> witnesses;
+
+  auto push_facet = [&](SemIR::InstId facet, bool allow_partially_identified) {
+    auto type_id = context.insts().Get(facet).type_id();
+    if (type_id == SemIR::TypeType::TypeId) {
+      return;
+    }
+    auto facet_const_id = context.constant_values().Get(facet);
+    auto facet_type = context.types().GetAs<SemIR::FacetType>(type_id);
+    auto identified =
+        TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
+                               allow_partially_identified);
+    if (identified.has_value()) {
+      witnesses.push_back({.facet = facet_const_id, .identified = identified});
+    }
+  };
+
+  auto collect_facets = [&](SemIR::TypeIterator& iter,
+                            bool allow_partially_identified) {
+    for (auto done = false; !done;) {
+      auto next = iter.Next();
+      CARBON_KIND_SWITCH(next.any) {
+        using Step = SemIR::TypeIterator::Step;
+        case CARBON_KIND(Step::Done _): {
+          done = true;
+          break;
+        }
+        case CARBON_KIND(Step::FacetValue value): {
+          // We want to store FacetValues since they come with final witnesses,
+          // regardless of whether they internally hold a concrete type or a
+          // symbolic one (with non-final witnesses of its own).
+          push_facet(value.facet_value_inst_id, allow_partially_identified);
+          break;
+        }
+        case CARBON_KIND(Step::SymbolicType symbolic): {
+          // We want to store SymbolicTypes. They may occur inside or outside of
+          // a FacetValue. If inside a FacetValue, they may provide a non-final
+          // witness for more things than the FacetValue would, since the
+          // FacetValue represents a conversion which can lose part of the facet
+          // type.
+          push_facet(symbolic.facet, allow_partially_identified);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  };
+
+  {
+    SemIR::TypeIterator iter(&context.sem_ir());
+    iter.Add(query_self_inst_id);
+    collect_facets(iter, /*allow_partially_identified=*/true);
   }
 
-  return TryToIdentifyFacetType(context, loc_id, query_self_const_id,
-                                *facet_type,
-                                /*allow_partially_identified=*/true);
+  {
+    SemIR::TypeIterator iter(&context.sem_ir());
+    iter.Add(context.insts().GetAs<SemIR::FacetType>(query_facet_type_inst_id));
+    collect_facets(iter, /*allow_partially_identified=*/false);
+  }
+
+  return witnesses;
 }
 
 // Given a query `orig_inst_self` and `orig_interface`, try find a matching
@@ -695,39 +764,31 @@ class IndexInFacetValue {
 inline constexpr auto IndexInFacetValue::None = IndexInFacetValue(-1);
 inline constexpr auto IndexInFacetValue::Unstable = IndexInFacetValue(-2);
 
-// Looks in the facet type of the query self facet value and returns the index
-// of `query_specific_interface` in the defined interface order for that facet
-// type. The order comes from the `query_self_type_identified_id` which must be
-// the IdentifiedFacetType of the type of `query_self_const_id `.
-//
-// If the query self is not a facet value, the IdentifiedFacetType would be
-// None.
+// Looks in the identified facet type and returns the index of a witness that
+// `query_self_const_id` impls `query_specific_interface` in the defined
+// interface order for that facet type.
 //
 // The IdentifiedFacetType must not be partially identified in order to find an
 // index, as that implies the interface order is not yet stable. In that case,
 // no index will be found.
 //
-// If the `query_specific_interface` is not part of the facet type of the query
-// self, returns -1 to indicate it was not found.
-static auto IndexOfImplWitnessInSelfFacetValue(
-    Context& context, SemIR::ConstantId query_self_const_id,
-    SemIR::IdentifiedFacetTypeId query_self_type_identified_id,
+// If the `query_specific_interface` is not part of the facet type, returns -1
+// to indicate it was not found.
+static auto IndexOfImplWitnessInIdentifiedFacetType(
+    Context& context, SemIR::IdentifiedFacetTypeId identified_facet_type_id,
+    SemIR::ConstantId query_self_const_id,
     SemIR::SpecificInterface query_specific_interface) -> IndexInFacetValue {
-  if (!query_self_type_identified_id.has_value()) {
-    return IndexInFacetValue::None;
-  }
-
   // The self in the identified facet type is a canonicalized facet value, so we
   // canonicalize the query for comparison.
-  auto canonical_query_self_const_id =
+  auto canonical_self =
       GetCanonicalFacetOrTypeValue(context, query_self_const_id);
 
   const auto& identified =
-      context.identified_facet_types().Get(query_self_type_identified_id);
+      context.identified_facet_types().Get(identified_facet_type_id);
   auto facet_type_req_impls = llvm::enumerate(identified.required_impls());
   auto it = llvm::find_if(facet_type_req_impls, [&](auto e) {
     auto [req_self, req_specific_interface] = e.value();
-    return req_self == canonical_query_self_const_id &&
+    return req_self == canonical_self &&
            req_specific_interface == query_specific_interface;
   });
   if (it == facet_type_req_impls.end()) {
@@ -740,44 +801,47 @@ static auto IndexOfImplWitnessInSelfFacetValue(
   return IndexInFacetValue(static_cast<int32_t>((*it).index()));
 }
 
-static auto FindFinalWitnessFromSelfFacetValue(
-    Context& context, SemIR::ConstantId query_self_const_id,
-    SemIR::IdentifiedFacetTypeId query_self_type_identified_id,
+static auto FindFinalWitnessFromFacetValue(
+    Context& context, llvm::ArrayRef<FacetWitnessSource> witness_sources,
+    SemIR::ConstantId query_self_const_id,
     SemIR::SpecificInterface query_specific_interface) -> SemIR::InstId {
-  auto facet_value = context.constant_values().TryGetInstAs<SemIR::FacetValue>(
-      query_self_const_id);
-  if (!facet_value) {
-    return SemIR::InstId::None;
-  }
+  for (auto [facet, identified_id] : witness_sources) {
+    auto facet_value =
+        context.constant_values().TryGetInstAs<SemIR::FacetValue>(facet);
+    if (!facet_value) {
+      // This facet can not provide a final witness, keep looking.
+      continue;
+    }
 
-  auto index_in_facet_value = IndexOfImplWitnessInSelfFacetValue(
-      context, query_self_const_id, query_self_type_identified_id,
-      query_specific_interface);
-  auto stable_index = index_in_facet_value.GetStableIndex();
-  if (stable_index < 0) {
-    return SemIR::InstId::None;
-  }
+    auto index_in_facet_value = IndexOfImplWitnessInIdentifiedFacetType(
+        context, identified_id, query_self_const_id, query_specific_interface);
+    auto stable_index = index_in_facet_value.GetStableIndex();
+    if (stable_index < 0) {
+      // No witness in this facet, keep looking.
+      continue;
+    }
 
-  auto witness_id =
-      context.inst_blocks().Get(facet_value->witnesses_block_id)[stable_index];
-  if (context.insts().Is<SemIR::LookupImplWitness>(witness_id)) {
-    // Did not find a final witness.
-    return SemIR::InstId::None;
+    auto witness_id = context.inst_blocks().Get(
+        facet_value->witnesses_block_id)[stable_index];
+    if (!context.insts().Is<SemIR::LookupImplWitness>(witness_id)) {
+      // Found a final witness.
+      return witness_id;
+    }
   }
-
-  return witness_id;
+  return SemIR::InstId::None;
 }
 
 static auto FindNonFinalWitness(
     Context& context, SemIR::LocId loc_id,
+    llvm::ArrayRef<FacetWitnessSource> witness_sources,
     SemIR::ConstantId query_self_const_id,
-    SemIR::IdentifiedFacetTypeId query_self_type_identified_id,
     SemIR::SpecificInterface query_specific_interface) -> bool {
-  auto index = IndexOfImplWitnessInSelfFacetValue(context, query_self_const_id,
-                                                  query_self_type_identified_id,
-                                                  query_specific_interface);
-  if (index.WasFound()) {
-    return true;
+  for (auto [_, identified_id] : witness_sources) {
+    auto index = IndexOfImplWitnessInIdentifiedFacetType(
+        context, identified_id, query_self_const_id, query_specific_interface);
+    if (index.WasFound()) {
+      return true;
+    }
   }
 
   // TODO: Remove SpecificInterfaceId from LookupCustomWitness apis, switch to
@@ -869,6 +933,10 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
     return SemIR::InstBlockId::Empty;
   }
 
+  // Find all the facets in the query and their witnesses.
+  auto witness_sources = CollectFacetWitnessSources(
+      context, loc_id, query_self_const_id, query_facet_type_const_id);
+
   // Cycles are diagnosed even if they are found when diagnostics are otherwise
   // being suppressed (such as during deduce).
   if (FindAndDiagnoseImplLookupCycle(context, context.impl_lookup_stack(),
@@ -891,17 +959,12 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
   // order of the interfaces in `req_impls`.
   llvm::SmallVector<SemIR::InstId> result_witness_ids;
   for (const auto& req_impl : req_impls) {
-    // Identify the type of the requirement's self up front, if it's a facet, so
-    // we only have to do this once.
-    auto req_self_type_identified_id =
-        IdentifyQuerySelfFacetType(context, loc_id, req_impl.self_facet_value);
-
     // If the self facet contains a final witness for the required interface, we
     // use that and avoid any further work. This is strictly an optimization,
     // since that same final witness should be found by evaluating a
     // LookupImplWitness instruction for the required self+interface pair.
-    auto result_witness_id = FindFinalWitnessFromSelfFacetValue(
-        context, req_impl.self_facet_value, req_self_type_identified_id,
+    auto result_witness_id = FindFinalWitnessFromFacetValue(
+        context, witness_sources, req_impl.self_facet_value,
         req_impl.specific_interface);
     if (result_witness_id.has_value()) {
       // Found a final witness, use it.
@@ -933,8 +996,8 @@ auto LookupImplWitness(Context& context, SemIR::LocId loc_id,
     // Did not find a final witness. If we find a non-final witness, then we use
     // the `LookupImplWitness` as our witness so that monomorphization can
     // produce a final witness later.
-    if (!FindNonFinalWitness(context, loc_id, req_impl.self_facet_value,
-                             req_self_type_identified_id,
+    if (!FindNonFinalWitness(context, loc_id, witness_sources,
+                             req_impl.self_facet_value,
                              req_impl.specific_interface)) {
       // At least one queried interface in the facet type has no witness for the
       // given type, we can stop looking for more.

--- a/toolchain/check/testdata/deduce/binding_pattern.carbon
+++ b/toolchain/check/testdata/deduce/binding_pattern.carbon
@@ -34,7 +34,7 @@ fn F(unused U:! type, V:! type) {
   C(V).Create({});
 }
 
-// --- fail_todo_compatible_deduce.carbon
+// --- compatible_deduce.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -42,18 +42,8 @@ class C(T:! type) {
   fn Create(unused value: T) {}
 }
 
-// TODO: This `where` should be sufficient to say that `{} as V` works.
-fn F(unused U:! type, V:! type where {} impls Core.ImplicitAs(.Self)) {
-  // CHECK:STDERR: fail_todo_compatible_deduce.carbon:[[@LINE+10]]:15: error: cannot implicitly convert expression of type `{}` to `V` [ConversionFailure]
-  // CHECK:STDERR:   C(V).Create({});
-  // CHECK:STDERR:               ^~
-  // CHECK:STDERR: fail_todo_compatible_deduce.carbon:[[@LINE+7]]:15: note: type `{}` does not implement interface `Core.ImplicitAs(V)` [MissingImplInMemberAccessInContext]
-  // CHECK:STDERR:   C(V).Create({});
-  // CHECK:STDERR:               ^~
-  // CHECK:STDERR: fail_todo_compatible_deduce.carbon:[[@LINE-11]]:20: note: initializing function parameter [InCallToFunctionParam]
-  // CHECK:STDERR:   fn Create(unused value: T) {}
-  // CHECK:STDERR:                    ^~~~~~~~
-  // CHECK:STDERR:
+// This `where` is sufficient to say that `{} as V` works.
+fn F(unused U:! type, V:! Core.Destroy where {} impls Core.ImplicitAs(.Self)) {
   C(V).Create({});
 }
 
@@ -253,11 +243,11 @@ fn F(unused U:! type, V:! type where {} impls Core.ImplicitAs(.Self)) {
 // CHECK:STDOUT:   %require_complete => constants.%require_complete.441
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_todo_compatible_deduce.carbon
+// CHECK:STDOUT: --- compatible_deduce.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %.Self.c39: %type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
 // CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %C.type: type = generic_class_type @C [concrete]
@@ -271,6 +261,8 @@ fn F(unused U:! type, V:! type where {} impls Core.ImplicitAs(.Self)) {
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
 // CHECK:STDOUT:   %require_complete.944: <witness> = require_complete_type %T [symbolic]
 // CHECK:STDOUT:   %U: type = symbolic_binding U, 0 [symbolic]
+// CHECK:STDOUT:   %Destroy.type: type = facet_type <@Destroy> [concrete]
+// CHECK:STDOUT:   %.Self.fc9: %Destroy.type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %empty_struct: %empty_struct_type = struct_value () [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.cc7: type = generic_interface_type @ImplicitAs [concrete]
 // CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.cc7 = struct_value () [concrete]
@@ -280,34 +272,50 @@ fn F(unused U:! type, V:! type where {} impls Core.ImplicitAs(.Self)) {
 // CHECK:STDOUT:   %ImplicitAs.assoc_type.ff3: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%Dest) [symbolic]
 // CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.b3a: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Dest, %Self.738) [symbolic]
 // CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.1de: %ImplicitAs.WithSelf.Convert.type.b3a = struct_value () [symbolic]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self [symbolic_self]
-// CHECK:STDOUT:   %ImplicitAs.type.9fd: type = facet_type <@ImplicitAs, @ImplicitAs(%.Self.as_type)> [symbolic_self]
-// CHECK:STDOUT:   %type_where: type = facet_type <type where %empty_struct_type impls @ImplicitAs, @ImplicitAs(%.Self.as_type)> [symbolic_self]
-// CHECK:STDOUT:   %pattern_type.9a5: type = pattern_type %type_where [symbolic_self]
-// CHECK:STDOUT:   %V: %type_where = symbolic_binding V, 1 [symbolic]
+// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self.fc9 [symbolic_self]
+// CHECK:STDOUT:   %ImplicitAs.type.5aa: type = facet_type <@ImplicitAs, @ImplicitAs(%.Self.as_type)> [symbolic_self]
+// CHECK:STDOUT:   %Destroy_where.type: type = facet_type <@Destroy where %empty_struct_type impls @ImplicitAs, @ImplicitAs(%.Self.as_type)> [symbolic_self]
+// CHECK:STDOUT:   %pattern_type.cac: type = pattern_type %Destroy_where.type [symbolic_self]
+// CHECK:STDOUT:   %V: %Destroy_where.type = symbolic_binding V, 1 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %V.as_type: type = facet_access_type %V [symbolic]
-// CHECK:STDOUT:   %C.771: type = class_type @C, @C(%V.as_type) [symbolic]
-// CHECK:STDOUT:   %C.Create.type.546: type = fn_type @C.Create, @C(%V.as_type) [symbolic]
-// CHECK:STDOUT:   %C.Create.efb: %C.Create.type.546 = struct_value () [symbolic]
-// CHECK:STDOUT:   %require_complete.8ea: <witness> = require_complete_type %C.771 [symbolic]
-// CHECK:STDOUT:   %pattern_type.eff: type = pattern_type %V.as_type [symbolic]
-// CHECK:STDOUT:   %C.Create.specific_fn: <specific function> = specific_function %C.Create.efb, @C.Create(%V.as_type) [symbolic]
-// CHECK:STDOUT:   %require_complete.63f: <witness> = require_complete_type %V.as_type [symbolic]
-// CHECK:STDOUT:   %ImplicitAs.type.596: type = facet_type <@ImplicitAs, @ImplicitAs(%V.as_type)> [symbolic]
-// CHECK:STDOUT:   %ImplicitAs.assoc_type.e29: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.as_type) [symbolic]
-// CHECK:STDOUT:   %assoc0.f06: %ImplicitAs.assoc_type.e29 = assoc_entity element0, imports.%Core.import_ref.201 [symbolic]
-// CHECK:STDOUT:   %require_complete.26d: <witness> = require_complete_type %ImplicitAs.type.596 [symbolic]
+// CHECK:STDOUT:   %C.b59: type = class_type @C, @C(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %C.Create.type.0f5: type = fn_type @C.Create, @C(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %C.Create.797: %C.Create.type.0f5 = struct_value () [symbolic]
+// CHECK:STDOUT:   %require_complete.3e0: <witness> = require_complete_type %C.b59 [symbolic]
+// CHECK:STDOUT:   %pattern_type.711: type = pattern_type %V.as_type [symbolic]
+// CHECK:STDOUT:   %C.Create.specific_fn: <specific function> = specific_function %C.Create.797, @C.Create(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %require_complete.af1: <witness> = require_complete_type %V.as_type [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.type.676: type = facet_type <@ImplicitAs, @ImplicitAs(%V.as_type)> [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type.781: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %assoc0.f30: %ImplicitAs.assoc_type.781 = assoc_entity element0, imports.%Core.import_ref.201 [symbolic]
+// CHECK:STDOUT:   %require_complete.fd3: <witness> = require_complete_type %ImplicitAs.type.676 [symbolic]
 // CHECK:STDOUT:   %assoc0.843: %ImplicitAs.assoc_type.ff3 = assoc_entity element0, imports.%Core.import_ref.cc1 [symbolic]
+// CHECK:STDOUT:   %Destroy.lookup_impl_witness: <witness> = lookup_impl_witness %V, @Destroy [symbolic]
+// CHECK:STDOUT:   %Destroy.facet: %Destroy.type = facet_value %V.as_type, (%Destroy.lookup_impl_witness) [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.lookup_impl_witness: <witness> = lookup_impl_witness %empty_struct_type, @ImplicitAs, @ImplicitAs(%V.as_type) [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.676 = facet_value %empty_struct_type, (%ImplicitAs.lookup_impl_witness) [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.40e: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%V.as_type, %ImplicitAs.facet) [symbolic]
+// CHECK:STDOUT:   %.dd5: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.40e, %ImplicitAs.facet [symbolic]
+// CHECK:STDOUT:   %impl.elem0.c5d: %.dd5 = impl_witness_access %ImplicitAs.lookup_impl_witness, element0 [symbolic]
+// CHECK:STDOUT:   %bound_method.83e: <bound method> = bound_method %empty_struct, %impl.elem0.c5d [symbolic]
+// CHECK:STDOUT:   %specific_impl_fn.1b8: <specific function> = specific_impl_function %impl.elem0.c5d, @ImplicitAs.WithSelf.Convert(%V.as_type, %ImplicitAs.facet) [symbolic]
+// CHECK:STDOUT:   %bound_method.cdf: <bound method> = bound_method %empty_struct, %specific_impl_fn.1b8 [symbolic]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.ebb: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Destroy.facet) [symbolic]
+// CHECK:STDOUT:   %.563: type = fn_type_with_self_type %Destroy.WithSelf.Op.type.ebb, %Destroy.facet [symbolic]
+// CHECK:STDOUT:   %impl.elem0.b4d: %.563 = impl_witness_access %Destroy.lookup_impl_witness, element0 [symbolic]
+// CHECK:STDOUT:   %specific_impl_fn.163: <specific function> = specific_impl_function %impl.elem0.b4d, @Destroy.WithSelf.Op(%Destroy.facet) [symbolic]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
 // CHECK:STDOUT:   %Core: <namespace> = namespace file.%Core.import, [concrete] {
+// CHECK:STDOUT:     .Destroy = %Core.Destroy
 // CHECK:STDOUT:     .ImplicitAs = %Core.ImplicitAs
 // CHECK:STDOUT:     import Core//prelude
 // CHECK:STDOUT:     import Core//prelude/...
 // CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Core.Destroy: type = import_ref Core//prelude/parts/destroy, Destroy, loaded [concrete = constants.%Destroy.type]
 // CHECK:STDOUT:   %Core.ImplicitAs: %ImplicitAs.type.cc7 = import_ref Core//prelude/parts/as, ImplicitAs, loaded [concrete = constants.%ImplicitAs.generic]
 // CHECK:STDOUT:   %Core.import_ref.178: @ImplicitAs.WithSelf.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.ff3) = import_ref Core//prelude/parts/as, loc{{\d+_\d+}}, loaded [symbolic = @ImplicitAs.WithSelf.%assoc0 (constants.%assoc0.843)]
 // CHECK:STDOUT:   %Core.import_ref.201: @ImplicitAs.WithSelf.%ImplicitAs.WithSelf.Convert.type (%ImplicitAs.WithSelf.Convert.type.b3a) = import_ref Core//prelude/parts/as, loc{{\d+_\d+}}, loaded [symbolic = @ImplicitAs.WithSelf.%ImplicitAs.WithSelf.Convert (constants.%ImplicitAs.WithSelf.Convert.1de)]
@@ -325,38 +333,39 @@ fn F(unused U:! type, V:! type where {} impls Core.ImplicitAs(.Self)) {
 // CHECK:STDOUT:     %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %.loc4_13.1: type = splice_block %.loc4_13.2 [concrete = type] {
-// CHECK:STDOUT:       %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:       %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
 // CHECK:STDOUT:       %.loc4_13.2: type = type_literal type [concrete = type]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %T.loc4_10.2: type = symbolic_binding T, 0 [symbolic = %T.loc4_10.1 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %U.patt: %pattern_type.98f = symbolic_binding_pattern U, 0 [concrete]
-// CHECK:STDOUT:     %V.patt: %pattern_type.9a5 = symbolic_binding_pattern V, 1 [concrete]
+// CHECK:STDOUT:     %V.patt: %pattern_type.cac = symbolic_binding_pattern V, 1 [concrete]
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %.loc9_17.1: type = splice_block %.loc9_17.2 [concrete = type] {
-// CHECK:STDOUT:       %.Self.loc9_14: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:       %.Self.loc9_14: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
 // CHECK:STDOUT:       %.loc9_17.2: type = type_literal type [concrete = type]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %U.loc9_14.2: type = symbolic_binding U, 0 [symbolic = %U.loc9_14.1 (constants.%U)]
-// CHECK:STDOUT:     %.loc9_32.1: type = splice_block %.loc9_32.2 [symbolic_self = constants.%type_where] {
-// CHECK:STDOUT:       %.Self.loc9_24: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:       %.loc9_27: type = type_literal type [concrete = type]
-// CHECK:STDOUT:       %.Self.loc9_32: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
-// CHECK:STDOUT:       %.loc9_39.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:       %Core.ref: <namespace> = name_ref Core, imports.%Core [concrete = imports.%Core]
+// CHECK:STDOUT:     %.loc9_40.1: type = splice_block %.loc9_40.2 [symbolic_self = constants.%Destroy_where.type] {
+// CHECK:STDOUT:       %.Self.loc9_24: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
+// CHECK:STDOUT:       %Core.ref.loc9_27: <namespace> = name_ref Core, imports.%Core [concrete = imports.%Core]
+// CHECK:STDOUT:       %Destroy.ref: type = name_ref Destroy, imports.%Core.Destroy [concrete = constants.%Destroy.type]
+// CHECK:STDOUT:       %.Self.loc9_40: %Destroy.type = symbolic_binding .Self [symbolic_self = constants.%.Self.fc9]
+// CHECK:STDOUT:       %.loc9_47.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:       %Core.ref.loc9_55: <namespace> = name_ref Core, imports.%Core [concrete = imports.%Core]
 // CHECK:STDOUT:       %ImplicitAs.ref: %ImplicitAs.type.cc7 = name_ref ImplicitAs, imports.%Core.ImplicitAs [concrete = constants.%ImplicitAs.generic]
-// CHECK:STDOUT:       %.Self.ref: %type = name_ref .Self, %.Self.loc9_32 [symbolic_self = constants.%.Self]
+// CHECK:STDOUT:       %.Self.ref: %Destroy.type = name_ref .Self, %.Self.loc9_40 [symbolic_self = constants.%.Self.fc9]
 // CHECK:STDOUT:       %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc9_68: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %ImplicitAs.type.loc9: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%.Self.as_type)> [symbolic_self = constants.%ImplicitAs.type.9fd]
-// CHECK:STDOUT:       %.loc9_39.2: type = converted %.loc9_39.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:       %.loc9_32.2: type = where_expr [symbolic_self = constants.%type_where] {
-// CHECK:STDOUT:         requirement_base_facet_type %.loc9_27
-// CHECK:STDOUT:         requirement_impls %.loc9_39.2, %ImplicitAs.type.loc9
+// CHECK:STDOUT:       %.loc9_76: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
+// CHECK:STDOUT:       %ImplicitAs.type.loc9: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%.Self.as_type)> [symbolic_self = constants.%ImplicitAs.type.5aa]
+// CHECK:STDOUT:       %.loc9_47.2: type = converted %.loc9_47.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
+// CHECK:STDOUT:       %.loc9_40.2: type = where_expr [symbolic_self = constants.%Destroy_where.type] {
+// CHECK:STDOUT:         requirement_base_facet_type %Destroy.ref
+// CHECK:STDOUT:         requirement_impls %.loc9_47.2, %ImplicitAs.type.loc9
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %V.loc9_24.2: %type_where = symbolic_binding V, 1 [symbolic = %V.loc9_24.1 (constants.%V)]
+// CHECK:STDOUT:     %V.loc9_24.2: %Destroy_where.type = symbolic_binding V, 1 [symbolic = %V.loc9_24.1 (constants.%V)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -399,39 +408,68 @@ fn F(unused U:! type, V:! type where {} impls Core.ImplicitAs(.Self)) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%U.loc9_14.2: type, %V.loc9_24.2: %type_where) {
+// CHECK:STDOUT: generic fn @F(%U.loc9_14.2: type, %V.loc9_24.2: %Destroy_where.type) {
 // CHECK:STDOUT:   %U.loc9_14.1: type = symbolic_binding U, 0 [symbolic = %U.loc9_14.1 (constants.%U)]
-// CHECK:STDOUT:   %V.loc9_24.1: %type_where = symbolic_binding V, 1 [symbolic = %V.loc9_24.1 (constants.%V)]
+// CHECK:STDOUT:   %V.loc9_24.1: %Destroy_where.type = symbolic_binding V, 1 [symbolic = %V.loc9_24.1 (constants.%V)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %V.as_type.loc20_6.2: type = facet_access_type %V.loc9_24.1 [symbolic = %V.as_type.loc20_6.2 (constants.%V.as_type)]
-// CHECK:STDOUT:   %C.loc20_6.2: type = class_type @C, @C(%V.as_type.loc20_6.2) [symbolic = %C.loc20_6.2 (constants.%C.771)]
-// CHECK:STDOUT:   %require_complete.loc20_7: <witness> = require_complete_type %C.loc20_6.2 [symbolic = %require_complete.loc20_7 (constants.%require_complete.8ea)]
-// CHECK:STDOUT:   %C.Create.type: type = fn_type @C.Create, @C(%V.as_type.loc20_6.2) [symbolic = %C.Create.type (constants.%C.Create.type.546)]
-// CHECK:STDOUT:   %C.Create: @F.%C.Create.type (%C.Create.type.546) = struct_value () [symbolic = %C.Create (constants.%C.Create.efb)]
-// CHECK:STDOUT:   %C.Create.specific_fn.loc20_7.2: <specific function> = specific_function %C.Create, @C.Create(%V.as_type.loc20_6.2) [symbolic = %C.Create.specific_fn.loc20_7.2 (constants.%C.Create.specific_fn)]
-// CHECK:STDOUT:   %require_complete.loc20_16.1: <witness> = require_complete_type %V.as_type.loc20_6.2 [symbolic = %require_complete.loc20_16.1 (constants.%require_complete.63f)]
-// CHECK:STDOUT:   %ImplicitAs.type.loc20_16.2: type = facet_type <@ImplicitAs, @ImplicitAs(%V.as_type.loc20_6.2)> [symbolic = %ImplicitAs.type.loc20_16.2 (constants.%ImplicitAs.type.596)]
-// CHECK:STDOUT:   %require_complete.loc20_16.2: <witness> = require_complete_type %ImplicitAs.type.loc20_16.2 [symbolic = %require_complete.loc20_16.2 (constants.%require_complete.26d)]
-// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.as_type.loc20_6.2) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.e29)]
-// CHECK:STDOUT:   %assoc0: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.e29) = assoc_entity element0, imports.%Core.import_ref.201 [symbolic = %assoc0 (constants.%assoc0.f06)]
+// CHECK:STDOUT:   %V.as_type.loc10_6.2: type = facet_access_type %V.loc9_24.1 [symbolic = %V.as_type.loc10_6.2 (constants.%V.as_type)]
+// CHECK:STDOUT:   %C.loc10_6.2: type = class_type @C, @C(%V.as_type.loc10_6.2) [symbolic = %C.loc10_6.2 (constants.%C.b59)]
+// CHECK:STDOUT:   %require_complete.loc10_7: <witness> = require_complete_type %C.loc10_6.2 [symbolic = %require_complete.loc10_7 (constants.%require_complete.3e0)]
+// CHECK:STDOUT:   %C.Create.type: type = fn_type @C.Create, @C(%V.as_type.loc10_6.2) [symbolic = %C.Create.type (constants.%C.Create.type.0f5)]
+// CHECK:STDOUT:   %C.Create: @F.%C.Create.type (%C.Create.type.0f5) = struct_value () [symbolic = %C.Create (constants.%C.Create.797)]
+// CHECK:STDOUT:   %C.Create.specific_fn.loc10_7.2: <specific function> = specific_function %C.Create, @C.Create(%V.as_type.loc10_6.2) [symbolic = %C.Create.specific_fn.loc10_7.2 (constants.%C.Create.specific_fn)]
+// CHECK:STDOUT:   %require_complete.loc10_16.1: <witness> = require_complete_type %V.as_type.loc10_6.2 [symbolic = %require_complete.loc10_16.1 (constants.%require_complete.af1)]
+// CHECK:STDOUT:   %ImplicitAs.type.loc10_16.2: type = facet_type <@ImplicitAs, @ImplicitAs(%V.as_type.loc10_6.2)> [symbolic = %ImplicitAs.type.loc10_16.2 (constants.%ImplicitAs.type.676)]
+// CHECK:STDOUT:   %require_complete.loc10_16.2: <witness> = require_complete_type %ImplicitAs.type.loc10_16.2 [symbolic = %require_complete.loc10_16.2 (constants.%require_complete.fd3)]
+// CHECK:STDOUT:   %ImplicitAs.assoc_type: type = assoc_entity_type @ImplicitAs, @ImplicitAs(%V.as_type.loc10_6.2) [symbolic = %ImplicitAs.assoc_type (constants.%ImplicitAs.assoc_type.781)]
+// CHECK:STDOUT:   %assoc0: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.781) = assoc_entity element0, imports.%Core.import_ref.201 [symbolic = %assoc0 (constants.%assoc0.f30)]
+// CHECK:STDOUT:   %ImplicitAs.lookup_impl_witness: <witness> = lookup_impl_witness constants.%empty_struct_type, @ImplicitAs, @ImplicitAs(%V.as_type.loc10_6.2) [symbolic = %ImplicitAs.lookup_impl_witness (constants.%ImplicitAs.lookup_impl_witness)]
+// CHECK:STDOUT:   %ImplicitAs.facet: @F.%ImplicitAs.type.loc10_16.2 (%ImplicitAs.type.676) = facet_value constants.%empty_struct_type, (%ImplicitAs.lookup_impl_witness) [symbolic = %ImplicitAs.facet (constants.%ImplicitAs.facet)]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%V.as_type.loc10_6.2, %ImplicitAs.facet) [symbolic = %ImplicitAs.WithSelf.Convert.type (constants.%ImplicitAs.WithSelf.Convert.type.40e)]
+// CHECK:STDOUT:   %.loc10_16.8: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type, %ImplicitAs.facet [symbolic = %.loc10_16.8 (constants.%.dd5)]
+// CHECK:STDOUT:   %impl.elem0.loc10_16.3: @F.%.loc10_16.8 (%.dd5) = impl_witness_access %ImplicitAs.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc10_16.3 (constants.%impl.elem0.c5d)]
+// CHECK:STDOUT:   %bound_method.loc10_16.5: <bound method> = bound_method constants.%empty_struct, %impl.elem0.loc10_16.3 [symbolic = %bound_method.loc10_16.5 (constants.%bound_method.83e)]
+// CHECK:STDOUT:   %specific_impl_fn.loc10_16.3: <specific function> = specific_impl_function %impl.elem0.loc10_16.3, @ImplicitAs.WithSelf.Convert(%V.as_type.loc10_6.2, %ImplicitAs.facet) [symbolic = %specific_impl_fn.loc10_16.3 (constants.%specific_impl_fn.1b8)]
+// CHECK:STDOUT:   %bound_method.loc10_16.6: <bound method> = bound_method constants.%empty_struct, %specific_impl_fn.loc10_16.3 [symbolic = %bound_method.loc10_16.6 (constants.%bound_method.cdf)]
+// CHECK:STDOUT:   %Destroy.lookup_impl_witness: <witness> = lookup_impl_witness %V.loc9_24.1, @Destroy [symbolic = %Destroy.lookup_impl_witness (constants.%Destroy.lookup_impl_witness)]
+// CHECK:STDOUT:   %Destroy.facet: %Destroy.type = facet_value %V.as_type.loc10_6.2, (%Destroy.lookup_impl_witness) [symbolic = %Destroy.facet (constants.%Destroy.facet)]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Destroy.facet) [symbolic = %Destroy.WithSelf.Op.type (constants.%Destroy.WithSelf.Op.type.ebb)]
+// CHECK:STDOUT:   %.loc10_16.9: type = fn_type_with_self_type %Destroy.WithSelf.Op.type, %Destroy.facet [symbolic = %.loc10_16.9 (constants.%.563)]
+// CHECK:STDOUT:   %impl.elem0.loc10_16.4: @F.%.loc10_16.9 (%.563) = impl_witness_access %Destroy.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc10_16.4 (constants.%impl.elem0.b4d)]
+// CHECK:STDOUT:   %specific_impl_fn.loc10_16.4: <specific function> = specific_impl_function %impl.elem0.loc10_16.4, @Destroy.WithSelf.Op(%Destroy.facet) [symbolic = %specific_impl_fn.loc10_16.4 (constants.%specific_impl_fn.163)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn() {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     %C.ref: %C.type = name_ref C, file.%C.decl [concrete = constants.%C.generic]
-// CHECK:STDOUT:     %V.ref: %type_where = name_ref V, %V.loc9_24.2 [symbolic = %V.loc9_24.1 (constants.%V)]
-// CHECK:STDOUT:     %V.as_type.loc20_6.1: type = facet_access_type %V.ref [symbolic = %V.as_type.loc20_6.2 (constants.%V.as_type)]
-// CHECK:STDOUT:     %.loc20_6: type = converted %V.ref, %V.as_type.loc20_6.1 [symbolic = %V.as_type.loc20_6.2 (constants.%V.as_type)]
-// CHECK:STDOUT:     %C.loc20_6.1: type = class_type @C, @C(constants.%V.as_type) [symbolic = %C.loc20_6.2 (constants.%C.771)]
-// CHECK:STDOUT:     %.loc20_7: @F.%C.Create.type (%C.Create.type.546) = specific_constant @C.%C.Create.decl, @C(constants.%V.as_type) [symbolic = %C.Create (constants.%C.Create.efb)]
-// CHECK:STDOUT:     %Create.ref: @F.%C.Create.type (%C.Create.type.546) = name_ref Create, %.loc20_7 [symbolic = %C.Create (constants.%C.Create.efb)]
-// CHECK:STDOUT:     %.loc20_16.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:     %C.Create.specific_fn.loc20_7.1: <specific function> = specific_function %Create.ref, @C.Create(constants.%V.as_type) [symbolic = %C.Create.specific_fn.loc20_7.2 (constants.%C.Create.specific_fn)]
-// CHECK:STDOUT:     %ImplicitAs.type.loc20_16.1: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%V.as_type)> [symbolic = %ImplicitAs.type.loc20_16.2 (constants.%ImplicitAs.type.596)]
-// CHECK:STDOUT:     %.loc20_16.2: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.e29) = specific_constant imports.%Core.import_ref.178, @ImplicitAs.WithSelf(constants.%V.as_type, constants.%Self.738) [symbolic = %assoc0 (constants.%assoc0.f06)]
-// CHECK:STDOUT:     %Convert.ref: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.e29) = name_ref Convert, %.loc20_16.2 [symbolic = %assoc0 (constants.%assoc0.f06)]
-// CHECK:STDOUT:     %.loc20_16.3: @F.%V.as_type.loc20_6.2 (%V.as_type) = converted %.loc20_16.1, <error> [concrete = <error>]
-// CHECK:STDOUT:     %C.Create.call: init %empty_tuple.type = call %C.Create.specific_fn.loc20_7.1(<error>)
+// CHECK:STDOUT:     %V.ref: %Destroy_where.type = name_ref V, %V.loc9_24.2 [symbolic = %V.loc9_24.1 (constants.%V)]
+// CHECK:STDOUT:     %V.as_type.loc10_6.1: type = facet_access_type %V.ref [symbolic = %V.as_type.loc10_6.2 (constants.%V.as_type)]
+// CHECK:STDOUT:     %.loc10_6: type = converted %V.ref, %V.as_type.loc10_6.1 [symbolic = %V.as_type.loc10_6.2 (constants.%V.as_type)]
+// CHECK:STDOUT:     %C.loc10_6.1: type = class_type @C, @C(constants.%V.as_type) [symbolic = %C.loc10_6.2 (constants.%C.b59)]
+// CHECK:STDOUT:     %.loc10_7: @F.%C.Create.type (%C.Create.type.0f5) = specific_constant @C.%C.Create.decl, @C(constants.%V.as_type) [symbolic = %C.Create (constants.%C.Create.797)]
+// CHECK:STDOUT:     %Create.ref: @F.%C.Create.type (%C.Create.type.0f5) = name_ref Create, %.loc10_7 [symbolic = %C.Create (constants.%C.Create.797)]
+// CHECK:STDOUT:     %.loc10_16.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %C.Create.specific_fn.loc10_7.1: <specific function> = specific_function %Create.ref, @C.Create(constants.%V.as_type) [symbolic = %C.Create.specific_fn.loc10_7.2 (constants.%C.Create.specific_fn)]
+// CHECK:STDOUT:     %ImplicitAs.type.loc10_16.1: type = facet_type <@ImplicitAs, @ImplicitAs(constants.%V.as_type)> [symbolic = %ImplicitAs.type.loc10_16.2 (constants.%ImplicitAs.type.676)]
+// CHECK:STDOUT:     %.loc10_16.2: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.781) = specific_constant imports.%Core.import_ref.178, @ImplicitAs.WithSelf(constants.%V.as_type, constants.%Self.738) [symbolic = %assoc0 (constants.%assoc0.f30)]
+// CHECK:STDOUT:     %Convert.ref: @F.%ImplicitAs.assoc_type (%ImplicitAs.assoc_type.781) = name_ref Convert, %.loc10_16.2 [symbolic = %assoc0 (constants.%assoc0.f30)]
+// CHECK:STDOUT:     %impl.elem0.loc10_16.1: @F.%.loc10_16.8 (%.dd5) = impl_witness_access constants.%ImplicitAs.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc10_16.3 (constants.%impl.elem0.c5d)]
+// CHECK:STDOUT:     %bound_method.loc10_16.1: <bound method> = bound_method %.loc10_16.1, %impl.elem0.loc10_16.1 [symbolic = %bound_method.loc10_16.5 (constants.%bound_method.83e)]
+// CHECK:STDOUT:     %specific_impl_fn.loc10_16.1: <specific function> = specific_impl_function %impl.elem0.loc10_16.1, @ImplicitAs.WithSelf.Convert(constants.%V.as_type, constants.%ImplicitAs.facet) [symbolic = %specific_impl_fn.loc10_16.3 (constants.%specific_impl_fn.1b8)]
+// CHECK:STDOUT:     %bound_method.loc10_16.2: <bound method> = bound_method %.loc10_16.1, %specific_impl_fn.loc10_16.1 [symbolic = %bound_method.loc10_16.6 (constants.%bound_method.cdf)]
+// CHECK:STDOUT:     %.loc10_16.3: ref @F.%V.as_type.loc10_6.2 (%V.as_type) = temporary_storage
+// CHECK:STDOUT:     %empty_struct: %empty_struct_type = struct_value () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %.loc10_16.4: %empty_struct_type = converted %.loc10_16.1, %empty_struct [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %ImplicitAs.WithSelf.Convert.call: init @F.%V.as_type.loc10_6.2 (%V.as_type) to %.loc10_16.3 = call %bound_method.loc10_16.2(%.loc10_16.4)
+// CHECK:STDOUT:     %.loc10_16.5: init @F.%V.as_type.loc10_6.2 (%V.as_type) = converted %.loc10_16.1, %ImplicitAs.WithSelf.Convert.call
+// CHECK:STDOUT:     %.loc10_16.6: ref @F.%V.as_type.loc10_6.2 (%V.as_type) = temporary %.loc10_16.3, %.loc10_16.5
+// CHECK:STDOUT:     %.loc10_16.7: @F.%V.as_type.loc10_6.2 (%V.as_type) = acquire_value %.loc10_16.6
+// CHECK:STDOUT:     %C.Create.call: init %empty_tuple.type = call %C.Create.specific_fn.loc10_7.1(%.loc10_16.7)
+// CHECK:STDOUT:     %impl.elem0.loc10_16.2: @F.%.loc10_16.9 (%.563) = impl_witness_access constants.%Destroy.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc10_16.4 (constants.%impl.elem0.b4d)]
+// CHECK:STDOUT:     %bound_method.loc10_16.3: <bound method> = bound_method %.loc10_16.6, %impl.elem0.loc10_16.2
+// CHECK:STDOUT:     %specific_impl_fn.loc10_16.2: <specific function> = specific_impl_function %impl.elem0.loc10_16.2, @Destroy.WithSelf.Op(constants.%Destroy.facet) [symbolic = %specific_impl_fn.loc10_16.4 (constants.%specific_impl_fn.163)]
+// CHECK:STDOUT:     %bound_method.loc10_16.4: <bound method> = bound_method %.loc10_16.6, %specific_impl_fn.loc10_16.2
+// CHECK:STDOUT:     %Destroy.WithSelf.Op.call: init %empty_tuple.type = call %bound_method.loc10_16.4(%.loc10_16.6)
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
@@ -458,15 +496,15 @@ fn F(unused U:! type, V:! type where {} impls Core.ImplicitAs(.Self)) {
 // CHECK:STDOUT:   %T.loc4_10.1 => constants.%V.as_type
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %C.Create.type => constants.%C.Create.type.546
-// CHECK:STDOUT:   %C.Create => constants.%C.Create.efb
+// CHECK:STDOUT:   %C.Create.type => constants.%C.Create.type.0f5
+// CHECK:STDOUT:   %C.Create => constants.%C.Create.797
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @C.Create(constants.%V.as_type) {
 // CHECK:STDOUT:   %T => constants.%V.as_type
-// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.eff
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.711
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete => constants.%require_complete.63f
+// CHECK:STDOUT:   %require_complete => constants.%require_complete.af1
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/partially_identified.carbon
+++ b/toolchain/check/testdata/facet/partially_identified.carbon
@@ -91,7 +91,7 @@ fn F() {
   G(C);
 }
 
-// --- fail_todo_facet_access_type_of_self_meets_constraint.carbon
+// --- facet_access_type_of_self_meets_constraint.carbon
 library "[[@TEST_NAME]]";
 
 class C(T:! type) {}
@@ -105,9 +105,6 @@ constraint W {
 }
 
 fn F(w:! W) {
-  // TODO: Lookups for `C(w) as <something>` need to look into the facet types
-  // of any facet value in the type `C(w)`, so that it can find a witness from
-  // the constraint `W`.
   C(w) as Y;
   D as NeedsY(C(w));
 }

--- a/toolchain/check/testdata/facet/partially_identified.carbon
+++ b/toolchain/check/testdata/facet/partially_identified.carbon
@@ -95,38 +95,21 @@ fn F() {
 library "[[@TEST_NAME]]";
 
 class C(T:! type) {}
+class D {}
 
 interface Y {}
 interface NeedsY(T:! Y) {}
 constraint W {
   require C(Self) impls Y;
-  // CHECK:STDERR: fail_todo_facet_access_type_of_self_meets_constraint.carbon:[[@LINE+7]]:17: error: cannot convert type `C(Self)` into type implementing `Y` [ConversionFailureTypeToFacet]
-  // CHECK:STDERR:   require impls NeedsY(C(Self));
-  // CHECK:STDERR:                 ^~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_facet_access_type_of_self_meets_constraint.carbon:[[@LINE-6]]:18: note: initializing generic parameter `T` declared here [InitializingGenericParam]
-  // CHECK:STDERR: interface NeedsY(T:! Y) {}
-  // CHECK:STDERR:                  ^~~~~
-  // CHECK:STDERR:
-  require impls NeedsY(C(Self));
+  require D impls NeedsY(C(Self));
 }
 
 fn F(w:! W) {
   // TODO: Lookups for `C(w) as <something>` need to look into the facet types
   // of any facet value in the type `C(w)`, so that it can find a witness from
   // the constraint `W`.
-  // CHECK:STDERR: fail_todo_facet_access_type_of_self_meets_constraint.carbon:[[@LINE+4]]:3: error: cannot convert type `C(w)` into type implementing `Y` [ConversionFailureTypeToFacet]
-  // CHECK:STDERR:   C(w) as Y;
-  // CHECK:STDERR:   ^~~~~~~~~
-  // CHECK:STDERR:
   C(w) as Y;
-  // CHECK:STDERR: fail_todo_facet_access_type_of_self_meets_constraint.carbon:[[@LINE+7]]:11: error: cannot convert type `C(w)` into type implementing `Y` [ConversionFailureTypeToFacet]
-  // CHECK:STDERR:   C(w) as NeedsY(C(w));
-  // CHECK:STDERR:           ^~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_facet_access_type_of_self_meets_constraint.carbon:[[@LINE-25]]:18: note: initializing generic parameter `T` declared here [InitializingGenericParam]
-  // CHECK:STDERR: interface NeedsY(T:! Y) {}
-  // CHECK:STDERR:                  ^~~~~
-  // CHECK:STDERR:
-  C(w) as NeedsY(C(w));
+  D as NeedsY(C(w));
 }
 
 // --- multiple_use_of_self.carbon

--- a/toolchain/check/testdata/facet/validate_impl_constraints.carbon
+++ b/toolchain/check/testdata/facet/validate_impl_constraints.carbon
@@ -363,7 +363,7 @@ fn G() {
   F(C);
 }
 
-// --- fail_todo_convert_to_period_self_preserves_self_facet_impls.carbon
+// --- convert_to_period_self_preserves_self_facet_impls.carbon
 library "[[@TEST_NAME]]";
 
 interface K {}
@@ -380,18 +380,5 @@ fn G(T:! I where .I1 impls K) {
   // Replaces `.Self` with `T`, which converts `T` to `I & J`. Doing so has to
   // invent a witness for `J`, and this tests we do so without losing the
   // information that `.I1 impls K`.
-  //
-  // TODO: When converting T to the type of U, the identified facet type
-  // includes `.Self.I1 impls K`, which is replaced with `T.I1 impls K`. The
-  // identified facet type of `T` also contains `T.I1 impls K` so we should find
-  // a witness for that.
-  //
-  // CHECK:STDERR: fail_todo_convert_to_period_self_preserves_self_facet_impls.carbon:[[@LINE+7]]:3: error: cannot convert type `T` that implements `I where .(I.I1) impls K` into type implementing `J & I where .(I.I1) impls K` [ConversionFailureFacetToFacet]
-  // CHECK:STDERR:   F(T);
-  // CHECK:STDERR:   ^~~~
-  // CHECK:STDERR: fail_todo_convert_to_period_self_preserves_self_facet_impls.carbon:[[@LINE-17]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
-  // CHECK:STDERR: fn F(unused U:! I & J where .I1 impls K) {}
-  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   F(T);
 }

--- a/toolchain/check/testdata/facet/validate_impl_constraints.carbon
+++ b/toolchain/check/testdata/facet/validate_impl_constraints.carbon
@@ -382,3 +382,39 @@ fn G(T:! I where .I1 impls K) {
   // information that `.I1 impls K`.
   F(T);
 }
+
+// --- find_witness_from_facet_in_lookup_target_facet_type.carbon
+library "[[@TEST_NAME]]";
+
+class D(T:! type) {}
+class E {}
+interface X(T:! type) {}
+interface V(T:! type) {}
+
+constraint W(T:! type) {
+  require Self impls X(T);
+}
+
+fn F(B:! W(E), C:! type where E impls V(.Self)) {
+  // These find a witness for `E as X(E)` from the facet `B`.
+  E as (V(C) where B impls X(.Self));
+  E as (V(C) where B impls X(E));
+}
+
+// --- find_witness_from_facet_in_specific_in_lookup_target_facet_type.carbon
+library "[[@TEST_NAME]]";
+
+class D(T:! type) {}
+class E {}
+interface X(T:! type) {}
+interface V(T:! type) {}
+
+constraint W(T:! type) {
+  require D(Self) impls X(T);
+}
+
+fn F(B:! W(E), C:! type where E impls V(.Self)) {
+  // These find a witness for `E as X(E)` from the facet `B`.
+  E as (V(C) where D(B) impls X(.Self));
+  E as (V(C) where D(B) impls X(E));
+}

--- a/toolchain/check/type_structure.cpp
+++ b/toolchain/check/type_structure.cpp
@@ -229,6 +229,10 @@ auto TypeStructureBuilder::Build(SemIR::TypeIterator type_iter)
         AppendStructuralSymbolic();
         break;
       }
+      case CARBON_KIND(Step::FacetValue _): {
+        // Ignored, as it may be concrete or symbolic. We will recurse into it.
+        break;
+      }
       case CARBON_KIND(Step::TemplateType _): {
         AppendStructuralSymbolic();
         break;
@@ -278,6 +282,15 @@ auto TypeStructureBuilder::Build(SemIR::TypeIterator type_iter)
       }
       case CARBON_KIND(Step::InterfaceStart interface_start): {
         AppendStructuralConcreteOpenParen(interface_start.interface_id);
+        break;
+      }
+      case CARBON_KIND(Step::NamedConstraintStartOnly named_constraint_start): {
+        AppendStructuralConcrete(named_constraint_start.named_constraint_id);
+        break;
+      }
+      case CARBON_KIND(Step::NamedConstraintStart named_constraint_start): {
+        AppendStructuralConcreteOpenParen(
+            named_constraint_start.named_constraint_id);
         break;
       }
       case CARBON_KIND(Step::IntStart int_start): {

--- a/toolchain/check/type_structure.h
+++ b/toolchain/check/type_structure.h
@@ -156,7 +156,8 @@ class TypeStructure : public Printable<TypeStructure> {
   // the struct type.
   using ConcreteType =
       std::variant<ConcreteTypeStart, SemIR::ClassId, SemIR::ConstantId,
-                   SemIR::InterfaceId, SemIR::NameId, SemIR::TypeId>;
+                   SemIR::InterfaceId, SemIR::NamedConstraintId, SemIR::NameId,
+                   SemIR::TypeId>;
 
   TypeStructure(llvm::SmallVector<Structural> structure,
                 llvm::SmallVector<int> symbolic_type_indices,

--- a/toolchain/sem_ir/type_iterator.cpp
+++ b/toolchain/sem_ir/type_iterator.cpp
@@ -133,6 +133,14 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
                                 .facet = access.facet_value_inst_id};
     }
 
+    case TupleAccess::Kind: {
+      // Tuple access of a concrete value would have evaluated to the accessed
+      // value, so we only see TupleAccess in a type when it's a symbolic value.
+      CARBON_CHECK(sem_ir_->constant_values().Get(inst_id).is_symbolic());
+      return Step::SymbolicType{.entity_name_id = EntityNameId::None,
+                                .facet = inst_id};
+    }
+
       // ==== Concrete types ====
 
     case AssociatedEntityType::Kind:
@@ -232,30 +240,6 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
           PushInstId(field.type_inst_id);
         }
         return Step::StructStart{.type_id = type_id};
-      }
-    }
-    case CARBON_KIND(TupleAccess access): {
-      if (access.tuple_id == SemIR::ErrorInst::InstId) {
-        return Step::Error();
-      }
-
-      auto tuple = sem_ir_->insts().Get(access.tuple_id);
-      if (auto value = tuple.TryAs<TupleValue>()) {
-        auto elements = sem_ir_->inst_blocks().GetOrEmpty(value->elements_id);
-        PushInstId(elements[access.index.index]);
-        return std::nullopt;
-      } else if (auto type = tuple.TryAs<TupleType>()) {
-        auto elements =
-            sem_ir_->inst_blocks().GetOrEmpty(type->type_elements_id);
-        PushInstId(elements[access.index.index]);
-        return std::nullopt;
-      } else {
-        if (access.type_id == TypeType::TypeId) {
-          return Step::ConcreteType{.type_id = TypeId::None};
-        } else {
-          return Step::SymbolicType{.entity_name_id = EntityNameId::None,
-                                    .facet = inst_id};
-        }
       }
     }
 

--- a/toolchain/sem_ir/type_iterator.cpp
+++ b/toolchain/sem_ir/type_iterator.cpp
@@ -26,6 +26,32 @@ auto TypeIterator::Next() -> Step {
       case CARBON_KIND(EndType _): {
         return Step::End();
       }
+      case CARBON_KIND(FacetType facet_type): {
+        const auto& info = sem_ir_->facet_types().Get(facet_type.facet_type_id);
+        for (const auto& extend : info.extend_constraints) {
+          Push(SpecificInterface{extend.interface_id, extend.specific_id});
+        }
+        for (const auto& extend : info.extend_named_constraints) {
+          Push(SpecificNamedConstraint{extend.named_constraint_id,
+                                       extend.specific_id});
+        }
+        for (const auto& impls : info.self_impls_constraints) {
+          Push(SpecificInterface{impls.interface_id, impls.specific_id});
+        }
+        for (const auto& impls : info.self_impls_named_constraints) {
+          Push(SpecificNamedConstraint{impls.named_constraint_id,
+                                       impls.specific_id});
+        }
+        for (const auto& type_impls : info.type_impls_interfaces) {
+          PushInstId(type_impls.self_type);
+          Push(type_impls.specific_interface);
+        }
+        for (const auto& type_impls : info.type_impls_named_constraints) {
+          PushInstId(type_impls.self_type);
+          Push(type_impls.specific_named_constraint);
+        }
+        break;
+      }
       case CARBON_KIND(SpecificInterface interface): {
         auto args = GetSpecificArgs(interface.specific_id);
         if (args.empty()) {
@@ -37,15 +63,31 @@ auto TypeIterator::Next() -> Step {
           return Step::InterfaceStart{.interface_id = interface.interface_id};
         }
       }
+      case CARBON_KIND(SpecificNamedConstraint constraint): {
+        auto args = GetSpecificArgs(constraint.specific_id);
+        if (args.empty()) {
+          return Step::NamedConstraintStartOnly{
+              {.named_constraint_id = constraint.named_constraint_id}};
+        } else {
+          Push(EndType());
+          PushArgs(args);
+          return Step::NamedConstraintStart{.named_constraint_id =
+                                                constraint.named_constraint_id};
+        }
+      }
       case CARBON_KIND(StructFieldName value): {
         return Step::StructFieldName{.name_id = value.name_id};
       }
       case CARBON_KIND(SymbolicNonTypeValue value): {
         return Step::SymbolicValue{.inst_id = value.inst_id};
       }
+      case CARBON_KIND(FacetValueItem facet_value): {
+        return Step::FacetValue{.facet_value_inst_id =
+                                    facet_value.facet_value_inst_id};
+      }
       case CARBON_KIND(SymbolicType symbolic): {
         return Step::SymbolicType{.entity_name_id = symbolic.entity_name_id,
-                                  .facet_type_id = symbolic.facet_type_id};
+                                  .facet = symbolic.facet};
       }
       case CARBON_KIND(TypeId type_id): {
         if (auto step = ProcessTypeId(type_id)) {
@@ -68,11 +110,11 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
 
     case CARBON_KIND(SymbolicBinding bind): {
       return Step::SymbolicType{.entity_name_id = bind.entity_name_id,
-                                .facet_type_id = type_id};
+                                .facet = inst_id};
     }
     case CARBON_KIND(SymbolicBindingPattern bind): {
       return Step::SymbolicType{.entity_name_id = bind.entity_name_id,
-                                .facet_type_id = type_id};
+                                .facet = inst_id};
     }
 
     case Call::Kind:
@@ -81,9 +123,6 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
     }
 
     case CARBON_KIND(FacetAccessType access): {
-      auto facet_type_id =
-          sem_ir_->insts().Get(access.facet_value_inst_id).type_id();
-
       auto entity_name_id = SemIR::EntityNameId::None;
       if (auto facet_value = sem_ir_->insts().TryGetAs<SemIR::SymbolicBinding>(
               access.facet_value_inst_id)) {
@@ -91,20 +130,7 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
       }
 
       return Step::SymbolicType{.entity_name_id = entity_name_id,
-                                .facet_type_id = facet_type_id};
-    }
-
-    case CARBON_KIND(TupleAccess access): {
-      auto facet_type_id = sem_ir_->insts().Get(access.tuple_id).type_id();
-
-      auto entity_name_id = SemIR::EntityNameId::None;
-      if (auto facet_value = sem_ir_->insts().TryGetAs<SemIR::SymbolicBinding>(
-              access.tuple_id)) {
-        entity_name_id = facet_value->entity_name_id;
-      }
-
-      return Step::SymbolicType{.entity_name_id = entity_name_id,
-                                .facet_type_id = facet_type_id};
+                                .facet = access.facet_value_inst_id};
     }
 
       // ==== Concrete types ====
@@ -208,6 +234,30 @@ auto TypeIterator::ProcessTypeId(TypeId type_id) -> std::optional<Step> {
         return Step::StructStart{.type_id = type_id};
       }
     }
+    case CARBON_KIND(TupleAccess access): {
+      if (access.tuple_id == SemIR::ErrorInst::InstId) {
+        return Step::Error();
+      }
+
+      auto tuple = sem_ir_->insts().Get(access.tuple_id);
+      if (auto value = tuple.TryAs<TupleValue>()) {
+        auto elements = sem_ir_->inst_blocks().GetOrEmpty(value->elements_id);
+        PushInstId(elements[access.index.index]);
+        return std::nullopt;
+      } else if (auto type = tuple.TryAs<TupleType>()) {
+        auto elements =
+            sem_ir_->inst_blocks().GetOrEmpty(type->type_elements_id);
+        PushInstId(elements[access.index.index]);
+        return std::nullopt;
+      } else {
+        if (access.type_id == TypeType::TypeId) {
+          return Step::ConcreteType{.type_id = TypeId::None};
+        } else {
+          return Step::SymbolicType{.entity_name_id = EntityNameId::None,
+                                    .facet = inst_id};
+        }
+      }
+    }
 
     case ErrorInst::Kind:
       return Step::Error();
@@ -248,8 +298,7 @@ auto TypeIterator::TryGetInstIdAsTypeId(InstId inst_id) const
             sem_ir_->insts().TryGetAs<SemIR::SymbolicBinding>(inst_id)) {
       entity_name_id = bind->entity_name_id;
     }
-    return SymbolicType{.entity_name_id = entity_name_id,
-                        .facet_type_id = type_id_of_inst_id};
+    return SymbolicType{.entity_name_id = entity_name_id, .facet = inst_id};
   }
   // Non-type values are concrete, only types are symbolic.
   if (type_id_of_inst_id != TypeType::TypeId) {
@@ -277,6 +326,12 @@ auto TypeIterator::PushArgs(llvm::ArrayRef<InstId> args) -> void {
 // Push an instruction's type value into the work queue, or a marker if the
 // instruction has a symbolic value.
 auto TypeIterator::PushInstId(InstId inst_id) -> void {
+  // We push FacetValues as a separate work step, then also recurse into them
+  // below.
+  if (sem_ir_->insts().Is<FacetValue>(inst_id)) {
+    Push(FacetValueItem{.facet_value_inst_id = inst_id});
+  }
+
   auto maybe_type_id = TryGetInstIdAsTypeId(inst_id);
   if (std::holds_alternative<SymbolicType>(maybe_type_id)) {
     Push(std::get<SymbolicType>(maybe_type_id));

--- a/toolchain/sem_ir/type_iterator.h
+++ b/toolchain/sem_ir/type_iterator.h
@@ -51,6 +51,14 @@ class TypeIterator {
   // The iterator will visit things in the reverse order that they are added.
   auto Add(SpecificInterface interface) -> void { Push(interface); }
 
+  // Add a facet type to be iterated over. Normally a facet type is not recursed
+  // into and is just returned as a single step. This will recurse into the
+  // facet type and iterate through each extend and impls constraint. Rewrite
+  // and equality constraints are ignored.
+  //
+  // The iterator will visit things in the reverse order that they are added.
+  auto Add(FacetType facet_type) -> void { Push(facet_type); }
+
   // Iterates and returns the next `Step`. Returns `Step::Done` when complete.
   auto Next() -> Step;
 
@@ -60,7 +68,11 @@ class TypeIterator {
   // A work item to mark a symbolic type.
   struct SymbolicType {
     EntityNameId entity_name_id;
-    TypeId facet_type_id;
+    InstId facet;
+  };
+  // A work item to mark a FacetValue instruction.
+  struct FacetValueItem {
+    InstId facet_value_inst_id;
   };
   // A work item to mark a concrete non-type value.
   struct ConcreteNonTypeValue {
@@ -75,9 +87,10 @@ class TypeIterator {
     NameId name_id;
   };
 
-  using WorkItem = std::variant<TypeId, SymbolicType, ConcreteNonTypeValue,
-                                SymbolicNonTypeValue, StructFieldName,
-                                SpecificInterface, EndType>;
+  using WorkItem =
+      std::variant<TypeId, SymbolicType, FacetValueItem, ConcreteNonTypeValue,
+                   SymbolicNonTypeValue, StructFieldName, SpecificInterface,
+                   SpecificNamedConstraint, FacetType, EndType>;
 
   // Processes `next` when it's a `TypeId`.
   auto ProcessTypeId(TypeId type_id) -> std::optional<Step>;
@@ -131,6 +144,10 @@ class TypeIterator::Step {
   struct InterfaceStart {
     InterfaceId interface_id;
   };
+  // Followed by generic parameters.
+  struct NamedConstraintStart {
+    NamedConstraintId named_constraint_id;
+  };
   // Followed by the bit width.
   struct IntStart {
     TypeId type_id;
@@ -154,6 +171,7 @@ class TypeIterator::Step {
   struct StructStartOnly : public StructStart {};
   struct TupleStartOnly : public TupleStart {};
   struct InterfaceStartOnly : public InterfaceStart {};
+  struct NamedConstraintStartOnly : public NamedConstraintStart {};
 
   // ===========================================================================
   // Individual result values, which appear on their own or inside some scope
@@ -168,8 +186,16 @@ class TypeIterator::Step {
     // If the symbolic type is simply a reference to a symbolic binding, this is
     // the entity name of that binding. Otherwise, it is None.
     EntityNameId entity_name_id;
-    // Either a FacetType or the TypeType singleton.
-    TypeId facet_type_id;
+    // The facet, whose type is either a FacetType or the TypeType singleton.
+    InstId facet;
+  };
+  // A FacetValue, representing the conversion of a type to a facet type, which
+  // may be symbolic or concrete depending on the type inside. The iterator will
+  // iterate into the FacetValue, so it's reasonable to ignore this step, unless
+  // the consumer wants to specifically collect FacetValues.
+  struct FacetValue {
+    // The FacetValue instruction.
+    InstId facet_value_inst_id;
   };
   // A symbolic template type value.
   struct TemplateType {};
@@ -201,13 +227,13 @@ class TypeIterator::Step {
   struct Error {};
 
   // Each step is one of these.
-  using Any =
-      std::variant<ConcreteType, SymbolicType, TemplateType, ConcreteValue,
-                   SymbolicValue, StructFieldName, ClassStartOnly,
-                   StructStartOnly, TupleStartOnly, InterfaceStartOnly,
-                   ClassStart, StructStart, TupleStart, InterfaceStart,
-                   IntStart, ArrayStart, ConstStart, MaybeUnformedStart,
-                   PartialStart, PointerStart, End, Done, Error>;
+  using Any = std::variant<
+      ConcreteType, SymbolicType, FacetValue, TemplateType, ConcreteValue,
+      SymbolicValue, StructFieldName, ClassStartOnly, StructStartOnly,
+      TupleStartOnly, InterfaceStartOnly, NamedConstraintStartOnly, ClassStart,
+      StructStart, TupleStart, InterfaceStart, NamedConstraintStart, IntStart,
+      ArrayStart, ConstStart, MaybeUnformedStart, PartialStart, PointerStart,
+      End, Done, Error>;
 
   template <typename T>
   auto Is() const -> bool {


### PR DESCRIPTION
This enables searching facets like `T:! Z where .Z1 impls Y` for queries like `T.Z1 as Y`, etc.

Any facet in the query self or the query target type may provide a witness for the requirements of the impl lookup, so search through them all.

We accept partially identified facet types in the query self, since `Self` can be used inside a named constraint before it's fully identified. But any use of `Self` being converted would put it in the query self, not the query target, which would be some generic parameter facet type that a type involving `Self` is being converted to.

TypeIterator is expanded to support this use case, by giving it the ability to walk through FacetType's extend/impls constraints. We return the facet values that we find in the iterator instead of a type id. And we also include FacetValue instructions as an iterator step for clients that want them, while also recursing through them.