### PR TITLE
Use impl's interface to get the specific interface from the identified facet type

### DIFF
--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -2721,21 +2721,6 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
       resolver, import_impl.constraint_id, constraint_const_id);
   new_impl.interface = GetLocalSpecificInterface(
       resolver, import_impl.interface, specific_interface_data);
-  // Create a local IdentifiedFacetType for the imported facet type, since impl
-  // declarations always identify the facet type.
-  if (auto facet_type =
-          resolver.local_constant_values().TryGetInstAs<SemIR::FacetType>(
-              constraint_const_id)) {
-    // Lookups later will be with the unattached constant, whereas
-    // GetLocalConstantId gave us an attached constant.
-    auto unattached_self_const_id =
-        resolver.local_constant_values().GetUnattachedConstant(self_const_id);
-    RequireIdentifiedFacetType(
-        resolver.local_context(), SemIR::LocId::None, unattached_self_const_id,
-        *facet_type, []([[maybe_unused]] auto& builder) {
-          CARBON_FATAL("Imported impl constraint can't be identified");
-        });
-  }
   if (import_impl.is_complete()) {
     ImportImplDefinition(resolver, import_impl, new_impl);
   }

--- a/toolchain/sem_ir/impl.cpp
+++ b/toolchain/sem_ir/impl.cpp
@@ -17,26 +17,11 @@ ImplStore::ImplStore(File& sem_ir)
 
 auto ImplStore::GetOrAddLookupBucket(const Impl& impl) -> LookupBucketRef {
   auto self_const_id = sem_ir_.constant_values().Get(impl.self_id);
-  auto impl_as_interface = SpecificInterface::None;
-  auto facet_type_type_id = TypeId::ForTypeConstant(
-      sem_ir_.constant_values().Get(impl.constraint_id));
-  if (auto facet_type =
-          sem_ir_.types().TryGetAs<FacetType>(facet_type_type_id)) {
-    auto identified_id = sem_ir_.identified_facet_types().Lookup(
-        {facet_type->facet_type_id, self_const_id});
-    CARBON_CHECK(identified_id.has_value(),
-                 "impl with unidentitied facet type");
-    const auto& identified =
-        sem_ir_.identified_facet_types().Get(identified_id);
-    if (identified.is_valid_impl_as_target()) {
-      impl_as_interface = identified.impl_as_target_interface();
-    }
-  }
-  return LookupBucketRef(
-      *this, lookup_
-                 .Insert(std::pair{self_const_id, impl_as_interface},
-                         [] { return ImplOrLookupBucketId::None; })
-                 .value());
+  return LookupBucketRef(*this,
+                         lookup_
+                             .Insert(std::pair{self_const_id, impl.interface},
+                                     [] { return ImplOrLookupBucketId::None; })
+                             .value());
 }
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/mangler.cpp
+++ b/toolchain/sem_ir/mangler.cpp
@@ -73,28 +73,14 @@ auto Mangler::MangleInverseQualifiedNameScope(llvm::raw_ostream& os,
     CARBON_KIND_SWITCH(sem_ir().insts().Get(name_scope.inst_id())) {
       case CARBON_KIND(SemIR::ImplDecl impl_decl): {
         const auto& impl = sem_ir().impls().Get(impl_decl.impl_id);
-
-        auto facet_type = insts().GetAs<SemIR::FacetType>(
-            constant_values().GetConstantInstId(impl.constraint_id));
-
-        auto identified_facet_type_id =
-            sem_ir().identified_facet_types().Lookup(
-                {.facet_type_id = facet_type.facet_type_id,
-                 .self_const_id =
-                     sem_ir().constant_values().Get(impl.self_id)});
-        CARBON_CHECK(identified_facet_type_id.has_value(),
-                     "ImplDecl with unidentified facet type constraint");
-        const auto& identified =
-            sem_ir().identified_facet_types().Get(identified_facet_type_id);
-        auto impl_target = identified.impl_as_target_interface();
         const auto& interface =
-            sem_ir().interfaces().Get(impl_target.interface_id);
+            sem_ir().interfaces().Get(impl.interface.interface_id);
         names_to_render.push_back(
             // We mangle names in an interface without `Self` in the specific
             // since it would just add noise and `Self` is not part of how you
             // name the entities syntactically.
             {.name_scope_id = interface.scope_without_self_id,
-             .specific_id = impl_target.specific_id,
+             .specific_id = impl.interface.specific_id,
              .prefix = ':'});
 
         auto self_const_inst_id =


### PR DESCRIPTION
Instead of doing a lookup for the identified facet type from the impl's self+constraint, we can use `impl.interface` to get the specific interface being implemented by the impl declaration. This is already the specific interface returned from the identified facet type. And that means we no longer have to identify the self+constraint for imported impls.

This is split out from https://github.com/carbon-language/carbon-lang/pull/7183#discussion_r3230571153