### PR TITLE
Roundtrip (export/reimport) class declarations

### DIFF
--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -116,8 +116,7 @@ auto ExportNameScopeToCpp(Context& context, SemIR::LocId loc_id,
 }
 
 auto ExportClassToCpp(Context& context, SemIR::LocId loc_id,
-                      SemIR::InstId class_inst_id, SemIR::ClassType class_type)
-    -> clang::TagDecl* {
+                      SemIR::ClassType class_type) -> clang::TagDecl* {
   // TODO: A lot of logic in this function is shared with ExportNameScopeToCpp.
   // This should be refactored.
 
@@ -131,9 +130,11 @@ auto ExportClassToCpp(Context& context, SemIR::LocId loc_id,
   // If this class was produced by importing a C++ declaration or has
   // already been exported to C++, return the corresponding Clang declaration.
   // That could either be a CXXRecordDecl or an EnumDecl.
-  if (auto* decl_context =
-          GetClangDeclContextForScope(context, class_info.scope_id)) {
-    return cast<clang::TagDecl>(decl_context);
+  if (auto clang_decl_id =
+          context.clang_decls().Lookup(class_info.first_decl_id());
+      clang_decl_id.has_value()) {
+    return cast<clang::TagDecl>(
+        context.clang_decls().Get(clang_decl_id).key.decl);
   }
 
   auto* identifier_info = GetClangIdentifierInfo(context, class_info.name_id);
@@ -157,8 +158,8 @@ auto ExportClassToCpp(Context& context, SemIR::LocId loc_id,
 
   auto key =
       SemIR::ClangDeclKey::ForNonFunctionDecl(cast<clang::Decl>(record_decl));
-  auto clang_decl_id =
-      context.clang_decls().Add({.key = key, .inst_id = class_inst_id});
+  auto clang_decl_id = context.clang_decls().Add(
+      {.key = key, .inst_id = class_info.first_decl_id()});
   if (class_info.scope_id.has_value()) {
     // TODO: Record the Carbon class -> clang declaration mapping for incomplete
     // classes too.

--- a/toolchain/check/cpp/export.h
+++ b/toolchain/check/cpp/export.h
@@ -28,8 +28,7 @@ auto ExportNameScopeToCpp(Context& context, SemIR::LocId loc_id,
 // Otherwise, creates a new C++ class and returns it. Returns nullptr if the
 // class could not be exported and an error was diagnosed.
 auto ExportClassToCpp(Context& context, SemIR::LocId loc_id,
-                      SemIR::InstId class_inst_id, SemIR::ClassType class_type)
-    -> clang::TagDecl*;
+                      SemIR::ClassType class_type) -> clang::TagDecl*;
 
 // Export all `SemIR::FieldDecl`s in the class body as `clang::FieldDecl`s.
 auto ExportAllFieldsToCpp(Context& context, SemIR::Class& class_info) -> void;

--- a/toolchain/check/cpp/type_mapping.cpp
+++ b/toolchain/check/cpp/type_mapping.cpp
@@ -226,8 +226,8 @@ static auto TryMapClassType(Context& context, SemIR::TypeInstId class_inst_id,
   }
 
   // Otherwise, find the existing C++ declaration or create a new one.
-  auto* tag_decl = ExportClassToCpp(context, SemIR::LocId(class_inst_id),
-                                    class_inst_id, class_type);
+  auto* tag_decl =
+      ExportClassToCpp(context, SemIR::LocId(class_inst_id), class_type);
   if (!tag_decl) {
     return clang::QualType();
   }

--- a/toolchain/check/testdata/interop/cpp/class/roundtrip.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/roundtrip.carbon
@@ -48,10 +48,6 @@ library "[[@TEST_NAME]]";
 
 import Cpp;
 
-// CHECK:STDERR: import.carbon:[[@LINE+4]]:1: error: class was forward declared here [ClassForwardDeclaredHere]
-// CHECK:STDERR: class Class1;
-// CHECK:STDERR: ^~~~~~~~~~~~~
-// CHECK:STDERR:
 class Class1;
 
 inline Cpp '''
@@ -59,12 +55,5 @@ void func(Carbon::Class1* _Nonnull);
 ''';
 
 fn Caller(p: Class1*) {
-  // CHECK:STDERR: import.carbon:[[@LINE+7]]:13: error: no matching function for call to 'func' [CppInteropParseError]
-  // CHECK:STDERR:    13 |   Cpp.func(p);
-  // CHECK:STDERR:       |             ^
-  // CHECK:STDERR: import.carbon:[[@LINE-7]]:6: note: candidate function not viable: cannot convert argument of incomplete type 'Carbon::Class1 * _Nonnull' to 'Carbon::Class1 * _Nonnull' (aka 'Carbon::Class1 *') for 1st argument [CppInteropParseNote]
-  // CHECK:STDERR:     9 | void func(Carbon::Class1* _Nonnull);
-  // CHECK:STDERR:       |      ^    ~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   Cpp.func(p);
 }

--- a/toolchain/check/testdata/interop/cpp/class/roundtrip.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/roundtrip.carbon
@@ -41,3 +41,30 @@ auto F(C *p) -> Carbon::CAlias* {
   return p;
 }
 ''';
+
+// --- import.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+// CHECK:STDERR: import.carbon:[[@LINE+4]]:1: error: class was forward declared here [ClassForwardDeclaredHere]
+// CHECK:STDERR: class Class1;
+// CHECK:STDERR: ^~~~~~~~~~~~~
+// CHECK:STDERR:
+class Class1;
+
+inline Cpp '''
+void func(Carbon::Class1* _Nonnull);
+''';
+
+fn Caller(p: Class1*) {
+  // CHECK:STDERR: import.carbon:[[@LINE+7]]:13: error: no matching function for call to 'func' [CppInteropParseError]
+  // CHECK:STDERR:    13 |   Cpp.func(p);
+  // CHECK:STDERR:       |             ^
+  // CHECK:STDERR: import.carbon:[[@LINE-7]]:6: note: candidate function not viable: cannot convert argument of incomplete type 'Carbon::Class1 * _Nonnull' to 'Carbon::Class1 * _Nonnull' (aka 'Carbon::Class1 *') for 1st argument [CppInteropParseNote]
+  // CHECK:STDERR:     9 | void func(Carbon::Class1* _Nonnull);
+  // CHECK:STDERR:       |      ^    ~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  Cpp.func(p);
+}


### PR DESCRIPTION
Roundtrip (export/reimport) class declarations

The remapping was previously implemented using name_scopes, which aren't
created for class declarations, only definitions - causing the reimport
to import a fresh copy of the type that mismatched with the original (as
seen in the test baseline).

By changing the mapping to use the reverse part of the clang_decls
mapping this should generalize better (& we probably should further
migrate to that mapping). Though it did trip over some issue with
exactly which instruction is used as the key in the clang_decls map -
this change moves towards standardizing on the first decl id of the
class as its map key.
