### PR TITLE
return 0 from `Run` when it doesn't specify a return value

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -548,9 +548,9 @@ auto FileContext::BuildFunctionBody(SemIR::FunctionId function_id,
 
   auto* subprogram = BuildDISubprogram(declaration_function, *function_info);
   FunctionContext function_lowering(
-      definition_context, function_info->llvm_function, *this, specific_id,
-      coalescer_.InitializeFingerprintForSpecific(specific_id), subprogram,
-      vlog_stream_);
+      definition_context, function_info->llvm_function, *this, function_id,
+      specific_id, coalescer_.InitializeFingerprintForSpecific(specific_id),
+      subprogram, vlog_stream_);
 
   auto call_param_ids = definition_ir.inst_blocks().GetOrEmpty(
       definition_function.call_params_id);

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -16,12 +16,15 @@ namespace Carbon::Lower {
 
 FunctionContext::FunctionContext(
     FileContext& file_context, llvm::Function* function,
-    FileContext& specific_file_context, SemIR::SpecificId specific_id,
+    FileContext& specific_file_context,
+    SemIR::FunctionId function_id,
+    SemIR::SpecificId specific_id,
     SpecificCoalescer::SpecificFunctionFingerprint* function_fingerprint,
     llvm::DISubprogram* di_subprogram, llvm::raw_ostream* vlog_stream)
     : file_context_(&file_context),
       function_(function),
       specific_file_context_(&specific_file_context),
+      function_id_(function_id),
       specific_id_(specific_id),
       builder_(file_context.llvm_context(), llvm::ConstantFolder(),
                Inserter(file_context.inst_namer())),

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -17,14 +17,14 @@ namespace Carbon::Lower {
 FunctionContext::FunctionContext(
     FileContext& file_context, llvm::Function* function,
     FileContext& specific_file_context,
-    SemIR::FunctionId function_id,
+    SemIR::FunctionId specific_sem_ir_function_id,
     SemIR::SpecificId specific_id,
     SpecificCoalescer::SpecificFunctionFingerprint* function_fingerprint,
     llvm::DISubprogram* di_subprogram, llvm::raw_ostream* vlog_stream)
     : file_context_(&file_context),
       function_(function),
       specific_file_context_(&specific_file_context),
-      function_id_(function_id),
+      specific_sem_ir_function_id_(specific_sem_ir_function_id),
       specific_id_(specific_id),
       builder_(file_context.llvm_context(), llvm::ConstantFolder(),
                Inserter(file_context.inst_namer())),

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -27,7 +27,8 @@ class FunctionContext {
   // be null (see members).
   explicit FunctionContext(
       FileContext& file_context, llvm::Function* function,
-      FileContext& specific_file_context, SemIR::FunctionId function_id,
+      FileContext& specific_file_context,
+      SemIR::FunctionId specific_sem_ir_function_id,
       SemIR::SpecificId specific_id,
       SpecificCoalescer::SpecificFunctionFingerprint* function_fingerprint,
       llvm::DISubprogram* di_subprogram, llvm::raw_ostream* vlog_stream);
@@ -244,7 +245,9 @@ class FunctionContext {
     return specific_file_context_->sem_ir();
   }
 
-  auto function_id() -> SemIR::FunctionId { return function_id_; }
+  auto specific_sem_ir_function_id() -> SemIR::FunctionId {
+    return specific_sem_ir_function_id_;
+  }
 
   // The specific ID for the function that is being lowered. Note that this is
   // an ID from `specific_sem_ir()`, not from `sem_ir()`.
@@ -318,7 +321,7 @@ class FunctionContext {
   FileContext* specific_file_context_;
 
   // The function id of the function we're lowering.
-  SemIR::FunctionId function_id_;
+  SemIR::FunctionId specific_sem_ir_function_id_;
 
   // The specific id, if the function is a specific.
   SemIR::SpecificId specific_id_;

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -27,7 +27,8 @@ class FunctionContext {
   // be null (see members).
   explicit FunctionContext(
       FileContext& file_context, llvm::Function* function,
-      FileContext& specific_file_context, SemIR::SpecificId specific_id,
+      FileContext& specific_file_context, SemIR::FunctionId function_id,
+      SemIR::SpecificId specific_id,
       SpecificCoalescer::SpecificFunctionFingerprint* function_fingerprint,
       llvm::DISubprogram* di_subprogram, llvm::raw_ostream* vlog_stream);
 
@@ -242,6 +243,9 @@ class FunctionContext {
   auto specific_sem_ir() -> const SemIR::File& {
     return specific_file_context_->sem_ir();
   }
+
+  auto function_id() -> SemIR::FunctionId { return function_id_; }
+
   // The specific ID for the function that is being lowered. Note that this is
   // an ID from `specific_sem_ir()`, not from `sem_ir()`.
   auto specific_id() -> SemIR::SpecificId { return specific_id_; }
@@ -312,6 +316,9 @@ class FunctionContext {
   // if we are lowering a specific that was generated for a generic function
   // defined in a different file.
   FileContext* specific_file_context_;
+
+  // The function id of the function we're lowering.
+  SemIR::FunctionId function_id_;
 
   // The specific id, if the function is a specific.
   SemIR::SpecificId specific_id_;

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Support/Casting.h"
 #include "toolchain/lower/function_context.h"
 #include "toolchain/sem_ir/builtin_function_kind.h"
+#include "toolchain/sem_ir/entry_point.h"
 #include "toolchain/sem_ir/expr_info.h"
 #include "toolchain/sem_ir/function.h"
 #include "toolchain/sem_ir/inst.h"
@@ -261,6 +262,13 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
 
 auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,
                 SemIR::Return /*inst*/) -> void {
+  // The 'Run()' entry point does not need to specify a return type, but
+  // calling programs expect an int32 return type. In this situation we
+  // modify the lowered IR to return 0i32.
+  if (SemIR::IsEntryPoint(context.sem_ir(), context.function_id())) {
+    context.builder().CreateRet(context.builder().getInt32(0));
+    return;
+  }
   context.builder().CreateRetVoid();
 }
 

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -263,9 +263,11 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
 auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,
                 SemIR::Return /*inst*/) -> void {
   // The 'Run()' entry point does not need to specify a return type, but
-  // calling programs expect an int32 return type. In this situation we
-  // modify the lowered IR to return 0i32.
-  if (SemIR::IsEntryPoint(context.sem_ir(), context.function_id())) {
+  // the C runtime and system ABI expects the entry point to return an `int`.
+  // In this situation we modify the lowered IR to return `0`
+  // with the expected LLVM type that corresponds to the `int` type.
+  if (SemIR::IsEntryPoint(context.specific_sem_ir(),
+                          context.specific_sem_ir_function_id())) {
     context.builder().CreateRet(context.builder().getInt32(0));
     return;
   }

--- a/toolchain/lower/testdata/array/assign_return_value.carbon
+++ b/toolchain/lower/testdata/array/assign_return_value.carbon
@@ -31,28 +31,28 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !10 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !10 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [2 x i32], align 4, !dbg !13
-// CHECK:STDOUT:   %.loc16_28.1.temp = alloca { i32, i32 }, align 8, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !13
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_28.1.temp), !dbg !14
-// CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_28.1.temp), !dbg !14
-// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_28.1.temp, i32 0, i32 0, !dbg !14
-// CHECK:STDOUT:   %.loc16_28.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc16_28.4.array.index = getelementptr inbounds [2 x i32], ptr %_.var, i32 0, i64 0, !dbg !14
-// CHECK:STDOUT:   store i32 %.loc16_28.3, ptr %.loc16_28.4.array.index, align 4, !dbg !14
-// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_28.1.temp, i32 0, i32 1, !dbg !14
-// CHECK:STDOUT:   %.loc16_28.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc16_28.7.array.index = getelementptr inbounds [2 x i32], ptr %_.var, i32 0, i64 1, !dbg !14
-// CHECK:STDOUT:   store i32 %.loc16_28.6, ptr %.loc16_28.7.array.index, align 4, !dbg !14
-// CHECK:STDOUT:   call void @"_COp.8e354c83fe88ab86:core.Destroy.Core"(ptr %.loc16_28.1.temp), !dbg !14
-// CHECK:STDOUT:   call void @"_COp.f53f00a5f9e218d2:core.Destroy.Core"(ptr %_.var), !dbg !13
-// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT:   %_.var = alloca [2 x i32], align 4, !dbg !14
+// CHECK:STDOUT:   %.loc16_28.1.temp = alloca { i32, i32 }, align 8, !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_28.1.temp), !dbg !15
+// CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_28.1.temp), !dbg !15
+// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_28.1.temp, i32 0, i32 0, !dbg !15
+// CHECK:STDOUT:   %.loc16_28.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !15
+// CHECK:STDOUT:   %.loc16_28.4.array.index = getelementptr inbounds [2 x i32], ptr %_.var, i32 0, i64 0, !dbg !15
+// CHECK:STDOUT:   store i32 %.loc16_28.3, ptr %.loc16_28.4.array.index, align 4, !dbg !15
+// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_28.1.temp, i32 0, i32 1, !dbg !15
+// CHECK:STDOUT:   %.loc16_28.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !15
+// CHECK:STDOUT:   %.loc16_28.7.array.index = getelementptr inbounds [2 x i32], ptr %_.var, i32 0, i64 1, !dbg !15
+// CHECK:STDOUT:   store i32 %.loc16_28.6, ptr %.loc16_28.7.array.index, align 4, !dbg !15
+// CHECK:STDOUT:   call void @"_COp.8e354c83fe88ab86:core.Destroy.Core"(ptr %.loc16_28.1.temp), !dbg !15
+// CHECK:STDOUT:   call void @"_COp.f53f00a5f9e218d2:core.Destroy.Core"(ptr %_.var), !dbg !14
+// CHECK:STDOUT:   ret i32 0, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !16 {
+// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !17 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
@@ -97,17 +97,17 @@ fn Run() {
 // CHECK:STDOUT: !9 = !DILocation(line: 13, column: 24, scope: !4)
 // CHECK:STDOUT: !10 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 15, type: !11, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !11 = !DISubroutineType(types: !12)
-// CHECK:STDOUT: !12 = !{null}
-// CHECK:STDOUT: !13 = !DILocation(line: 16, column: 3, scope: !10)
-// CHECK:STDOUT: !14 = !DILocation(line: 16, column: 26, scope: !10)
-// CHECK:STDOUT: !15 = !DILocation(line: 15, column: 1, scope: !10)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 16, type: !17, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
-// CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
-// CHECK:STDOUT: !18 = !{null, !19}
-// CHECK:STDOUT: !19 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !12 = !{!13}
+// CHECK:STDOUT: !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !14 = !DILocation(line: 16, column: 3, scope: !10)
+// CHECK:STDOUT: !15 = !DILocation(line: 16, column: 26, scope: !10)
+// CHECK:STDOUT: !16 = !DILocation(line: 15, column: 1, scope: !10)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 16, type: !18, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
+// CHECK:STDOUT: !18 = !DISubroutineType(types: !19)
+// CHECK:STDOUT: !19 = !{null, !13}
 // CHECK:STDOUT: !20 = !{!21}
-// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !16, type: !19)
-// CHECK:STDOUT: !22 = !DILocation(line: 16, column: 26, scope: !16)
+// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !17, type: !13)
+// CHECK:STDOUT: !22 = !DILocation(line: 16, column: 26, scope: !17)
 // CHECK:STDOUT: !23 = distinct !DISubprogram(name: "Op", linkageName: "_COp.8e354c83fe88ab86:core.Destroy.Core", scope: null, file: !3, line: 16, type: !24, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !26)
 // CHECK:STDOUT: !24 = !DISubroutineType(types: !25)
 // CHECK:STDOUT: !25 = !{null, !7}

--- a/toolchain/lower/testdata/array/base.carbon
+++ b/toolchain/lower/testdata/array/base.carbon
@@ -27,55 +27,55 @@ fn Run() {
 // CHECK:STDOUT: @tuple.ee6.loc17_3 = internal constant { i32, i32, i32 } { i32 1, i32 2, i32 3 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var.loc14 = alloca [1 x i32], align 4, !dbg !7
-// CHECK:STDOUT:   %_.var.loc15 = alloca [2 x double], align 8, !dbg !8
-// CHECK:STDOUT:   %_.var.loc16 = alloca [5 x {}], align 8, !dbg !9
-// CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 8, !dbg !10
-// CHECK:STDOUT:   %_.var.loc18 = alloca [3 x i32], align 4, !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc14), !dbg !7
-// CHECK:STDOUT:   %.loc14_29.3.array.index = getelementptr inbounds [1 x i32], ptr %_.var.loc14, i32 0, i64 0, !dbg !12
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %_.var.loc14, ptr align 4 @array.237.loc14_3, i64 4, i1 false), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc15), !dbg !8
-// CHECK:STDOUT:   %.loc15_37.3.array.index = getelementptr inbounds [2 x double], ptr %_.var.loc15, i32 0, i64 0, !dbg !13
-// CHECK:STDOUT:   %.loc15_37.6.array.index = getelementptr inbounds [2 x double], ptr %_.var.loc15, i32 0, i64 1, !dbg !13
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var.loc15, ptr align 8 @array.b91.loc15_3, i64 16, i1 false), !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc16), !dbg !9
-// CHECK:STDOUT:   %.loc16_45.2.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 0, !dbg !14
-// CHECK:STDOUT:   %.loc16_45.5.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 1, !dbg !14
-// CHECK:STDOUT:   %.loc16_45.8.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 2, !dbg !14
-// CHECK:STDOUT:   %.loc16_45.11.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 3, !dbg !14
-// CHECK:STDOUT:   %.loc16_45.14.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 4, !dbg !14
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var.loc16, ptr align 1 @array.1cb.loc16_3, i64 0, i1 false), !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !10
-// CHECK:STDOUT:   %tuple.elem0.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !15
-// CHECK:STDOUT:   %tuple.elem1.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !15
-// CHECK:STDOUT:   %tuple.elem2.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !15
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d.var, ptr align 4 @tuple.ee6.loc17_3, i64 12, i1 false), !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc18), !dbg !11
-// CHECK:STDOUT:   %tuple.elem0.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.1 = load i32, ptr %tuple.elem0.loc18.tuple.elem, align 4, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.2.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 0, !dbg !16
-// CHECK:STDOUT:   store i32 %.loc18_26.1, ptr %.loc18_26.2.array.index, align 4, !dbg !16
-// CHECK:STDOUT:   %tuple.elem1.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.4 = load i32, ptr %tuple.elem1.loc18.tuple.elem, align 4, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.5.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 1, !dbg !16
-// CHECK:STDOUT:   store i32 %.loc18_26.4, ptr %.loc18_26.5.array.index, align 4, !dbg !16
-// CHECK:STDOUT:   %tuple.elem2.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.7 = load i32, ptr %tuple.elem2.loc18.tuple.elem, align 4, !dbg !16
-// CHECK:STDOUT:   %.loc18_26.8.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 2, !dbg !16
-// CHECK:STDOUT:   store i32 %.loc18_26.7, ptr %.loc18_26.8.array.index, align 4, !dbg !16
-// CHECK:STDOUT:   call void @"_COp.bfd302cd235977c4:core.Destroy.Core"(ptr %_.var.loc18), !dbg !11
-// CHECK:STDOUT:   call void @"_COp.819e9e1e390140e8:core.Destroy.Core"(ptr %d.var), !dbg !10
-// CHECK:STDOUT:   call void @"_COp.fd2b1e64e898d326:core.Destroy.Core"(ptr %_.var.loc16), !dbg !9
-// CHECK:STDOUT:   call void @"_COp.aca92e88ce95a52e:core.Destroy.Core"(ptr %_.var.loc15), !dbg !8
-// CHECK:STDOUT:   call void @"_COp.d26f73ac8e1728e0:core.Destroy.Core"(ptr %_.var.loc14), !dbg !7
-// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT:   %_.var.loc14 = alloca [1 x i32], align 4, !dbg !8
+// CHECK:STDOUT:   %_.var.loc15 = alloca [2 x double], align 8, !dbg !9
+// CHECK:STDOUT:   %_.var.loc16 = alloca [5 x {}], align 8, !dbg !10
+// CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 8, !dbg !11
+// CHECK:STDOUT:   %_.var.loc18 = alloca [3 x i32], align 4, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc14), !dbg !8
+// CHECK:STDOUT:   %.loc14_29.3.array.index = getelementptr inbounds [1 x i32], ptr %_.var.loc14, i32 0, i64 0, !dbg !13
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %_.var.loc14, ptr align 4 @array.237.loc14_3, i64 4, i1 false), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc15), !dbg !9
+// CHECK:STDOUT:   %.loc15_37.3.array.index = getelementptr inbounds [2 x double], ptr %_.var.loc15, i32 0, i64 0, !dbg !14
+// CHECK:STDOUT:   %.loc15_37.6.array.index = getelementptr inbounds [2 x double], ptr %_.var.loc15, i32 0, i64 1, !dbg !14
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var.loc15, ptr align 8 @array.b91.loc15_3, i64 16, i1 false), !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc16), !dbg !10
+// CHECK:STDOUT:   %.loc16_45.2.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 0, !dbg !15
+// CHECK:STDOUT:   %.loc16_45.5.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 1, !dbg !15
+// CHECK:STDOUT:   %.loc16_45.8.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 2, !dbg !15
+// CHECK:STDOUT:   %.loc16_45.11.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 3, !dbg !15
+// CHECK:STDOUT:   %.loc16_45.14.array.index = getelementptr inbounds [5 x {}], ptr %_.var.loc16, i32 0, i64 4, !dbg !15
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var.loc16, ptr align 1 @array.1cb.loc16_3, i64 0, i1 false), !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !11
+// CHECK:STDOUT:   %tuple.elem0.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !16
+// CHECK:STDOUT:   %tuple.elem1.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !16
+// CHECK:STDOUT:   %tuple.elem2.loc17.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !16
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %d.var, ptr align 4 @tuple.ee6.loc17_3, i64 12, i1 false), !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc18), !dbg !12
+// CHECK:STDOUT:   %tuple.elem0.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 0, !dbg !17
+// CHECK:STDOUT:   %.loc18_26.1 = load i32, ptr %tuple.elem0.loc18.tuple.elem, align 4, !dbg !17
+// CHECK:STDOUT:   %.loc18_26.2.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 0, !dbg !17
+// CHECK:STDOUT:   store i32 %.loc18_26.1, ptr %.loc18_26.2.array.index, align 4, !dbg !17
+// CHECK:STDOUT:   %tuple.elem1.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 1, !dbg !17
+// CHECK:STDOUT:   %.loc18_26.4 = load i32, ptr %tuple.elem1.loc18.tuple.elem, align 4, !dbg !17
+// CHECK:STDOUT:   %.loc18_26.5.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 1, !dbg !17
+// CHECK:STDOUT:   store i32 %.loc18_26.4, ptr %.loc18_26.5.array.index, align 4, !dbg !17
+// CHECK:STDOUT:   %tuple.elem2.loc18.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %d.var, i32 0, i32 2, !dbg !17
+// CHECK:STDOUT:   %.loc18_26.7 = load i32, ptr %tuple.elem2.loc18.tuple.elem, align 4, !dbg !17
+// CHECK:STDOUT:   %.loc18_26.8.array.index = getelementptr inbounds [3 x i32], ptr %_.var.loc18, i32 0, i64 2, !dbg !17
+// CHECK:STDOUT:   store i32 %.loc18_26.7, ptr %.loc18_26.8.array.index, align 4, !dbg !17
+// CHECK:STDOUT:   call void @"_COp.bfd302cd235977c4:core.Destroy.Core"(ptr %_.var.loc18), !dbg !12
+// CHECK:STDOUT:   call void @"_COp.819e9e1e390140e8:core.Destroy.Core"(ptr %d.var), !dbg !11
+// CHECK:STDOUT:   call void @"_COp.fd2b1e64e898d326:core.Destroy.Core"(ptr %_.var.loc16), !dbg !10
+// CHECK:STDOUT:   call void @"_COp.aca92e88ce95a52e:core.Destroy.Core"(ptr %_.var.loc15), !dbg !9
+// CHECK:STDOUT:   call void @"_COp.d26f73ac8e1728e0:core.Destroy.Core"(ptr %_.var.loc14), !dbg !8
+// CHECK:STDOUT:   ret i32 0, !dbg !18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !18 {
+// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
@@ -139,25 +139,25 @@ fn Run() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "base.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 18, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 14, column: 26, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 15, column: 26, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 16, column: 25, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 17, column: 28, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 18, column: 26, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 13, column: 1, scope: !4)
-// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 18, type: !19, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !22)
-// CHECK:STDOUT: !19 = !DISubroutineType(types: !20)
-// CHECK:STDOUT: !20 = !{null, !21}
-// CHECK:STDOUT: !21 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 17, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 18, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 14, column: 26, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 15, column: 26, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 16, column: 25, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 28, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 18, column: 26, scope: !4)
+// CHECK:STDOUT: !18 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 18, type: !20, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !22)
+// CHECK:STDOUT: !20 = !DISubroutineType(types: !21)
+// CHECK:STDOUT: !21 = !{null, !7}
 // CHECK:STDOUT: !22 = !{!23}
-// CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !18, type: !21)
-// CHECK:STDOUT: !24 = !DILocation(line: 18, column: 3, scope: !18)
+// CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !19, type: !7)
+// CHECK:STDOUT: !24 = !DILocation(line: 18, column: 3, scope: !19)
 // CHECK:STDOUT: !25 = distinct !DISubprogram(name: "Op", linkageName: "_COp.bfd302cd235977c4:core.Destroy.Core", scope: null, file: !3, line: 18, type: !26, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !29)
 // CHECK:STDOUT: !26 = !DISubroutineType(types: !27)
 // CHECK:STDOUT: !27 = !{null, !28}

--- a/toolchain/lower/testdata/class/basic.carbon
+++ b/toolchain/lower/testdata/class/basic.carbon
@@ -28,20 +28,20 @@ fn Run() {
 // CHECK:STDOUT: declare void @_CF.Main(ptr sret({ i32, ptr }), ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca { i32, ptr }, align 8, !dbg !7
-// CHECK:STDOUT:   %_.var = alloca { i32, ptr }, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !8
-// CHECK:STDOUT:   call void @_CF.Main(ptr %_.var, ptr %c.var), !dbg !9
-// CHECK:STDOUT:   call void @"_COp.71e25083d63c4d6c:core.Destroy.Core"(ptr %_.var), !dbg !8
-// CHECK:STDOUT:   call void @"_COp.71e25083d63c4d6c:core.Destroy.Core"(ptr %c.var), !dbg !7
-// CHECK:STDOUT:   ret void, !dbg !10
+// CHECK:STDOUT:   %c.var = alloca { i32, ptr }, align 8, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { i32, ptr }, align 8, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
+// CHECK:STDOUT:   call void @_CF.Main(ptr %_.var, ptr %c.var), !dbg !10
+// CHECK:STDOUT:   call void @"_COp.71e25083d63c4d6c:core.Destroy.Core"(ptr %_.var), !dbg !9
+// CHECK:STDOUT:   call void @"_COp.71e25083d63c4d6c:core.Destroy.Core"(ptr %c.var), !dbg !8
+// CHECK:STDOUT:   ret i32 0, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !11 {
+// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !12 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !17
 // CHECK:STDOUT: }
@@ -77,18 +77,18 @@ fn Run() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "basic.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 20, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 21, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 22, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 22, column: 14, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 20, column: 1, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 22, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !15)
-// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
-// CHECK:STDOUT: !13 = !{null, !14}
-// CHECK:STDOUT: !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 21, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 22, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 22, column: 14, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 20, column: 1, scope: !4)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 22, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !15)
+// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
+// CHECK:STDOUT: !14 = !{null, !7}
 // CHECK:STDOUT: !15 = !{!16}
-// CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !11, type: !14)
-// CHECK:STDOUT: !17 = !DILocation(line: 22, column: 3, scope: !11)
+// CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !12, type: !7)
+// CHECK:STDOUT: !17 = !DILocation(line: 22, column: 3, scope: !12)
 // CHECK:STDOUT: !18 = distinct !DISubprogram(name: "Op", linkageName: "_COp.e7e7253cfbad8551:core.Destroy.Core", scope: null, file: !3, line: 22, type: !19, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !22)
 // CHECK:STDOUT: !19 = !DISubroutineType(types: !20)
 // CHECK:STDOUT: !20 = !{null, !21}

--- a/toolchain/lower/testdata/class/field.carbon
+++ b/toolchain/lower/testdata/class/field.carbon
@@ -166,37 +166,37 @@ fn Run() {
 // CHECK:STDOUT: @Other.val.loc15_33.5 = internal constant {} zeroinitializer
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %o.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %_.var = alloca { ptr, {} }, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %o.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !8
-// CHECK:STDOUT:   %.loc15_33.2.a = getelementptr inbounds nuw { ptr, {} }, ptr %_.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   store ptr %o.var, ptr %.loc15_33.2.a, align 8, !dbg !9
-// CHECK:STDOUT:   %.loc15_33.4.b = getelementptr inbounds nuw { ptr, {} }, ptr %_.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc15_33.4.b, ptr align 1 @Other.val.loc15_33.5, i64 0, i1 false), !dbg !9
-// CHECK:STDOUT:   call void @"_COp.6354d5454c7bf77d:core.Destroy.Core"(ptr %_.var), !dbg !8
-// CHECK:STDOUT:   call void @"_COp.49a4972657b05a86:core.Destroy.Core"(ptr %o.var), !dbg !7
-// CHECK:STDOUT:   ret void, !dbg !10
+// CHECK:STDOUT:   %o.var = alloca {}, align 8, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { ptr, {} }, align 8, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %o.var), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
+// CHECK:STDOUT:   %.loc15_33.2.a = getelementptr inbounds nuw { ptr, {} }, ptr %_.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   store ptr %o.var, ptr %.loc15_33.2.a, align 8, !dbg !10
+// CHECK:STDOUT:   %.loc15_33.4.b = getelementptr inbounds nuw { ptr, {} }, ptr %_.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %.loc15_33.4.b, ptr align 1 @Other.val.loc15_33.5, i64 0, i1 false), !dbg !10
+// CHECK:STDOUT:   call void @"_COp.6354d5454c7bf77d:core.Destroy.Core"(ptr %_.var), !dbg !9
+// CHECK:STDOUT:   call void @"_COp.49a4972657b05a86:core.Destroy.Core"(ptr %o.var), !dbg !8
+// CHECK:STDOUT:   ret i32 0, !dbg !11
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.49a4972657b05a86:core.Destroy.Core"(ptr %self) #0 !dbg !11 {
+// CHECK:STDOUT: define weak_odr void @"_COp.49a4972657b05a86:core.Destroy.Core"(ptr %self) #0 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT:   ret void, !dbg !18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.93fc877b6ab5c8f9:core.Destroy.Core"(ptr %self) #0 !dbg !18 {
+// CHECK:STDOUT: define weak_odr void @"_COp.93fc877b6ab5c8f9:core.Destroy.Core"(ptr %self) #0 !dbg !19 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !21
+// CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.6354d5454c7bf77d:core.Destroy.Core"(ptr %self) #0 !dbg !22 {
+// CHECK:STDOUT: define weak_odr void @"_COp.6354d5454c7bf77d:core.Destroy.Core"(ptr %self) #0 !dbg !23 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !25
+// CHECK:STDOUT:   ret void, !dbg !26
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -221,50 +221,51 @@ fn Run() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "inplace_init_with_nonconst.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 15, column: 16, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 11, column: 1, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Op", linkageName: "_COp.49a4972657b05a86:core.Destroy.Core", scope: null, file: !3, line: 15, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !15)
-// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
-// CHECK:STDOUT: !13 = !{null, !14}
-// CHECK:STDOUT: !14 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
-// CHECK:STDOUT: !15 = !{!16}
-// CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !11, type: !14)
-// CHECK:STDOUT: !17 = !DILocation(line: 15, column: 3, scope: !11)
-// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "Op", linkageName: "_COp.93fc877b6ab5c8f9:core.Destroy.Core", scope: null, file: !3, line: 15, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !19)
-// CHECK:STDOUT: !19 = !{!20}
-// CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !18, type: !14)
-// CHECK:STDOUT: !21 = !DILocation(line: 15, column: 3, scope: !18)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "Op", linkageName: "_COp.6354d5454c7bf77d:core.Destroy.Core", scope: null, file: !3, line: 15, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !23)
-// CHECK:STDOUT: !23 = !{!24}
-// CHECK:STDOUT: !24 = !DILocalVariable(arg: 1, scope: !22, type: !14)
-// CHECK:STDOUT: !25 = !DILocation(line: 15, column: 3, scope: !22)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 12, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 15, column: 16, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 11, column: 1, scope: !4)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Op", linkageName: "_COp.49a4972657b05a86:core.Destroy.Core", scope: null, file: !3, line: 15, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !16)
+// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
+// CHECK:STDOUT: !14 = !{null, !15}
+// CHECK:STDOUT: !15 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !16 = !{!17}
+// CHECK:STDOUT: !17 = !DILocalVariable(arg: 1, scope: !12, type: !15)
+// CHECK:STDOUT: !18 = !DILocation(line: 15, column: 3, scope: !12)
+// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "Op", linkageName: "_COp.93fc877b6ab5c8f9:core.Destroy.Core", scope: null, file: !3, line: 15, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
+// CHECK:STDOUT: !20 = !{!21}
+// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !19, type: !15)
+// CHECK:STDOUT: !22 = !DILocation(line: 15, column: 3, scope: !19)
+// CHECK:STDOUT: !23 = distinct !DISubprogram(name: "Op", linkageName: "_COp.6354d5454c7bf77d:core.Destroy.Core", scope: null, file: !3, line: 15, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !24)
+// CHECK:STDOUT: !24 = !{!25}
+// CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !23, type: !15)
+// CHECK:STDOUT: !26 = !DILocation(line: 15, column: 3, scope: !23)
 // CHECK:STDOUT: ; ModuleID = 'implicit_init_with_nonempty_nonconst.carbon'
 // CHECK:STDOUT: source_filename = "implicit_init_with_nonempty_nonconst.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: @Other.val.loc17_40.5 = internal constant { i32 } { i32 42 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %o.var = alloca { i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %_.var = alloca <{ ptr, { i32 } }>, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %o.var), !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !8
-// CHECK:STDOUT:   %.loc17_40.2.a = getelementptr inbounds nuw <{ ptr, { i32 } }>, ptr %_.var, i32 0, i32 0, !dbg !9
-// CHECK:STDOUT:   store ptr %o.var, ptr %.loc17_40.2.a, align 8, !dbg !9
-// CHECK:STDOUT:   %.loc17_40.4.b = getelementptr inbounds nuw <{ ptr, { i32 } }>, ptr %_.var, i32 0, i32 1, !dbg !9
-// CHECK:STDOUT:   %.loc17_39.3.v = getelementptr inbounds nuw { i32 }, ptr %.loc17_40.4.b, i32 0, i32 0, !dbg !10
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %.loc17_40.4.b, ptr align 4 @Other.val.loc17_40.5, i64 4, i1 false), !dbg !9
-// CHECK:STDOUT:   call void @"_COp.6354d5454c7bf77d:core.Destroy.Core"(ptr %_.var), !dbg !8
-// CHECK:STDOUT:   call void @"_COp.49a4972657b05a86:core.Destroy.Core"(ptr %o.var), !dbg !7
-// CHECK:STDOUT:   ret void, !dbg !11
+// CHECK:STDOUT:   %o.var = alloca { i32 }, align 8, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca <{ ptr, { i32 } }>, align 8, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %o.var), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
+// CHECK:STDOUT:   %.loc17_40.2.a = getelementptr inbounds nuw <{ ptr, { i32 } }>, ptr %_.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   store ptr %o.var, ptr %.loc17_40.2.a, align 8, !dbg !10
+// CHECK:STDOUT:   %.loc17_40.4.b = getelementptr inbounds nuw <{ ptr, { i32 } }>, ptr %_.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   %.loc17_39.3.v = getelementptr inbounds nuw { i32 }, ptr %.loc17_40.4.b, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %.loc17_40.4.b, ptr align 4 @Other.val.loc17_40.5, i64 4, i1 false), !dbg !10
+// CHECK:STDOUT:   call void @"_COp.6354d5454c7bf77d:core.Destroy.Core"(ptr %_.var), !dbg !9
+// CHECK:STDOUT:   call void @"_COp.49a4972657b05a86:core.Destroy.Core"(ptr %o.var), !dbg !8
+// CHECK:STDOUT:   ret i32 0, !dbg !12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !12 {
+// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !18
 // CHECK:STDOUT: }
@@ -315,19 +316,19 @@ fn Run() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "implicit_init_with_nonempty_nonconst.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 17, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 17, column: 16, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 31, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 13, column: 1, scope: !4)
-// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 17, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !16)
-// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
-// CHECK:STDOUT: !14 = !{null, !15}
-// CHECK:STDOUT: !15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 17, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 16, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 17, column: 31, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT: !13 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 17, type: !14, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !16)
+// CHECK:STDOUT: !14 = !DISubroutineType(types: !15)
+// CHECK:STDOUT: !15 = !{null, !7}
 // CHECK:STDOUT: !16 = !{!17}
-// CHECK:STDOUT: !17 = !DILocalVariable(arg: 1, scope: !12, type: !15)
-// CHECK:STDOUT: !18 = !DILocation(line: 17, column: 3, scope: !12)
+// CHECK:STDOUT: !17 = !DILocalVariable(arg: 1, scope: !13, type: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 17, column: 3, scope: !13)
 // CHECK:STDOUT: !19 = distinct !DISubprogram(name: "Op", linkageName: "_COp.8e62c7e21e7d5467:core.Destroy.Core", scope: null, file: !3, line: 17, type: !20, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !23)
 // CHECK:STDOUT: !20 = !DISubroutineType(types: !21)
 // CHECK:STDOUT: !21 = !{null, !22}

--- a/toolchain/lower/testdata/function/generic/call_different_impls.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_impls.carbon
@@ -53,27 +53,27 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !12 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CG.Main.e55c78367db83a6b(), !dbg !13
-// CHECK:STDOUT:   call void @_CG.Main.95a632fb0c368a62(), !dbg !14
-// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT:   call void @_CG.Main.e55c78367db83a6b(), !dbg !16
+// CHECK:STDOUT:   call void @_CG.Main.95a632fb0c368a62(), !dbg !17
+// CHECK:STDOUT:   ret i32 0, !dbg !18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CG.Main.e55c78367db83a6b() #0 !dbg !16 {
+// CHECK:STDOUT: define linkonce_odr void @_CG.Main.e55c78367db83a6b() #0 !dbg !19 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @"_CF.X.Main:I.Main"(), !dbg !17
-// CHECK:STDOUT:   ret void, !dbg !18
+// CHECK:STDOUT:   call void @"_CF.X.Main:I.Main"(), !dbg !20
+// CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CG.Main.95a632fb0c368a62() #0 !dbg !19 {
+// CHECK:STDOUT: define linkonce_odr void @_CG.Main.95a632fb0c368a62() #0 !dbg !22 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @"_CF.Y.Main:I.Main"(), !dbg !20
-// CHECK:STDOUT:   ret void, !dbg !21
+// CHECK:STDOUT:   call void @"_CF.Y.Main:I.Main"(), !dbg !23
+// CHECK:STDOUT:   ret void, !dbg !24
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -96,13 +96,16 @@ fn Run() {
 // CHECK:STDOUT: !9 = distinct !DISubprogram(name: "F", linkageName: "_CF.Y.Main:I.Main", scope: null, file: !3, line: 24, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !10 = !DILocation(line: 24, column: 12, scope: !9)
 // CHECK:STDOUT: !11 = !DILocation(line: 24, column: 3, scope: !9)
-// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !13 = !DILocation(line: 32, column: 3, scope: !12)
-// CHECK:STDOUT: !14 = !DILocation(line: 33, column: 3, scope: !12)
-// CHECK:STDOUT: !15 = !DILocation(line: 31, column: 1, scope: !12)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e55c78367db83a6b", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !17 = !DILocation(line: 29, column: 15, scope: !16)
-// CHECK:STDOUT: !18 = !DILocation(line: 29, column: 1, scope: !16)
-// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.95a632fb0c368a62", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 31, type: !13, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
+// CHECK:STDOUT: !14 = !{!15}
+// CHECK:STDOUT: !15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !16 = !DILocation(line: 32, column: 3, scope: !12)
+// CHECK:STDOUT: !17 = !DILocation(line: 33, column: 3, scope: !12)
+// CHECK:STDOUT: !18 = !DILocation(line: 31, column: 1, scope: !12)
+// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e55c78367db83a6b", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !20 = !DILocation(line: 29, column: 15, scope: !19)
 // CHECK:STDOUT: !21 = !DILocation(line: 29, column: 1, scope: !19)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.95a632fb0c368a62", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !23 = !DILocation(line: 29, column: 15, scope: !22)
+// CHECK:STDOUT: !24 = !DILocation(line: 29, column: 1, scope: !22)

--- a/toolchain/lower/testdata/function/generic/call_different_impls_with_const.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_impls_with_const.carbon
@@ -68,17 +68,17 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !22 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !22 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CG.Main.27a852a6bab6ed2e(), !dbg !25
-// CHECK:STDOUT:   call void @_CG.Main.2de7c972fe093485(), !dbg !26
-// CHECK:STDOUT:   ret void, !dbg !27
+// CHECK:STDOUT:   call void @_CG.Main.27a852a6bab6ed2e(), !dbg !23
+// CHECK:STDOUT:   call void @_CG.Main.2de7c972fe093485(), !dbg !24
+// CHECK:STDOUT:   ret i32 0, !dbg !25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CG.Main.27a852a6bab6ed2e() #0 !dbg !28 {
+// CHECK:STDOUT: define linkonce_odr void @_CG.Main.27a852a6bab6ed2e() #0 !dbg !26 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc37_20.1.temp = alloca i1, align 1, !dbg !29
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc37_20.1.temp), !dbg !29
@@ -137,15 +137,15 @@ fn Run() {
 // CHECK:STDOUT: !19 = !{!13}
 // CHECK:STDOUT: !20 = !DILocation(line: 29, column: 5, scope: !17)
 // CHECK:STDOUT: !21 = !DILocation(line: 30, column: 5, scope: !17)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 40, type: !23, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !23 = !DISubroutineType(types: !24)
-// CHECK:STDOUT: !24 = !{null}
-// CHECK:STDOUT: !25 = !DILocation(line: 41, column: 3, scope: !22)
-// CHECK:STDOUT: !26 = !DILocation(line: 42, column: 3, scope: !22)
-// CHECK:STDOUT: !27 = !DILocation(line: 40, column: 1, scope: !22)
-// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.27a852a6bab6ed2e", scope: null, file: !3, line: 36, type: !23, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !29 = !DILocation(line: 37, column: 16, scope: !28)
-// CHECK:STDOUT: !30 = !DILocation(line: 36, column: 1, scope: !28)
-// CHECK:STDOUT: !31 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.2de7c972fe093485", scope: null, file: !3, line: 36, type: !23, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 40, type: !18, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !23 = !DILocation(line: 41, column: 3, scope: !22)
+// CHECK:STDOUT: !24 = !DILocation(line: 42, column: 3, scope: !22)
+// CHECK:STDOUT: !25 = !DILocation(line: 40, column: 1, scope: !22)
+// CHECK:STDOUT: !26 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.27a852a6bab6ed2e", scope: null, file: !3, line: 36, type: !27, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !27 = !DISubroutineType(types: !28)
+// CHECK:STDOUT: !28 = !{null}
+// CHECK:STDOUT: !29 = !DILocation(line: 37, column: 16, scope: !26)
+// CHECK:STDOUT: !30 = !DILocation(line: 36, column: 1, scope: !26)
+// CHECK:STDOUT: !31 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.2de7c972fe093485", scope: null, file: !3, line: 36, type: !27, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !32 = !DILocation(line: 37, column: 16, scope: !31)
 // CHECK:STDOUT: !33 = !DILocation(line: 36, column: 1, scope: !31)

--- a/toolchain/lower/testdata/function/generic/call_recursive_impl.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_impl.carbon
@@ -61,45 +61,45 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !12 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %G.call.loc40 = call i32 @_CG.Main.e55c78367db83a6b(i32 0), !dbg !13
-// CHECK:STDOUT:   %G.call.loc41 = call i32 @_CG.Main.95a632fb0c368a62(i32 0), !dbg !14
-// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT:   %G.call.loc40 = call i32 @_CG.Main.e55c78367db83a6b(i32 0), !dbg !16
+// CHECK:STDOUT:   %G.call.loc41 = call i32 @_CG.Main.95a632fb0c368a62(i32 0), !dbg !17
+// CHECK:STDOUT:   ret i32 0, !dbg !18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare i32 @printf(ptr, ...)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.e55c78367db83a6b(i32 %count) #0 !dbg !16 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.e55c78367db83a6b(i32 %count) #0 !dbg !19 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @"_CF.X.Main:I.Main"(), !dbg !22
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.call = icmp sgt i32 %count, 0, !dbg !23
-// CHECK:STDOUT:   br i1 %Int.as.OrderedWith.impl.Greater.call, label %if.then, label %if.else, !dbg !24
+// CHECK:STDOUT:   call void @"_CF.X.Main:I.Main"(), !dbg !24
+// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.call = icmp sgt i32 %count, 0, !dbg !25
+// CHECK:STDOUT:   br i1 %Int.as.OrderedWith.impl.Greater.call, label %if.then, label %if.else, !dbg !26
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret i32 %count, !dbg !25
+// CHECK:STDOUT:   ret i32 %count, !dbg !27
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %count, 1, !dbg !26
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.e55c78367db83a6b(i32 %Int.as.AddWith.impl.Op.call), !dbg !27
-// CHECK:STDOUT:   ret i32 %G.call, !dbg !28
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %count, 1, !dbg !28
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.e55c78367db83a6b(i32 %Int.as.AddWith.impl.Op.call), !dbg !29
+// CHECK:STDOUT:   ret i32 %G.call, !dbg !30
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.95a632fb0c368a62(i32 %count) #0 !dbg !29 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.95a632fb0c368a62(i32 %count) #0 !dbg !31 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @"_CF.Y.Main:I.Main"(), !dbg !32
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.call = icmp sgt i32 %count, 0, !dbg !33
-// CHECK:STDOUT:   br i1 %Int.as.OrderedWith.impl.Greater.call, label %if.then, label %if.else, !dbg !34
+// CHECK:STDOUT:   call void @"_CF.Y.Main:I.Main"(), !dbg !34
+// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Greater.call = icmp sgt i32 %count, 0, !dbg !35
+// CHECK:STDOUT:   br i1 %Int.as.OrderedWith.impl.Greater.call, label %if.then, label %if.else, !dbg !36
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   ret i32 %count, !dbg !35
+// CHECK:STDOUT:   ret i32 %count, !dbg !37
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %count, 1, !dbg !36
-// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.95a632fb0c368a62(i32 %Int.as.AddWith.impl.Op.call), !dbg !37
-// CHECK:STDOUT:   ret i32 %G.call, !dbg !38
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %count, 1, !dbg !38
+// CHECK:STDOUT:   %G.call = call i32 @_CG.Main.95a632fb0c368a62(i32 %Int.as.AddWith.impl.Op.call), !dbg !39
+// CHECK:STDOUT:   ret i32 %G.call, !dbg !40
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
@@ -122,30 +122,32 @@ fn Run() {
 // CHECK:STDOUT: !9 = distinct !DISubprogram(name: "F", linkageName: "_CF.Y.Main:I.Main", scope: null, file: !3, line: 24, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !10 = !DILocation(line: 24, column: 12, scope: !9)
 // CHECK:STDOUT: !11 = !DILocation(line: 24, column: 3, scope: !9)
-// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 39, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !13 = !DILocation(line: 40, column: 3, scope: !12)
-// CHECK:STDOUT: !14 = !DILocation(line: 41, column: 3, scope: !12)
-// CHECK:STDOUT: !15 = !DILocation(line: 39, column: 1, scope: !12)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e55c78367db83a6b", scope: null, file: !3, line: 30, type: !17, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
-// CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
-// CHECK:STDOUT: !18 = !{!19, !19}
-// CHECK:STDOUT: !19 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !20 = !{!21}
-// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !16, type: !19)
-// CHECK:STDOUT: !22 = !DILocation(line: 31, column: 3, scope: !16)
-// CHECK:STDOUT: !23 = !DILocation(line: 33, column: 7, scope: !16)
-// CHECK:STDOUT: !24 = !DILocation(line: 33, column: 6, scope: !16)
-// CHECK:STDOUT: !25 = !DILocation(line: 34, column: 5, scope: !16)
-// CHECK:STDOUT: !26 = !DILocation(line: 36, column: 15, scope: !16)
-// CHECK:STDOUT: !27 = !DILocation(line: 36, column: 10, scope: !16)
-// CHECK:STDOUT: !28 = !DILocation(line: 36, column: 3, scope: !16)
-// CHECK:STDOUT: !29 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.95a632fb0c368a62", scope: null, file: !3, line: 30, type: !17, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !30)
-// CHECK:STDOUT: !30 = !{!31}
-// CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !19)
-// CHECK:STDOUT: !32 = !DILocation(line: 31, column: 3, scope: !29)
-// CHECK:STDOUT: !33 = !DILocation(line: 33, column: 7, scope: !29)
-// CHECK:STDOUT: !34 = !DILocation(line: 33, column: 6, scope: !29)
-// CHECK:STDOUT: !35 = !DILocation(line: 34, column: 5, scope: !29)
-// CHECK:STDOUT: !36 = !DILocation(line: 36, column: 15, scope: !29)
-// CHECK:STDOUT: !37 = !DILocation(line: 36, column: 10, scope: !29)
-// CHECK:STDOUT: !38 = !DILocation(line: 36, column: 3, scope: !29)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 39, type: !13, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
+// CHECK:STDOUT: !14 = !{!15}
+// CHECK:STDOUT: !15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !16 = !DILocation(line: 40, column: 3, scope: !12)
+// CHECK:STDOUT: !17 = !DILocation(line: 41, column: 3, scope: !12)
+// CHECK:STDOUT: !18 = !DILocation(line: 39, column: 1, scope: !12)
+// CHECK:STDOUT: !19 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.e55c78367db83a6b", scope: null, file: !3, line: 30, type: !20, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !22)
+// CHECK:STDOUT: !20 = !DISubroutineType(types: !21)
+// CHECK:STDOUT: !21 = !{!15, !15}
+// CHECK:STDOUT: !22 = !{!23}
+// CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !19, type: !15)
+// CHECK:STDOUT: !24 = !DILocation(line: 31, column: 3, scope: !19)
+// CHECK:STDOUT: !25 = !DILocation(line: 33, column: 7, scope: !19)
+// CHECK:STDOUT: !26 = !DILocation(line: 33, column: 6, scope: !19)
+// CHECK:STDOUT: !27 = !DILocation(line: 34, column: 5, scope: !19)
+// CHECK:STDOUT: !28 = !DILocation(line: 36, column: 15, scope: !19)
+// CHECK:STDOUT: !29 = !DILocation(line: 36, column: 10, scope: !19)
+// CHECK:STDOUT: !30 = !DILocation(line: 36, column: 3, scope: !19)
+// CHECK:STDOUT: !31 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.95a632fb0c368a62", scope: null, file: !3, line: 30, type: !20, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !32)
+// CHECK:STDOUT: !32 = !{!33}
+// CHECK:STDOUT: !33 = !DILocalVariable(arg: 1, scope: !31, type: !15)
+// CHECK:STDOUT: !34 = !DILocation(line: 31, column: 3, scope: !31)
+// CHECK:STDOUT: !35 = !DILocation(line: 33, column: 7, scope: !31)
+// CHECK:STDOUT: !36 = !DILocation(line: 33, column: 6, scope: !31)
+// CHECK:STDOUT: !37 = !DILocation(line: 34, column: 5, scope: !31)
+// CHECK:STDOUT: !38 = !DILocation(line: 36, column: 15, scope: !31)
+// CHECK:STDOUT: !39 = !DILocation(line: 36, column: 10, scope: !31)
+// CHECK:STDOUT: !40 = !DILocation(line: 36, column: 3, scope: !31)

--- a/toolchain/lower/testdata/function/generic/cross_library_name_collision_private.carbon
+++ b/toolchain/lower/testdata/function/generic/cross_library_name_collision_private.carbon
@@ -75,15 +75,15 @@ fn Run() {
 // CHECK:STDOUT: source_filename = "todo_use.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Lib1CallF.call = call i32 @_CLib1CallF.Main.2382f01eaa053e7b(i32 1, i32 2), !dbg !7
-// CHECK:STDOUT:   %Lib2CallF.call = call i32 @_CLib2CallF.Main.2382f01eaa053e7b(i32 1, i32 2), !dbg !8
-// CHECK:STDOUT:   ret void, !dbg !9
+// CHECK:STDOUT:   %Lib1CallF.call = call i32 @_CLib1CallF.Main.2382f01eaa053e7b(i32 1, i32 2), !dbg !8
+// CHECK:STDOUT:   %Lib2CallF.call = call i32 @_CLib2CallF.Main.2382f01eaa053e7b(i32 1, i32 2), !dbg !9
+// CHECK:STDOUT:   ret i32 0, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CLib1CallF.Main.2382f01eaa053e7b(i32 %a, i32 %b) #0 !dbg !10 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CLib1CallF.Main.2382f01eaa053e7b(i32 %a, i32 %b) #0 !dbg !11 {
 // CHECK:STDOUT:   %1 = call i32 @_CF.Main.2382f01eaa053e7b(i32 %a, i32 %b), !dbg !18
 // CHECK:STDOUT:   ret i32 %1, !dbg !19
 // CHECK:STDOUT: }
@@ -113,29 +113,29 @@ fn Run() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "todo_use.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 9, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 10, column: 16, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 11, column: 16, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 9, column: 1, scope: !4)
-// CHECK:STDOUT: !10 = distinct !DISubprogram(name: "Lib1CallF", linkageName: "_CLib1CallF.Main.2382f01eaa053e7b", scope: null, file: !11, line: 8, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !15)
-// CHECK:STDOUT: !11 = !DIFile(filename: "lib1.carbon", directory: "")
-// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
-// CHECK:STDOUT: !13 = !{!14, !14, !14}
-// CHECK:STDOUT: !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 10, column: 16, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 11, column: 16, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 9, column: 1, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Lib1CallF", linkageName: "_CLib1CallF.Main.2382f01eaa053e7b", scope: null, file: !12, line: 8, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !15)
+// CHECK:STDOUT: !12 = !DIFile(filename: "lib1.carbon", directory: "")
+// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
+// CHECK:STDOUT: !14 = !{!7, !7, !7}
 // CHECK:STDOUT: !15 = !{!16, !17}
-// CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !10, type: !14)
-// CHECK:STDOUT: !17 = !DILocalVariable(arg: 2, scope: !10, type: !14)
-// CHECK:STDOUT: !18 = !DILocation(line: 9, column: 10, scope: !10)
-// CHECK:STDOUT: !19 = !DILocation(line: 9, column: 3, scope: !10)
-// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "Lib2CallF", linkageName: "_CLib2CallF.Main.2382f01eaa053e7b", scope: null, file: !21, line: 11, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !22)
+// CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !11, type: !7)
+// CHECK:STDOUT: !17 = !DILocalVariable(arg: 2, scope: !11, type: !7)
+// CHECK:STDOUT: !18 = !DILocation(line: 9, column: 10, scope: !11)
+// CHECK:STDOUT: !19 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !20 = distinct !DISubprogram(name: "Lib2CallF", linkageName: "_CLib2CallF.Main.2382f01eaa053e7b", scope: null, file: !21, line: 11, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !22)
 // CHECK:STDOUT: !21 = !DIFile(filename: "lib2.carbon", directory: "")
 // CHECK:STDOUT: !22 = !{!23, !24}
-// CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !20, type: !14)
-// CHECK:STDOUT: !24 = !DILocalVariable(arg: 2, scope: !20, type: !14)
+// CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !20, type: !7)
+// CHECK:STDOUT: !24 = !DILocalVariable(arg: 2, scope: !20, type: !7)
 // CHECK:STDOUT: !25 = !DILocation(line: 12, column: 10, scope: !20)
 // CHECK:STDOUT: !26 = !DILocation(line: 12, column: 3, scope: !20)
-// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.2382f01eaa053e7b", scope: null, file: !11, line: 4, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !28)
+// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.2382f01eaa053e7b", scope: null, file: !12, line: 4, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !28)
 // CHECK:STDOUT: !28 = !{!29, !30}
-// CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !14)
-// CHECK:STDOUT: !30 = !DILocalVariable(arg: 2, scope: !27, type: !14)
+// CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !7)
+// CHECK:STDOUT: !30 = !DILocalVariable(arg: 2, scope: !27, type: !7)
 // CHECK:STDOUT: !31 = !DILocation(line: 5, column: 3, scope: !27)

--- a/toolchain/lower/testdata/function/generic/import_core_witness.carbon
+++ b/toolchain/lower/testdata/function/generic/import_core_witness.carbon
@@ -57,19 +57,19 @@ fn Run() {
 // CHECK:STDOUT: source_filename = "main.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CF.Main.ea4dcbbefe9f139a(), !dbg !7
-// CHECK:STDOUT:   ret void, !dbg !8
+// CHECK:STDOUT:   call void @_CF.Main.ea4dcbbefe9f139a(), !dbg !8
+// CHECK:STDOUT:   ret i32 0, !dbg !9
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CF.Main.ea4dcbbefe9f139a() #0 !dbg !9 {
-// CHECK:STDOUT:   %1 = alloca i32, align 4, !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %1), !dbg !11
-// CHECK:STDOUT:   store i32 0, ptr %1, align 4, !dbg !11
-// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %1), !dbg !11
-// CHECK:STDOUT:   ret void, !dbg !12
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.ea4dcbbefe9f139a() #0 !dbg !10 {
+// CHECK:STDOUT:   %1 = alloca i32, align 4, !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %1), !dbg !14
+// CHECK:STDOUT:   store i32 0, ptr %1, align 4, !dbg !14
+// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %1), !dbg !14
+// CHECK:STDOUT:   ret void, !dbg !15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr)
@@ -89,10 +89,13 @@ fn Run() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "main.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 4, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 5, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 4, column: 1, scope: !4)
-// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.ea4dcbbefe9f139a", scope: null, file: !10, line: 4, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !10 = !DIFile(filename: "lib.carbon", directory: "")
-// CHECK:STDOUT: !11 = !DILocation(line: 7, column: 3, scope: !9)
-// CHECK:STDOUT: !12 = !DILocation(line: 4, column: 1, scope: !9)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 5, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 4, column: 1, scope: !4)
+// CHECK:STDOUT: !10 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.ea4dcbbefe9f139a", scope: null, file: !11, line: 4, type: !12, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !11 = !DIFile(filename: "lib.carbon", directory: "")
+// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
+// CHECK:STDOUT: !13 = !{null}
+// CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !10)
+// CHECK:STDOUT: !15 = !DILocation(line: 4, column: 1, scope: !10)

--- a/toolchain/lower/testdata/index/array_element_access.carbon
+++ b/toolchain/lower/testdata/index/array_element_access.carbon
@@ -45,49 +45,49 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !13 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !13 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca [2 x i32], align 4, !dbg !16
-// CHECK:STDOUT:   %.loc17_28.1.temp = alloca { i32, i32 }, align 8, !dbg !17
-// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !18
-// CHECK:STDOUT:   %_.var.loc19 = alloca i32, align 4, !dbg !19
-// CHECK:STDOUT:   %_.var.loc20 = alloca i32, align 4, !dbg !20
-// CHECK:STDOUT:   %.loc20_18.1.temp = alloca [2 x i32], align 4, !dbg !21
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !16
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_28.1.temp), !dbg !17
-// CHECK:STDOUT:   call void @_CA.Main(ptr %.loc17_28.1.temp), !dbg !17
-// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc17_28.1.temp, i32 0, i32 0, !dbg !17
-// CHECK:STDOUT:   %.loc17_28.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !17
-// CHECK:STDOUT:   %.loc17_28.4.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 0, !dbg !17
-// CHECK:STDOUT:   store i32 %.loc17_28.3, ptr %.loc17_28.4.array.index, align 4, !dbg !17
-// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc17_28.1.temp, i32 0, i32 1, !dbg !17
-// CHECK:STDOUT:   %.loc17_28.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !17
-// CHECK:STDOUT:   %.loc17_28.7.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 1, !dbg !17
-// CHECK:STDOUT:   store i32 %.loc17_28.6, ptr %.loc17_28.7.array.index, align 4, !dbg !17
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !18
-// CHECK:STDOUT:   store i32 1, ptr %b.var, align 4, !dbg !18
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc19), !dbg !19
-// CHECK:STDOUT:   %.loc19_18 = load i32, ptr %b.var, align 4, !dbg !22
-// CHECK:STDOUT:   %.loc19_19.1.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i32 %.loc19_18, !dbg !23
-// CHECK:STDOUT:   %.loc19_19.2 = load i32, ptr %.loc19_19.1.array.index, align 4, !dbg !23
-// CHECK:STDOUT:   store i32 %.loc19_19.2, ptr %_.var.loc19, align 4, !dbg !19
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc20), !dbg !20
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_18.1.temp), !dbg !21
-// CHECK:STDOUT:   call void @_CB.Main(ptr %.loc20_18.1.temp), !dbg !21
-// CHECK:STDOUT:   %.loc20_21.1.array.index = getelementptr inbounds [2 x i32], ptr %.loc20_18.1.temp, i32 0, i32 1, !dbg !21
-// CHECK:STDOUT:   %.loc20_21.2 = load i32, ptr %.loc20_21.1.array.index, align 4, !dbg !21
-// CHECK:STDOUT:   store i32 %.loc20_21.2, ptr %_.var.loc20, align 4, !dbg !20
-// CHECK:STDOUT:   call void @"_COp.f53f00a5f9e218d2:core.Destroy.Core"(ptr %.loc20_18.1.temp), !dbg !21
-// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %_.var.loc20), !dbg !20
-// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %_.var.loc19), !dbg !19
-// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %b.var), !dbg !18
-// CHECK:STDOUT:   call void @"_COp.8e354c83fe88ab86:core.Destroy.Core"(ptr %.loc17_28.1.temp), !dbg !17
-// CHECK:STDOUT:   call void @"_COp.f53f00a5f9e218d2:core.Destroy.Core"(ptr %a.var), !dbg !16
-// CHECK:STDOUT:   ret void, !dbg !24
+// CHECK:STDOUT:   %a.var = alloca [2 x i32], align 4, !dbg !17
+// CHECK:STDOUT:   %.loc17_28.1.temp = alloca { i32, i32 }, align 8, !dbg !18
+// CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !19
+// CHECK:STDOUT:   %_.var.loc19 = alloca i32, align 4, !dbg !20
+// CHECK:STDOUT:   %_.var.loc20 = alloca i32, align 4, !dbg !21
+// CHECK:STDOUT:   %.loc20_18.1.temp = alloca [2 x i32], align 4, !dbg !22
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_28.1.temp), !dbg !18
+// CHECK:STDOUT:   call void @_CA.Main(ptr %.loc17_28.1.temp), !dbg !18
+// CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc17_28.1.temp, i32 0, i32 0, !dbg !18
+// CHECK:STDOUT:   %.loc17_28.3 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !18
+// CHECK:STDOUT:   %.loc17_28.4.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 0, !dbg !18
+// CHECK:STDOUT:   store i32 %.loc17_28.3, ptr %.loc17_28.4.array.index, align 4, !dbg !18
+// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc17_28.1.temp, i32 0, i32 1, !dbg !18
+// CHECK:STDOUT:   %.loc17_28.6 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !18
+// CHECK:STDOUT:   %.loc17_28.7.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i64 1, !dbg !18
+// CHECK:STDOUT:   store i32 %.loc17_28.6, ptr %.loc17_28.7.array.index, align 4, !dbg !18
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !19
+// CHECK:STDOUT:   store i32 1, ptr %b.var, align 4, !dbg !19
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc19), !dbg !20
+// CHECK:STDOUT:   %.loc19_18 = load i32, ptr %b.var, align 4, !dbg !23
+// CHECK:STDOUT:   %.loc19_19.1.array.index = getelementptr inbounds [2 x i32], ptr %a.var, i32 0, i32 %.loc19_18, !dbg !24
+// CHECK:STDOUT:   %.loc19_19.2 = load i32, ptr %.loc19_19.1.array.index, align 4, !dbg !24
+// CHECK:STDOUT:   store i32 %.loc19_19.2, ptr %_.var.loc19, align 4, !dbg !20
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc20), !dbg !21
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_18.1.temp), !dbg !22
+// CHECK:STDOUT:   call void @_CB.Main(ptr %.loc20_18.1.temp), !dbg !22
+// CHECK:STDOUT:   %.loc20_21.1.array.index = getelementptr inbounds [2 x i32], ptr %.loc20_18.1.temp, i32 0, i32 1, !dbg !22
+// CHECK:STDOUT:   %.loc20_21.2 = load i32, ptr %.loc20_21.1.array.index, align 4, !dbg !22
+// CHECK:STDOUT:   store i32 %.loc20_21.2, ptr %_.var.loc20, align 4, !dbg !21
+// CHECK:STDOUT:   call void @"_COp.f53f00a5f9e218d2:core.Destroy.Core"(ptr %.loc20_18.1.temp), !dbg !22
+// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %_.var.loc20), !dbg !21
+// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %_.var.loc19), !dbg !20
+// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %b.var), !dbg !19
+// CHECK:STDOUT:   call void @"_COp.8e354c83fe88ab86:core.Destroy.Core"(ptr %.loc17_28.1.temp), !dbg !18
+// CHECK:STDOUT:   call void @"_COp.f53f00a5f9e218d2:core.Destroy.Core"(ptr %a.var), !dbg !17
+// CHECK:STDOUT:   ret i32 0, !dbg !25
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !25 {
+// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !26 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !31
 // CHECK:STDOUT: }
@@ -138,23 +138,23 @@ fn Run() {
 // CHECK:STDOUT: !12 = !DILocation(line: 14, column: 27, scope: !10)
 // CHECK:STDOUT: !13 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 16, type: !14, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !14 = !DISubroutineType(types: !15)
-// CHECK:STDOUT: !15 = !{null}
-// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 3, scope: !13)
-// CHECK:STDOUT: !17 = !DILocation(line: 17, column: 26, scope: !13)
-// CHECK:STDOUT: !18 = !DILocation(line: 18, column: 3, scope: !13)
-// CHECK:STDOUT: !19 = !DILocation(line: 19, column: 3, scope: !13)
-// CHECK:STDOUT: !20 = !DILocation(line: 20, column: 3, scope: !13)
-// CHECK:STDOUT: !21 = !DILocation(line: 20, column: 16, scope: !13)
-// CHECK:STDOUT: !22 = !DILocation(line: 19, column: 18, scope: !13)
-// CHECK:STDOUT: !23 = !DILocation(line: 19, column: 16, scope: !13)
-// CHECK:STDOUT: !24 = !DILocation(line: 16, column: 1, scope: !13)
-// CHECK:STDOUT: !25 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 20, type: !26, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !29)
-// CHECK:STDOUT: !26 = !DISubroutineType(types: !27)
-// CHECK:STDOUT: !27 = !{null, !28}
-// CHECK:STDOUT: !28 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !15 = !{!16}
+// CHECK:STDOUT: !16 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !17 = !DILocation(line: 17, column: 3, scope: !13)
+// CHECK:STDOUT: !18 = !DILocation(line: 17, column: 26, scope: !13)
+// CHECK:STDOUT: !19 = !DILocation(line: 18, column: 3, scope: !13)
+// CHECK:STDOUT: !20 = !DILocation(line: 19, column: 3, scope: !13)
+// CHECK:STDOUT: !21 = !DILocation(line: 20, column: 3, scope: !13)
+// CHECK:STDOUT: !22 = !DILocation(line: 20, column: 16, scope: !13)
+// CHECK:STDOUT: !23 = !DILocation(line: 19, column: 18, scope: !13)
+// CHECK:STDOUT: !24 = !DILocation(line: 19, column: 16, scope: !13)
+// CHECK:STDOUT: !25 = !DILocation(line: 16, column: 1, scope: !13)
+// CHECK:STDOUT: !26 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 20, type: !27, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !29)
+// CHECK:STDOUT: !27 = !DISubroutineType(types: !28)
+// CHECK:STDOUT: !28 = !{null, !16}
 // CHECK:STDOUT: !29 = !{!30}
-// CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !25, type: !28)
-// CHECK:STDOUT: !31 = !DILocation(line: 20, column: 16, scope: !25)
+// CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !26, type: !16)
+// CHECK:STDOUT: !31 = !DILocation(line: 20, column: 16, scope: !26)
 // CHECK:STDOUT: !32 = distinct !DISubprogram(name: "Op", linkageName: "_COp.f53f00a5f9e218d2:core.Destroy.Core", scope: null, file: !3, line: 20, type: !33, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !35)
 // CHECK:STDOUT: !33 = !DISubroutineType(types: !34)
 // CHECK:STDOUT: !34 = !{null, !7}

--- a/toolchain/lower/testdata/interop/cpp/cpp_run.carbon
+++ b/toolchain/lower/testdata/interop/cpp/cpp_run.carbon
@@ -34,10 +34,10 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #1 !dbg !11 {
+// CHECK:STDOUT: define i32 @main() #1 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_ZN1N3RunEv(), !dbg !14
-// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT:   call void @_ZN1N3RunEv(), !dbg !15
+// CHECK:STDOUT:   ret i32 0, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
@@ -60,6 +60,7 @@ fn Run() {
 // CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
 // CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !6, line: 8, type: !12, spFlags: DISPFlagDefinition, unit: !5)
 // CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
-// CHECK:STDOUT: !13 = !{null}
-// CHECK:STDOUT: !14 = !DILocation(line: 9, column: 3, scope: !11)
-// CHECK:STDOUT: !15 = !DILocation(line: 8, column: 1, scope: !11)
+// CHECK:STDOUT: !13 = !{!14}
+// CHECK:STDOUT: !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !15 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !16 = !DILocation(line: 8, column: 1, scope: !11)

--- a/toolchain/lower/testdata/namespace/namespace_run.carbon
+++ b/toolchain/lower/testdata/namespace/namespace_run.carbon
@@ -28,10 +28,10 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !8 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !8 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CRun.Foo.Main(), !dbg !9
-// CHECK:STDOUT:   ret void, !dbg !10
+// CHECK:STDOUT:   call void @_CRun.Foo.Main(), !dbg !12
+// CHECK:STDOUT:   ret i32 0, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
@@ -47,6 +47,9 @@ fn Run() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 15, column: 1, scope: !4)
-// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !9 = !DILocation(line: 18, column: 5, scope: !8)
-// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 1, scope: !8)
+// CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 17, type: !9, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !9 = !DISubroutineType(types: !10)
+// CHECK:STDOUT: !10 = !{!11}
+// CHECK:STDOUT: !11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !12 = !DILocation(line: 18, column: 5, scope: !8)
+// CHECK:STDOUT: !13 = !DILocation(line: 17, column: 1, scope: !8)

--- a/toolchain/lower/testdata/return/function_ids_in_different_files.carbon
+++ b/toolchain/lower/testdata/return/function_ids_in_different_files.carbon
@@ -6,31 +6,27 @@
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
-// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/class/import.carbon
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/return/function_ids_in_different_files.carbon
 // TIP: To dump output, run:
-// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/class/import.carbon
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/return/function_ids_in_different_files.carbon
 
 // --- a.carbon
-
-library "X";
-base class D[T:! type](X:! T) {
-}
-class C {
-  fn F();
-  extend base: D(F);
+library "[[@TEST_NAME]]";
+fn F(unused T:! type) {
+  // Explicit no-argument `return` in a generic function.
+  return;
 }
 
 // --- b.carbon
-
-import library "X";
-fn Run() {
-  C.F();
+library "[[@TEST_NAME]]";
+import library "a";
+fn G() {
+  // Create specific in a different file.
+  F({});
 }
 
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
-// CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_CF.C.Main()
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!2}
@@ -43,13 +39,16 @@ fn Run() {
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
+// CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CF.C.Main(), !dbg !8
-// CHECK:STDOUT:   ret i32 0, !dbg !9
+// CHECK:STDOUT:   call void @_CF.Main.6944efcfbb6a8360(), !dbg !7
+// CHECK:STDOUT:   ret void, !dbg !8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @_CF.C.Main()
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @_CF.Main.6944efcfbb6a8360() #0 !dbg !9 {
+// CHECK:STDOUT:   ret void, !dbg !11
+// CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
 // CHECK:STDOUT:
@@ -60,9 +59,11 @@ fn Run() {
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 // CHECK:STDOUT: !3 = !DIFile(filename: "b.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 3, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main", scope: null, file: !3, line: 3, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{!7}
-// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !8 = !DILocation(line: 4, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 3, column: 1, scope: !4)
+// CHECK:STDOUT: !6 = !{null}
+// CHECK:STDOUT: !7 = !DILocation(line: 5, column: 3, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 3, column: 1, scope: !4)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.6944efcfbb6a8360", scope: null, file: !10, line: 2, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = !DIFile(filename: "a.carbon", directory: "")
+// CHECK:STDOUT: !11 = !DILocation(line: 4, column: 3, scope: !9)

--- a/toolchain/lower/testdata/return/no_return_from_run.carbon
+++ b/toolchain/lower/testdata/return/no_return_from_run.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/return/no_return_from_run.carbon
 
-// We expect this to lower to LLVM IR that returns int32 0.
+// We expect this to lower to LLVM IR that returns i32 0.
 fn Run() {}
 
 // LLVM IR for calls to Run should reflect the i32 call type of the lowered Run function.

--- a/toolchain/lower/testdata/return/no_return_from_run.carbon
+++ b/toolchain/lower/testdata/return/no_return_from_run.carbon
@@ -1,0 +1,55 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/convert.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/return/no_return_from_run.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/return/no_return_from_run.carbon
+
+// We expect this to lower to LLVM IR that returns int32 0.
+fn Run() {}
+
+// LLVM IR for calls to Run should reflect the i32 call type of the lowered Run function.
+fn Foo() {
+  Run();
+}
+
+// CHECK:STDOUT: ; ModuleID = 'no_return_from_run.carbon'
+// CHECK:STDOUT: source_filename = "no_return_from_run.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret i32 0, !dbg !8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CFoo.Main() #0 !dbg !9 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Run.call = call i32 @main(), !dbg !12
+// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "no_return_from_run.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 1, scope: !4)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "Foo", linkageName: "_CFoo.Main", scope: null, file: !3, line: 17, type: !10, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = !DISubroutineType(types: !11)
+// CHECK:STDOUT: !11 = !{null}
+// CHECK:STDOUT: !12 = !DILocation(line: 18, column: 3, scope: !9)
+// CHECK:STDOUT: !13 = !DILocation(line: 17, column: 1, scope: !9)

--- a/toolchain/lower/testdata/tuple/access/return_value_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/return_value_access.carbon
@@ -31,23 +31,23 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !10 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !10 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !13
-// CHECK:STDOUT:   %.loc16_18.1.temp = alloca { i32, i32 }, align 8, !dbg !14
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !13
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_18.1.temp), !dbg !14
-// CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_18.1.temp), !dbg !14
-// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_18.1.temp, i32 0, i32 1, !dbg !14
-// CHECK:STDOUT:   %.loc16_19 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !14
-// CHECK:STDOUT:   store i32 %.loc16_19, ptr %_.var, align 4, !dbg !13
-// CHECK:STDOUT:   call void @"_COp.8e354c83fe88ab86:core.Destroy.Core"(ptr %.loc16_18.1.temp), !dbg !14
-// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %_.var), !dbg !13
-// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !14
+// CHECK:STDOUT:   %.loc16_18.1.temp = alloca { i32, i32 }, align 8, !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_18.1.temp), !dbg !15
+// CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_18.1.temp), !dbg !15
+// CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc16_18.1.temp, i32 0, i32 1, !dbg !15
+// CHECK:STDOUT:   %.loc16_19 = load i32, ptr %tuple.elem1.tuple.elem, align 4, !dbg !15
+// CHECK:STDOUT:   store i32 %.loc16_19, ptr %_.var, align 4, !dbg !14
+// CHECK:STDOUT:   call void @"_COp.8e354c83fe88ab86:core.Destroy.Core"(ptr %.loc16_18.1.temp), !dbg !15
+// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %_.var), !dbg !14
+// CHECK:STDOUT:   ret i32 0, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !16 {
+// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !17 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !22
 // CHECK:STDOUT: }
@@ -86,17 +86,17 @@ fn Run() {
 // CHECK:STDOUT: !9 = !DILocation(line: 13, column: 24, scope: !4)
 // CHECK:STDOUT: !10 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 15, type: !11, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !11 = !DISubroutineType(types: !12)
-// CHECK:STDOUT: !12 = !{null}
-// CHECK:STDOUT: !13 = !DILocation(line: 16, column: 3, scope: !10)
-// CHECK:STDOUT: !14 = !DILocation(line: 16, column: 16, scope: !10)
-// CHECK:STDOUT: !15 = !DILocation(line: 15, column: 1, scope: !10)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 16, type: !17, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
-// CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
-// CHECK:STDOUT: !18 = !{null, !19}
-// CHECK:STDOUT: !19 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !12 = !{!13}
+// CHECK:STDOUT: !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !14 = !DILocation(line: 16, column: 3, scope: !10)
+// CHECK:STDOUT: !15 = !DILocation(line: 16, column: 16, scope: !10)
+// CHECK:STDOUT: !16 = !DILocation(line: 15, column: 1, scope: !10)
+// CHECK:STDOUT: !17 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 16, type: !18, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
+// CHECK:STDOUT: !18 = !DISubroutineType(types: !19)
+// CHECK:STDOUT: !19 = !{null, !13}
 // CHECK:STDOUT: !20 = !{!21}
-// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !16, type: !19)
-// CHECK:STDOUT: !22 = !DILocation(line: 16, column: 16, scope: !16)
+// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !17, type: !13)
+// CHECK:STDOUT: !22 = !DILocation(line: 16, column: 16, scope: !17)
 // CHECK:STDOUT: !23 = distinct !DISubprogram(name: "Op", linkageName: "_COp.8e354c83fe88ab86:core.Destroy.Core", scope: null, file: !3, line: 16, type: !24, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !26)
 // CHECK:STDOUT: !24 = !DISubroutineType(types: !25)
 // CHECK:STDOUT: !25 = !{null, !7}

--- a/toolchain/lower/testdata/var/uninitialized.carbon
+++ b/toolchain/lower/testdata/var/uninitialized.carbon
@@ -23,37 +23,37 @@ fn Run() {
 // CHECK:STDOUT: source_filename = "uninitialized.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define void @main() #0 !dbg !4 {
+// CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca i32, align 4, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca double, align 8, !dbg !8
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !9
-// CHECK:STDOUT:   %d.var = alloca {}, align 8, !dbg !10
-// CHECK:STDOUT:   %e.var = alloca i1, align 1, !dbg !11
-// CHECK:STDOUT:   %f.var = alloca ptr, align 8, !dbg !12
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !7
-// CHECK:STDOUT:   store i32 poison, ptr %a.var, align 4, !dbg !7
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !8
-// CHECK:STDOUT:   store double poison, ptr %b.var, align 8, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !10
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %e.var), !dbg !11
-// CHECK:STDOUT:   store i8 poison, ptr %e.var, align 1, !dbg !11
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %f.var), !dbg !12
-// CHECK:STDOUT:   store ptr poison, ptr %f.var, align 8, !dbg !12
-// CHECK:STDOUT:   call void @"_COp.98006a366c2ffd6c:core.Destroy.Core"(ptr %b.var), !dbg !8
-// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %a.var), !dbg !7
-// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT:   %a.var = alloca i32, align 4, !dbg !8
+// CHECK:STDOUT:   %b.var = alloca double, align 8, !dbg !9
+// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !10
+// CHECK:STDOUT:   %d.var = alloca {}, align 8, !dbg !11
+// CHECK:STDOUT:   %e.var = alloca i1, align 1, !dbg !12
+// CHECK:STDOUT:   %f.var = alloca ptr, align 8, !dbg !13
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !8
+// CHECK:STDOUT:   store i32 poison, ptr %a.var, align 4, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !9
+// CHECK:STDOUT:   store double poison, ptr %b.var, align 8, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %e.var), !dbg !12
+// CHECK:STDOUT:   store i8 poison, ptr %e.var, align 1, !dbg !12
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %f.var), !dbg !13
+// CHECK:STDOUT:   store ptr poison, ptr %f.var, align 8, !dbg !13
+// CHECK:STDOUT:   call void @"_COp.98006a366c2ffd6c:core.Destroy.Core"(ptr %b.var), !dbg !9
+// CHECK:STDOUT:   call void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %a.var), !dbg !8
+// CHECK:STDOUT:   ret i32 0, !dbg !14
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.98006a366c2ffd6c:core.Destroy.Core"(ptr %self) #0 !dbg !14 {
+// CHECK:STDOUT: define weak_odr void @"_COp.98006a366c2ffd6c:core.Destroy.Core"(ptr %self) #0 !dbg !15 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   ret void, !dbg !20
+// CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !21 {
+// CHECK:STDOUT: define weak_odr void @"_COp.7e389eab4a7e5487:core.Destroy.Core"(ptr %self) #0 !dbg !22 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !27
 // CHECK:STDOUT: }
@@ -76,25 +76,25 @@ fn Run() {
 // CHECK:STDOUT: !3 = !DIFile(filename: "uninitialized.carbon", directory: "")
 // CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Run", linkageName: "main", scope: null, file: !3, line: 13, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
-// CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 16, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 18, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 19, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 13, column: 1, scope: !4)
-// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "Op", linkageName: "_COp.98006a366c2ffd6c:core.Destroy.Core", scope: null, file: !3, line: 15, type: !15, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !18)
-// CHECK:STDOUT: !15 = !DISubroutineType(types: !16)
-// CHECK:STDOUT: !16 = !{null, !17}
-// CHECK:STDOUT: !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
-// CHECK:STDOUT: !18 = !{!19}
-// CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !14, type: !17)
-// CHECK:STDOUT: !20 = !DILocation(line: 15, column: 3, scope: !14)
-// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 14, type: !22, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !25)
-// CHECK:STDOUT: !22 = !DISubroutineType(types: !23)
-// CHECK:STDOUT: !23 = !{null, !24}
-// CHECK:STDOUT: !24 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 17, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 18, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 19, column: 3, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "Op", linkageName: "_COp.98006a366c2ffd6c:core.Destroy.Core", scope: null, file: !3, line: 15, type: !16, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !19)
+// CHECK:STDOUT: !16 = !DISubroutineType(types: !17)
+// CHECK:STDOUT: !17 = !{null, !18}
+// CHECK:STDOUT: !18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !19 = !{!20}
+// CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !15, type: !18)
+// CHECK:STDOUT: !21 = !DILocation(line: 15, column: 3, scope: !15)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7e389eab4a7e5487:core.Destroy.Core", scope: null, file: !3, line: 14, type: !23, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !25)
+// CHECK:STDOUT: !23 = !DISubroutineType(types: !24)
+// CHECK:STDOUT: !24 = !{null, !7}
 // CHECK:STDOUT: !25 = !{!26}
-// CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !21, type: !24)
-// CHECK:STDOUT: !27 = !DILocation(line: 14, column: 3, scope: !21)
+// CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !22, type: !7)
+// CHECK:STDOUT: !27 = !DILocation(line: 14, column: 3, scope: !22)

--- a/toolchain/lower/type.cpp
+++ b/toolchain/lower/type.cpp
@@ -13,6 +13,7 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "toolchain/base/kind_switch.h"
 #include "toolchain/lower/file_context.h"
+#include "toolchain/sem_ir/entry_point.h"
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst.h"
@@ -135,6 +136,15 @@ class FunctionTypeInfoBuilder {
     auto lowered_return_types = GetLoweredTypes(func_ctx, return_type_id);
     return_type_ = lowered_return_types.llvm_ir_type;
     param_di_types_.push_back(lowered_return_types.llvm_di_type);
+    return true;
+  }
+
+  // Modifies the lowered return type of the entry point function to return
+  // an int32, to conform with expectations from calling programs.
+  auto SetEntryPointReturnInt32(const FunctionInContext& func_ctx) -> bool {
+    return_type_ = llvm::Type::getInt32Ty(func_ctx.context->llvm_context());
+    param_di_types_.push_back(context_->di_builder().createBasicType(
+        "int", 32, llvm::dwarf::DW_ATE_signed));
     return true;
   }
 
@@ -269,9 +279,6 @@ class FunctionTypeInfoBuilder {
 };
 
 auto FunctionTypeInfoBuilder::Build() && -> FunctionTypeInfo {
-  // TODO: For the `Run` entry point, remap return type to i32 if it doesn't
-  // return a value.
-
   // Determine how the parameters are numbered in SemIR, and make sure it's the
   // same for all versions of the function.
   auto semir_info = GetSemIRIndexInfo(functions_.front());
@@ -325,6 +332,12 @@ auto FunctionTypeInfoBuilder::TryHandleReturnForm(
       func_ctx.context->sem_ir().functions().Get(func_ctx.function_id);
   auto return_form_inst_id = function.return_form_inst_id;
   if (!return_form_inst_id.has_value()) {
+    // If this is the entry point 'Run()` function, and it doesn't specify a
+    // return type, we modify the lowered return type to be an int32 and emit IR
+    // to return 0i32.
+    if (SemIR::IsEntryPoint(func_ctx.context->sem_ir(), func_ctx.function_id)) {
+      return SetEntryPointReturnInt32(func_ctx);
+    }
     return SetReturnByCopy(func_ctx, SemIR::TypeId::None);
   }
 


### PR DESCRIPTION
https://carbon.compiler-explorer.com/z/88K9Kh5Wo shows the program
exiting with a garbage value copied from uninitialized memory.

This PR modifies `lower` to detect if the function lowered is the
entry point and doesn't specify a return type. If so, it emits
different LLVM IR to return int32 0, and modifies the lowered
function signature to match the int32 return type.