### PR TITLE
Don't re-require complete types for extended scopes

### DIFF
--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -491,7 +491,7 @@ auto CarbonExternalASTSource::FindExternalVisibleDeclsByName(
   if (!AppendLookupScopesForConstant(
           *context_, SemIR::LocId::None,
           context_->constant_values().Get(decl_context_inst_id),
-          SemIR::ConstantId::None, &lookup_scopes)) {
+          SemIR::ConstantId::None, /*extended_scope=*/false, &lookup_scopes)) {
     return false;
   }
 

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -493,7 +493,8 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
       base_const_id.is_constant()) {
     llvm::SmallVector<LookupScope> lookup_scopes;
     if (AppendLookupScopesForConstant(context, loc_id, base_const_id,
-                                      base_const_id, &lookup_scopes)) {
+                                      base_const_id, /*extended_scope=*/false,
+                                      &lookup_scopes)) {
       return LookupMemberNameInScope(
           context, loc_id, base_id, name_id, base_const_id, lookup_scopes,
           /*lookup_in_type_of_base=*/false, required);
@@ -534,7 +535,8 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
       auto base_type_const_id = context.types().GetConstantId(base_type_id);
       llvm::SmallVector<LookupScope> lookup_scopes;
       if (AppendLookupScopesForConstant(context, loc_id, base_type_const_id,
-                                        base_const_id, &lookup_scopes)) {
+                                        base_const_id, /*extended_scope=*/false,
+                                        &lookup_scopes)) {
         // The name scope constant needs to be a type, but is currently a
         // FacetType, so perform `as type` to get a FacetAccessType.
         auto base_as_type = ExprAsType(context, loc_id, base_id);
@@ -596,7 +598,8 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
           //
           // TODO: This can be replaced with `lookup_const_id` once we stop
           // having to look through the facet at its type for the scope.
-          context.types().GetConstantId(base_type_id), &lookup_scopes)) {
+          context.types().GetConstantId(base_type_id), /*extended_scope=*/false,
+          &lookup_scopes)) {
     auto member_id = LookupMemberNameInScope(
         context, loc_id, base_id, name_id, lookup_const_id, lookup_scopes,
         /*lookup_in_type_of_base=*/true, required);

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -345,6 +345,7 @@ static auto GetSelfFacetForInterfaceFromLookupSelfType(
 auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
                                    SemIR::ConstantId lookup_const_id,
                                    SemIR::ConstantId self_type_const_id,
+                                   bool extended_scope,
                                    llvm::SmallVector<LookupScope>* scopes)
     -> bool {
   auto lookup_inst_id = context.constant_values().GetInstId(lookup_const_id);
@@ -357,17 +358,19 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
     return true;
   }
   if (auto class_ty = lookup.TryAs<SemIR::ClassType>()) {
-    // TODO: Allow name lookup into classes that are being defined even if they
-    // are not complete.
-    RequireCompleteType(
-        context, context.types().GetTypeIdForTypeConstantId(lookup_const_id),
-        loc_id, [&](auto& builder) {
-          CARBON_DIAGNOSTIC(QualifiedExprInIncompleteClassScope, Context,
-                            "member access into incomplete class {0}",
-                            InstIdAsType);
-          builder.Context(loc_id, QualifiedExprInIncompleteClassScope,
-                          lookup_inst_id);
-        });
+    if (!extended_scope) {
+      // TODO: Allow name lookup into classes that are being defined even if
+      // they are not complete.
+      RequireCompleteType(
+          context, context.types().GetTypeIdForTypeConstantId(lookup_const_id),
+          loc_id, [&](auto& builder) {
+            CARBON_DIAGNOSTIC(QualifiedExprInIncompleteClassScope, Context,
+                              "member access into incomplete class {0}",
+                              InstIdAsType);
+            builder.Context(loc_id, QualifiedExprInIncompleteClassScope,
+                            lookup_inst_id);
+          });
+    }
     auto& class_info = context.classes().Get(class_ty->class_id);
     scopes->push_back(LookupScope{.name_scope_id = class_info.scope_id,
                                   .specific_id = class_ty->specific_id,
@@ -376,58 +379,62 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
   }
   // Extended scopes may point to a FacetType.
   if (auto facet_type = lookup.TryAs<SemIR::FacetType>()) {
-    // TODO: Allow name lookup into facet types that are being defined even if
-    // they are not complete.
-    if (RequireCompleteType(
-            context,
-            context.types().GetTypeIdForTypeConstantId(lookup_const_id), loc_id,
-            [&](auto& builder) {
-              CARBON_DIAGNOSTIC(
-                  QualifiedExprInIncompleteFacetTypeScope, Context,
-                  "member access into incomplete facet type {0}", InstIdAsType);
-              builder.Context(loc_id, QualifiedExprInIncompleteFacetTypeScope,
-                              lookup_inst_id);
-            })) {
-      auto facet_type_info =
-          context.facet_types().Get(facet_type->facet_type_id);
-      // Name lookup into "extend" constraints but not "self impls" constraints.
-      for (const auto& extend : facet_type_info.extend_constraints) {
-        auto& interface = context.interfaces().Get(extend.interface_id);
-
-        // We need to build the inner interface-with-self specific. To do that
-        // we need to determine the self facet value to use.
-        auto self_facet = GetSelfFacetForInterfaceFromLookupSelfType(
-            context, interface.generic_with_self_id, self_type_const_id);
-        auto interface_with_self_specific_id = MakeSpecificWithInnerSelf(
-            context, loc_id, interface.generic_id,
-            interface.generic_with_self_id, extend.specific_id, self_facet);
-
-        scopes->push_back({.name_scope_id = interface.scope_with_self_id,
-                           .specific_id = interface_with_self_specific_id,
-                           .self_const_id = self_type_const_id});
+    if (!extended_scope) {
+      // TODO: Allow name lookup into facet types that are being defined even if
+      // they are not complete.
+      if (!RequireCompleteType(
+              context,
+              context.types().GetTypeIdForTypeConstantId(lookup_const_id),
+              loc_id, [&](auto& builder) {
+                CARBON_DIAGNOSTIC(
+                    QualifiedExprInIncompleteFacetTypeScope, Context,
+                    "member access into incomplete facet type {0}",
+                    InstIdAsType);
+                builder.Context(loc_id, QualifiedExprInIncompleteFacetTypeScope,
+                                lookup_inst_id);
+              })) {
+        // Lookup into this scope should fail without producing an error since
+        // `RequireCompleteFacetType` has already issued a diagnostic.
+        scopes->push_back(
+            LookupScope{.name_scope_id = SemIR::NameScopeId::None,
+                        .specific_id = SemIR::SpecificId::None,
+                        .self_const_id = SemIR::ConstantId::None});
+        return true;
       }
-      for (const auto& extend : facet_type_info.extend_named_constraints) {
-        auto& constraint =
-            context.named_constraints().Get(extend.named_constraint_id);
+    }
 
-        // We need to build the inner constraint-with-self specific. To do that
-        // we need to determine the self facet value to use.
-        auto self_facet = GetSelfFacetForInterfaceFromLookupSelfType(
-            context, constraint.generic_with_self_id, self_type_const_id);
-        auto constraint_with_self_specific_id = MakeSpecificWithInnerSelf(
-            context, loc_id, constraint.generic_id,
-            constraint.generic_with_self_id, extend.specific_id, self_facet);
+    auto facet_type_info = context.facet_types().Get(facet_type->facet_type_id);
+    // Name lookup into "extend" constraints but not "self impls" constraints.
+    for (const auto& extend : facet_type_info.extend_constraints) {
+      auto& interface = context.interfaces().Get(extend.interface_id);
 
-        scopes->push_back({.name_scope_id = constraint.scope_with_self_id,
-                           .specific_id = constraint_with_self_specific_id,
-                           .self_const_id = self_type_const_id});
-      }
-    } else {
-      // Lookup into this scope should fail without producing an error since
-      // `RequireCompleteFacetType` has already issued a diagnostic.
-      scopes->push_back(LookupScope{.name_scope_id = SemIR::NameScopeId::None,
-                                    .specific_id = SemIR::SpecificId::None,
-                                    .self_const_id = SemIR::ConstantId::None});
+      // We need to build the inner interface-with-self specific. To do that
+      // we need to determine the self facet value to use.
+      auto self_facet = GetSelfFacetForInterfaceFromLookupSelfType(
+          context, interface.generic_with_self_id, self_type_const_id);
+      auto interface_with_self_specific_id = MakeSpecificWithInnerSelf(
+          context, loc_id, interface.generic_id, interface.generic_with_self_id,
+          extend.specific_id, self_facet);
+
+      scopes->push_back({.name_scope_id = interface.scope_with_self_id,
+                         .specific_id = interface_with_self_specific_id,
+                         .self_const_id = self_type_const_id});
+    }
+    for (const auto& extend : facet_type_info.extend_named_constraints) {
+      auto& constraint =
+          context.named_constraints().Get(extend.named_constraint_id);
+
+      // We need to build the inner constraint-with-self specific. To do that
+      // we need to determine the self facet value to use.
+      auto self_facet = GetSelfFacetForInterfaceFromLookupSelfType(
+          context, constraint.generic_with_self_id, self_type_const_id);
+      auto constraint_with_self_specific_id = MakeSpecificWithInnerSelf(
+          context, loc_id, constraint.generic_id,
+          constraint.generic_with_self_id, extend.specific_id, self_facet);
+
+      scopes->push_back({.name_scope_id = constraint.scope_with_self_id,
+                         .specific_id = constraint_with_self_specific_id,
+                         .self_const_id = self_type_const_id});
     }
     return true;
   }
@@ -540,7 +547,8 @@ auto LookupQualifiedName(Context& context, SemIR::LocId loc_id,
         SemIR::ConstantId const_id = GetConstantValueInSpecific(
             context.sem_ir(), specific_id, extended_id);
         if (!AppendLookupScopesForConstant(context, loc_id, const_id,
-                                           self_const_id, &scopes)) {
+                                           self_const_id,
+                                           /*extended_scope=*/true, &scopes)) {
           // TODO: Handle case where we have a symbolic type and instead should
           // look in its type.
         }

--- a/toolchain/check/name_lookup.h
+++ b/toolchain/check/name_lookup.h
@@ -89,11 +89,20 @@ auto LookupNameInExactScope(Context& context, SemIR::LocId loc_id,
 // needs to know the self-type in order to produce a correct specific scope in
 // the result.
 //
+// When `extended_scope` is true, it indicates the scopes are being added from
+// an `extend` relationship to another scope. The extended scopes are required
+// to be complete when that relationship is established, and should not be
+// checked again in this call. This prevents a dependency on a name lookup into
+// an interface/constraint on a nested extended scope being complete, as that
+// introduces a symbolic dependency on `Self` which is incorrect from outside
+// the interface/constraint.
+//
 // Returns `false` if not a scope. On invalid scopes, prints a diagnostic, but
 // still updates `*scopes` and returns `true`.
 auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
                                    SemIR::ConstantId lookup_const_id,
                                    SemIR::ConstantId self_type_const_id,
+                                   bool extended_scope,
                                    llvm::SmallVector<LookupScope>* scopes)
     -> bool;
 

--- a/toolchain/check/testdata/class/generic/member_lookup.carbon
+++ b/toolchain/check/testdata/class/generic/member_lookup.carbon
@@ -133,8 +133,8 @@ fn AccessMissingConcrete(x: Derived(i32)) -> i32 {
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %Base: type = class_type @Base, @Base(%T.as_type.loc19_42.1) [symbolic = %Base (constants.%Base.7da)]
-// CHECK:STDOUT:   %require_complete.loc21_11: <witness> = require_complete_type %Base [symbolic = %require_complete.loc21_11 (constants.%require_complete.692)]
 // CHECK:STDOUT:   %Base.elem: type = unbound_element_type %Base, %T.as_type.loc19_42.1 [symbolic = %Base.elem (constants.%Base.elem.90f)]
+// CHECK:STDOUT:   %require_complete.loc21_11: <witness> = require_complete_type %Base [symbolic = %require_complete.loc21_11 (constants.%require_complete.692)]
 // CHECK:STDOUT:   %require_complete.loc21_13: <witness> = require_complete_type %T.as_type.loc19_42.1 [symbolic = %require_complete.loc21_13 (constants.%require_complete.89e)]
 // CHECK:STDOUT:   %Copy.WithSelf.Op.type: type = fn_type @Copy.WithSelf.Op, @Copy.WithSelf(%T.loc19_16.1) [symbolic = %Copy.WithSelf.Op.type (constants.%Copy.WithSelf.Op.type.735e75.2)]
 // CHECK:STDOUT:   %.loc21_11.5: type = fn_type_with_self_type %Copy.WithSelf.Op.type, %T.loc19_16.1 [symbolic = %.loc21_11.5 (constants.%.023)]

--- a/toolchain/check/testdata/class/method/virtual.carbon
+++ b/toolchain/check/testdata/class/method/virtual.carbon
@@ -1393,12 +1393,12 @@ class T2(G2:! type) {
 // CHECK:STDOUT:         %Self.ref: type = name_ref Self, %.loc10_30.2 [symbolic = %Derived (constants.%Derived)]
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:       %self: @Derived.F.%Derived (%Derived) = value_binding self, %self.param
-// CHECK:STDOUT:       %t.param: @Derived.F.%ptr.loc10_46 (%ptr.e8f) = value_param call_param1
-// CHECK:STDOUT:       %.loc10_47: type = splice_block %ptr.loc10_47 [symbolic = %ptr.loc10_46 (constants.%ptr.e8f)] {
+// CHECK:STDOUT:       %t.param: @Derived.F.%ptr.loc10_47.1 (%ptr.e8f) = value_param call_param1
+// CHECK:STDOUT:       %.loc10_47: type = splice_block %ptr.loc10_47.2 [symbolic = %ptr.loc10_47.1 (constants.%ptr.e8f)] {
 // CHECK:STDOUT:         %T.ref: type = name_ref T, @Derived.%T.loc7_16.2 [symbolic = %T (constants.%T)]
-// CHECK:STDOUT:         %ptr.loc10_47: type = ptr_type %T.ref [symbolic = %ptr.loc10_46 (constants.%ptr.e8f)]
+// CHECK:STDOUT:         %ptr.loc10_47.2: type = ptr_type %T.ref [symbolic = %ptr.loc10_47.1 (constants.%ptr.e8f)]
 // CHECK:STDOUT:       }
-// CHECK:STDOUT:       %t: @Derived.F.%ptr.loc10_46 (%ptr.e8f) = value_binding t, %t.param
+// CHECK:STDOUT:       %t: @Derived.F.%ptr.loc10_47.1 (%ptr.e8f) = value_binding t, %t.param
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:     complete_type_witness = %complete_type.loc12_1.1
@@ -1426,16 +1426,14 @@ class T2(G2:! type) {
 // CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic = %T (constants.%T)]
 // CHECK:STDOUT:   %Derived: type = class_type @Derived, @Derived(%T) [symbolic = %Derived (constants.%Derived)]
 // CHECK:STDOUT:   %pattern_type.loc10_28: type = pattern_type %Derived [symbolic = %pattern_type.loc10_28 (constants.%pattern_type.b9d)]
-// CHECK:STDOUT:   %ptr.loc10_46: type = ptr_type %T [symbolic = %ptr.loc10_46 (constants.%ptr.e8f)]
-// CHECK:STDOUT:   %Base: type = class_type @Base, @Base(%ptr.loc10_46) [symbolic = %Base (constants.%Base.f29)]
-// CHECK:STDOUT:   %require_complete.loc10_46: <witness> = require_complete_type %Base [symbolic = %require_complete.loc10_46 (constants.%require_complete.b3c)]
-// CHECK:STDOUT:   %pattern_type.loc10_44: type = pattern_type %ptr.loc10_46 [symbolic = %pattern_type.loc10_44 (constants.%pattern_type.4f4)]
+// CHECK:STDOUT:   %ptr.loc10_47.1: type = ptr_type %T [symbolic = %ptr.loc10_47.1 (constants.%ptr.e8f)]
+// CHECK:STDOUT:   %pattern_type.loc10_44: type = pattern_type %ptr.loc10_47.1 [symbolic = %pattern_type.loc10_44 (constants.%pattern_type.4f4)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete.loc10_28: <witness> = require_complete_type %Derived [symbolic = %require_complete.loc10_28 (constants.%require_complete.a43)]
-// CHECK:STDOUT:   %require_complete.loc10_44: <witness> = require_complete_type %ptr.loc10_46 [symbolic = %require_complete.loc10_44 (constants.%require_complete.ef1)]
+// CHECK:STDOUT:   %require_complete.loc10_44: <witness> = require_complete_type %ptr.loc10_47.1 [symbolic = %require_complete.loc10_44 (constants.%require_complete.ef1)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   override fn(%self.param: @Derived.F.%Derived (%Derived), %t.param: @Derived.F.%ptr.loc10_46 (%ptr.e8f)) {
+// CHECK:STDOUT:   override fn(%self.param: @Derived.F.%Derived (%Derived), %t.param: @Derived.F.%ptr.loc10_47.1 (%ptr.e8f)) {
 // CHECK:STDOUT:   !entry:
 // CHECK:STDOUT:     return
 // CHECK:STDOUT:   }
@@ -1461,9 +1459,7 @@ class T2(G2:! type) {
 // CHECK:STDOUT:   %T => constants.%T
 // CHECK:STDOUT:   %Derived => constants.%Derived
 // CHECK:STDOUT:   %pattern_type.loc10_28 => constants.%pattern_type.b9d
-// CHECK:STDOUT:   %ptr.loc10_46 => constants.%ptr.e8f
-// CHECK:STDOUT:   %Base => constants.%Base.f29
-// CHECK:STDOUT:   %require_complete.loc10_46 => constants.%require_complete.b3c
+// CHECK:STDOUT:   %ptr.loc10_47.1 => constants.%ptr.e8f
 // CHECK:STDOUT:   %pattern_type.loc10_44 => constants.%pattern_type.4f4
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:

--- a/toolchain/check/testdata/facet/require_import.carbon
+++ b/toolchain/check/testdata/facet/require_import.carbon
@@ -66,7 +66,7 @@ fn F(B:! Y) {
 // CHECK:STDOUT:   %Z.WithSelf.F.type.091: type = fn_type @Z.WithSelf.F, @Z.WithSelf(%T, %Self.984) [symbolic]
 // CHECK:STDOUT:   %Z.WithSelf.F.073: %Z.WithSelf.F.type.091 = struct_value () [symbolic]
 // CHECK:STDOUT:   %Z.type.67cf45.1: type = facet_type <@Z, @Z(%Self.as_type.190)> [symbolic]
-// CHECK:STDOUT:   %Self.9e6a89.1: %Z.type.67cf45.1 = symbolic_binding Self, 1 [symbolic]
+// CHECK:STDOUT:   %Self.9e6: %Z.type.67cf45.1 = symbolic_binding Self, 1 [symbolic]
 // CHECK:STDOUT:   %require_complete.5aca91.1: <witness> = require_complete_type %Z.type.67cf45.1 [symbolic]
 // CHECK:STDOUT:   %pattern_type.9a5: type = pattern_type %X.type [concrete]
 // CHECK:STDOUT:   %A: %X.type = symbolic_binding A, 0 [symbolic]
@@ -82,13 +82,10 @@ fn F(B:! Y) {
 // CHECK:STDOUT:   %A.as_type: type = facet_access_type %A [symbolic]
 // CHECK:STDOUT:   %Z.type.67cf45.2: type = facet_type <@Z, @Z(%A.as_type)> [symbolic]
 // CHECK:STDOUT:   %require_complete.5aca91.2: <witness> = require_complete_type %Z.type.67cf45.2 [symbolic]
-// CHECK:STDOUT:   %Self.9e6a89.2: %Z.type.67cf45.2 = symbolic_binding Self, 1 [symbolic]
-// CHECK:STDOUT:   %Z.WithSelf.F.type.c44: type = fn_type @Z.WithSelf.F, @Z.WithSelf(%A.as_type, %Self.984) [symbolic]
-// CHECK:STDOUT:   %Z.WithSelf.F.e33: %Z.WithSelf.F.type.c44 = struct_value () [symbolic]
-// CHECK:STDOUT:   %Z.assoc_type.221: type = assoc_entity_type @Z, @Z(%A.as_type) [symbolic]
-// CHECK:STDOUT:   %assoc0.b43: %Z.assoc_type.221 = assoc_entity element0, imports.%Main.import_ref.7b4 [symbolic]
 // CHECK:STDOUT:   %Z.WithSelf.F.type.f05: type = fn_type @Z.WithSelf.F, @Z.WithSelf(%A.as_type, %A) [symbolic]
 // CHECK:STDOUT:   %Z.WithSelf.F.364: %Z.WithSelf.F.type.f05 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Z.assoc_type.221: type = assoc_entity_type @Z, @Z(%A.as_type) [symbolic]
+// CHECK:STDOUT:   %assoc0.b43: %Z.assoc_type.221 = assoc_entity element0, imports.%Main.import_ref.7b4 [symbolic]
 // CHECK:STDOUT:   %assoc0.20d: %Z.assoc_type.0bf = assoc_entity element0, imports.%Main.import_ref.47b [symbolic]
 // CHECK:STDOUT:   %Z.lookup_impl_witness: <witness> = lookup_impl_witness %A, @Z, @Z(%A.as_type) [symbolic]
 // CHECK:STDOUT:   %Z.facet: %Z.type.67cf45.2 = facet_value %A.as_type, (%Z.lookup_impl_witness) [symbolic]
@@ -212,10 +209,9 @@ fn F(B:! Y) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %A.as_type.loc5_4.2: type = facet_access_type %A.loc4_7.1 [symbolic = %A.as_type.loc5_4.2 (constants.%A.as_type)]
-// CHECK:STDOUT:   %Z.type: type = facet_type <@Z, @Z(%A.as_type.loc5_4.2)> [symbolic = %Z.type (constants.%Z.type.67cf45.2)]
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %Z.type [symbolic = %require_complete (constants.%require_complete.5aca91.2)]
 // CHECK:STDOUT:   %Z.assoc_type: type = assoc_entity_type @Z, @Z(%A.as_type.loc5_4.2) [symbolic = %Z.assoc_type (constants.%Z.assoc_type.221)]
 // CHECK:STDOUT:   %assoc0: @F.%Z.assoc_type (%Z.assoc_type.221) = assoc_entity element0, imports.%Main.import_ref.7b4 [symbolic = %assoc0 (constants.%assoc0.b43)]
+// CHECK:STDOUT:   %Z.type: type = facet_type <@Z, @Z(%A.as_type.loc5_4.2)> [symbolic = %Z.type (constants.%Z.type.67cf45.2)]
 // CHECK:STDOUT:   %Z.lookup_impl_witness: <witness> = lookup_impl_witness %A.loc4_7.1, @Z, @Z(%A.as_type.loc5_4.2) [symbolic = %Z.lookup_impl_witness (constants.%Z.lookup_impl_witness)]
 // CHECK:STDOUT:   %Z.facet: @F.%Z.type (%Z.type.67cf45.2) = facet_value %A.as_type.loc5_4.2, (%Z.lookup_impl_witness) [symbolic = %Z.facet (constants.%Z.facet)]
 // CHECK:STDOUT:   %Z.WithSelf.F.type: type = fn_type @Z.WithSelf.F, @Z.WithSelf(%A.as_type.loc5_4.2, %Z.facet) [symbolic = %Z.WithSelf.F.type (constants.%Z.WithSelf.F.type.0d8)]
@@ -250,7 +246,7 @@ fn F(B:! Y) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %Z.type => constants.%Z.type.67cf45.1
-// CHECK:STDOUT:   %Self => constants.%Self.9e6a89.1
+// CHECK:STDOUT:   %Self => constants.%Self.9e6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @X.WithSelf(constants.%Self.f45) {
@@ -298,21 +294,6 @@ fn F(B:! Y) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Z(constants.%A.as_type) {
 // CHECK:STDOUT:   %T => constants.%A.as_type
-// CHECK:STDOUT:
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %Z.type => constants.%Z.type.67cf45.2
-// CHECK:STDOUT:   %Self => constants.%Self.9e6a89.2
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @Z.WithSelf(constants.%A.as_type, constants.%Self.984) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %T => constants.%A.as_type
-// CHECK:STDOUT:   %Z.type => constants.%Z.type.67cf45.2
-// CHECK:STDOUT:   %Self => constants.%Self.984
-// CHECK:STDOUT:   %Z.WithSelf.F.type => constants.%Z.WithSelf.F.type.c44
-// CHECK:STDOUT:   %Z.WithSelf.F => constants.%Z.WithSelf.F.e33
-// CHECK:STDOUT:   %Z.assoc_type => constants.%Z.assoc_type.221
-// CHECK:STDOUT:   %assoc0 => constants.%assoc0.b43
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @Z.WithSelf(constants.%A.as_type, constants.%A) {

--- a/toolchain/check/testdata/impl/extend_impl_generic.carbon
+++ b/toolchain/check/testdata/impl/extend_impl_generic.carbon
@@ -623,8 +623,6 @@ class X(U:! type) {
 // CHECK:STDOUT:   %U: type = symbolic_binding U, 0 [symbolic = %U (constants.%U)]
 // CHECK:STDOUT:   %X: type = class_type @X, @X(%U) [symbolic = %X (constants.%X)]
 // CHECK:STDOUT:   %pattern_type.loc10_21: type = pattern_type %X [symbolic = %pattern_type.loc10_21 (constants.%pattern_type.e07)]
-// CHECK:STDOUT:   %I.type: type = facet_type <@I, @I(%U)> [symbolic = %I.type (constants.%I.type.1ab3e4.2)]
-// CHECK:STDOUT:   %require_complete.loc10_39: <witness> = require_complete_type %I.type [symbolic = %require_complete.loc10_39 (constants.%require_complete.e36)]
 // CHECK:STDOUT:   %pattern_type.loc10_37: type = pattern_type %U [symbolic = %pattern_type.loc10_37 (constants.%pattern_type.51d1c4.2)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
@@ -695,8 +693,6 @@ class X(U:! type) {
 // CHECK:STDOUT:   %U => constants.%U
 // CHECK:STDOUT:   %X => constants.%X
 // CHECK:STDOUT:   %pattern_type.loc10_21 => constants.%pattern_type.e07
-// CHECK:STDOUT:   %I.type => constants.%I.type.1ab3e4.2
-// CHECK:STDOUT:   %require_complete.loc10_39 => constants.%require_complete.e36
 // CHECK:STDOUT:   %pattern_type.loc10_37 => constants.%pattern_type.51d1c4.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/named_constraint/require.carbon
+++ b/toolchain/check/testdata/named_constraint/require.carbon
@@ -892,16 +892,16 @@ fn G(T:! Z) {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   <elided>
-// CHECK:STDOUT:   %Y.type.loc15: type = facet_type <@Y, @Y(%T.as_type.loc13_16.1)> [symbolic = %Y.type.loc15 (constants.%Y.type.229)]
-// CHECK:STDOUT:   %require_complete.loc15: <witness> = require_complete_type %Y.type.loc15 [symbolic = %require_complete.loc15 (constants.%require_complete.db1)]
 // CHECK:STDOUT:   %Y.assoc_type: type = assoc_entity_type @Y, @Y(%T.as_type.loc13_16.1) [symbolic = %Y.assoc_type (constants.%Y.assoc_type.44d)]
 // CHECK:STDOUT:   %assoc0: @F.%Y.assoc_type (%Y.assoc_type.44d) = assoc_entity element0, @Y.WithSelf.%Y.WithSelf.YY.decl [symbolic = %assoc0 (constants.%assoc0.e5b)]
+// CHECK:STDOUT:   %Y.type.loc15: type = facet_type <@Y, @Y(%T.as_type.loc13_16.1)> [symbolic = %Y.type.loc15 (constants.%Y.type.229)]
 // CHECK:STDOUT:   %Y.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc13_7.1, @Y, @Y(%T.as_type.loc13_16.1) [symbolic = %Y.lookup_impl_witness (constants.%Y.lookup_impl_witness)]
 // CHECK:STDOUT:   %Y.facet.loc15: @F.%Y.type.loc15 (%Y.type.229) = facet_value %T.as_type.loc13_16.1, (%Y.lookup_impl_witness) [symbolic = %Y.facet.loc15 (constants.%Y.facet)]
 // CHECK:STDOUT:   %Y.WithSelf.YY.type: type = fn_type @Y.WithSelf.YY, @Y.WithSelf(%T.as_type.loc13_16.1, %Y.facet.loc15) [symbolic = %Y.WithSelf.YY.type (constants.%Y.WithSelf.YY.type.4a6)]
 // CHECK:STDOUT:   %.loc15_4.3: type = fn_type_with_self_type %Y.WithSelf.YY.type, %Y.facet.loc15 [symbolic = %.loc15_4.3 (constants.%.52c)]
 // CHECK:STDOUT:   %impl.elem0.loc15_4.2: @F.%.loc15_4.3 (%.52c) = impl_witness_access %Y.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc15_4.2 (constants.%impl.elem0)]
 // CHECK:STDOUT:   %specific_impl_fn.loc15_4.2: <specific function> = specific_impl_function %impl.elem0.loc15_4.2, @Y.WithSelf.YY(%T.as_type.loc13_16.1, %Y.facet.loc15) [symbolic = %specific_impl_fn.loc15_4.2 (constants.%specific_impl_fn)]
+// CHECK:STDOUT:   %require_complete.loc16: <witness> = require_complete_type %Y.type.loc15 [symbolic = %require_complete.loc16 (constants.%require_complete.db1)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn(%t.param: @F.%T.as_type.loc13_16.1 (%T.as_type)) {
 // CHECK:STDOUT:   !entry:


### PR DESCRIPTION
When an outer type defines an `extend` relationship to an inner type, we require that inner type to be complete so that we can know that name lookup can search both scopes as soon as the outer type is complete.

When doing name lookup, we require the type in which we are looking to be complete. Then, we recursively add extended scopes, but then also require each of them to be complete again, which inserts RequireCompleteType instructions into the block doing lookup.

While these new instructions may differ in terms of their specifics, they are redundant since we already required the type to be complete, and specifics can not change the completeness of a type. They are also problematic because a named constraint or interface can extend a scope with a symbolic specific, by using `Self` as an argument. This inserts a symbolic instruction into the block doing name lookup, even though that block may not be generic.