### PR TITLE
Avoid replacing .Self in designators more robustly in rewrite constraints

### DIFF
--- a/toolchain/check/period_self.cpp
+++ b/toolchain/check/period_self.cpp
@@ -46,16 +46,94 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
   explicit SubstPeriodSelfCallbacks(
       Context* context, SemIR::LocId loc_id,
       SemIR::ConstantId period_self_replacement_id,
-      SubstPeriodSelfRebuildInst rebuild)
+      SubstPeriodSelfBehaviour behaviour, SubstPeriodSelfRebuildInst rebuild)
       : SubstInstCallbacks(context),
         loc_id_(loc_id),
         period_self_replacement_id_(period_self_replacement_id),
+        behaviour_(behaviour),
         rebuild_callback_(rebuild) {}
 
-  virtual ~SubstPeriodSelfCallbacks() = default;
+  virtual ~SubstPeriodSelfCallbacks() {
+    CARBON_CHECK(designator_states_.empty());
+  }
+
+  auto Subst(SemIR::InstId& inst_id) -> SubstResult override {
+    // FacetTypes are concrete even if they have `.Self` inside them, but we
+    // don't recurse into FacetTypes, so we can use this as a base case. This
+    // avoids infinite recursion on TypeType and ErrorInst.
+    if (context().constant_values().Get(inst_id).is_concrete()) {
+      return FullySubstituted;
+    }
+    // Don't recurse into nested facet types, even if they are symbolic. Leave
+    // their `.Self` as is.
+    if (context().insts().Is<SemIR::FacetType>(inst_id)) {
+      return FullySubstituted;
+    }
+
+    // Look for implicit use of `.Self` in designators: `.X` is really
+    // `.Self.X`.
+    if (auto access =
+            context().insts().TryGetAs<SemIR::ImplWitnessAccess>(inst_id)) {
+      if (auto witness = context().insts().TryGetAs<SemIR::LookupImplWitness>(
+              access->witness_id)) {
+        // Canonicalization not necessary; we are working with the constant
+        // value already, and the query self in a witness is already
+        // canonicalized.
+        if (IsPeriodSelf(context(), witness->query_self_inst_id,
+                         /*canonicalize=*/false)) {
+          // We are entering a designator. We watch for the witness next.
+          designator_states_.push_back(WitnessNext);
+          return SubstOperands;
+        }
+      }
+    }
+
+    if (GetDesignatorState() == WitnessNext) {
+      if (auto witness =
+              context().insts().TryGetAs<SemIR::LookupImplWitness>(inst_id)) {
+        // The query self comes next, before the specific interface. This
+        // deepnds on the order of the operands in the LookupImplWitness, and
+        // that Subst visits them in top to bottom order.
+        designator_states_.back() = WitnessSelfNext;
+        return SubstOperands;
+      }
+    }
+
+    // Canonicalization not necessary; we are working with the constant
+    // value already, and the query self in a witness is already
+    // canonicalized.
+    if (IsPeriodSelf(context(), inst_id,
+                     /*canonicalize=*/false)) {
+      bool is_implicit_self_in_desigator = false;
+      if (GetDesignatorState() == WitnessSelfNext) {
+        is_implicit_self_in_desigator = true;
+        designator_states_.back() = RebuildNext;
+      }
+
+      switch (behaviour_) {
+        case SubstPeriodSelfBehaviour::All:
+          inst_id = GetReplacement(inst_id);
+          break;
+        case SubstPeriodSelfBehaviour::ImplicitOnly:
+          if (is_implicit_self_in_desigator) {
+            inst_id = GetReplacement(inst_id);
+          }
+          break;
+        case SubstPeriodSelfBehaviour::ExplicitOnly:
+          if (!is_implicit_self_in_desigator) {
+            inst_id = GetReplacement(inst_id);
+          }
+          break;
+      }
+      return FullySubstituted;
+    }
+
+    return SubstOperands;
+  }
 
   auto Rebuild(SemIR::InstId orig_inst_id, SemIR::Inst new_inst)
       -> SemIR::InstId override {
+    TryPopDesignatorState(orig_inst_id);
     if (rebuild_callback_) {
       if (auto inst_id = rebuild_callback_(new_inst); inst_id.has_value()) {
         return inst_id;
@@ -64,7 +142,27 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
     return RebuildNewInst(SemIR::LocId(orig_inst_id), new_inst);
   }
 
- protected:
+  auto ReuseUnchanged(SemIR::InstId orig_inst_id) -> SemIR::InstId override {
+    TryPopDesignatorState(orig_inst_id);
+    return orig_inst_id;
+  }
+
+ private:
+  enum DesignatorState {
+    // We are not inside a designator.
+    None,
+    // We are looking for the LookupImplWitness of a designator next.
+    WitnessNext,
+    // We are looking for `.Self`, the next one will be the query self of the
+    // LookupImplWitness of a designator. This is the implicit use of `.Self`.
+    WitnessSelfNext,
+    // We have seen the query self of the designator, and are now looking for
+    // the designator to be rebuilt with the replacement. Any other `.Self` that
+    // we find are explicit uses of `.Self`, such as in the designator's
+    // specific interface.
+    RebuildNext,
+  };
+
   auto GetReplacement(SemIR::InstId period_self) -> SemIR::InstId {
     auto period_self_type_id = context().insts().Get(period_self).type_id();
     CARBON_CHECK(context().types().Is<SemIR::FacetType>(period_self_type_id));
@@ -93,7 +191,6 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
     return cached_replacement_id_;
   }
 
- private:
   auto ConvertReplacement(SemIR::InstId replacement_self_inst_id,
                           SemIR::TypeId replacement_type_id,
                           SemIR::TypeId period_self_type_id) -> SemIR::InstId {
@@ -162,115 +259,6 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
             }));
   }
 
-  SemIR::LocId loc_id_;
-  SemIR::ConstantId period_self_replacement_id_;
-  SubstPeriodSelfRebuildInst rebuild_callback_;
-
-  // The last output of GetReplacement().
-  SemIR::InstId cached_replacement_id_ = SemIR::InstId::None;
-  // The type of the last output of GetReplacement(). If the type of `.Self`
-  // matches, we can reuse the `cached_replacement_id_`.
-  SemIR::TypeId cached_replacement_type_id_ = SemIR::TypeId::None;
-};
-
-class SubstDesignatorPeriodSelfCallbacks : public SubstPeriodSelfCallbacks {
- public:
-  explicit SubstDesignatorPeriodSelfCallbacks(
-      Context* context, SemIR::LocId loc_id,
-      SemIR::ConstantId period_self_replacement_id,
-      SubstPeriodSelfRebuildInst rebuild)
-      : SubstPeriodSelfCallbacks(context, loc_id, period_self_replacement_id,
-                                 rebuild) {}
-
-  ~SubstDesignatorPeriodSelfCallbacks() override {
-    CARBON_CHECK(designator_states_.empty());
-  }
-
-  auto Subst(SemIR::InstId& inst_id) -> SubstResult override {
-    // FacetTypes are concrete even if they have `.Self` inside them, but we
-    // don't recurse into FacetTypes, so we can use this as a base case. This
-    // avoids infinite recursion on TypeType and ErrorInst.
-    if (context().constant_values().Get(inst_id).is_concrete()) {
-      return FullySubstituted;
-    }
-    // Don't recurse into nested facet types, even if they are symbolic. Leave
-    // their `.Self` as is.
-    if (context().insts().Is<SemIR::FacetType>(inst_id)) {
-      return FullySubstituted;
-    }
-
-    // Look for implicit use of `.Self` in designators: `.X` is really
-    // `.Self.X`.
-    if (auto access =
-            context().insts().TryGetAs<SemIR::ImplWitnessAccess>(inst_id)) {
-      if (auto witness = context().insts().TryGetAs<SemIR::LookupImplWitness>(
-              access->witness_id)) {
-        // Canonicalization not necessary; we are working with the constant
-        // value already, and the query self in a witness is already
-        // canonicalized.
-        if (IsPeriodSelf(context(), witness->query_self_inst_id,
-                         /*canonicalize=*/false)) {
-          // We are entering a designator. We watch for the witness next.
-          designator_states_.push_back(WitnessNext);
-          return SubstOperands;
-        }
-      }
-    }
-
-    if (GetDesignatorState() == WitnessNext) {
-      if (auto witness =
-              context().insts().TryGetAs<SemIR::LookupImplWitness>(inst_id)) {
-        // The query self comes next, before the specific interface. This
-        // deepnds on the order of the operands in the LookupImplWitness, and
-        // that Subst visits them in top to bottom order.
-        designator_states_.back() = WitnessSelfNext;
-        return SubstOperands;
-      }
-    }
-
-    if (GetDesignatorState() == WitnessSelfNext) {
-      // Canonicalization not necessary; we are working with the constant
-      // value already, and the query self in a witness is already
-      // canonicalized.
-      if (IsPeriodSelf(context(), inst_id,
-                       /*canonicalize=*/false)) {
-        // Found the implicit use of `.Self` in a designator.
-        inst_id = GetReplacement(inst_id);
-        designator_states_.back() = RebuildNext;
-        return FullySubstituted;
-      }
-    }
-
-    return SubstOperands;
-  }
-
-  auto Rebuild(SemIR::InstId orig_inst_id, SemIR::Inst new_inst)
-      -> SemIR::InstId override {
-    TryPopDesignatorState(orig_inst_id);
-    return SubstPeriodSelfCallbacks::Rebuild(orig_inst_id, new_inst);
-  }
-
-  auto ReuseUnchanged(SemIR::InstId orig_inst_id) -> SemIR::InstId override {
-    TryPopDesignatorState(orig_inst_id);
-    return SubstPeriodSelfCallbacks::ReuseUnchanged(orig_inst_id);
-  }
-
- private:
-  enum DesignatorState {
-    // We are not inside a designator.
-    None,
-    // We are looking for the LookupImplWitness of a designator next.
-    WitnessNext,
-    // We are looking for `.Self`, the next one will be the query self of the
-    // LookupImplWitness of a designator. This is the implicit use of `.Self`.
-    WitnessSelfNext,
-    // We have seen the query self of the designator, and are now looking for
-    // the designator to be rebuilt with the replacement. Any other `.Self` that
-    // we find are explicit uses of `.Self`, such as in the designator's
-    // specific interface.
-    RebuildNext,
-  };
-
   auto GetDesignatorState() const -> DesignatorState {
     return designator_states_.empty() ? DesignatorState::None
                                       : designator_states_.back();
@@ -294,39 +282,18 @@ class SubstDesignatorPeriodSelfCallbacks : public SubstPeriodSelfCallbacks {
     }
   }
 
+  SemIR::LocId loc_id_;
+  SemIR::ConstantId period_self_replacement_id_;
+  SubstPeriodSelfBehaviour behaviour_;
+  SubstPeriodSelfRebuildInst rebuild_callback_;
+
+  // The last output of GetReplacement().
+  SemIR::InstId cached_replacement_id_ = SemIR::InstId::None;
+  // The type of the last output of GetReplacement(). If the type of `.Self`
+  // matches, we can reuse the `cached_replacement_id_`.
+  SemIR::TypeId cached_replacement_type_id_ = SemIR::TypeId::None;
+
   llvm::SmallVector<DesignatorState> designator_states_;
-};
-
-class SubstAllPeriodSelfCallbacks : public SubstPeriodSelfCallbacks {
- public:
-  explicit SubstAllPeriodSelfCallbacks(
-      Context* context, SemIR::LocId loc_id,
-      SemIR::ConstantId period_self_replacement_id,
-      SubstPeriodSelfRebuildInst rebuild)
-      : SubstPeriodSelfCallbacks(context, loc_id, period_self_replacement_id,
-                                 rebuild) {}
-
-  auto Subst(SemIR::InstId& inst_id) -> SubstResult override {
-    // FacetTypes are concrete even if they have `.Self` inside them, but we
-    // don't recurse into FacetTypes, so we can use this as a base case. This
-    // avoids infinite recursion on TypeType and ErrorInst.
-    if (context().constant_values().Get(inst_id).is_concrete()) {
-      return FullySubstituted;
-    }
-    // Don't recurse into nested facet types, even if they are symbolic. Leave
-    // their `.Self` as is.
-    if (context().insts().Is<SemIR::FacetType>(inst_id)) {
-      return FullySubstituted;
-    }
-
-    if (IsPeriodSelf(context(), inst_id,
-                     /*canonicalize=*/false)) {
-      inst_id = GetReplacement(inst_id);
-      return FullySubstituted;
-    }
-
-    return SubstOperands;
-  }
 };
 
 auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
@@ -345,22 +312,11 @@ auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
     return const_id;
   }
 
-  switch (behaviour) {
-    case SubstPeriodSelfBehaviour::All: {
-      SubstAllPeriodSelfCallbacks callbacks(
-          &context, loc_id, period_self_replacement_id, rebuild);
-      auto subst_id = SubstInst(
-          context, context.constant_values().GetInstId(const_id), callbacks);
-      return context.constant_values().Get(subst_id);
-    }
-    case SubstPeriodSelfBehaviour::ImplicitOnly: {
-      SubstDesignatorPeriodSelfCallbacks callbacks(
-          &context, loc_id, period_self_replacement_id, rebuild);
-      auto subst_id = SubstInst(
-          context, context.constant_values().GetInstId(const_id), callbacks);
-      return context.constant_values().Get(subst_id);
-    }
-  }
+  SubstPeriodSelfCallbacks callbacks(
+      &context, loc_id, period_self_replacement_id, behaviour, rebuild);
+  auto subst_id = SubstInst(
+      context, context.constant_values().GetInstId(const_id), callbacks);
+  return context.constant_values().Get(subst_id);
 }
 
 static auto SubstPeriodSelfInSpecific(
@@ -460,21 +416,15 @@ auto SubstPeriodSelfInFacetType(Context& context, SemIR::LocId loc_id,
   };
   auto replace_rewrite = [&](SemIR::FacetTypeInfo::RewriteConstraint r)
       -> SemIR::FacetTypeInfo::RewriteConstraint {
-    // Replace `.Self` only on the RHS, and only if's not a simple designator.
-    // The LHS is always a simple designator since only that is allowed.
-    if (auto access =
-            context.insts().TryGetAs<SemIR::ImplWitnessAccess>(r.rhs_id)) {
-      if (auto lookup = context.insts().TryGetAs<SemIR::LookupImplWitness>(
-              access->witness_id)) {
-        if (IsPeriodSelf(context, lookup->query_self_inst_id)) {
-          // Found a simple designator. Leave it alone.
-          return r;
-        }
-      }
-    }
+    // Designators in rewrite constraints are left alone so they can be found
+    // for rewrite constraint resolution. Using rewrites later requires further
+    // substitution of the `.Self` references inside designators.
+    //
+    // The LHS is always a simple designator since only that is allowed, so we
+    // just substitute the RHS.
     auto rhs = SubstPeriodSelf(
         context, loc_id, context.constant_values().Get(r.rhs_id),
-        period_self_replacement_id, SubstPeriodSelfBehaviour::All);
+        period_self_replacement_id, SubstPeriodSelfBehaviour::ExplicitOnly);
     return {r.lhs_id, context.constant_values().GetInstId(rhs)};
   };
 

--- a/toolchain/check/period_self.h
+++ b/toolchain/check/period_self.h
@@ -23,6 +23,7 @@ auto MakePeriodSelfFacetValue(Context& context, SemIR::LocId loc_id,
 
 enum class SubstPeriodSelfBehaviour {
   ImplicitOnly,
+  ExplicitOnly,
   All,
 };
 
@@ -30,6 +31,7 @@ using SubstPeriodSelfRebuildInst =
     llvm::function_ref<auto(SemIR::Inst)->SemIR::InstId>;
 
 // Replace `.Self` references in `const_id` with `period_self_replacement_id`.
+//
 // The `behaviour` specifies if all `.Self` are replaced or just implicit use in
 // designators. The `rebuild` callback can optionally be specified to override
 // how an instruction is re-constructed to form an InstId after replacement. It
@@ -41,7 +43,7 @@ auto SubstPeriodSelf(
     SubstPeriodSelfRebuildInst rebuild = nullptr) -> SemIR::ConstantId;
 
 // Replace `.Self` references in the specific of the interface or named
-// constraint.
+// constraint with `period_self_replacement_id`.
 //
 // The `behaviour` specifies if all `.Self` are replaced or just implicit use in
 // designators. The `rebuild` callback can optionally be specified to override
@@ -60,8 +62,12 @@ auto SubstPeriodSelf(
     SubstPeriodSelfRebuildInst rebuild = nullptr)
     -> SemIR::SpecificNamedConstraint;
 
-// Replace all `.Self` references with the self-type. The `facet_type_inst_id`
-// must be a `FacetType` instruction (or error).
+// Replace `.Self` references with the self-type. The `facet_type_inst_id` must
+// be a `FacetType` instruction (or error).
+//
+// The implicit `.Self` in designators is not replaced in rewrite constraints,
+// to allow for rewrite constraint resolution to recognise the designators.
+// Later use of rewrite constraints requires further `.Self` replacement.
 //
 // Unlike SubstPeriodSelf, which works with constant values and thus canonical
 // instructions, this operation can be done for non-canonical facet types. A new


### PR DESCRIPTION
When replacing `.Self` in a facet type we don't want to destroy the structure of designators in rewrite constraints so that rewrite constraint resolution and other similar code can still find them. We were doing this only for the LHS, and for the RHS if it was a standalone designator, like `.X = .Y` but we want to do this more robustly to also avoid rewrite the `.Self` in `.Y` in the expression `.X = C(.Y)`. This allows resolution, and ImplWitnessAccess to recognize the designator and replace the `.Y` with the RHS value of another rewrite constraint assigning to `.Y`.