### PR TITLE
clang-format: Indent lambdas relative to the outer scope.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,7 @@ ExperimentalAutoDetectBinPacking: 'false'
 FixNamespaceComments: 'true'
 InsertBraces: 'true'
 InsertTrailingCommas: None
+LambdaBodyIndentation: OuterScope
 PointerAlignment: Left
 # We abuse control macros for formatting other kinds of macros.
 SpaceBeforeParens: ControlStatementsExceptControlMacros

--- a/common/check_internal.cpp
+++ b/common/check_internal.cpp
@@ -35,9 +35,9 @@ auto CheckFailImpl(const char* kind, const char* file, int line,
   // Register another signal handler to print the message. This is because we
   // want it at the bottom of output, after LLVM's builtin stack output, rather
   // than the top.
-  llvm::sys::AddSignalHandler(
-      [](void* str) { llvm::errs() << reinterpret_cast<char*>(str); },
-      const_cast<char*>(message.c_str()));
+  llvm::sys::AddSignalHandler([](void* str) {
+    llvm::errs() << reinterpret_cast<char*>(str);
+  }, const_cast<char*>(message.c_str()));
 
   // It's useful to exit the program with `std::abort()` for integration with
   // debuggers and other tools. We also assume LLVM's exit handling is

--- a/common/check_test.cpp
+++ b/common/check_test.cpp
@@ -19,9 +19,8 @@ auto AlwaysFalse() -> bool { return false; }
 TEST(CheckTest, CheckTrue) { CARBON_CHECK(AlwaysTrue()); }
 
 TEST(CheckTest, CheckFalse) {
-  ASSERT_DEATH(
-      { CARBON_CHECK(AlwaysFalse()); },
-      R"(
+  ASSERT_DEATH({ CARBON_CHECK(AlwaysFalse()); },
+               R"(
 CHECK failure at common/check_test.cpp:\d+: AlwaysFalse\(\)
 )");
 }
@@ -41,9 +40,8 @@ TEST(CheckTest, CheckTrueCallbackNotUsed) {
 }
 
 TEST(CheckTest, CheckFalseMessage) {
-  ASSERT_DEATH(
-      { CARBON_CHECK(AlwaysFalse(), "msg"); },
-      R"(
+  ASSERT_DEATH({ CARBON_CHECK(AlwaysFalse(), "msg"); },
+               R"(
 CHECK failure at common/check_test.cpp:.+: AlwaysFalse\(\): msg
 )");
 }
@@ -67,9 +65,8 @@ TEST(CheckTest, CheckOutputForms) {
 }
 
 TEST(CheckTest, Fatal) {
-  ASSERT_DEATH(
-      { CARBON_FATAL("msg"); },
-      "\nFATAL failure at common/check_test.cpp:.+: msg\n");
+  ASSERT_DEATH({ CARBON_FATAL("msg"); },
+               "\nFATAL failure at common/check_test.cpp:.+: msg\n");
 }
 
 TEST(CheckTest, FatalHasStackDump) {
@@ -79,9 +76,8 @@ TEST(CheckTest, FatalHasStackDump) {
 auto FatalNoReturnRequired() -> int { CARBON_FATAL("msg"); }
 
 TEST(ErrorTest, FatalNoReturnRequired) {
-  ASSERT_DEATH(
-      { FatalNoReturnRequired(); },
-      "\nFATAL failure at common/check_test.cpp:.+: msg\n");
+  ASSERT_DEATH({ FatalNoReturnRequired(); },
+               "\nFATAL failure at common/check_test.cpp:.+: msg\n");
 }
 
 // Detects whether `CARBON_CHECK(F())` compiles.

--- a/common/command_line.cpp
+++ b/common/command_line.cpp
@@ -250,20 +250,19 @@ auto MetaPrinter::RegisterWithCommand(const Command& command,
   // actions, but still silently support using the flags. But we never want to
   // *add* subcommands if they aren't already being used.
   if (has_subcommands) {
-    builder.AddSubcommand(
-        is_subcommand ? SubHelpCommandInfo : HelpCommandInfo,
-        [&](CommandBuilder& sub_b) {
-          sub_b.AddStringPositionalArg(HelpSubcommandArgInfo, [&](auto& arg_b) {
-            arg_b.Set(&help_subcommand_);
-          });
-          sub_b.Meta([this, &command]() {
-            if (help_subcommand_.empty()) {
-              PrintHelp(command);
-            } else {
-              PrintHelpForSubcommandName(command, help_subcommand_);
-            }
-          });
-        });
+    builder.AddSubcommand(is_subcommand ? SubHelpCommandInfo : HelpCommandInfo,
+                          [&](CommandBuilder& sub_b) {
+      sub_b.AddStringPositionalArg(HelpSubcommandArgInfo, [&](auto& arg_b) {
+        arg_b.Set(&help_subcommand_);
+      });
+      sub_b.Meta([this, &command]() {
+        if (help_subcommand_.empty()) {
+          PrintHelp(command);
+        } else {
+          PrintHelpForSubcommandName(command, help_subcommand_);
+        }
+      });
+    });
 
     // Only add version printing support if there is a version string
     // configured for this command.
@@ -273,17 +272,17 @@ auto MetaPrinter::RegisterWithCommand(const Command& command,
       });
     }
   }
-  builder.AddOneOfOption(
-      is_subcommand ? SubHelpArgInfo : HelpArgInfo, [&](auto& arg_b) {
-        arg_b.HelpHidden(has_subcommands);
-        arg_b.SetOneOf(
-            {
-                arg_b.OneOfValue("full", false).Default(true),
-                arg_b.OneOfValue("short", true),
-            },
-            &short_help_);
-        arg_b.MetaAction([this, &command]() { PrintHelp(command); });
-      });
+  builder.AddOneOfOption(is_subcommand ? SubHelpArgInfo : HelpArgInfo,
+                         [&](auto& arg_b) {
+    arg_b.HelpHidden(has_subcommands);
+    arg_b.SetOneOf(
+        {
+            arg_b.OneOfValue("full", false).Default(true),
+            arg_b.OneOfValue("short", true),
+        },
+        &short_help_);
+    arg_b.MetaAction([this, &command]() { PrintHelp(command); });
+  });
 
   // Only add version printing support if there is a version string configured
   // for this command.
@@ -361,8 +360,8 @@ auto MetaPrinter::PrintSubcommands(const Command& command) const -> void {
   PrintListOfAlternatives<std::unique_ptr<Command>>(
       *out_, command.subcommands,
       [](const std::unique_ptr<Command>& subcommand) {
-        return subcommand->info.name;
-      });
+    return subcommand->info.name;
+  });
 }
 
 auto MetaPrinter::PrintRawVersion(const Command& command,

--- a/common/command_line.h
+++ b/common/command_line.h
@@ -769,9 +769,8 @@ auto OneOfArgBuilder::SetOneOf(const OneOfValueT<U> (&values)[N], T* result)
     -> void {
   static_assert(N > 0, "Must include at least one value.");
   arg()->is_append = false;
-  OneOfImpl(
-      values, [result](T value) { *result = value; },
-      std::make_index_sequence<N>{});
+  OneOfImpl(values, [result](T value) { *result = value; },
+            std::make_index_sequence<N>{});
 }
 
 template <typename T, typename U, size_t N>
@@ -779,9 +778,8 @@ auto OneOfArgBuilder::AppendOneOf(const OneOfValueT<U> (&values)[N],
                                   llvm::SmallVectorImpl<T>* sequence) -> void {
   static_assert(N > 0, "Must include at least one value.");
   arg()->is_append = true;
-  OneOfImpl(
-      values, [sequence](T value) { sequence->push_back(value); },
-      std::make_index_sequence<N>{});
+  OneOfImpl(values, [sequence](T value) { sequence->push_back(value); },
+            std::make_index_sequence<N>{});
 }
 
 // An implementation tool for the one-of value candidate handling. Delegating to
@@ -810,15 +808,15 @@ auto OneOfArgBuilder::OneOfImpl(const OneOfValueT<U> (&input_values)[N],
   // by index.
   new (&arg()->value_action) Arg::ValueActionT(
       [values, match](const Arg& arg, llvm::StringRef value_string) -> bool {
-        for (auto [value, arg_value_string] :
-             llvm::zip_equal(values, arg.value_strings)) {
-          if (value_string == arg_value_string) {
-            match(value);
-            return true;
-          }
-        }
-        return false;
-      });
+    for (auto [value, arg_value_string] :
+         llvm::zip_equal(values, arg.value_strings)) {
+      if (value_string == arg_value_string) {
+        match(value);
+        return true;
+      }
+    }
+    return false;
+  });
 
   // Fold over all the input values to see if there is a default.
   if ((input_values[Indices].is_default || ...)) {

--- a/common/command_line_test.cpp
+++ b/common/command_line_test.cpp
@@ -165,9 +165,9 @@ TEST(ArgParserTest, ShortArgs) {
                 [&](auto& arg_b) { arg_b.Set(&example); });
       b.AddIntegerOption({.name = "option1", .short_name = "o"},
                          [&](auto& arg_b) {
-                           arg_b.Default(123);
-                           arg_b.Set(&integer_option);
-                         });
+        arg_b.Default(123);
+        arg_b.Set(&integer_option);
+      });
       b.AddIntegerOption({.name = "option2", .short_name = "z"},
                          [&](auto& arg_b) { arg_b.Set(&integer_option); });
       b.Do([] {});
@@ -506,13 +506,13 @@ TEST(ArgParserTest, OneOfOptionWithTwoOptions) {
   RawStringOstream os;
   EXPECT_THAT(ParseOneOfOption({"--option=z"}, os,
                                [&](auto& arg_b) {
-                                 arg_b.SetOneOf(
-                                     {
-                                         arg_b.OneOfValue("x", 1),
-                                         arg_b.OneOfValue("y", 2),
-                                     },
-                                     &value);
-                               }),
+    arg_b.SetOneOf(
+        {
+            arg_b.OneOfValue("x", 1),
+            arg_b.OneOfValue("y", 2),
+        },
+        &value);
+  }),
               IsError(StrEq("option `--option=z` has an invalid value `z`; "
                             "valid values are: `x` or `y`")));
 }
@@ -522,12 +522,12 @@ TEST(ArgParserTest, OneOfOptionWithOneOption) {
   RawStringOstream os;
   EXPECT_THAT(ParseOneOfOption({"--option=z"}, os,
                                [&](auto& arg_b) {
-                                 arg_b.SetOneOf(
-                                     {
-                                         arg_b.OneOfValue("x", 1),
-                                     },
-                                     &value);
-                               }),
+    arg_b.SetOneOf(
+        {
+            arg_b.OneOfValue("x", 1),
+        },
+        &value);
+  }),
               IsError(StrEq("option `--option=z` has an invalid value `z`; "
                             "valid values are: `x`")));
 }
@@ -673,103 +673,103 @@ Closing remarks.
 )""",
         },
         [&](auto& b) {
-          b.AddFlag(
-              {
-                  .name = "flag",
-                  .short_name = "f",
-                  .help = R"""(
+      b.AddFlag(
+          {
+              .name = "flag",
+              .short_name = "f",
+              .help = R"""(
 A boolean flag.
 )""",
-              },
-              [&](auto& arg_b) { arg_b.Set(&flag); });
-          b.AddFlag(
-              {
-                  .name = "hidden_flag",
-                  .help = R"""(
+          },
+          [&](auto& arg_b) { arg_b.Set(&flag); });
+      b.AddFlag(
+          {
+              .name = "hidden_flag",
+              .help = R"""(
 A *hidden* boolean flag.
 )""",
-              },
-              [&](auto& arg_b) {
-                arg_b.HelpHidden(true);
-                arg_b.Set(&flag);
-              });
-          b.AddSubcommand(
-              {
-                  .name = "edit",
-                  .help = R"""(
+          },
+          [&](auto& arg_b) {
+        arg_b.HelpHidden(true);
+        arg_b.Set(&flag);
+      });
+      b.AddSubcommand(
+          {
+              .name = "edit",
+              .help = R"""(
 Edit the widget.
 
 This will take the provided widgets and edit them.
 )""",
-                  .help_epilogue = R"""(
+              .help_epilogue = R"""(
 That's all.
 )""",
-              },
-              [&](auto& sub_b) {
-                sub_b.AddIntegerOption(
-                    {
-                        .name = "option",
-                        .short_name = "o",
-                        .help = R"""(
+          },
+          [&](auto& sub_b) {
+        sub_b.AddIntegerOption(
+            {
+                .name = "option",
+                .short_name = "o",
+                .help = R"""(
 An integer option.
 )""",
-                    },
-                    [&](auto& arg_b) { arg_b.Set(&storage); });
-                sub_b.Do([] {});
-              });
-          b.AddSubcommand(
-              {
-                  .name = "run",
-                  .help = R"""(
+            },
+            [&](auto& arg_b) { arg_b.Set(&storage); });
+        sub_b.Do([] {});
+      });
+      b.AddSubcommand(
+          {
+              .name = "run",
+              .help = R"""(
 Run wombats across the screen.
 
 This will cause several wombats to run across your screen.
 )""",
-                  .help_epilogue = R"""(
+              .help_epilogue = R"""(
 Or it won't, who knows.
 )""",
-              },
-              [&](auto& sub_b) {
-                sub_b.AddStringOption(
-                    {
-                        .name = "option",
-                        .short_name = "o",
-                        .help = R"""(
+          },
+          [&](auto& sub_b) {
+        sub_b.AddStringOption(
+            {
+                .name = "option",
+                .short_name = "o",
+                .help = R"""(
 A string option.
 )""",
-                    },
-                    [&](auto& arg_b) { arg_b.Set(&string); });
-                sub_b.AddOneOfOption(
-                    {
-                        .name = "one-of-option",
-                        .help = R"""(
+            },
+            [&](auto& arg_b) { arg_b.Set(&string); });
+        sub_b.AddOneOfOption(
+            {
+                .name = "one-of-option",
+                .help = R"""(
 A one-of option.
 )""",
-                    },
-                    [&](auto& arg_b) {
-                      arg_b.SetOneOf(
-                          {
-                              arg_b.OneOfValue("x", 1),
-                              arg_b.OneOfValue("y", 2),
-                              arg_b.OneOfValue("z", 3),
-                          },
-                          &storage);
-                    });
-                sub_b.Do([] {});
-              });
-          b.AddSubcommand(
+            },
+            [&](auto& arg_b) {
+          arg_b.SetOneOf(
               {
-                  .name = "hidden",
-                  .help = R"""(
+                  arg_b.OneOfValue("x", 1),
+                  arg_b.OneOfValue("y", 2),
+                  arg_b.OneOfValue("z", 3),
+              },
+              &storage);
+        });
+        sub_b.Do([] {});
+      });
+      b.AddSubcommand(
+          {
+              .name = "hidden",
+              .help = R"""(
 A hidden subcommand.
 )""",
-              },
-              [&](auto& sub_b) {
-                sub_b.HelpHidden(true);
-                sub_b.Do([] {});
-              });
-          b.RequiresSubcommand();
-        });
+          },
+          [&](auto& sub_b) {
+        sub_b.HelpHidden(true);
+        sub_b.Do([] {});
+      });
+      b.RequiresSubcommand();
+    });
   };
 
   RawStringOstream os;
@@ -909,10 +909,10 @@ TEST(ArgParserTest, HelpMarkdownLike) {
   auto parse = [&](llvm::ArrayRef<llvm::StringRef> args, llvm::raw_ostream& s) {
     return Parse(  // Force line break.
         args, s, {.name = "test"}, [&](auto& b) {
-          b.AddFlag(
-              {
-                  .name = "flag",
-                  .help = R"""(
+      b.AddFlag(
+          {
+              .name = "flag",
+              .help = R"""(
 A boolean flag.
 
     Preformatted
@@ -931,10 +931,10 @@ x
   z
 ```
 )""",
-              },
-              [&](auto& arg_b) { arg_b.Set(&flag); });
-          b.Do([] {});
-        });
+          },
+          [&](auto& arg_b) { arg_b.Set(&flag); });
+      b.Do([] {});
+    });
   };
 
   RawStringOstream os;

--- a/common/map.h
+++ b/common/map.h
@@ -429,9 +429,9 @@ auto MapView<InputKeyT, InputValueT, InputKeyContextT>::ForEach(
     CallbackT callback) -> void
   requires(std::invocable<CallbackT, KeyT&, ValueT&>)
 {
-  this->ForEachEntry(
-      [callback](EntryT& entry) { callback(entry.key(), entry.value()); },
-      [](auto...) {});
+  this->ForEachEntry([callback](EntryT& entry) {
+    callback(entry.key(), entry.value());
+  }, [](auto...) {});
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
@@ -443,10 +443,9 @@ MapBase<InputKeyT, InputValueT, InputKeyContextT>::Insert(
   return Insert(
       lookup_key,
       [&new_v](LookupKeyT lookup_key, void* key_storage, void* value_storage) {
-        new (key_storage) KeyT(lookup_key);
-        new (value_storage) ValueT(std::move(new_v));
-      },
-      key_context);
+    new (key_storage) KeyT(lookup_key);
+    new (value_storage) ValueT(std::move(new_v));
+  }, key_context);
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
@@ -459,14 +458,13 @@ MapBase<InputKeyT, InputValueT, InputKeyContextT>::Insert(
       !std::same_as<ValueT, ValueCallbackT> &&
       std::convertible_to<decltype(std::declval<ValueCallbackT>()()), ValueT>)
 {
-  return Insert(
-      lookup_key,
-      [&value_cb](LookupKeyT lookup_key, void* key_storage,
-                  void* value_storage) {
-        new (key_storage) KeyT(lookup_key);
-        new (value_storage) ValueT(value_cb());
-      },
-      key_context);
+  return Insert(lookup_key,
+                [&value_cb](LookupKeyT lookup_key, void* key_storage,
+                            void* value_storage) {
+    new (key_storage) KeyT(lookup_key);
+    new (value_storage) ValueT(value_cb());
+  },
+                key_context);
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
@@ -499,14 +497,12 @@ MapBase<InputKeyT, InputValueT, InputKeyContextT>::Update(
   return Update(
       lookup_key,
       [&new_v](LookupKeyT lookup_key, void* key_storage, void* value_storage) {
-        new (key_storage) KeyT(lookup_key);
-        new (value_storage) ValueT(std::move(new_v));
-      },
-      [&new_v](KeyT& /*key*/, ValueT& value) {
-        value.~ValueT();
-        new (&value) ValueT(std::move(new_v));
-      },
-      key_context);
+    new (key_storage) KeyT(lookup_key);
+    new (value_storage) ValueT(std::move(new_v));
+  }, [&new_v](KeyT& /*key*/, ValueT& value) {
+    value.~ValueT();
+    new (&value) ValueT(std::move(new_v));
+  }, key_context);
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
@@ -519,18 +515,16 @@ MapBase<InputKeyT, InputValueT, InputKeyContextT>::Update(
       !std::same_as<ValueT, ValueCallbackT> &&
       std::convertible_to<decltype(std::declval<ValueCallbackT>()()), ValueT>)
 {
-  return Update(
-      lookup_key,
-      [&value_cb](LookupKeyT lookup_key, void* key_storage,
-                  void* value_storage) {
-        new (key_storage) KeyT(lookup_key);
-        new (value_storage) ValueT(value_cb());
-      },
-      [&value_cb](KeyT& /*key*/, ValueT& value) {
-        value.~ValueT();
-        new (&value) ValueT(value_cb());
-      },
-      key_context);
+  return Update(lookup_key,
+                [&value_cb](LookupKeyT lookup_key, void* key_storage,
+                            void* value_storage) {
+    new (key_storage) KeyT(lookup_key);
+    new (value_storage) ValueT(value_cb());
+  },
+                [&value_cb](KeyT& /*key*/, ValueT& value) {
+    value.~ValueT();
+    new (&value) ValueT(value_cb());
+  }, key_context);
 }
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>

--- a/common/map_test.cpp
+++ b/common/map_test.cpp
@@ -135,9 +135,9 @@ TYPED_TEST(MapTest, Basic) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     EXPECT_TRUE(m.Insert(i, i * 100).is_inserted());
   }
-  ExpectMapElementsAre(
-      m, MakeKeyValues([](int k) { return k * 100 + static_cast<int>(k == 1); },
-                       llvm::seq(1, 512)));
+  ExpectMapElementsAre(m, MakeKeyValues([](int k) {
+    return k * 100 + static_cast<int>(k == 1);
+  }, llvm::seq(1, 512)));
   for (int i : llvm::seq(1, 512)) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     EXPECT_FALSE(m.Insert(i, i * 100 + 1).is_inserted());
@@ -159,8 +159,8 @@ TYPED_TEST(MapTest, FactoryApi) {
   EXPECT_EQ(100, *m[1]);
   // Reinsertion doesn't invoke the callback.
   EXPECT_FALSE(m.Insert(1, []() -> int {
-                  llvm_unreachable("Should never be called!");
-                }).is_inserted());
+    llvm_unreachable("Should never be called!");
+  }).is_inserted());
   // Update does invoke the callback.
   auto i_result = m.Update(1, [] { return 101; });
   EXPECT_FALSE(i_result.is_inserted());
@@ -645,9 +645,9 @@ TYPED_TEST(MapTest, ComplexOpSequence) {
   EXPECT_TRUE(m.Insert(73, 73 * 100 + 3).is_inserted());
   EXPECT_EQ(73 * 100 + 3, *m[73]);
 
-  ExpectMapElementsAre(
-      m, MakeKeyValues([](int k) { return k * 100 + 2 + (k == 73); },
-                       llvm::seq(50, 102), llvm::seq(136, 150)));
+  ExpectMapElementsAre(m, MakeKeyValues([](int k) {
+    return k * 100 + 2 + (k == 73);
+  }, llvm::seq(50, 102), llvm::seq(136, 150)));
 
   // Reset back to empty and small.
   m.Reset();
@@ -700,9 +700,9 @@ TYPED_TEST(MapTest, ComplexOpSequence) {
   EXPECT_TRUE(m.Insert(93, 93 * 100 + 3).is_inserted());
   EXPECT_EQ(93 * 100 + 3, *m[93]);
 
-  ExpectMapElementsAre(
-      m, MakeKeyValues([](int k) { return k * 100 + 2 + (k == 93); },
-                       llvm::seq(75, 102), llvm::seq(136, 175)));
+  ExpectMapElementsAre(m, MakeKeyValues([](int k) {
+    return k * 100 + 2 + (k == 93);
+  }, llvm::seq(75, 102), llvm::seq(136, 175)));
 }
 
 template <typename MapT>
@@ -745,25 +745,25 @@ TYPED_TEST(MapCollisionTest, Basic) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     EXPECT_TRUE(m.Insert(i, i * 100 + 1).is_inserted());
   }
-  ExpectMapElementsAre(m,
-                       MakeKeyValues([](int k) { return k * 100 + (k >= 192); },
-                                     llvm::seq(1, 256)));
+  ExpectMapElementsAre(m, MakeKeyValues([](int k) {
+    return k * 100 + (k >= 192);
+  }, llvm::seq(1, 256)));
 
   // Erase and re-fill from the front.
   for (int i : llvm::seq(1, 64)) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     EXPECT_TRUE(m.Erase(i));
   }
-  ExpectMapElementsAre(m,
-                       MakeKeyValues([](int k) { return k * 100 + (k >= 192); },
-                                     llvm::seq(64, 256)));
+  ExpectMapElementsAre(m, MakeKeyValues([](int k) {
+    return k * 100 + (k >= 192);
+  }, llvm::seq(64, 256)));
   for (int i : llvm::seq(1, 64)) {
     SCOPED_TRACE(llvm::formatv("Key: {0}", i).str());
     EXPECT_TRUE(m.Insert(i, i * 100 + 1).is_inserted());
   }
-  ExpectMapElementsAre(
-      m, MakeKeyValues([](int k) { return k * 100 + (k < 64) + (k >= 192); },
-                       llvm::seq(1, 256)));
+  ExpectMapElementsAre(m, MakeKeyValues([](int k) {
+    return k * 100 + (k < 64) + (k >= 192);
+  }, llvm::seq(1, 256)));
 
   // Erase and re-fill from the middle.
   for (int i : llvm::seq(64, 192)) {
@@ -794,10 +794,9 @@ TYPED_TEST(MapCollisionTest, Basic) {
       EXPECT_TRUE(m.Insert(i, i * 100 + 2).is_inserted());
     }
   }
-  ExpectMapElementsAre(
-      m,
-      MakeKeyValues([](int k) { return k * 100 + 1 + (k < 64) + (k >= 192); },
-                    llvm::seq(1, 256)));
+  ExpectMapElementsAre(m, MakeKeyValues([](int k) {
+    return k * 100 + 1 + (k < 64) + (k >= 192);
+  }, llvm::seq(1, 256)));
 
   // And update the middle elements in place.
   for (int i : llvm::seq(64, 192)) {

--- a/common/raw_hashtable.h
+++ b/common/raw_hashtable.h
@@ -1114,16 +1114,14 @@ auto BaseImpl<InputKeyT, InputValueT, InputKeyContextT>::EraseImpl(
 
 template <typename InputKeyT, typename InputValueT, typename InputKeyContextT>
 auto BaseImpl<InputKeyT, InputValueT, InputKeyContextT>::ClearImpl() -> void {
-  view_impl_.ForEachEntry(
-      [](EntryT& entry) {
-        if constexpr (!EntryT::IsTriviallyDestructible) {
-          entry.Destroy();
-        }
-      },
-      [](uint8_t* metadata_group) {
-        // Clear the group.
-        std::memset(metadata_group, 0, GroupSize);
-      });
+  view_impl_.ForEachEntry([](EntryT& entry) {
+    if constexpr (!EntryT::IsTriviallyDestructible) {
+      entry.Destroy();
+    }
+  }, [](uint8_t* metadata_group) {
+    // Clear the group.
+    std::memset(metadata_group, 0, GroupSize);
+  });
   growth_budget_ = GrowthThresholdForAllocSize(alloc_size());
 }
 

--- a/common/raw_hashtable_benchmark_helpers.cpp
+++ b/common/raw_hashtable_benchmark_helpers.cpp
@@ -59,17 +59,17 @@ static auto MakeFourCharStrs(llvm::ArrayRef<char> characters, absl::BitGen& gen)
   constexpr ssize_t NumCharsShift = llvm::ConstantLog2<NumChars>();
   llvm::SmallVector<std::array<char, 4>> four_char_strs(
       llvm::map_range(llvm::seq(NumFourCharStrs), [&](auto i) {
-        std::array<char, 4> str;
-        str[0] = characters[i & NumCharsMask];
-        i >>= NumCharsShift;
-        str[1] = characters[i & NumCharsMask];
-        i >>= NumCharsShift;
-        str[2] = characters[i & NumCharsMask];
-        i >>= NumCharsShift;
-        CARBON_CHECK((i & ~NumCharsMask) == 0);
-        str[3] = characters[i];
-        return str;
-      }));
+    std::array<char, 4> str;
+    str[0] = characters[i & NumCharsMask];
+    i >>= NumCharsShift;
+    str[1] = characters[i & NumCharsMask];
+    i >>= NumCharsShift;
+    str[2] = characters[i & NumCharsMask];
+    i >>= NumCharsShift;
+    CARBON_CHECK((i & ~NumCharsMask) == 0);
+    str[3] = characters[i];
+    return str;
+  }));
   Shuffle<std::array<char, 4>>(four_char_strs, gen);
   return four_char_strs;
 }
@@ -84,8 +84,8 @@ static auto MakeRandomChars(llvm::ArrayRef<char> characters, int max_length,
                             absl::BitGen& gen) -> llvm::SmallVector<char> {
   return llvm::SmallVector<char>(
       llvm::map_range(llvm::seq(NumRandomChars + max_length), [&](auto /*i*/) {
-        return characters[absl::Uniform<ssize_t>(gen, 0, NumChars)];
-      }));
+    return characters[absl::Uniform<ssize_t>(gen, 0, NumChars)];
+  }));
 }
 
 // Make a small vector of pointers into a single allocation of raw strings. The
@@ -262,11 +262,10 @@ auto GetShuffledLookupKeys(ssize_t table_keys_size, ssize_t lookup_keys_size)
       (*lookup_keys_storage<T>)[{table_keys_size, lookup_keys_size}];
   if (lookup_keys.empty()) {
     auto raw_keys = GetRawKeys<T>();
-    llvm::append_range(
-        lookup_keys,
-        llvm::map_range(llvm::seq(lookup_keys_size), [&](int index) {
-          return raw_keys[index % table_keys_size];
-        }));
+    llvm::append_range(lookup_keys, llvm::map_range(llvm::seq(lookup_keys_size),
+                                                    [&](int index) {
+      return raw_keys[index % table_keys_size];
+    }));
     absl::BitGen gen;
     Shuffle<T>(lookup_keys, gen);
   }
@@ -371,9 +370,8 @@ auto DumpHashStatistics(llvm::ArrayRef<T> keys) -> void {
   ssize_t max_group_index =
       llvm::max_element(grouped_key_indices,
                         [](const auto& lhs, const auto& rhs) {
-                          return lhs.size() < rhs.size();
-                        }) -
-      grouped_key_indices.begin();
+    return lhs.size() < rhs.size();
+  }) - grouped_key_indices.begin();
 
   // If the max number of collisions on the index is less than or equal to the
   // group size, there shouldn't be any necessary probing (outside of deletion)

--- a/common/set.h
+++ b/common/set.h
@@ -347,12 +347,9 @@ template <typename LookupKeyT>
 auto SetBase<InputKeyT, InputKeyContextT>::Insert(LookupKeyT lookup_key,
                                                   KeyContextT key_context)
     -> InsertResult {
-  return Insert(
-      lookup_key,
-      [](LookupKeyT lookup_key, void* key_storage) {
-        new (key_storage) KeyT(std::move(lookup_key));
-      },
-      key_context);
+  return Insert(lookup_key, [](LookupKeyT lookup_key, void* key_storage) {
+    new (key_storage) KeyT(std::move(lookup_key));
+  }, key_context);
 }
 
 template <typename InputKeyT, typename InputKeyContextT>
@@ -364,12 +361,10 @@ auto SetBase<InputKeyT, InputKeyContextT>::Insert(LookupKeyT lookup_key,
   requires(!std::same_as<KeyT, KeyCallbackT> &&
            std::convertible_to<decltype(std::declval<KeyCallbackT>()()), KeyT>)
 {
-  return Insert(
-      lookup_key,
-      [&key_cb](LookupKeyT /*lookup_key*/, void* key_storage) {
-        new (key_storage) KeyT(key_cb());
-      },
-      key_context);
+  return Insert(lookup_key,
+                [&key_cb](LookupKeyT /*lookup_key*/, void* key_storage) {
+    new (key_storage) KeyT(key_cb());
+  }, key_context);
 }
 
 template <typename InputKeyT, typename InputKeyContextT>

--- a/common/set_test.cpp
+++ b/common/set_test.cpp
@@ -108,13 +108,13 @@ TYPED_TEST(SetTest, FactoryApi) {
   using SetT = TypeParam;
   SetT s;
   EXPECT_TRUE(s.Insert(1, [](int k, void* key_storage) {
-                 return new (key_storage) int(k);
-               }).is_inserted());
+    return new (key_storage) int(k);
+  }).is_inserted());
   ASSERT_TRUE(s.Contains(1));
   // Reinsertion doesn't invoke the callback.
   EXPECT_FALSE(s.Insert(1, [](int, void*) -> int* {
-                  llvm_unreachable("Should never be called!");
-                }).is_inserted());
+    llvm_unreachable("Should never be called!");
+  }).is_inserted());
 }
 
 TYPED_TEST(SetTest, Copy) {

--- a/testing/base/source_gen.cpp
+++ b/testing/base/source_gen.cpp
@@ -391,13 +391,12 @@ auto SourceGen::GetShuffledUniqueIdentifiers(int number, int min_length,
 auto SourceGen::GetIdentifiers(int number, int min_length, int max_length,
                                bool uniform)
     -> llvm::SmallVector<llvm::StringRef> {
-  llvm::SmallVector<llvm::StringRef> idents = GetIdentifiersImpl(
-      number, min_length, max_length, uniform,
-      [this](int length, int length_count,
-             llvm::SmallVectorImpl<llvm::StringRef>& dest) {
-        llvm::append_range(dest,
-                           GetSingleLengthIdentifiers(length, length_count));
-      });
+  llvm::SmallVector<llvm::StringRef> idents =
+      GetIdentifiersImpl(number, min_length, max_length, uniform,
+                         [this](int length, int length_count,
+                                llvm::SmallVectorImpl<llvm::StringRef>& dest) {
+    llvm::append_range(dest, GetSingleLengthIdentifiers(length, length_count));
+  });
 
   return idents;
 }
@@ -412,8 +411,8 @@ auto SourceGen::GetUniqueIdentifiers(int number, int min_length, int max_length,
       GetIdentifiersImpl(number, min_length, max_length, uniform,
                          [this](int length, int length_count,
                                 llvm::SmallVectorImpl<llvm::StringRef>& dest) {
-                           AppendUniqueIdentifiers(length, length_count, dest);
-                         });
+    AppendUniqueIdentifiers(length, length_count, dest);
+  });
 
   return idents;
 }
@@ -866,20 +865,19 @@ auto SourceGen::GenerateClassDef(const ClassParams& params,
   llvm::ListSeparator line_sep("\n");
   for ([[maybe_unused]] auto _ : llvm::seq(params.public_function_decls)) {
     os << line_sep;
-    GenerateFunctionDecl(
-        unique_member_names.Pop(), /*is_private=*/false,
-        /*is_method=*/false,
-        state.public_function_param_counts().pop_back_val(),
-        /*indent=*/"  ", state.param_names(),
-        [&] { return state.GetValidTypeName(); }, os);
+    GenerateFunctionDecl(unique_member_names.Pop(), /*is_private=*/false,
+                         /*is_method=*/false,
+                         state.public_function_param_counts().pop_back_val(),
+                         /*indent=*/"  ", state.param_names(),
+                         [&] { return state.GetValidTypeName(); }, os);
   }
   for ([[maybe_unused]] auto _ : llvm::seq(params.public_method_decls)) {
     os << line_sep;
-    GenerateFunctionDecl(
-        unique_member_names.Pop(), /*is_private=*/false,
-        /*is_method=*/true, state.public_method_param_counts().pop_back_val(),
-        /*indent=*/"  ", state.param_names(),
-        [&] { return state.GetValidTypeName(); }, os);
+    GenerateFunctionDecl(unique_member_names.Pop(), /*is_private=*/false,
+                         /*is_method=*/true,
+                         state.public_method_param_counts().pop_back_val(),
+                         /*indent=*/"  ", state.param_names(),
+                         [&] { return state.GetValidTypeName(); }, os);
   }
 
   if (IsCpp()) {
@@ -890,20 +888,19 @@ auto SourceGen::GenerateClassDef(const ClassParams& params,
 
   for ([[maybe_unused]] auto _ : llvm::seq(params.private_function_decls)) {
     os << line_sep;
-    GenerateFunctionDecl(
-        unique_member_names.Pop(), /*is_private=*/true,
-        /*is_method=*/false,
-        state.private_function_param_counts().pop_back_val(),
-        /*indent=*/"  ", state.param_names(),
-        [&] { return state.GetValidTypeName(); }, os);
+    GenerateFunctionDecl(unique_member_names.Pop(), /*is_private=*/true,
+                         /*is_method=*/false,
+                         state.private_function_param_counts().pop_back_val(),
+                         /*indent=*/"  ", state.param_names(),
+                         [&] { return state.GetValidTypeName(); }, os);
   }
   for ([[maybe_unused]] auto _ : llvm::seq(params.private_method_decls)) {
     os << line_sep;
-    GenerateFunctionDecl(
-        unique_member_names.Pop(), /*is_private=*/true,
-        /*is_method=*/true, state.private_method_param_counts().pop_back_val(),
-        /*indent=*/"  ", state.param_names(),
-        [&] { return state.GetValidTypeName(); }, os);
+    GenerateFunctionDecl(unique_member_names.Pop(), /*is_private=*/true,
+                         /*is_method=*/true,
+                         state.private_method_param_counts().pop_back_val(),
+                         /*indent=*/"  ", state.param_names(),
+                         [&] { return state.GetValidTypeName(); }, os);
   }
   os << line_sep;
   for (llvm::StringRef type_name : field_type_names) {

--- a/testing/base/source_gen_main.cpp
+++ b/testing/base/source_gen_main.cpp
@@ -57,25 +57,24 @@ auto Run(llvm::ArrayRef<llvm::StringRef> args) -> bool {
   int lines = 10'000;
   SourceGen::Language language;
 
-  auto parse_result = CommandLine::Parse(
-      args, llvm::outs(), Info, [&](CommandLine::CommandBuilder& b) {
-        b.AddStringOption(OutputArgInfo,
-                          [&](auto& arg_b) { arg_b.Set(&output_filename); });
-        b.AddIntegerOption(LinesArgInfo,
-                           [&](auto& arg_b) { arg_b.Set(&lines); });
-        b.AddOneOfOption(LanguageArgInfo, [&](auto& arg_b) {
-          arg_b.SetOneOf(
-              {
-                  arg_b.OneOfValue("carbon", SourceGen::Language::Carbon)
-                      .Default(true),
-                  arg_b.OneOfValue("cpp", SourceGen::Language::Cpp),
-              },
-              &language);
-        });
+  auto parse_result = CommandLine::Parse(args, llvm::outs(), Info,
+                                         [&](CommandLine::CommandBuilder& b) {
+    b.AddStringOption(OutputArgInfo,
+                      [&](auto& arg_b) { arg_b.Set(&output_filename); });
+    b.AddIntegerOption(LinesArgInfo, [&](auto& arg_b) { arg_b.Set(&lines); });
+    b.AddOneOfOption(LanguageArgInfo, [&](auto& arg_b) {
+      arg_b.SetOneOf(
+          {
+              arg_b.OneOfValue("carbon", SourceGen::Language::Carbon)
+                  .Default(true),
+              arg_b.OneOfValue("cpp", SourceGen::Language::Cpp),
+          },
+          &language);
+    });
 
-        // No-op action as there is only one operation for this command.
-        b.Do([] {});
-      });
+    // No-op action as there is only one operation for this command.
+    b.Do([] {});
+  });
   if (!parse_result.ok()) {
     llvm::errs() << "error: " << *parse_result << "\n";
     return false;

--- a/testing/base/source_gen_test.cpp
+++ b/testing/base/source_gen_test.cpp
@@ -64,8 +64,8 @@ TEST(SourceGenTest, Identifiers) {
     });
     for (int long_size : llvm::seq_inclusive(5, 64)) {
       EXPECT_THAT(short_count, Gt(llvm::count_if(idents, [&](auto ident) {
-                    return static_cast<int>(ident.size()) == long_size;
-                  })));
+        return static_cast<int>(ident.size()) == long_size;
+      })));
     }
   }
 

--- a/testing/file_test/file_test_base.cpp
+++ b/testing/file_test/file_test_base.cpp
@@ -193,12 +193,10 @@ static auto RunAutoupdater(FileTestBase* test_base, const TestFile& test_file,
              test_base->GetDefaultFileRE(expected_filenames),
              test_base->GetLineNumberReplacements(expected_filenames),
              [&](std::string& line) {
-               test_base->DoExtraCheckReplacements(line);
-             },
-             [&](FileTestBase::CheckLineArray& lines, bool is_stderr) {
-               test_base->FinalizeCheckLines(lines, is_stderr);
-             })
-      .Run(dry_run);
+    test_base->DoExtraCheckReplacements(line);
+  }, [&](FileTestBase::CheckLineArray& lines, bool is_stderr) {
+    test_base->FinalizeCheckLines(lines, is_stderr);
+  }).Run(dry_run);
 }
 
 auto FileTestCase::TestBody() -> void {
@@ -531,8 +529,8 @@ auto FileTestEventListener::OnTestProgramStart(
         llvm::make_pointer_range(tests_));
     llvm::sort(sorted_tests,
                [](const FileTestInfo* lhs, const FileTestInfo* rhs) {
-                 return lhs->elapsed_ms > rhs->elapsed_ms;
-               });
+      return lhs->elapsed_ms > rhs->elapsed_ms;
+    });
 
     llvm::errs() << "  Slowest tests:\n";
     int count = print_slowest_tests > 0 ? print_slowest_tests : run_count;

--- a/testing/file_test/file_test_base.h
+++ b/testing/file_test/file_test_base.h
@@ -154,8 +154,8 @@ extern auto GetFileTestFactory() -> FileTestFactory;
 #define CARBON_FILE_TEST_FACTORY(Name)                                       \
   auto GetFileTestFactory() -> FileTestFactory {                             \
     return {#Name, [](llvm::StringRef exe_path, llvm::StringRef test_name) { \
-              return std::make_unique<Name>(exe_path, test_name);            \
-            }};                                                              \
+      return std::make_unique<Name>(exe_path, test_name);                    \
+    }};                                                                      \
   }
 
 }  // namespace Carbon::Testing

--- a/testing/file_test/file_test_base_test.cpp
+++ b/testing/file_test/file_test_base_test.cpp
@@ -292,20 +292,18 @@ auto FileTestBaseTest::Run(
           .Case("unattached_multi_file.carbon", &TestUnattachedMultiFile)
           .Case("fail_multi_success_overall_fail.carbon",
                 [&](TestParams&) {
-                  return HandleMultiSuccessTests(/*overall=*/false, /*a=*/true,
-                                                 /*b=*/true);
-                })
+    return HandleMultiSuccessTests(/*overall=*/false, /*a=*/true,
+                                   /*b=*/true);
+  })
           .Case("multi_success.carbon",
                 [&](TestParams&) {
-                  return HandleMultiSuccessTests(/*overall=*/true, /*a=*/true,
-                                                 /*b=*/true);
-                })
-          .Case("multi_success_and_fail.carbon",
-                [&](TestParams&) {
-                  return HandleMultiSuccessTests(/*overall=*/false, /*a=*/true,
-                                                 /*b=*/false);
-                })
-          .Default(&EchoFileContent);
+    return HandleMultiSuccessTests(/*overall=*/true, /*a=*/true,
+                                   /*b=*/true);
+  })
+          .Case("multi_success_and_fail.carbon", [&](TestParams&) {
+    return HandleMultiSuccessTests(/*overall=*/false, /*a=*/true,
+                                   /*b=*/false);
+  }).Default(&EchoFileContent);
 
   // Call the appropriate test function for the file.
   TestParams params = {.fs = *fs,

--- a/toolchain/base/block_value_store.h
+++ b/toolchain/base/block_value_store.h
@@ -91,8 +91,8 @@ class BlockValueStore
   auto MakeCanonical(IdT id) -> IdT {
     // Get the content first so that we don't have unnecessary translation of
     // the `id` into the content during insertion.
-    auto result = canonical_blocks_.Insert(
-        Get(id), [id] { return id; }, KeyContext(this));
+    auto result = canonical_blocks_.Insert(Get(id), [id] { return id; },
+                                           KeyContext(this));
     return result.key();
   }
 
@@ -101,10 +101,10 @@ class BlockValueStore
       for (auto [block_id, block] : values_.enumerate()) {
         map.Add(PrintToString(block_id),
                 Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                  for (auto [i, elem_id] : llvm::enumerate(block)) {
-                    map.Add(llvm::itostr(i), Yaml::OutputScalar(elem_id));
-                  }
-                }));
+          for (auto [i, elem_id] : llvm::enumerate(block)) {
+            map.Add(llvm::itostr(i), Yaml::OutputScalar(elem_id));
+          }
+        }));
       }
     });
   }

--- a/toolchain/base/mem_usage.h
+++ b/toolchain/base/mem_usage.h
@@ -123,15 +123,15 @@ class MemUsage {
         total_reserved += entry.reserved_bytes;
         map.Add(entry.label,
                 Yaml::OutputMapping([&](Yaml::OutputMapping::Map byte_map) {
-                  byte_map.Add("used_bytes", entry.used_bytes);
-                  byte_map.Add("reserved_bytes", entry.reserved_bytes);
-                }));
+          byte_map.Add("used_bytes", entry.used_bytes);
+          byte_map.Add("reserved_bytes", entry.reserved_bytes);
+        }));
       }
       map.Add("Total",
               Yaml::OutputMapping([&](Yaml::OutputMapping::Map byte_map) {
-                byte_map.Add("used_bytes", total_used);
-                byte_map.Add("reserved_bytes", total_reserved);
-              }));
+        byte_map.Add("used_bytes", total_used);
+        byte_map.Add("reserved_bytes", total_reserved);
+      }));
     });
   }
 

--- a/toolchain/base/shared_value_stores.h
+++ b/toolchain/base/shared_value_stores.h
@@ -57,12 +57,12 @@ class SharedValueStores : public Yaml::Printable<SharedValueStores> {
       }
       map.Add("shared_values",
               Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                map.Add("ints", ints_.OutputYaml());
-                map.Add("reals", reals_.OutputYaml());
-                map.Add("floats", floats_.OutputYaml());
-                map.Add("identifiers", identifiers_.OutputYaml());
-                map.Add("strings", string_literals_.OutputYaml());
-              }));
+        map.Add("ints", ints_.OutputYaml());
+        map.Add("reals", reals_.OutputYaml());
+        map.Add("floats", floats_.OutputYaml());
+        map.Add("identifiers", identifiers_.OutputYaml());
+        map.Add("strings", string_literals_.OutputYaml());
+      }));
     });
   }
 

--- a/toolchain/base/timings.h
+++ b/toolchain/base/timings.h
@@ -51,15 +51,14 @@ class Timings {
       map.Add("filename", filename);
       map.Add("nanoseconds",
               Yaml::OutputMapping([&](Yaml::OutputMapping::Map label_map) {
-                std::chrono::nanoseconds total_nanoseconds(0);
-                for (const auto& entry : timings_) {
-                  total_nanoseconds += entry.nanoseconds;
-                  label_map.Add(entry.label, static_cast<int64_t>(
-                                                 entry.nanoseconds.count()));
-                }
-                label_map.Add("Total",
-                              static_cast<int64_t>(total_nanoseconds.count()));
-              }));
+        std::chrono::nanoseconds total_nanoseconds(0);
+        for (const auto& entry : timings_) {
+          total_nanoseconds += entry.nanoseconds;
+          label_map.Add(entry.label,
+                        static_cast<int64_t>(entry.nanoseconds.count()));
+        }
+        label_map.Add("Total", static_cast<int64_t>(total_nanoseconds.count()));
+      }));
     });
   }
 

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -67,8 +67,8 @@ class ValueStore
       // can use llvm::seq to walk all indices in the store.
       return llvm::map_range(llvm::seq(store.size_),
                              [&](int32_t i) -> ConstRefType {
-                               return store.Get(IdType(store.tag_.Apply(i)));
-                             });
+        return store.Get(IdType(store.tag_.Apply(i)));
+      });
     }
 
     using FlattenedRangeType =

--- a/toolchain/check/action.cpp
+++ b/toolchain/check/action.cpp
@@ -118,11 +118,9 @@ template <typename BundleT>
 static auto OperandDependence(Context& context,
                               SemIR::BundleId<BundleT> bundle_id)
     -> SemIR::ConstantDependence {
-  return std::apply(
-      [&](auto... ids) {
-        return std::max({OperandDependence(context, ids)...});
-      },
-      context.bundles().GetAsTuple(bundle_id));
+  return std::apply([&](auto... ids) {
+    return std::max({OperandDependence(context, ids)...});
+  }, context.bundles().GetAsTuple(bundle_id));
 }
 
 template <typename IdT>

--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -238,12 +238,12 @@ auto PerformCallToFunction(Context& context, SemIR::LocId loc_id,
 
   auto return_arg_id = SemIR::InstId::None;
   if (callee.return_pattern_id.has_value()) {
-    Diagnostics::AnnotationScope annotate_diagnostics(
-        &context.emitter(), [&](auto& builder) {
-          CARBON_DIAGNOSTIC(IncompleteReturnTypeHere, Note,
-                            "return type declared here");
-          builder.Note(callee.return_pattern_id, IncompleteReturnTypeHere);
-        });
+    Diagnostics::AnnotationScope annotate_diagnostics(&context.emitter(),
+                                                      [&](auto& builder) {
+      CARBON_DIAGNOSTIC(IncompleteReturnTypeHere, Note,
+                        "return type declared here");
+      builder.Note(callee.return_pattern_id, IncompleteReturnTypeHere);
+    });
     auto arg_type_id = CheckFunctionReturnPatternType(
         context, loc_id, callee.return_pattern_id, *callee_specific_id);
     if (arg_type_id == SemIR::ErrorInst::TypeId) {

--- a/toolchain/check/check.cpp
+++ b/toolchain/check/check.cpp
@@ -414,9 +414,9 @@ auto CheckParseTrees(
   // stack.
   llvm::SmallVector<UnitAndImports, 0> unit_infos(
       llvm::map_range(units, [&](Unit& unit) {
-        return UnitAndImports(
-            &unit, tree_and_subtrees_getters.Get(unit.sem_ir->check_ir_id()));
-      }));
+    return UnitAndImports(
+        &unit, tree_and_subtrees_getters.Get(unit.sem_ir->check_ir_id()));
+  }));
 
   // Dump the raw SemIR in the event of a crash. We dump it to a separate file
   // to keep the stack trace manageable.

--- a/toolchain/check/class.cpp
+++ b/toolchain/check/class.cpp
@@ -195,14 +195,14 @@ static auto BuildVtable(Context& context, Parse::ClassDefinitionId node_id,
       const auto& fn = context.sem_ir().functions().Get(fn_id);
       const auto* i = llvm::find_if(
           vtable_contents, [&](SemIR::InstId override_fn_decl_id) -> bool {
-            const auto& override_fn = context.functions().Get(
-                context.insts()
-                    .GetAs<SemIR::FunctionDecl>(override_fn_decl_id)
-                    .function_id);
-            return override_fn.virtual_modifier ==
-                       SemIR::FunctionFields::VirtualModifier::Override &&
-                   override_fn.name_id == fn.name_id;
-          });
+        const auto& override_fn = context.functions().Get(
+            context.insts()
+                .GetAs<SemIR::FunctionDecl>(override_fn_decl_id)
+                .function_id);
+        return override_fn.virtual_modifier ==
+                   SemIR::FunctionFields::VirtualModifier::Override &&
+               override_fn.name_id == fn.name_id;
+      });
       if (i != vtable_contents.end()) {
         auto override_fn_id =
             context.insts().GetAs<SemIR::FunctionDecl>(*i).function_id;

--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -1201,11 +1201,11 @@ static auto PerformBuiltinConversion(Context& context, SemIR::LocId loc_id,
         // While the types are the same, the conversion can still fail if it
         // performs a copy while converting the value to another category, and
         // the type (or some part of it) is not copyable.
-        Diagnostics::AnnotationScope annotate_diagnostics(
-            &context.emitter(), [&](auto& builder) {
-              CARBON_DIAGNOSTIC(InCopy, Note, "in copy of {0}", TypeOfInstId);
-              builder.Note(value_id, InCopy, value_id);
-            });
+        Diagnostics::AnnotationScope annotate_diagnostics(&context.emitter(),
+                                                          [&](auto& builder) {
+          CARBON_DIAGNOSTIC(InCopy, Note, "in copy of {0}", TypeOfInstId);
+          builder.Note(value_id, InCopy, value_id);
+        });
 
         foundation_value_id = PerformBuiltinConversion(
             context, loc_id, foundation_value_id,
@@ -1554,10 +1554,10 @@ static auto PerformCopy(Context& context, SemIR::InstId expr_id,
   auto copy_id = BuildUnaryOperator(
       context, SemIR::LocId(expr_id), {.interface_name = CoreIdentifier::Copy},
       expr_id, target.diagnose, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(CopyOfUncopyableType, Context,
-                          "cannot copy value of type {0}", TypeOfInstId);
-        builder.Context(expr_id, CopyOfUncopyableType, expr_id);
-      });
+    CARBON_DIAGNOSTIC(CopyOfUncopyableType, Context,
+                      "cannot copy value of type {0}", TypeOfInstId);
+    builder.Context(expr_id, CopyOfUncopyableType, expr_id);
+  });
   return copy_id;
 }
 
@@ -1902,31 +1902,26 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
   // need the type to be complete.
   if (ConversionNeedsCompleteTarget(context, expr_id, target)) {
     if (target.diagnose) {
-      if (!RequireConcreteType(
-              context, target.type_id, loc_id,
-              [&](auto& builder) {
-                CARBON_CHECK(
-                    !target.is_initializer(),
-                    "Initialization of incomplete types is expected to be "
-                    "caught elsewhere.");
-                CARBON_DIAGNOSTIC(IncompleteTypeInValueConversion, Context,
-                                  "forming value of incomplete type {0}",
-                                  SemIR::TypeId);
-                CARBON_DIAGNOSTIC(IncompleteTypeInConversion, Context,
-                                  "invalid use of incomplete type {0}",
-                                  SemIR::TypeId);
-                builder.Context(loc_id,
-                                target.kind == ConversionTarget::Value
-                                    ? IncompleteTypeInValueConversion
-                                    : IncompleteTypeInConversion,
-                                target.type_id);
-              },
-              [&](auto& builder) {
-                CARBON_DIAGNOSTIC(AbstractTypeInInit, Context,
-                                  "initialization of abstract type {0}",
-                                  SemIR::TypeId);
-                builder.Context(loc_id, AbstractTypeInInit, target.type_id);
-              })) {
+      if (!RequireConcreteType(context, target.type_id, loc_id,
+                               [&](auto& builder) {
+        CARBON_CHECK(!target.is_initializer(),
+                     "Initialization of incomplete types is expected to be "
+                     "caught elsewhere.");
+        CARBON_DIAGNOSTIC(IncompleteTypeInValueConversion, Context,
+                          "forming value of incomplete type {0}",
+                          SemIR::TypeId);
+        CARBON_DIAGNOSTIC(IncompleteTypeInConversion, Context,
+                          "invalid use of incomplete type {0}", SemIR::TypeId);
+        builder.Context(loc_id,
+                        target.kind == ConversionTarget::Value
+                            ? IncompleteTypeInValueConversion
+                            : IncompleteTypeInConversion,
+                        target.type_id);
+      }, [&](auto& builder) {
+        CARBON_DIAGNOSTIC(AbstractTypeInInit, Context,
+                          "initialization of abstract type {0}", SemIR::TypeId);
+        builder.Context(loc_id, AbstractTypeInInit, target.type_id);
+      })) {
         return SemIR::ErrorInst::InstId;
       }
     } else {
@@ -1991,35 +1986,34 @@ auto Convert(Context& context, SemIR::LocId loc_id, SemIR::InstId expr_id,
         .interface_args_ref = interface_args,
         .op_name = CoreIdentifier::Convert,
     };
-    expr_id = BuildUnaryOperator(
-        context, loc_id, op, expr_id, target.diagnose, [&](auto& builder) {
-          int target_kind_for_diag =
-              target.kind == ConversionTarget::ExplicitAs         ? 1
-              : target.kind == ConversionTarget::ExplicitUnsafeAs ? 2
-                                                                  : 0;
-          if (target.type_id == SemIR::TypeType::TypeId ||
-              sem_ir.types().Is<SemIR::FacetType>(target.type_id)) {
-            CARBON_DIAGNOSTIC(
-                ConversionFailureNonTypeToFacet, Context,
-                "cannot{0:=0: implicitly|:} convert non-type value of type {1} "
-                "{2:to|into type implementing} {3}"
-                "{0:=1: with `as`|=2: with `unsafe as`|:}",
-                Diagnostics::IntAsSelect, TypeOfInstId,
-                Diagnostics::BoolAsSelect, SemIR::TypeId);
-            builder.Context(loc_id, ConversionFailureNonTypeToFacet,
-                            target_kind_for_diag, expr_id,
-                            target.type_id == SemIR::TypeType::TypeId,
-                            target.type_id);
-          } else {
-            CARBON_DIAGNOSTIC(
-                ConversionFailure, Context,
-                "cannot{0:=0: implicitly|:} convert expression of type "
-                "{1} to {2}{0:=1: with `as`|=2: with `unsafe as`|:}",
-                Diagnostics::IntAsSelect, TypeOfInstId, SemIR::TypeId);
-            builder.Context(loc_id, ConversionFailure, target_kind_for_diag,
-                            expr_id, target.type_id);
-          }
-        });
+    expr_id = BuildUnaryOperator(context, loc_id, op, expr_id, target.diagnose,
+                                 [&](auto& builder) {
+      int target_kind_for_diag =
+          target.kind == ConversionTarget::ExplicitAs         ? 1
+          : target.kind == ConversionTarget::ExplicitUnsafeAs ? 2
+                                                              : 0;
+      if (target.type_id == SemIR::TypeType::TypeId ||
+          sem_ir.types().Is<SemIR::FacetType>(target.type_id)) {
+        CARBON_DIAGNOSTIC(
+            ConversionFailureNonTypeToFacet, Context,
+            "cannot{0:=0: implicitly|:} convert non-type value of type {1} "
+            "{2:to|into type implementing} {3}"
+            "{0:=1: with `as`|=2: with `unsafe as`|:}",
+            Diagnostics::IntAsSelect, TypeOfInstId, Diagnostics::BoolAsSelect,
+            SemIR::TypeId);
+        builder.Context(
+            loc_id, ConversionFailureNonTypeToFacet, target_kind_for_diag,
+            expr_id, target.type_id == SemIR::TypeType::TypeId, target.type_id);
+      } else {
+        CARBON_DIAGNOSTIC(
+            ConversionFailure, Context,
+            "cannot{0:=0: implicitly|:} convert expression of type "
+            "{1} to {2}{0:=1: with `as`|=2: with `unsafe as`|:}",
+            Diagnostics::IntAsSelect, TypeOfInstId, SemIR::TypeId);
+        builder.Context(loc_id, ConversionFailure, target_kind_for_diag,
+                        expr_id, target.type_id);
+      }
+    });
 
     // Pull a value directly out of the initializer if possible and wanted.
     if (expr_id != SemIR::ErrorInst::InstId &&

--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -133,14 +133,13 @@ static auto BuildCopyWitness(
   }
   if (auto* class_decl = dyn_cast<clang::CXXRecordDecl>(tag_decl)) {
     auto class_type_id = SemIR::TypeId::ForTypeConstant(query_self_const_id);
-    if (!Check::RequireCompleteType(
-            context, class_type_id, SemIR::LocId::None, [&](auto& builder) {
-              CARBON_DIAGNOSTIC(IncompleteTypeInCopyWitness, Context,
-                                "argument to C++ call has incomplete type {0}",
-                                SemIR::TypeId);
-              builder.Context(loc_id, IncompleteTypeInCopyWitness,
-                              class_type_id);
-            })) {
+    if (!Check::RequireCompleteType(context, class_type_id, SemIR::LocId::None,
+                                    [&](auto& builder) {
+      CARBON_DIAGNOSTIC(IncompleteTypeInCopyWitness, Context,
+                        "argument to C++ call has incomplete type {0}",
+                        SemIR::TypeId);
+      builder.Context(loc_id, IncompleteTypeInCopyWitness, class_type_id);
+    })) {
       return SemIR::ErrorInst::InstId;
     }
 

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -112,15 +112,12 @@ static auto AddNamespace(Context& context, PackageNameId cpp_package_id,
              GetSingletonType(context, SemIR::NamespaceType::TypeInstId),
              SemIR::NameId::ForPackageName(cpp_package_id),
              SemIR::NameScopeId::Package,
-             /*diagnose_duplicate_namespace=*/false,
-             [&]() {
-               return AddInst<SemIR::ImportCppDecl>(
-                   context,
-                   context.parse_tree().As<Parse::ImportDeclId>(
-                       imports.front().node_id),
-                   {});
-             })
-      .add_result.name_scope_id;
+             /*diagnose_duplicate_namespace=*/false, [&]() {
+    return AddInst<SemIR::ImportCppDecl>(
+        context,
+        context.parse_tree().As<Parse::ImportDeclId>(imports.front().node_id),
+        {});
+  }).add_result.name_scope_id;
 }
 
 auto ImportCpp(Context& context,
@@ -137,8 +134,8 @@ auto ImportCpp(Context& context,
   PackageNameId package_id = imports.front().package_id;
   CARBON_CHECK(
       llvm::all_of(imports, [&](const Parse::Tree::PackagingNames& import) {
-        return import.package_id == package_id;
-      }));
+    return import.package_id == package_id;
+  }));
 
   auto name_scope_id = AddNamespace(context, package_id, imports);
   SemIR::NameScope& name_scope = context.name_scopes().Get(name_scope_id);
@@ -1903,12 +1900,12 @@ static auto ImportFunctionDecl(Context& context, SemIR::LocId loc_id,
 
   SemIR::Function& function_info = context.functions().Get(*function_id);
   if (IsCppThunkRequired(context, function_info)) {
-    Diagnostics::AnnotationScope annotate_diagnostics(
-        &context.emitter(), [&](auto& builder) {
-          CARBON_DIAGNOSTIC(InCppThunk, Note,
-                            "in thunk for C++ function used here");
-          builder.Note(loc_id, InCppThunk);
-        });
+    Diagnostics::AnnotationScope annotate_diagnostics(&context.emitter(),
+                                                      [&](auto& builder) {
+      CARBON_DIAGNOSTIC(InCppThunk, Note,
+                        "in thunk for C++ function used here");
+      builder.Note(loc_id, InCppThunk);
+    });
 
     if (clang::FunctionDecl* thunk_clang_decl =
             BuildCppThunk(context, function_info)) {
@@ -2492,12 +2489,12 @@ auto GetClangIdentifierInfo(Context& context, SemIR::NameId name_id)
 auto ImportNameFromCpp(Context& context, SemIR::LocId loc_id,
                        SemIR::NameScopeId scope_id, SemIR::NameId name_id)
     -> SemIR::ScopeLookupResult {
-  Diagnostics::AnnotationScope annotate_diagnostics(
-      &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(InCppNameLookup, Note,
-                          "in `Cpp` name lookup for `{0}`", SemIR::NameId);
-        builder.Note(loc_id, InCppNameLookup, name_id);
-      });
+  Diagnostics::AnnotationScope annotate_diagnostics(&context.emitter(),
+                                                    [&](auto& builder) {
+    CARBON_DIAGNOSTIC(InCppNameLookup, Note, "in `Cpp` name lookup for `{0}`",
+                      SemIR::NameId);
+    builder.Note(loc_id, InCppNameLookup, name_id);
+  });
   if (IsIncompleteClass(context, scope_id)) {
     return SemIR::ScopeLookupResult::MakeError();
   }

--- a/toolchain/check/cpp/type_mapping.cpp
+++ b/toolchain/check/cpp/type_mapping.cpp
@@ -209,8 +209,8 @@ static auto TryMapClassType(Context& context, SemIR::TypeInstId class_inst_id,
               .inner_type_id = context.types().GetTypeIdForTypeInstId(
                   pointer_type->pointee_id),
               .wrap_fn = [](Context& context, clang::QualType inner_type) {
-                return context.ast_context().getPointerType(inner_type);
-              }};
+            return context.ast_context().getPointerType(inner_type);
+          }};
         }
       }
       break;
@@ -259,8 +259,8 @@ static auto TryMapType(Context& context, SemIR::TypeId type_id)
           .inner_type_id =
               context.types().GetTypeIdForTypeInstId(const_type.inner_id),
           .wrap_fn = [](Context& /*context*/, clang::QualType inner_type) {
-            return inner_type.withConst();
-          }};
+        return inner_type.withConst();
+      }};
     }
     case SemIR::FloatLiteralType::Kind: {
       return context.ast_context().DoubleTy;
@@ -270,11 +270,10 @@ static auto TryMapType(Context& context, SemIR::TypeId type_id)
           .inner_type_id =
               context.types().GetTypeIdForTypeInstId(pointer_type.pointee_id),
           .wrap_fn = [](Context& context, clang::QualType inner_type) {
-            auto pointer_type =
-                context.ast_context().getPointerType(inner_type);
-            return context.ast_context().getAttributedType(
-                clang::attr::TypeNonNull, pointer_type, pointer_type);
-          }};
+        auto pointer_type = context.ast_context().getPointerType(inner_type);
+        return context.ast_context().getAttributedType(
+            clang::attr::TypeNonNull, pointer_type, pointer_type);
+      }};
     }
 
     default: {

--- a/toolchain/check/custom_witness.cpp
+++ b/toolchain/check/custom_witness.cpp
@@ -463,28 +463,26 @@ auto BuildCustomWitness(Context& context, SemIR::LocId loc_id,
   // restriction doesn't impact whether or not a type is definable.
   auto update_interface_with_self_specific_id =
       [&](SemIR::InstId assoc_entity_id) {
-        auto decl_id =
-            context.constant_values().GetConstantInstId(assoc_entity_id);
-        CARBON_CHECK(decl_id.has_value(), "Non-constant associated entity");
-        auto decl = context.insts().Get(decl_id);
-        auto new_associated_entity_state =
-            decl.kind() == SemIR::AssociatedConstantDecl::Kind
-                ? AssociatedEntityState::AssociatedConstant
-                : AssociatedEntityState::AssociatedFunction;
-        CARBON_CHECK(new_associated_entity_state >= associated_entity_state,
-                     "Implementation restriction: associated constants must be "
-                     "defined before associated functions");
-        if (associated_entity_state < new_associated_entity_state) {
-          auto self_facet = MakeSelfFacetWithCustomWitness(
-              context, loc_id, query_types_for_self_facet,
-              query_specific_interface_id, context.inst_blocks().Add(entries));
-          interface_with_self_specific_id = MakeSpecificWithInnerSelf(
-              context, loc_id, interface.generic_id,
-              interface.generic_with_self_id,
-              query_specific_interface.specific_id, self_facet);
-          associated_entity_state = new_associated_entity_state;
-        }
-      };
+    auto decl_id = context.constant_values().GetConstantInstId(assoc_entity_id);
+    CARBON_CHECK(decl_id.has_value(), "Non-constant associated entity");
+    auto decl = context.insts().Get(decl_id);
+    auto new_associated_entity_state =
+        decl.kind() == SemIR::AssociatedConstantDecl::Kind
+            ? AssociatedEntityState::AssociatedConstant
+            : AssociatedEntityState::AssociatedFunction;
+    CARBON_CHECK(new_associated_entity_state >= associated_entity_state,
+                 "Implementation restriction: associated constants must be "
+                 "defined before associated functions");
+    if (associated_entity_state < new_associated_entity_state) {
+      auto self_facet = MakeSelfFacetWithCustomWitness(
+          context, loc_id, query_types_for_self_facet,
+          query_specific_interface_id, context.inst_blocks().Add(entries));
+      interface_with_self_specific_id = MakeSpecificWithInnerSelf(
+          context, loc_id, interface.generic_id, interface.generic_with_self_id,
+          query_specific_interface.specific_id, self_facet);
+      associated_entity_state = new_associated_entity_state;
+    }
+  };
 
   // Fill in the witness table.
   for (const auto& [assoc_entity_id, value_id] :

--- a/toolchain/check/decl_name_stack.cpp
+++ b/toolchain/check/decl_name_stack.cpp
@@ -379,14 +379,14 @@ static auto DiagnoseQualifiedDeclInIncompleteClassScope(Context& context,
                                                         SemIR::LocId loc_id,
                                                         SemIR::ClassId class_id)
     -> void {
-  Diagnostics::ContextScope diagnostic_context(
-      &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(QualifiedDeclInIncompleteClassScope, Context,
-                          "cannot declare a member of incomplete class {0}",
-                          SemIR::TypeId);
-        builder.Context(loc_id, QualifiedDeclInIncompleteClassScope,
-                        context.classes().Get(class_id).self_type_id);
-      });
+  Diagnostics::ContextScope diagnostic_context(&context.emitter(),
+                                               [&](auto& builder) {
+    CARBON_DIAGNOSTIC(QualifiedDeclInIncompleteClassScope, Context,
+                      "cannot declare a member of incomplete class {0}",
+                      SemIR::TypeId);
+    builder.Context(loc_id, QualifiedDeclInIncompleteClassScope,
+                    context.classes().Get(class_id).self_type_id);
+  });
   DiagnoseIncompleteClass(context, class_id);
 }
 
@@ -395,14 +395,14 @@ static auto DiagnoseQualifiedDeclInIncompleteClassScope(Context& context,
 static auto DiagnoseQualifiedDeclInUndefinedInterfaceScope(
     Context& context, SemIR::LocId loc_id, SemIR::InterfaceId interface_id,
     SemIR::InstId interface_inst_id) -> void {
-  Diagnostics::ContextScope diagnostic_context(
-      &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(QualifiedDeclInUndefinedInterfaceScope, Context,
-                          "cannot declare a member of undefined interface {0}",
-                          InstIdAsType);
-        builder.Context(loc_id, QualifiedDeclInUndefinedInterfaceScope,
-                        interface_inst_id);
-      });
+  Diagnostics::ContextScope diagnostic_context(&context.emitter(),
+                                               [&](auto& builder) {
+    CARBON_DIAGNOSTIC(QualifiedDeclInUndefinedInterfaceScope, Context,
+                      "cannot declare a member of undefined interface {0}",
+                      InstIdAsType);
+    builder.Context(loc_id, QualifiedDeclInUndefinedInterfaceScope,
+                    interface_inst_id);
+  });
   DiagnoseIncompleteInterface(context, interface_id);
 }
 

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -300,12 +300,12 @@ auto DeductionContext::Deduce() -> bool {
       // compile-time value (e.g. TupleType) that we can decompose further.
       // So we do this conversion here, even though we will later try convert
       // again when we have deduced all of the bindings.
-      Diagnostics::AnnotationScope annotate_diagnostics(
-          &context().emitter(), [&](auto& builder) {
-            if (diagnose_) {
-              NoteInitializingParam(param_id, builder);
-            }
-          });
+      Diagnostics::AnnotationScope annotate_diagnostics(&context().emitter(),
+                                                        [&](auto& builder) {
+        if (diagnose_) {
+          NoteInitializingParam(param_id, builder);
+        }
+      });
       // TODO: The call logic should reuse the conversion here (if any) instead
       // of doing the same conversion again. At the moment we throw away the
       // converted arg_id.
@@ -509,12 +509,12 @@ auto DeductionContext::CheckDeductionIsComplete() -> bool {
       binding_type_id =
           context().types().GetTypeIdForTypeConstantId(param_type_const_id);
 
-      Diagnostics::AnnotationScope annotate_diagnostics(
-          &context().emitter(), [&](auto& builder) {
-            if (diagnose_) {
-              NoteInitializingParam(binding_id, builder);
-            }
-          });
+      Diagnostics::AnnotationScope annotate_diagnostics(&context().emitter(),
+                                                        [&](auto& builder) {
+        if (diagnose_) {
+          NoteInitializingParam(binding_id, builder);
+        }
+      });
       auto converted_arg_id =
           diagnose_ ? ConvertToValueOfType(context(), loc_id_, deduced_arg_id,
                                            binding_type_id)

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -858,11 +858,10 @@ template <typename BundleT>
 static auto GetConstantValue(EvalContext& eval_context,
                              SemIR::BundleId<BundleT> bundle_id, Phase* phase)
     -> SemIR::BundleId<BundleT> {
-  return eval_context.context().bundles().AddCanonical(std::apply(
-      [&]<typename... Ids>(Ids... ids) -> BundleT {
-        return {GetConstantValueOrPassThrough(eval_context, ids, phase)...};
-      },
-      eval_context.context().bundles().GetAsTuple(bundle_id)));
+  return eval_context.context().bundles().AddCanonical(
+      std::apply([&]<typename... Ids>(Ids... ids) -> BundleT {
+    return {GetConstantValueOrPassThrough(eval_context, ids, phase)...};
+  }, eval_context.context().bundles().GetAsTuple(bundle_id)));
 }
 
 // Replaces the specified field of the given typed instruction with its constant
@@ -1052,11 +1051,9 @@ template <typename BundleT>
 static auto ResolveSpecificDeclForArg(EvalContext& eval_context,
                                       SemIR::BundleId<BundleT> bundle_id)
     -> void {
-  std::apply(
-      [&](auto... ids) -> void {
-        (..., ResolveSpecificDeclForArg(eval_context, ids));
-      },
-      eval_context.context().bundles().GetAsTuple(bundle_id));
+  std::apply([&](auto... ids) -> void {
+    (..., ResolveSpecificDeclForArg(eval_context, ids));
+  }, eval_context.context().bundles().GetAsTuple(bundle_id));
 }
 
 // Resolves the specific declarations for a specific id in any field of the
@@ -2803,13 +2800,12 @@ auto TryEvalBlockForSpecific(Context& context, SemIR::LocId loc_id,
                                .values = result,
                            });
 
-  Diagnostics::ContextScope diagnostic_context(
-      &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ResolvingSpecificHere, SoftContext,
-                          "unable to monomorphize specific {0}",
-                          SemIR::SpecificId);
-        builder.Context(loc_id, ResolvingSpecificHere, specific_id);
-      });
+  Diagnostics::ContextScope diagnostic_context(&context.emitter(),
+                                               [&](auto& builder) {
+    CARBON_DIAGNOSTIC(ResolvingSpecificHere, SoftContext,
+                      "unable to monomorphize specific {0}", SemIR::SpecificId);
+    builder.Context(loc_id, ResolvingSpecificHere, specific_id);
+  });
 
   bool has_error = false;
   for (auto [i, inst_id] : llvm::enumerate(eval_block)) {
@@ -3167,12 +3163,12 @@ static auto TryEvalCall(EvalContext& outer_eval_context, SemIR::LocId loc_id,
   FunctionExecContext eval_context(&outer_eval_context.context(), loc_id,
                                    specific_id, &locals, args_id);
 
-  Diagnostics::AnnotationScope annotate_diagnostics(
-      &eval_context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(InCallToEvalFn, Note, "in call to {0} here",
-                          SemIR::NameId);
-        builder.Note(loc_id, InCallToEvalFn, function.name_id);
-      });
+  Diagnostics::AnnotationScope annotate_diagnostics(&eval_context.emitter(),
+                                                    [&](auto& builder) {
+    CARBON_DIAGNOSTIC(InCallToEvalFn, Note, "in call to {0} here",
+                      SemIR::NameId);
+    builder.Note(loc_id, InCallToEvalFn, function.name_id);
+  });
 
   // Execute the function decl block followed by the body.
   eval_context.PushBlock(function.body_block_ids.front());

--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -544,17 +544,17 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
   auto complete_type_id =
       context.types().GetTypeIdForTypeInstId(inst.complete_type_inst_id);
   if (complete_type_id.is_concrete()) {
-    Diagnostics::ContextScope diagnostic_context(
-        &context.emitter(), [&](auto& builder) {
-          CARBON_DIAGNOSTIC(IncompleteTypeInMonomorphization, Context,
-                            "{0} evaluates to incomplete type {1}",
-                            InstIdAsType, InstIdAsType);
-          builder.Context(inst_id, IncompleteTypeInMonomorphization,
-                          context.insts()
-                              .GetAs<SemIR::RequireCompleteType>(inst_id)
-                              .complete_type_inst_id,
-                          inst.complete_type_inst_id);
-        });
+    Diagnostics::ContextScope diagnostic_context(&context.emitter(),
+                                                 [&](auto& builder) {
+      CARBON_DIAGNOSTIC(IncompleteTypeInMonomorphization, Context,
+                        "{0} evaluates to incomplete type {1}", InstIdAsType,
+                        InstIdAsType);
+      builder.Context(inst_id, IncompleteTypeInMonomorphization,
+                      context.insts()
+                          .GetAs<SemIR::RequireCompleteType>(inst_id)
+                          .complete_type_inst_id,
+                      inst.complete_type_inst_id);
+    });
     // We use TryToCompleteType() instead of RequireCompleteType() because we
     // are currently evaluating a RequireCompleteType instruction, and calling
     // RequireCompleteType() would insert another copy of the same instruction.

--- a/toolchain/check/function.cpp
+++ b/toolchain/check/function.cpp
@@ -333,22 +333,17 @@ auto CheckFunctionReturnPatternType(Context& context, SemIR::LocId loc_id,
   if (!init_repr.is_valid()) {
     // TODO: Consider suppressing the diagnostics if we've already diagnosed a
     // definition or call to this function.
-    if (!RequireConcreteType(
-            context, arg_type_id, SemIR::LocId(return_pattern_id),
-            [&](auto& builder) {
-              CARBON_DIAGNOSTIC(IncompleteTypeInFunctionReturnType, Context,
-                                "function returns incomplete type {0}",
-                                SemIR::TypeId);
-              builder.Context(loc_id, IncompleteTypeInFunctionReturnType,
-                              arg_type_id);
-            },
-            [&](auto& builder) {
-              CARBON_DIAGNOSTIC(AbstractTypeInFunctionReturnType, Context,
-                                "function returns abstract type {0}",
-                                SemIR::TypeId);
-              builder.Context(loc_id, AbstractTypeInFunctionReturnType,
-                              arg_type_id);
-            })) {
+    if (!RequireConcreteType(context, arg_type_id,
+                             SemIR::LocId(return_pattern_id),
+                             [&](auto& builder) {
+      CARBON_DIAGNOSTIC(IncompleteTypeInFunctionReturnType, Context,
+                        "function returns incomplete type {0}", SemIR::TypeId);
+      builder.Context(loc_id, IncompleteTypeInFunctionReturnType, arg_type_id);
+    }, [&](auto& builder) {
+      CARBON_DIAGNOSTIC(AbstractTypeInFunctionReturnType, Context,
+                        "function returns abstract type {0}", SemIR::TypeId);
+      builder.Context(loc_id, AbstractTypeInFunctionReturnType, arg_type_id);
+    })) {
       return SemIR::ErrorInst::TypeId;
     }
   }
@@ -380,13 +375,13 @@ auto CheckFunctionDefinitionSignature(Context& context,
     RequireCompleteType(
         context, context.insts().GetAs<SemIR::AnyParam>(param_ref_id).type_id,
         SemIR::LocId(param_ref_id), [&](auto& builder) {
-          CARBON_DIAGNOSTIC(
-              IncompleteTypeInFunctionParam, Context,
-              "parameter has incomplete type {0} in function definition",
-              TypeOfInstId);
-          builder.Context(param_ref_id, IncompleteTypeInFunctionParam,
-                          param_ref_id);
-        });
+      CARBON_DIAGNOSTIC(
+          IncompleteTypeInFunctionParam, Context,
+          "parameter has incomplete type {0} in function definition",
+          TypeOfInstId);
+      builder.Context(param_ref_id, IncompleteTypeInFunctionParam,
+                      param_ref_id);
+    });
   }
 
   // Check the return type is complete.

--- a/toolchain/check/handle_binding_pattern.cpp
+++ b/toolchain/check/handle_binding_pattern.cpp
@@ -497,18 +497,16 @@ auto HandleParseNode(Context& context, Parse::FieldNameAndTypeId node_id)
   auto parent_class_decl =
       context.scope_stack().TryGetCurrentScopeAs<SemIR::ClassDecl>();
   CARBON_CHECK(parent_class_decl);
-  if (!RequireConcreteType(
-          context, cast_type_id, type_node,
-          [&](auto& builder) {
-            CARBON_DIAGNOSTIC(IncompleteTypeInFieldDecl, Context,
-                              "field has incomplete type {0}", SemIR::TypeId);
-            builder.Context(type_node, IncompleteTypeInFieldDecl, cast_type_id);
-          },
-          [&](auto& builder) {
-            CARBON_DIAGNOSTIC(AbstractTypeInFieldDecl, Context,
-                              "field has abstract type {0}", SemIR::TypeId);
-            builder.Context(type_node, AbstractTypeInFieldDecl, cast_type_id);
-          })) {
+  if (!RequireConcreteType(context, cast_type_id, type_node,
+                           [&](auto& builder) {
+    CARBON_DIAGNOSTIC(IncompleteTypeInFieldDecl, Context,
+                      "field has incomplete type {0}", SemIR::TypeId);
+    builder.Context(type_node, IncompleteTypeInFieldDecl, cast_type_id);
+  }, [&](auto& builder) {
+    CARBON_DIAGNOSTIC(AbstractTypeInFieldDecl, Context,
+                      "field has abstract type {0}", SemIR::TypeId);
+    builder.Context(type_node, AbstractTypeInFieldDecl, cast_type_id);
+  })) {
     cast_type_id = SemIR::ErrorInst::TypeId;
   }
   if (cast_type_id == SemIR::ErrorInst::TypeId) {

--- a/toolchain/check/handle_choice.cpp
+++ b/toolchain/check/handle_choice.cpp
@@ -210,11 +210,10 @@ static auto MakeLetBinding(Context& context, const ChoiceInfo& choice_info,
                   .type_id = choice_info.self_struct_type_id,
                   .elements_id =
                       [&] {
-                        context.inst_block_stack().Push();
-                        context.inst_block_stack().AddInstId(
-                            discriminant_value_id);
-                        return context.inst_block_stack().Pop();
-                      }(),
+    context.inst_block_stack().Push();
+    context.inst_block_stack().AddInstId(discriminant_value_id);
+    return context.inst_block_stack().Pop();
+  }(),
               }),
       choice_info.self_type_id);
 

--- a/toolchain/check/handle_class.cpp
+++ b/toolchain/check/handle_class.cpp
@@ -373,22 +373,16 @@ auto HandleParseNode(Context& context, Parse::AdaptDeclId node_id) -> bool {
 
   auto [adapted_type_inst_id, adapted_type_id] =
       ExprAsType(context, node_id, adapted_type_expr_id);
-  if (!RequireConcreteType(
-          context, adapted_type_id, node_id,
-          [&](auto& builder) {
-            CARBON_DIAGNOSTIC(IncompleteTypeInAdaptDecl, Context,
-                              "adapted type {0} is an incomplete type",
-                              InstIdAsType);
-            builder.Context(node_id, IncompleteTypeInAdaptDecl,
-                            adapted_type_inst_id);
-          },
-          [&](auto& builder) {
-            CARBON_DIAGNOSTIC(AbstractTypeInAdaptDecl, Context,
-                              "adapted type {0} is an abstract type",
-                              InstIdAsType);
-            builder.Context(node_id, AbstractTypeInAdaptDecl,
-                            adapted_type_inst_id);
-          })) {
+  if (!RequireConcreteType(context, adapted_type_id, node_id,
+                           [&](auto& builder) {
+    CARBON_DIAGNOSTIC(IncompleteTypeInAdaptDecl, Context,
+                      "adapted type {0} is an incomplete type", InstIdAsType);
+    builder.Context(node_id, IncompleteTypeInAdaptDecl, adapted_type_inst_id);
+  }, [&](auto& builder) {
+    CARBON_DIAGNOSTIC(AbstractTypeInAdaptDecl, Context,
+                      "adapted type {0} is an abstract type", InstIdAsType);
+    builder.Context(node_id, AbstractTypeInAdaptDecl, adapted_type_inst_id);
+  })) {
     adapted_type_id = SemIR::ErrorInst::TypeId;
   }
   if (adapted_type_id == SemIR::ErrorInst::TypeId) {
@@ -452,10 +446,10 @@ static auto CheckBaseType(Context& context, Parse::NodeId node_id,
     return BaseInfo::Error;
   }
   if (!RequireCompleteType(context, base_type_id, node_id, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(IncompleteTypeInBaseDecl, Context,
-                          "base {0} is an incomplete type", InstIdAsType);
-        builder.Context(node_id, IncompleteTypeInBaseDecl, base_type_inst_id);
-      })) {
+    CARBON_DIAGNOSTIC(IncompleteTypeInBaseDecl, Context,
+                      "base {0} is an incomplete type", InstIdAsType);
+    builder.Context(node_id, IncompleteTypeInBaseDecl, base_type_inst_id);
+  })) {
     return BaseInfo::Error;
   }
 

--- a/toolchain/check/handle_name.cpp
+++ b/toolchain/check/handle_name.cpp
@@ -208,13 +208,13 @@ auto HandleParseNode(Context& context, Parse::DesignatorExprId node_id)
       // instead so we can generate a "name `.Self` implicitly referenced by
       // designated expression, but not found" diagnostic instead of adding a
       // note to the current "name `.Self` not found" message.
-      Diagnostics::AnnotationScope annotate_diagnostics(
-          &context.emitter(), [&](auto& builder) {
-            CARBON_DIAGNOSTIC(
-                NoPeriodSelfForDesignator, Note,
-                "designator may only be used when `.Self` is in scope");
-            builder.Note(SemIR::LocId::None, NoPeriodSelfForDesignator);
-          });
+      Diagnostics::AnnotationScope annotate_diagnostics(&context.emitter(),
+                                                        [&](auto& builder) {
+        CARBON_DIAGNOSTIC(
+            NoPeriodSelfForDesignator, Note,
+            "designator may only be used when `.Self` is in scope");
+        builder.Note(SemIR::LocId::None, NoPeriodSelfForDesignator);
+      });
       period_self_id =
           HandleNameAsExpr(context, node_id, SemIR::NameId::PeriodSelf);
     }

--- a/toolchain/check/handle_operator.cpp
+++ b/toolchain/check/handle_operator.cpp
@@ -374,26 +374,26 @@ auto HandleParseNode(Context& context, Parse::PrefixOperatorStarId node_id)
   auto deref_base_id = PerformPointerDereference(
       context, node_id, base_id,
       [&context, &node_id](SemIR::TypeId not_pointer_type_id) {
-        // TODO: Pass in the expression we're trying to dereference to produce a
-        // better diagnostic.
-        CARBON_DIAGNOSTIC(DerefOfNonPointer, Error,
-                          "cannot dereference operand of non-pointer type {0}",
-                          SemIR::TypeId);
+    // TODO: Pass in the expression we're trying to dereference to produce a
+    // better diagnostic.
+    CARBON_DIAGNOSTIC(DerefOfNonPointer, Error,
+                      "cannot dereference operand of non-pointer type {0}",
+                      SemIR::TypeId);
 
-        auto builder =
-            context.emitter().Build(LocIdForDiagnostics::TokenOnly(node_id),
-                                    DerefOfNonPointer, not_pointer_type_id);
+    auto builder =
+        context.emitter().Build(LocIdForDiagnostics::TokenOnly(node_id),
+                                DerefOfNonPointer, not_pointer_type_id);
 
-        // TODO: Check for any facet here, rather than only a type.
-        if (not_pointer_type_id == SemIR::TypeType::TypeId) {
-          CARBON_DIAGNOSTIC(
-              DerefOfType, Note,
-              "to form a pointer type, write the `*` after the pointee type");
-          builder.Note(LocIdForDiagnostics::TokenOnly(node_id), DerefOfType);
-        }
+    // TODO: Check for any facet here, rather than only a type.
+    if (not_pointer_type_id == SemIR::TypeType::TypeId) {
+      CARBON_DIAGNOSTIC(
+          DerefOfType, Note,
+          "to form a pointer type, write the `*` after the pointee type");
+      builder.Note(LocIdForDiagnostics::TokenOnly(node_id), DerefOfType);
+    }
 
-        builder.Emit();
-      });
+    builder.Emit();
+  });
 
   context.node_stack().Push(node_id, deref_base_id);
   return true;

--- a/toolchain/check/handle_require.cpp
+++ b/toolchain/check/handle_require.cpp
@@ -245,13 +245,13 @@ static auto ValidateRequire(Context& context, SemIR::LocId full_require_loc_id,
   auto identified_facet_type_id = RequireIdentifiedFacetType(
       context, constraint_loc_id, self_type_id.AsConstantId(),
       *constraint_facet_type, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(
-            RequireImplsUnidentifiedFacetType, Context,
-            "facet type {0} cannot be identified in `require` declaration",
-            SemIR::TypeId);
-        builder.Context(constraint_loc_id, RequireImplsUnidentifiedFacetType,
-                        constraint_type_id);
-      });
+    CARBON_DIAGNOSTIC(
+        RequireImplsUnidentifiedFacetType, Context,
+        "facet type {0} cannot be identified in `require` declaration",
+        SemIR::TypeId);
+    builder.Context(constraint_loc_id, RequireImplsUnidentifiedFacetType,
+                    constraint_type_id);
+  });
   if (!identified_facet_type_id.has_value()) {
     // The constraint can't be used. A diagnostic was emitted by
     // RequireIdentifiedFacetType().
@@ -350,13 +350,12 @@ auto HandleParseNode(Context& context, Parse::RequireDeclId node_id) -> bool {
             context,
             context.types().GetTypeIdForTypeInstId(constraint_type_inst_id),
             constraint_node_id, [&](auto& builder) {
-              CARBON_DIAGNOSTIC(RequireImplsIncompleteFacetType, Context,
-                                "`extend require` of incomplete facet type {0}",
-                                InstIdAsType);
-              builder.Context(constraint_node_id,
-                              RequireImplsIncompleteFacetType,
-                              constraint_type_inst_id);
-            })) {
+      CARBON_DIAGNOSTIC(RequireImplsIncompleteFacetType, Context,
+                        "`extend require` of incomplete facet type {0}",
+                        InstIdAsType);
+      builder.Context(constraint_node_id, RequireImplsIncompleteFacetType,
+                      constraint_type_inst_id);
+    })) {
       return true;
     }
 

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -284,12 +284,12 @@ static auto ApplyExtendImplAs(Context& context, SemIR::LocId loc_id,
   if (!RequireCompleteType(
           context, context.types().GetTypeIdForTypeInstId(impl.constraint_id),
           SemIR::LocId(impl.constraint_id), [&](auto& builder) {
-            CARBON_DIAGNOSTIC(ExtendImplAsIncomplete, Context,
-                              "`extend impl as` incomplete facet type {0}",
-                              InstIdAsType);
-            builder.Context(impl.latest_decl_id(), ExtendImplAsIncomplete,
-                            impl.constraint_id);
-          })) {
+    CARBON_DIAGNOSTIC(ExtendImplAsIncomplete, Context,
+                      "`extend impl as` incomplete facet type {0}",
+                      InstIdAsType);
+    builder.Context(impl.latest_decl_id(), ExtendImplAsIncomplete,
+                    impl.constraint_id);
+  })) {
     parent_scope.set_has_error();
     return false;
   }
@@ -429,11 +429,11 @@ auto AddImplWitnessForDeclaration(Context& context, SemIR::LocId loc_id,
   auto rewrites_into_interface_to_witness = llvm::make_filter_range(
       facet_type_info.rewrite_constraints,
       [&](const SemIR::FacetTypeInfo::RewriteConstraint& rewrite) {
-        auto access = context.insts().GetAs<SemIR::ImplWitnessAccess>(
-            GetImplWitnessAccessWithoutSubstitution(context, rewrite.lhs_id));
-        return WitnessQueryMatchesInterface(context, loc_id, impl.self_id,
-                                            access.witness_id, impl.interface);
-      });
+    auto access = context.insts().GetAs<SemIR::ImplWitnessAccess>(
+        GetImplWitnessAccessWithoutSubstitution(context, rewrite.lhs_id));
+    return WitnessQueryMatchesInterface(context, loc_id, impl.self_id,
+                                        access.witness_id, impl.interface);
+  });
 
   if (rewrites_into_interface_to_witness.empty()) {
     // The witness table is not needed until the definition. Make a placeholder
@@ -596,14 +596,12 @@ auto ImplWitnessStartDefinition(Context& context, SemIR::Impl& impl) -> void {
     if (!RequireCompleteType(
             context, context.types().GetTypeIdForTypeInstId(impl.constraint_id),
             SemIR::LocId(impl.constraint_id), [&](auto& builder) {
-              CARBON_DIAGNOSTIC(
-                  ImplAsIncompleteFacetTypeDefinition, Context,
-                  "definition of impl as incomplete facet type {0}",
-                  InstIdAsType);
-              builder.Context(SemIR::LocId(impl.latest_decl_id()),
-                              ImplAsIncompleteFacetTypeDefinition,
-                              impl.constraint_id);
-            })) {
+      CARBON_DIAGNOSTIC(ImplAsIncompleteFacetTypeDefinition, Context,
+                        "definition of impl as incomplete facet type {0}",
+                        InstIdAsType);
+      builder.Context(SemIR::LocId(impl.latest_decl_id()),
+                      ImplAsIncompleteFacetTypeDefinition, impl.constraint_id);
+    })) {
       FillImplWitnessWithErrors(context, impl);
       return;
     }
@@ -883,11 +881,11 @@ auto CheckConstraintIsInterface(Context& context, SemIR::LocId loc_id,
   auto identified_id = RequireIdentifiedFacetType(
       context, SemIR::LocId(constraint_id),
       context.constant_values().Get(self_id), facet_type, [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ImplOfUnidentifiedFacetType, Context,
-                          "facet type {0} cannot be identified in `impl as`",
-                          InstIdAsType);
-        builder.Context(loc_id, ImplOfUnidentifiedFacetType, constraint_id);
-      });
+    CARBON_DIAGNOSTIC(ImplOfUnidentifiedFacetType, Context,
+                      "facet type {0} cannot be identified in `impl as`",
+                      InstIdAsType);
+    builder.Context(loc_id, ImplOfUnidentifiedFacetType, constraint_id);
+  });
   if (!identified_id.has_value()) {
     return SemIR::SpecificInterface::None;
   }

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -222,15 +222,14 @@ static auto GetRequiredImplsFromConstraint(
   const auto& facet_type_info =
       context.facet_types().Get(facet_type_inst.facet_type_id);
 
-  auto identified_id = RequireIdentifiedFacetType(
-      context, loc_id, query_self_const_id, facet_type_inst,
-      [&](auto& builder) {
-        CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetType, Context,
-                          "facet type {0} can not be identified", InstIdAsType);
-        builder.Context(loc_id, ImplLookupInUnidentifiedFacetType,
-                        facet_type_inst_id);
-      },
-      diagnose);
+  auto identified_id =
+      RequireIdentifiedFacetType(context, loc_id, query_self_const_id,
+                                 facet_type_inst, [&](auto& builder) {
+    CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetType, Context,
+                      "facet type {0} can not be identified", InstIdAsType);
+    builder.Context(loc_id, ImplLookupInUnidentifiedFacetType,
+                    facet_type_inst_id);
+  }, diagnose);
   if (!identified_id.has_value()) {
     return std::nullopt;
   }

--- a/toolchain/check/impl_validation.cpp
+++ b/toolchain/check/impl_validation.cpp
@@ -558,14 +558,14 @@ auto ValidateImplsInFile(Context& context) -> void {
       llvm::make_filter_range(
           context.impls().enumerate(),
           [](std::pair<SemIR::ImplId, const SemIR::Impl&> pair) {
-            return pair.second.witness_id != SemIR::ErrorInst::InstId &&
-                   pair.second.interface.interface_id.has_value();
-          }),
+    return pair.second.witness_id != SemIR::ErrorInst::InstId &&
+           pair.second.interface.interface_id.has_value();
+  }),
       [&](std::pair<SemIR::ImplId, const SemIR::Impl&> pair) {
-        return GetImplInfo(context, pair.first);
-      }));
-  llvm::stable_sort(impl_ids_by_interface, [](const ImplInfo& lhs,
-                                              const ImplInfo& rhs) {
+    return GetImplInfo(context, pair.first);
+  }));
+  llvm::stable_sort(impl_ids_by_interface,
+                    [](const ImplInfo& lhs, const ImplInfo& rhs) {
     return lhs.interface.interface_id.index < rhs.interface.interface_id.index;
   });
 

--- a/toolchain/check/import.cpp
+++ b/toolchain/check/import.cpp
@@ -642,12 +642,12 @@ auto ImportNameFromOtherPackage(
   }
 
   // Annotate diagnostics as occurring during this name lookup.
-  Diagnostics::AnnotationScope annotate_diagnostics(
-      &context.emitter(), [&](auto& builder) {
-        CARBON_DIAGNOSTIC(InNameLookup, Note, "in name lookup for `{0}`",
-                          SemIR::NameId);
-        builder.Note(loc_id, InNameLookup, name_id);
-      });
+  Diagnostics::AnnotationScope annotate_diagnostics(&context.emitter(),
+                                                    [&](auto& builder) {
+    CARBON_DIAGNOSTIC(InNameLookup, Note, "in name lookup for `{0}`",
+                      SemIR::NameId);
+    builder.Note(loc_id, InNameLookup, name_id);
+  });
 
   // Although we track the result here and look in each IR, we pretty much use
   // the first result.

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -2730,11 +2730,11 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
     // GetLocalConstantId gave us an attached constant.
     auto unattached_self_const_id =
         resolver.local_constant_values().GetUnattachedConstant(self_const_id);
-    RequireIdentifiedFacetType(
-        resolver.local_context(), SemIR::LocId::None, unattached_self_const_id,
-        *facet_type, []([[maybe_unused]] auto& builder) {
-          CARBON_FATAL("Imported impl constraint can't be identified");
-        });
+    RequireIdentifiedFacetType(resolver.local_context(), SemIR::LocId::None,
+                               unattached_self_const_id, *facet_type,
+                               []([[maybe_unused]] auto& builder) {
+      CARBON_FATAL("Imported impl constraint can't be identified");
+    });
   }
   if (import_impl.is_complete()) {
     ImportImplDefinition(resolver, import_impl, new_impl);

--- a/toolchain/check/literal.cpp
+++ b/toolchain/check/literal.cpp
@@ -172,13 +172,12 @@ static auto GetStringLiteralRepr(Context& context, SemIR::LocId loc_id,
 auto MakeStringLiteral(Context& context, Parse::StringLiteralId node_id,
                        StringLiteralValueId value_id) -> SemIR::InstId {
   auto str_type = MakeStringType(context, SemIR::LocId(node_id).AsDesugared());
-  if (!RequireCompleteType(
-          context, str_type.type_id, node_id, [&](auto& builder) {
-            CARBON_DIAGNOSTIC(StringLiteralTypeIncomplete, Context,
-                              "type {0} is incomplete", InstIdAsType);
-            builder.Context(node_id, StringLiteralTypeIncomplete,
-                            str_type.inst_id);
-          })) {
+  if (!RequireCompleteType(context, str_type.type_id, node_id,
+                           [&](auto& builder) {
+    CARBON_DIAGNOSTIC(StringLiteralTypeIncomplete, Context,
+                      "type {0} is incomplete", InstIdAsType);
+    builder.Context(node_id, StringLiteralTypeIncomplete, str_type.inst_id);
+  })) {
     return SemIR::ErrorInst::InstId;
   }
 

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -515,15 +515,14 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
       // lookup on the facet directly instead of the facet type. For now it's
       // here to provide a better diagnostic than what we get when looking for
       // scopes directly on the facet type.
-      if (!RequireCompleteType(
-              context, base_type_id, SemIR::LocId(base_id), [&](auto& builder) {
-                CARBON_DIAGNOSTIC(
-                    IncompleteTypeInMemberAccessOfFacet, Context,
-                    "member access into facet of incomplete type {0}",
-                    SemIR::TypeId);
-                builder.Context(base_id, IncompleteTypeInMemberAccessOfFacet,
-                                base_type_id);
-              })) {
+      if (!RequireCompleteType(context, base_type_id, SemIR::LocId(base_id),
+                               [&](auto& builder) {
+        CARBON_DIAGNOSTIC(IncompleteTypeInMemberAccessOfFacet, Context,
+                          "member access into facet of incomplete type {0}",
+                          SemIR::TypeId);
+        builder.Context(base_id, IncompleteTypeInMemberAccessOfFacet,
+                        base_type_id);
+      })) {
         // If the scope is invalid in AppendLookupScopesForConstant we still
         // return true and proceed with lookup, just ignoring that scope.
         // Match behaviour here for when this moves into
@@ -558,14 +557,13 @@ static auto PerformActionHelper(Context& context, SemIR::LocId loc_id,
   //
   // TODO: ConvertToValueOrRefExpr could take context about the operation being
   // done to give a better error than "invalid use of" an incomplete type?
-  if (!RequireCompleteType(
-          context, base_type_id, SemIR::LocId(base_id), [&](auto& builder) {
-            CARBON_DIAGNOSTIC(
-                IncompleteTypeInMemberAccess, Context,
-                "member access into object of incomplete type {0}",
-                TypeOfInstId);
-            builder.Context(base_id, IncompleteTypeInMemberAccess, base_id);
-          })) {
+  if (!RequireCompleteType(context, base_type_id, SemIR::LocId(base_id),
+                           [&](auto& builder) {
+    CARBON_DIAGNOSTIC(IncompleteTypeInMemberAccess, Context,
+                      "member access into object of incomplete type {0}",
+                      TypeOfInstId);
+    builder.Context(base_id, IncompleteTypeInMemberAccess, base_id);
+  })) {
     return SemIR::ErrorInst::InstId;
   }
 

--- a/toolchain/check/name_lookup.cpp
+++ b/toolchain/check/name_lookup.cpp
@@ -362,12 +362,12 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
     RequireCompleteType(
         context, context.types().GetTypeIdForTypeConstantId(lookup_const_id),
         loc_id, [&](auto& builder) {
-          CARBON_DIAGNOSTIC(QualifiedExprInIncompleteClassScope, Context,
-                            "member access into incomplete class {0}",
-                            InstIdAsType);
-          builder.Context(loc_id, QualifiedExprInIncompleteClassScope,
-                          lookup_inst_id);
-        });
+      CARBON_DIAGNOSTIC(QualifiedExprInIncompleteClassScope, Context,
+                        "member access into incomplete class {0}",
+                        InstIdAsType);
+      builder.Context(loc_id, QualifiedExprInIncompleteClassScope,
+                      lookup_inst_id);
+    });
     auto& class_info = context.classes().Get(class_ty->class_id);
     scopes->push_back(LookupScope{.name_scope_id = class_info.scope_id,
                                   .specific_id = class_ty->specific_id,
@@ -382,12 +382,12 @@ auto AppendLookupScopesForConstant(Context& context, SemIR::LocId loc_id,
             context,
             context.types().GetTypeIdForTypeConstantId(lookup_const_id), loc_id,
             [&](auto& builder) {
-              CARBON_DIAGNOSTIC(
-                  QualifiedExprInIncompleteFacetTypeScope, Context,
-                  "member access into incomplete facet type {0}", InstIdAsType);
-              builder.Context(loc_id, QualifiedExprInIncompleteFacetTypeScope,
-                              lookup_inst_id);
-            })) {
+      CARBON_DIAGNOSTIC(QualifiedExprInIncompleteFacetTypeScope, Context,
+                        "member access into incomplete facet type {0}",
+                        InstIdAsType);
+      builder.Context(loc_id, QualifiedExprInIncompleteFacetTypeScope,
+                      lookup_inst_id);
+    })) {
       auto facet_type_info =
           context.facet_types().Get(facet_type->facet_type_id);
       // Name lookup into "extend" constraints but not "self impls" constraints.

--- a/toolchain/check/operator.cpp
+++ b/toolchain/check/operator.cpp
@@ -78,8 +78,8 @@ auto BuildUnaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
   // https://github.com/carbon-language/carbon-lang/blob/db0a00d713015436844c55e7ac190a0f95556499/toolchain/check/operator.cpp#L76
   if (HasCppClassType(context, operand_id) ||
       llvm::any_of(op.interface_args_ref, [&](SemIR::InstId arg_id) {
-        return IsCppClassType(context, arg_id);
-      })) {
+    return IsCppClassType(context, arg_id);
+  })) {
     op_fn_id = LookupCppOperator(context, loc_id, op, {operand_id});
 
     // If C++ operator lookup found a non-method operator, call it with one call
@@ -130,8 +130,8 @@ auto BuildBinaryOperator(Context& context, SemIR::LocId loc_id, Operator op,
   // https://github.com/carbon-language/carbon-lang/pull/5996/files/5d01fa69511b76f87efbc0387f5e40abcf4c911a#r2308664536
   if (HasCppClassType(context, lhs_id) || HasCppClassType(context, rhs_id) ||
       llvm::any_of(op.interface_args_ref, [&](SemIR::InstId arg_id) {
-        return IsCppClassType(context, arg_id);
-      })) {
+    return IsCppClassType(context, arg_id);
+  })) {
     op_fn_id = LookupCppOperator(context, loc_id, op, {lhs_id, rhs_id});
 
     // If C++ operator lookup found a non-method operator, call it with two call

--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -671,13 +671,13 @@ auto MatchContext::DoPreWork(State state, SemIR::TuplePattern tuple_pattern,
   }
   auto add_all_subscrutinees =
       [&](llvm::ArrayRef<SemIR::InstId> subscrutinee_ids) {
-        for (auto [subpattern_id, subscrutinee_id] :
-             llvm::reverse(llvm::zip_equal(subpattern_ids, subscrutinee_ids))) {
-          AddWork({.pattern_id = subpattern_id,
-                   .work = PreWork{.scrutinee_id = subscrutinee_id},
-                   .allow_unmarked_ref = entry.allow_unmarked_ref});
-        }
-      };
+    for (auto [subpattern_id, subscrutinee_id] :
+         llvm::reverse(llvm::zip_equal(subpattern_ids, subscrutinee_ids))) {
+      AddWork({.pattern_id = subpattern_id,
+               .work = PreWork{.scrutinee_id = subscrutinee_id},
+               .allow_unmarked_ref = entry.allow_unmarked_ref});
+    }
+  };
   if (!scrutinee_id.has_value()) {
     CARBON_CHECK(std::holds_alternative<CalleeState*>(state) ||
                  std::holds_alternative<ThunkState*>(state));
@@ -805,14 +805,14 @@ auto MatchContext::Dispatch(State state, WorkItem entry) -> void {
     }
     return;
   }
-  Diagnostics::AnnotationScope annotate_diagnostics(
-      &context_.emitter(), [&](auto& builder) {
-        if (std::holds_alternative<CallerState*>(state)) {
-          CARBON_DIAGNOSTIC(InCallToFunctionParam, Note,
-                            "initializing function parameter");
-          builder.Note(entry.pattern_id, InCallToFunctionParam);
-        }
-      });
+  Diagnostics::AnnotationScope annotate_diagnostics(&context_.emitter(),
+                                                    [&](auto& builder) {
+    if (std::holds_alternative<CallerState*>(state)) {
+      CARBON_DIAGNOSTIC(InCallToFunctionParam, Note,
+                        "initializing function parameter");
+      builder.Note(entry.pattern_id, InCallToFunctionParam);
+    }
+  });
   auto pattern = context_.insts().Get(entry.pattern_id);
   CARBON_KIND_SWITCH(entry.work) {
     case CARBON_KIND(PreWork work): {

--- a/toolchain/check/period_self.cpp
+++ b/toolchain/check/period_self.cpp
@@ -128,12 +128,12 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
         context(), loc_id_,
         context().constant_values().Get(replacement_self_inst_id),
         period_self_facet_type, [&](auto& /*builder*/) {
-          // The facet type containing this `.Self` should have already been
-          // identified, which would ensure that the type of `.Self` can be
-          // identified since it can only depend on things to the left of it
-          // inside the same facet type.
-          CARBON_FATAL("could not identify type of `.Self`");
-        });
+      // The facet type containing this `.Self` should have already been
+      // identified, which would ensure that the type of `.Self` can be
+      // identified since it can only depend on things to the left of it
+      // inside the same facet type.
+      CARBON_FATAL("could not identify type of `.Self`");
+    });
     const auto& identified_period_self_type =
         context().identified_facet_types().Get(identified_period_self_type_id);
     auto required_impls = identified_period_self_type.required_impls();

--- a/toolchain/check/scope_stack.cpp
+++ b/toolchain/check/scope_stack.cpp
@@ -246,8 +246,8 @@ auto ScopeStack::LookupInLexicalScopes(SemIR::NameId name_id,
   auto* first_non_lexical_scope = llvm::lower_bound(
       non_lexical_scope_stack_, lexical_results.back().scope_index,
       [](const NonLexicalScope& scope, ScopeIndex index) {
-        return scope.scope_index < index;
-      });
+    return scope.scope_index < index;
+  });
   return {
       lexical_results.back().inst_id,
       llvm::ArrayRef(first_non_lexical_scope, non_lexical_scope_stack_.end())};
@@ -267,9 +267,8 @@ auto ScopeStack::LookupOrAddName(SemIR::NameId name_id, SemIR::InstId target_id,
     scope_depth =
         llvm::lower_bound(scope_stack_, scope_index,
                           [](const ScopeStackEntry& entry, ScopeIndex index) {
-                            return entry.index < index;
-                          }) -
-        scope_stack_.begin();
+      return entry.index < index;
+    }) - scope_stack_.begin();
     CARBON_CHECK(scope_stack_[scope_depth].index == scope_index,
                  "Declaring name in scope that has already ended");
   } else {

--- a/toolchain/check/thunk.cpp
+++ b/toolchain/check/thunk.cpp
@@ -174,10 +174,10 @@ static auto ClonePatternBlock(Context& context, SemIR::SpecificId specific_id,
   if (!inst_block_id.has_value()) {
     return SemIR::InstBlockId::None;
   }
-  return context.inst_blocks().Transform(
-      inst_block_id, [&](SemIR::InstId inst_id) {
-        return ClonePattern(context, specific_id, inst_id);
-      });
+  return context.inst_blocks().Transform(inst_block_id,
+                                         [&](SemIR::InstId inst_id) {
+    return ClonePattern(context, specific_id, inst_id);
+  });
 }
 
 static auto CloneInstId(Context& context, SemIR::SpecificId specific_id,
@@ -330,12 +330,12 @@ static auto StartThunkFunctionDefinition(Context& context,
                                          SemIR::InstId callee_id) {
   // The check below produces diagnostics referring to the signature, so also
   // note the callee.
-  Diagnostics::AnnotationScope annot_scope(
-      &context.emitter(), [&](DiagnosticBuilder& builder) {
-        CARBON_DIAGNOSTIC(ThunkCallee, Note,
-                          "while building thunk calling this function");
-        builder.Note(callee_id, ThunkCallee);
-      });
+  Diagnostics::AnnotationScope annot_scope(&context.emitter(),
+                                           [&](DiagnosticBuilder& builder) {
+    CARBON_DIAGNOSTIC(ThunkCallee, Note,
+                      "while building thunk calling this function");
+    builder.Note(callee_id, ThunkCallee);
+  });
 
   StartFunctionDefinition(context, thunk_id, function_id);
 }
@@ -357,14 +357,14 @@ static auto BuildThunkDefinition(Context& context,
 
   // The checks below produce diagnostics pointing at the callee, so also note
   // the signature.
-  Diagnostics::AnnotationScope annot_scope(
-      &context.emitter(), [&](DiagnosticBuilder& builder) {
-        CARBON_DIAGNOSTIC(
-            ThunkSignature, Note,
-            "while building thunk to match the signature of this function");
-        builder.Note(context.functions().Get(signature_id).first_owning_decl_id,
-                     ThunkSignature);
-      });
+  Diagnostics::AnnotationScope annot_scope(&context.emitter(),
+                                           [&](DiagnosticBuilder& builder) {
+    CARBON_DIAGNOSTIC(
+        ThunkSignature, Note,
+        "while building thunk to match the signature of this function");
+    builder.Note(context.functions().Get(signature_id).first_owning_decl_id,
+                 ThunkSignature);
+  });
 
   const auto& function = context.functions().Get(function_id);
   llvm::ArrayRef<SemIR::InstId> param_pattern_ids;

--- a/toolchain/check/type_structure.h
+++ b/toolchain/check/type_structure.h
@@ -59,10 +59,10 @@ class TypeStructure : public Printable<TypeStructure> {
         lhs.symbolic_type_indices_.begin(), lhs.symbolic_type_indices_.end(),
         rhs.symbolic_type_indices_.begin(), rhs.symbolic_type_indices_.end(),
         [](int lhs_index, int rhs_index) {
-          // A higher symbolic type index is a better match, so we need to
-          // reverse the order.
-          return rhs_index < lhs_index;
-        });
+      // A higher symbolic type index is a better match, so we need to
+      // reverse the order.
+      return rhs_index < lhs_index;
+    });
   }
 
   // Equality of type structures. This compares that the structures are

--- a/toolchain/diagnostics/emitter.h
+++ b/toolchain/diagnostics/emitter.h
@@ -439,8 +439,8 @@ auto Emitter<LocT>::Builder::AddMessage(
   auto converted = emitter_->ConvertLoc(
       loc,
       [&](Loc context_loc, const DiagnosticBase<>& context_diagnostic_base) {
-        AddMessageWithLoc(context_loc, context_diagnostic_base, {});
-      });
+    AddMessageWithLoc(context_loc, context_diagnostic_base, {});
+  });
   // Use the last byte offset from the first message.
   if (diagnostic_.messages.empty()) {
     diagnostic_.last_byte_offset = converted.last_byte_offset;
@@ -468,9 +468,9 @@ auto Emitter<LocT>::Builder::AddMessageWithLoc(
               .format = diagnostic_base.Format,
               .format_args = std::move(args),
               .format_fn = [](const Message& message) -> std::string {
-                return FormatFn<Args...>(
-                    message, std::make_index_sequence<sizeof...(Args)>());
-              }});
+    return FormatFn<Args...>(message,
+                             std::make_index_sequence<sizeof...(Args)>());
+  }});
 }
 
 template <typename LocT>

--- a/toolchain/diagnostics/sorting_consumer.h
+++ b/toolchain/diagnostics/sorting_consumer.h
@@ -40,23 +40,23 @@ class SortingConsumer : public Consumer {
 
   // Sorts and flushes buffered diagnostics.
   auto Flush() -> void override {
-    llvm::stable_sort(
-        diagnostics_, [](const Diagnostic& lhs, const Diagnostic& rhs) {
-          if (lhs.last_byte_offset != rhs.last_byte_offset) {
-            return lhs.last_byte_offset < rhs.last_byte_offset;
-          }
+    llvm::stable_sort(diagnostics_,
+                      [](const Diagnostic& lhs, const Diagnostic& rhs) {
+      if (lhs.last_byte_offset != rhs.last_byte_offset) {
+        return lhs.last_byte_offset < rhs.last_byte_offset;
+      }
 
-          if (lhs.is_on_scope && rhs.is_on_scope) {
-            // When both are on-scope, we need to compare the locations.
-            const auto& lhs_loc = lhs.messages[0].loc;
-            const auto& rhs_loc = rhs.messages[0].loc;
-            return std::tie(lhs_loc.line_number, lhs_loc.column_number) <
-                   std::tie(rhs_loc.line_number, rhs_loc.column_number);
-          } else {
-            // Order non-on-scope before on-scope diagnostics.
-            return !lhs.is_on_scope && rhs.is_on_scope;
-          }
-        });
+      if (lhs.is_on_scope && rhs.is_on_scope) {
+        // When both are on-scope, we need to compare the locations.
+        const auto& lhs_loc = lhs.messages[0].loc;
+        const auto& rhs_loc = rhs.messages[0].loc;
+        return std::tie(lhs_loc.line_number, lhs_loc.column_number) <
+               std::tie(rhs_loc.line_number, rhs_loc.column_number);
+      } else {
+        // Order non-on-scope before on-scope diagnostics.
+        return !lhs.is_on_scope && rhs.is_on_scope;
+      }
+    });
     for (auto& diag : diagnostics_) {
       next_consumer_->HandleDiagnostic(std::move(diag));
     }

--- a/toolchain/driver/clang_runner_test.cpp
+++ b/toolchain/driver/clang_runner_test.cpp
@@ -104,12 +104,11 @@ TEST_F(ClangRunnerTest, DashC) {
   ClangRunner runner(&install_paths_, vfs_, &verbose_out);
   std::string out;
   std::string err;
-  EXPECT_THAT(Testing::CallWithCapturedOutput(
-                  out, err,
-                  [&] {
-                    return runner.RunWithNoRuntimes(
-                        {"-c", test_file.string(), "-o", test_output.string()});
-                  }),
+  EXPECT_THAT(Testing::CallWithCapturedOutput(out, err,
+                                              [&] {
+    return runner.RunWithNoRuntimes(
+        {"-c", test_file.string(), "-o", test_output.string()});
+  }),
               IsSuccess(true))
       << "Verbose output from runner:\n"
       << verbose_out.TakeStr() << "\n";
@@ -134,12 +133,11 @@ TEST_F(ClangRunnerTest, BuitinHeaders) {
   ClangRunner runner(&install_paths_, vfs_, &verbose_out);
   std::string out;
   std::string err;
-  EXPECT_THAT(Testing::CallWithCapturedOutput(
-                  out, err,
-                  [&] {
-                    return runner.RunWithNoRuntimes(
-                        {"-c", test_file.string(), "-o", test_output.string()});
-                  }),
+  EXPECT_THAT(Testing::CallWithCapturedOutput(out, err,
+                                              [&] {
+    return runner.RunWithNoRuntimes(
+        {"-c", test_file.string(), "-o", test_output.string()});
+  }),
               IsSuccess(true))
       << "Verbose output from runner:\n"
       << verbose_out.TakeStr() << "\n";
@@ -162,12 +160,11 @@ TEST_F(ClangRunnerTest, CompileMultipleFiles) {
     ClangRunner runner(&install_paths_, vfs_, &verbose_out);
     std::string out;
     std::string err;
-    EXPECT_THAT(Testing::CallWithCapturedOutput(
-                    out, err,
-                    [&] {
-                      return runner.RunWithNoRuntimes(
-                          {"-c", file.string(), "-o", output.string()});
-                    }),
+    EXPECT_THAT(Testing::CallWithCapturedOutput(out, err,
+                                                [&] {
+      return runner.RunWithNoRuntimes(
+          {"-c", file.string(), "-o", output.string()});
+    }),
                 IsSuccess(true))
         << "Verbose output from runner:\n"
         << verbose_out.TakeStr() << "\n";
@@ -198,18 +195,16 @@ TEST_F(ClangRunnerTest, LinkCommandEcho) {
   ClangRunner runner(&install_paths_, vfs_, &verbose_out);
   std::string out;
   std::string err;
-  EXPECT_THAT(
-      Testing::CallWithCapturedOutput(
-          out, err,
-          [&] {
-            // Note that we use the target independent run command here because
-            // we're just getting the echo-ed output back. For this to actually
-            // link, we'd need to have the target-dependent resources, but those
-            // are expensive to build so we only want to test them once (above).
-            return runner.RunWithNoRuntimes(
-                {"-###", "-o", "binary", foo_file.string(), bar_file.string()});
-          }),
-      IsSuccess(true))
+  EXPECT_THAT(Testing::CallWithCapturedOutput(out, err,
+                                              [&] {
+    // Note that we use the target independent run command here because
+    // we're just getting the echo-ed output back. For this to actually
+    // link, we'd need to have the target-dependent resources, but those
+    // are expensive to build so we only want to test them once (above).
+    return runner.RunWithNoRuntimes(
+        {"-###", "-o", "binary", foo_file.string(), bar_file.string()});
+  }),
+              IsSuccess(true))
       << "Verbose output from runner:\n"
       << verbose_out.TakeStr() << "\n";
   verbose_out.clear();
@@ -245,13 +240,11 @@ TEST_F(ClangRunnerTest, ParamsFile) {
 
   std::string out;
   std::string err;
-  EXPECT_THAT(
-      Testing::CallWithCapturedOutput(out, err,
-                                      [&] {
-                                        return runner.RunWithNoRuntimes(
-                                            {"@" + params_path.native()});
-                                      }),
-      IsSuccess(true))
+  EXPECT_THAT(Testing::CallWithCapturedOutput(out, err,
+                                              [&] {
+    return runner.RunWithNoRuntimes({"@" + params_path.native()});
+  }),
+              IsSuccess(true))
       << "Verbose output:\n"
       << verbose_out.TakeStr();
   verbose_out.clear();
@@ -284,15 +277,13 @@ _Z4testv:
   ClangRunner runner(&install_paths_, vfs_, &verbose_out);
   std::string out;
   std::string err;
-  EXPECT_THAT(
-      Testing::CallWithCapturedOutput(
-          out, err,
-          [&] {
-            return runner.RunWithNoRuntimes(
-                {"-c", test_file.string(), "--target=aarch64-unknown-linux-gnu",
-                 "-o", test_output.string()});
-          }),
-      IsSuccess(true))
+  EXPECT_THAT(Testing::CallWithCapturedOutput(out, err,
+                                              [&] {
+    return runner.RunWithNoRuntimes({"-c", test_file.string(),
+                                     "--target=aarch64-unknown-linux-gnu", "-o",
+                                     test_output.string()});
+  }),
+              IsSuccess(true))
       << "Verbose output from runner:\n"
       << verbose_out.TakeStr() << "\n";
   verbose_out.clear();

--- a/toolchain/driver/clang_runtimes.cpp
+++ b/toolchain/driver/clang_runtimes.cpp
@@ -294,9 +294,9 @@ auto ClangArchiveRuntimesBuilder<Component>::CollectSrcFiles()
   if constexpr (Component == Runtimes::LibUnwind) {
     return llvm::to_vector_of<llvm::StringRef>(llvm::make_filter_range(
         RuntimesBuildInfo::LibunwindSrcs, [](llvm::StringRef src) {
-          return src.ends_with(".c") || src.ends_with(".cpp") ||
-                 src.ends_with(".S");
-        }));
+      return src.ends_with(".c") || src.ends_with(".cpp") ||
+             src.ends_with(".S");
+    }));
   } else if constexpr (Component == Runtimes::Libcxx) {
     auto libcxx_target_srcs =
         target_triple_.isOSWindows()

--- a/toolchain/driver/codegen_options.cpp
+++ b/toolchain/driver/codegen_options.cpp
@@ -20,9 +20,9 @@ https://clang.llvm.org/docs/CrossCompilation.html#target-triple
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Default(host);
-        arg_b.Set(&target);
-      });
+    arg_b.Default(host);
+    arg_b.Set(&target);
+  });
 }
 
 }  // namespace Carbon

--- a/toolchain/driver/compile_subcommand.cpp
+++ b/toolchain/driver/compile_subcommand.cpp
@@ -44,9 +44,9 @@ The input Carbon source file to compile.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Required(true);
-        arg_b.Append(&input_filenames);
-      });
+    arg_b.Required(true);
+    arg_b.Append(&input_filenames);
+  });
 
   b.AddOneOfOption(
       {
@@ -58,17 +58,17 @@ compile to machine code.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.SetOneOf(
-            {
-                arg_b.OneOfValue("lex", Phase::Lex),
-                arg_b.OneOfValue("parse", Phase::Parse),
-                arg_b.OneOfValue("check", Phase::Check),
-                arg_b.OneOfValue("lower", Phase::Lower),
-                arg_b.OneOfValue("optimize", Phase::Optimize),
-                arg_b.OneOfValue("codegen", Phase::CodeGen).Default(true),
-            },
-            &phase);
-      });
+    arg_b.SetOneOf(
+        {
+            arg_b.OneOfValue("lex", Phase::Lex),
+            arg_b.OneOfValue("parse", Phase::Parse),
+            arg_b.OneOfValue("check", Phase::Check),
+            arg_b.OneOfValue("lower", Phase::Lower),
+            arg_b.OneOfValue("optimize", Phase::Optimize),
+            arg_b.OneOfValue("codegen", Phase::CodeGen).Default(true),
+        },
+        &phase);
+  });
 
   b.AddStringOption(
       {
@@ -122,24 +122,24 @@ Selects the amount of optimization to perform.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.SetOneOf(
-            {
-                // We intentionally don't expose O2 and Os. The difference
-                // between these levels tends to reflect what achieves the
-                // best speed for a specific application, as they all
-                // largely optimize for speed as the primary factor.
-                //
-                // Instead of controlling this with more nuanced flags, we
-                // plan to support profile and in-source hints to the
-                // optimizer to adjust its strategy in the specific places
-                // where the default doesn't have the desired results.
-                arg_b.OneOfValue("none", Lower::OptimizationLevel::None),
-                arg_b.OneOfValue("debug", Lower::OptimizationLevel::Debug),
-                arg_b.OneOfValue("speed", Lower::OptimizationLevel::Speed),
-                arg_b.OneOfValue("size", Lower::OptimizationLevel::Size),
-            },
-            &opt_level);
-      });
+    arg_b.SetOneOf(
+        {
+            // We intentionally don't expose O2 and Os. The difference
+            // between these levels tends to reflect what achieves the
+            // best speed for a specific application, as they all
+            // largely optimize for speed as the primary factor.
+            //
+            // Instead of controlling this with more nuanced flags, we
+            // plan to support profile and in-source hints to the
+            // optimizer to adjust its strategy in the specific places
+            // where the default doesn't have the desired results.
+            arg_b.OneOfValue("none", Lower::OptimizationLevel::None),
+            arg_b.OneOfValue("debug", Lower::OptimizationLevel::Debug),
+            arg_b.OneOfValue("speed", Lower::OptimizationLevel::Speed),
+            arg_b.OneOfValue("size", Lower::OptimizationLevel::Size),
+        },
+        &opt_level);
+  });
 
   // Include the common code generation options at this point to render it
   // after the more common options above, but before the more unusual options
@@ -260,16 +260,16 @@ prints full SemIR.
 )""",
       },
       [&](auto& arg_b) {
-        using DumpSemIRRanges = Check::CheckParseTreesOptions::DumpSemIRRanges;
-        arg_b.SetOneOf(
-            {
-                arg_b.OneOfValue("if-present", DumpSemIRRanges::IfPresent)
-                    .Default(true),
-                arg_b.OneOfValue("only", DumpSemIRRanges::Only),
-                arg_b.OneOfValue("ignore", DumpSemIRRanges::Ignore),
-            },
-            &dump_sem_ir_ranges);
-      });
+    using DumpSemIRRanges = Check::CheckParseTreesOptions::DumpSemIRRanges;
+    arg_b.SetOneOf(
+        {
+            arg_b.OneOfValue("if-present", DumpSemIRRanges::IfPresent)
+                .Default(true),
+            arg_b.OneOfValue("only", DumpSemIRRanges::Only),
+            arg_b.OneOfValue("ignore", DumpSemIRRanges::Ignore),
+        },
+        &dump_sem_ir_ranges);
+  });
 
   b.AddFlag(
       {
@@ -319,9 +319,9 @@ Whether to use the implicit prelude import. Enabled by default.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Default(true);
-        arg_b.Set(&prelude_import);
-      });
+    arg_b.Default(true);
+    arg_b.Set(&prelude_import);
+  });
   b.AddFlag(
       {
           .name = "custom-core",
@@ -336,9 +336,9 @@ to be specified in the compile command line.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Default(false);
-        arg_b.Set(&custom_core);
-      });
+    arg_b.Default(false);
+    arg_b.Set(&custom_core);
+  });
   b.AddStringOption(
       {
           .name = "exclude-dump-file-prefix",
@@ -356,9 +356,9 @@ Whether to emit DWARF debug information.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Default(true);
-        arg_b.Set(&include_debug_info);
-      });
+    arg_b.Default(true);
+    arg_b.Set(&include_debug_info);
+  });
   b.AddFlag(
       {
           .name = "output-last-input-only",
@@ -378,9 +378,9 @@ Whether to run the LLVM verifier on modules.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Default(true);
-        arg_b.Set(&run_llvm_verifier);
-      });
+    arg_b.Default(true);
+    arg_b.Set(&run_llvm_verifier);
+  });
   b.AddStringOption(
       {
           .name = "sem-ir-crash-dump",
@@ -635,12 +635,11 @@ class MultiUnitCache {
         // If this is first accessed after lexing is complete, we need to apply
         // per-file includes. Otherwise, this is based only on the exclude
         // option.
-        bool include =
-            unit->has_include_in_dumps() ||
-            llvm::none_of(options_->exclude_dump_file_prefixes,
-                          [&](auto prefix) {
-                            return unit->input_filename().starts_with(prefix);
-                          });
+        bool include = unit->has_include_in_dumps() ||
+                       llvm::none_of(options_->exclude_dump_file_prefixes,
+                                     [&](auto prefix) {
+          return unit->input_filename().starts_with(prefix);
+        });
         include_in_dumps_->Set(SemIR::CheckIRId(i), include);
       }
     }
@@ -947,11 +946,11 @@ auto CompilationUnit::RunOptimize(
 
   if (vlog_stream_) {
     CARBON_VLOG("*** Running pass pipeline: ");
-    pass_manager.printPipeline(
-        *vlog_stream_, [&pic](llvm::StringRef class_name) {
-          auto pass_name = pic.getPassNameForClassName(class_name);
-          return pass_name.empty() ? class_name : pass_name;
-        });
+    pass_manager.printPipeline(*vlog_stream_,
+                               [&pic](llvm::StringRef class_name) {
+      auto pass_name = pic.getPassNameForClassName(class_name);
+      return pass_name.empty() ? class_name : pass_name;
+    });
     CARBON_VLOG(" ***\n");
   }
 

--- a/toolchain/driver/config_subcommand.cpp
+++ b/toolchain/driver/config_subcommand.cpp
@@ -42,9 +42,9 @@ Render output as a JSON map for easy parsing.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Default(false);
-        arg_b.Set(&json_output);
-      });
+    arg_b.Default(false);
+    arg_b.Set(&json_output);
+  });
 
   codegen_options.Build(b);
 }

--- a/toolchain/driver/driver.cpp
+++ b/toolchain/driver/driver.cpp
@@ -128,9 +128,9 @@ the installation tree in the default searched locations.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Default(true);
-        arg_b.Set(&build_runtimes_on_demand);
-      });
+    arg_b.Default(true);
+    arg_b.Set(&build_runtimes_on_demand);
+  });
 
   b.AddFlag(
       {
@@ -164,9 +164,9 @@ when there are errors or other output.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Default(true);
-        arg_b.Set(&threads);
-      });
+    arg_b.Default(true);
+    arg_b.Set(&threads);
+  });
 
   runtimes.AddTo(b, &selected_subcommand);
   clang.AddTo(b, &selected_subcommand);

--- a/toolchain/driver/driver_subcommand.h
+++ b/toolchain/driver/driver_subcommand.h
@@ -34,8 +34,8 @@ class DriverSubcommand {
              DriverSubcommand** selected_subcommand) -> void {
     b.AddSubcommand(
         info_, [this, selected_subcommand](CommandLine::CommandBuilder& sub_b) {
-          BuildOptionsAndSetAction(sub_b, selected_subcommand);
-        });
+      BuildOptionsAndSetAction(sub_b, selected_subcommand);
+    });
   }
 
   // Adds command line options.

--- a/toolchain/driver/driver_test.cpp
+++ b/toolchain/driver/driver_test.cpp
@@ -296,10 +296,9 @@ TEST_F(DriverTest, LinkWithFlagLikeFiles) {
   std::string out;
   std::string err;
   EXPECT_FALSE(CallWithCapturedOutput(out, err, [&] {
-                 return driver_.RunCommand({"--no-build-runtimes", "link",
-                                            "--output=test", "--", "--test.o",
-                                            "--", "-lc", "-lm", "-Wl,--"});
-               }).success);
+    return driver_.RunCommand({"--no-build-runtimes", "link", "--output=test",
+                               "--", "--test.o", "--", "-lc", "-lm", "-Wl,--"});
+  }).success);
   EXPECT_THAT(test_error_stream_.TakeStr(), StrEq(""));
   EXPECT_THAT(out, StrEq(""));
   // This error seems to stem from incorrectly handling `--` in the LLD command

--- a/toolchain/driver/format_subcommand.cpp
+++ b/toolchain/driver/format_subcommand.cpp
@@ -24,9 +24,9 @@ The input Carbon source file(s) to format.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.Required(true);
-        arg_b.Append(&input_filenames);
-      });
+    arg_b.Required(true);
+    arg_b.Append(&input_filenames);
+  });
   b.AddStringOption(
       {
           .name = "output",

--- a/toolchain/driver/lld_runner_test.cpp
+++ b/toolchain/driver/lld_runner_test.cpp
@@ -89,26 +89,24 @@ static auto CompileTwoSources(const InstallPaths& install_paths,
   std::string target_arg = llvm::formatv("--target={0}", target).str();
   std::string out;
   std::string err;
-  CARBON_CHECK(*Testing::CallWithCapturedOutput(
-                   out, err,
-                   [&] {
-                     auto run_result = clang.RunWithNoRuntimes(
-                         {target_arg, "-fPIE", "-c", test_a_file.string(), "-o",
-                          test_a_output.string()});
-                     return run_result;
-                   }),
+  CARBON_CHECK(*Testing::CallWithCapturedOutput(out, err,
+                                                [&] {
+    auto run_result = clang.RunWithNoRuntimes({target_arg, "-fPIE", "-c",
+                                               test_a_file.string(), "-o",
+                                               test_a_output.string()});
+    return run_result;
+  }),
                "Verbose output from runner:\n{0}\nStderr:\n{1}\n",
                verbose_out.TakeStr(), err);
   verbose_out.clear();
 
-  CARBON_CHECK(*Testing::CallWithCapturedOutput(
-                   out, err,
-                   [&] {
-                     auto run_result = clang.RunWithNoRuntimes(
-                         {target_arg, "-fPIE", "-c", test_b_file.string(), "-o",
-                          test_b_output.string()});
-                     return run_result;
-                   }),
+  CARBON_CHECK(*Testing::CallWithCapturedOutput(out, err,
+                                                [&] {
+    auto run_result = clang.RunWithNoRuntimes({target_arg, "-fPIE", "-c",
+                                               test_b_file.string(), "-o",
+                                               test_b_output.string()});
+    return run_result;
+  }),
                "Verbose output from runner:\n{0}\nStderr:\n{1}\n",
                verbose_out.TakeStr(), err);
   verbose_out.clear();
@@ -140,14 +138,12 @@ TEST(LldRunnerTest, ElfLinkTest) {
   // C-runtime built artifacts available in the toolchain. We should revisit
   // this once we have those in place. This also prevents us from testing a
   // failed link easily.
-  EXPECT_TRUE(Testing::CallWithCapturedOutput(
-      out, err,
-      [&] {
-        return lld.ElfLink({"-m", "aarch64linux", "--relocatable", "-o",
-                            test_output.string(), test_a_output.string(),
-                            test_b_output.string()});
-      }))
-      << "Verbose output from runner:\n"
+  EXPECT_TRUE(Testing::CallWithCapturedOutput(out, err,
+                                              [&] {
+    return lld.ElfLink({"-m", "aarch64linux", "--relocatable", "-o",
+                        test_output.string(), test_a_output.string(),
+                        test_b_output.string()});
+  })) << "Verbose output from runner:\n"
       << verbose_out.TakeStr() << "\n";
   verbose_out.clear();
 
@@ -177,14 +173,12 @@ TEST(LldRunnerTest, MachOLinkTest) {
   // but seems to succeed currently. The goal isn't to test any *particular*
   // link, but just than an actual link occurs successfully.
   LldRunner lld(&install_paths, &verbose_out);
-  EXPECT_TRUE(Testing::CallWithCapturedOutput(
-      out, err,
-      [&] {
-        return lld.MachOLink({"-arch", "arm64", "-platform_version", "macos",
-                              "10.4.0", "10.4.0", "-o", test_output.string(),
-                              test_a_output.string(), test_b_output.string()});
-      }))
-      << "Verbose output from runner:\n"
+  EXPECT_TRUE(Testing::CallWithCapturedOutput(out, err,
+                                              [&] {
+    return lld.MachOLink({"-arch", "arm64", "-platform_version", "macos",
+                          "10.4.0", "10.4.0", "-o", test_output.string(),
+                          test_a_output.string(), test_b_output.string()});
+  })) << "Verbose output from runner:\n"
       << verbose_out.TakeStr() << "\n";
   verbose_out.clear();
 
@@ -194,14 +188,12 @@ TEST(LldRunnerTest, MachOLinkTest) {
 
   // Re-do the link, but with only one of the inputs. This should fail due to an
   // unresolved symbol.
-  EXPECT_FALSE(Testing::CallWithCapturedOutput(
-      out, err,
-      [&] {
-        return lld.MachOLink({"-arch", "arm64", "-platform_version", "macos",
-                              "10.4.0", "10.4.0", "-o", test_output.string(),
-                              test_b_output.string()});
-      }))
-      << "Verbose output from runner:\n"
+  EXPECT_FALSE(Testing::CallWithCapturedOutput(out, err,
+                                               [&] {
+    return lld.MachOLink({"-arch", "arm64", "-platform_version", "macos",
+                          "10.4.0", "10.4.0", "-o", test_output.string(),
+                          test_b_output.string()});
+  })) << "Verbose output from runner:\n"
       << verbose_out.TakeStr() << "\n";
   verbose_out.clear();
 

--- a/toolchain/driver/lld_subcommand.cpp
+++ b/toolchain/driver/lld_subcommand.cpp
@@ -39,20 +39,20 @@ target's platform.
 )""",
       },
       [&](auto& arg_b) {
-        arg_b.SetOneOf(
-            {
-                arg_b.OneOfValue("elf", Platform::Elf),
-                // Some of LLD documentation uses "Unix" or "GNU", so
-                // include an alias here.
-                arg_b.OneOfValue("gnu", Platform::Elf),
-                arg_b.OneOfValue("unix", Platform::Elf),
+    arg_b.SetOneOf(
+        {
+            arg_b.OneOfValue("elf", Platform::Elf),
+            // Some of LLD documentation uses "Unix" or "GNU", so
+            // include an alias here.
+            arg_b.OneOfValue("gnu", Platform::Elf),
+            arg_b.OneOfValue("unix", Platform::Elf),
 
-                arg_b.OneOfValue("macho", Platform::MachO),
-                // Darwin is also sometimes used, include it as an alias here.
-                arg_b.OneOfValue("darwin", Platform::MachO),
-            },
-            &platform);
-      });
+            arg_b.OneOfValue("macho", Platform::MachO),
+            // Darwin is also sometimes used, include it as an alias here.
+            arg_b.OneOfValue("darwin", Platform::MachO),
+        },
+        &platform);
+  });
   b.AddStringPositionalArg(
       {
           .name = "ARG",

--- a/toolchain/language_server/incoming_messages.cpp
+++ b/toolchain/language_server/incoming_messages.cpp
@@ -87,8 +87,8 @@ auto IncomingMessages::onCall(llvm::StringRef name, llvm::json::Value params,
   if (auto result = call_handlers_.Lookup(name)) {
     (result.value())(*context_, std::move(params),
                      [&](llvm::Expected<llvm::json::Value> reply) {
-                       transport_->reply(id, std::move(reply));
-                     });
+      transport_->reply(id, std::move(reply));
+    });
   } else {
     transport_->reply(id, llvm::make_error<clang::clangd::LSPError>(
                               llvm::formatv("unsupported call `{0}`", name),

--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -1437,22 +1437,22 @@ auto Lexer::LexError(llvm::StringRef source_text, ssize_t& position)
     -> LexResult {
   llvm::StringRef error_text =
       source_text.substr(position).take_while([](char c) {
-        if (IsAlnum(c)) {
-          return false;
-        }
-        switch (c) {
-          case '_':
-          case '\t':
-          case '\n':
-            return false;
-          default:
-            break;
-        }
-        return llvm::StringSwitch<bool>(llvm::StringRef(&c, 1))
+    if (IsAlnum(c)) {
+      return false;
+    }
+    switch (c) {
+      case '_':
+      case '\t':
+      case '\n':
+        return false;
+      default:
+        break;
+    }
+    return llvm::StringSwitch<bool>(llvm::StringRef(&c, 1))
 #define CARBON_SYMBOL_TOKEN(Name, Spelling) .StartsWith(Spelling, false)
 #include "toolchain/lex/token_kind.def"
-            .Default(true);
-      });
+        .Default(true);
+  });
   if (error_text.empty()) {
     // TODO: Reimplement this to use the lexer properly. In the meantime,
     // guarantee that we eat at least one byte.
@@ -1679,12 +1679,11 @@ auto Lexer::DiagnoseAndFixMismatchedBrackets() -> void {
     }
 
     // Find the innermost matching opening symbol.
-    auto opening_it = llvm::find_if(
-        llvm::reverse(open_groups_), [&](TokenIndex opening_token) {
-          return buffer_.token_infos_.Get(opening_token)
-                     .kind()
-                     .closing_symbol() == kind;
-        });
+    auto opening_it = llvm::find_if(llvm::reverse(open_groups_),
+                                    [&](TokenIndex opening_token) {
+      return buffer_.token_infos_.Get(opening_token).kind().closing_symbol() ==
+             kind;
+    });
     if (opening_it == open_groups_.rend()) {
       CARBON_DIAGNOSTIC(
           UnmatchedClosing, Error,

--- a/toolchain/lex/numeric_literal_test.cpp
+++ b/toolchain/lex/numeric_literal_test.cpp
@@ -323,14 +323,12 @@ TEST_F(NumericLiteralTest, HandlesRealLiteral) {
 TEST_F(NumericLiteralTest, HandlesRealLiteralOverflow) {
   llvm::StringLiteral input = "0x1.000001p-9223372036854775800";
   error_tracker.Reset();
-  EXPECT_THAT(
-      Parse(input),
-      HasRealValue({.radix = 2,
-                    .mantissa = IsUnsignedInt(0x1000001),
-                    .exponent = Truly([](llvm::APInt exponent) {
-                      return (exponent + 9223372036854775800).getSExtValue() ==
-                             -24;
-                    })}));
+  EXPECT_THAT(Parse(input),
+              HasRealValue({.radix = 2,
+                            .mantissa = IsUnsignedInt(0x1000001),
+                            .exponent = Truly([](llvm::APInt exponent) {
+    return (exponent + 9223372036854775800).getSExtValue() == -24;
+  })}));
   EXPECT_FALSE(error_tracker.seen_error());
 }
 

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -333,8 +333,8 @@ auto TokenizedBuffer::FindLineIndex(int32_t byte_offset) const -> LineIndex {
   auto line_range = line_infos_.values();
   auto line_it =
       llvm::partition_point(line_range, [byte_offset](LineInfo line_info) {
-        return line_info.start <= byte_offset;
-      });
+    return line_info.start <= byte_offset;
+  });
   --line_it;
 
   // If this isn't the first line but it starts past the end of the source, then

--- a/toolchain/lex/tokenized_buffer_benchmark.cpp
+++ b/toolchain/lex/tokenized_buffer_benchmark.cpp
@@ -647,28 +647,28 @@ constexpr char DispatchSpecializableSymbols[] = {
 // to be exhaustive.
 constexpr std::array<char, 26 * 2 + 10 + sizeof(DispatchSpecializableSymbols)>
     DispatchSpecializableChars = []() {
-      constexpr int Size = sizeof(DispatchSpecializableChars);
-      std::array<char, Size> chars = {};
-      int i = 0;
-      for (char c = '0'; c <= '9'; ++c) {
-        chars[i] = c;
-        ++i;
-      }
-      for (char c = 'A'; c <= 'Z'; ++c) {
-        chars[i] = c;
-        ++i;
-      }
-      for (char c = 'a'; c <= 'z'; ++c) {
-        chars[i] = c;
-        ++i;
-      }
-      for (char c : DispatchSpecializableSymbols) {
-        chars[i] = c;
-        ++i;
-      }
-      CARBON_CHECK(i == Size);
-      return chars;
-    }();
+  constexpr int Size = sizeof(DispatchSpecializableChars);
+  std::array<char, Size> chars = {};
+  int i = 0;
+  for (char c = '0'; c <= '9'; ++c) {
+    chars[i] = c;
+    ++i;
+  }
+  for (char c = 'A'; c <= 'Z'; ++c) {
+    chars[i] = c;
+    ++i;
+  }
+  for (char c = 'a'; c <= 'z'; ++c) {
+    chars[i] = c;
+    ++i;
+  }
+  for (char c : DispatchSpecializableSymbols) {
+    chars[i] = c;
+    ++i;
+  }
+  CARBON_CHECK(i == Size);
+  return chars;
+}();
 
 // Instantiate a number of specialized dispatch functions for characters in the
 // array above, and assign those function addresses to the character's entry in

--- a/toolchain/lower/specific_coalescer.cpp
+++ b/toolchain/lower/specific_coalescer.cpp
@@ -73,10 +73,10 @@ auto SpecificCoalescer::CoalesceEquivalentSpecifics(
           visited_equivalent_specifics.ForEach(
               [&](std::pair<SemIR::SpecificId, SemIR::SpecificId>
                       equivalent_entry) {
-                CARBON_VLOG("Found equivalent specifics: {0}, {1}",
-                            equivalent_entry.first, equivalent_entry.second);
-                ProcessSpecificEquivalence(equivalent_entry);
-              });
+            CARBON_VLOG("Found equivalent specifics: {0}, {1}",
+                        equivalent_entry.first, equivalent_entry.second);
+            ProcessSpecificEquivalence(equivalent_entry);
+          });
 
           // Removed the replaced specific from the list of emitted specifics.
           // Only the top level, since the others are somewhere else in the

--- a/toolchain/lower/type.cpp
+++ b/toolchain/lower/type.cpp
@@ -282,10 +282,10 @@ auto FunctionTypeInfoBuilder::Build() && -> FunctionTypeInfo {
   // Determine how the parameters are numbered in SemIR, and make sure it's the
   // same for all versions of the function.
   auto semir_info = GetSemIRIndexInfo(functions_.front());
-  CARBON_CHECK(llvm::all_of(
-      functions_.drop_front(), [&](const FunctionInContext& fn_in_context) {
-        return GetSemIRIndexInfo(fn_in_context) == semir_info;
-      }));
+  CARBON_CHECK(llvm::all_of(functions_.drop_front(),
+                            [&](const FunctionInContext& fn_in_context) {
+    return GetSemIRIndexInfo(fn_in_context) == semir_info;
+  }));
 
   num_params_ = semir_info.num_params;
   lowered_param_indices_.reserve(num_params_);

--- a/toolchain/sem_ir/builtin_function_kind.cpp
+++ b/toolchain/sem_ir/builtin_function_kind.cpp
@@ -334,10 +334,10 @@ static auto ValidateSignature(const File& sem_ir,
 
   // Argument types must match.
   if (![&]<size_t... Indexes>(std::index_sequence<Indexes...>) {
-        return ((CheckParam<typename SignatureTraits::template arg_t<Indexes>>(
-                    sem_ir, state, call_params[Indexes])) &&
-                ...);
-      }(std::make_index_sequence<SignatureTraits::num_args>())) {
+    return ((CheckParam<typename SignatureTraits::template arg_t<Indexes>>(
+                sem_ir, state, call_params[Indexes])) &&
+            ...);
+  }(std::make_index_sequence<SignatureTraits::num_args>())) {
     return false;
   }
 

--- a/toolchain/sem_ir/bundle.h
+++ b/toolchain/sem_ir/bundle.h
@@ -171,11 +171,10 @@ class BundleStore {
   auto BundleToArray(const BundleT& bundle) -> auto {
     static_assert(std::is_aggregate_v<BundleT>,
                   "Only aggregates are supported");
-    return std::apply(
-        [](auto... ids)->std::array<AnyRawId, sizeof...(ids)> {
-          return {AnyRawId(ToRaw(ids))...};
-        },
-        StructReflection::AsTuple(bundle));
+    return std::apply([](auto... ids)->std::array<AnyRawId, sizeof...(ids)> {
+      return {AnyRawId(ToRaw(ids))...};
+    },
+                      StructReflection::AsTuple(bundle));
   }
 
   // Helper class for converting an array of `AnyRawId`s back to typed IDs.
@@ -227,9 +226,9 @@ class BundleStore {
     llvm::ListSeparator sep;
     size_t i = 0;
     out << "{";
-    std::apply(
-        [&](auto... ids) { (..., PrintBundleField(out, sep, i++, ids)); },
-        GetAsTuple(bundle_id));
+    std::apply([&](auto... ids) {
+      (..., PrintBundleField(out, sep, i++, ids));
+    }, GetAsTuple(bundle_id));
     out << "}";
     return out.TakeStr();
   }

--- a/toolchain/sem_ir/clang_decl.cpp
+++ b/toolchain/sem_ir/clang_decl.cpp
@@ -38,8 +38,8 @@ auto ClangDeclSignature::Print(llvm::raw_ostream& out) const -> void {
   };
 
   if (!passing_modes.empty() && llvm::any_of(passing_modes, [](auto mode) {
-        return mode != PassingMode::ByVar;
-      })) {
+    return mode != PassingMode::ByVar;
+  })) {
     out << ", modes: [";
     llvm::ListSeparator sep;
     for (auto mode : passing_modes) {

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -269,18 +269,18 @@ class ConstantValueStore {
 
   // Outputs assigned constant values, and all symbolic constants.
   auto OutputYaml(bool include_singletons) const -> Yaml::OutputMapping {
-    return Yaml::OutputMapping([&, include_singletons](
-                                   Yaml::OutputMapping::Map map) {
+    return Yaml::OutputMapping(
+        [&, include_singletons](Yaml::OutputMapping::Map map) {
       map.Add("values", Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                for (auto [id, value] : values_.enumerate()) {
-                  if (!include_singletons && IsSingletonInstId(id)) {
-                    continue;
-                  }
-                  if (!value.has_value() || value.is_constant()) {
-                    map.Add(PrintToString(id), Yaml::OutputScalar(value));
-                  }
-                }
-              }));
+        for (auto [id, value] : values_.enumerate()) {
+          if (!include_singletons && IsSingletonInstId(id)) {
+            continue;
+          }
+          if (!value.has_value() || value.is_constant()) {
+            map.Add(PrintToString(id), Yaml::OutputScalar(value));
+          }
+        }
+      }));
       map.Add("symbolic_constants", symbolic_constants_.OutputYaml());
     });
   }

--- a/toolchain/sem_ir/entity_name.h
+++ b/toolchain/sem_ir/entity_name.h
@@ -121,8 +121,7 @@ class EntityNameStore::KeyContext : public TranslatingKeyContext<KeyContext> {
 
 inline auto EntityNameStore::AddCanonical(EntityName name) -> EntityNameId {
   return canonical_ids_
-      .Insert(
-          name, [&] { return Add(name); }, KeyContext(this))
+      .Insert(name, [&] { return Add(name); }, KeyContext(this))
       .key();
 }
 

--- a/toolchain/sem_ir/file.cpp
+++ b/toolchain/sem_ir/file.cpp
@@ -141,46 +141,44 @@ auto File::Verify() const -> ErrorOr<Success> {
 }
 
 auto File::OutputYaml(bool include_singletons) const -> Yaml::OutputMapping {
-  return Yaml::OutputMapping([this, include_singletons](
-                                 Yaml::OutputMapping::Map map) {
+  return Yaml::OutputMapping(
+      [this, include_singletons](Yaml::OutputMapping::Map map) {
     map.Add("filename", filename_);
-    map.Add(
-        "sem_ir", Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-          map.Add("names", names().OutputYaml());
-          map.Add("import_irs", import_irs_.OutputYaml());
-          map.Add("import_ir_insts", import_ir_insts_.OutputYaml());
-          map.Add("clang_decls", clang_decls_.OutputYaml());
-          map.Add("clang_decl_signatures", clang_decl_signatures_.OutputYaml());
-          map.Add("name_scopes", name_scopes_.OutputYaml());
-          map.Add("entity_names", entity_names_.OutputYaml());
-          map.Add("cpp_global_vars", cpp_global_vars_.OutputYaml());
-          map.Add("functions", functions_.OutputYaml());
-          map.Add("classes", classes_.OutputYaml());
-          map.Add("interfaces", interfaces_.OutputYaml());
-          map.Add("associated_constants", associated_constants_.OutputYaml());
-          map.Add("impls", impls_.OutputYaml());
-          map.Add("generics", generics_.OutputYaml());
-          map.Add("specifics", specifics_.OutputYaml());
-          map.Add("specific_interfaces", specific_interfaces_.OutputYaml());
-          map.Add("struct_type_fields", struct_type_fields_.OutputYaml());
-          map.Add("types", types_.OutputYaml());
-          map.Add("facet_types", facet_types_.OutputYaml());
-          map.Add("insts",
-                  Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                    for (auto [id, inst] : insts_.enumerate()) {
-                      inst.CacheBundleDebugKinds(bundles_);
-                      if (!include_singletons && IsSingletonInstId(id)) {
-                        continue;
-                      }
-                      map.Add(PrintToString(id), Yaml::OutputScalar(inst));
-                    }
-                  }));
-          map.Add("bundles", bundles_.OutputYaml());
-          map.Add("constant_values",
-                  constant_values_.OutputYaml(include_singletons));
-          map.Add("inst_blocks", inst_blocks_.OutputYaml());
-          map.Add("value_stores", value_stores_->OutputYaml());
-        }));
+    map.Add("sem_ir", Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+      map.Add("names", names().OutputYaml());
+      map.Add("import_irs", import_irs_.OutputYaml());
+      map.Add("import_ir_insts", import_ir_insts_.OutputYaml());
+      map.Add("clang_decls", clang_decls_.OutputYaml());
+      map.Add("clang_decl_signatures", clang_decl_signatures_.OutputYaml());
+      map.Add("name_scopes", name_scopes_.OutputYaml());
+      map.Add("entity_names", entity_names_.OutputYaml());
+      map.Add("cpp_global_vars", cpp_global_vars_.OutputYaml());
+      map.Add("functions", functions_.OutputYaml());
+      map.Add("classes", classes_.OutputYaml());
+      map.Add("interfaces", interfaces_.OutputYaml());
+      map.Add("associated_constants", associated_constants_.OutputYaml());
+      map.Add("impls", impls_.OutputYaml());
+      map.Add("generics", generics_.OutputYaml());
+      map.Add("specifics", specifics_.OutputYaml());
+      map.Add("specific_interfaces", specific_interfaces_.OutputYaml());
+      map.Add("struct_type_fields", struct_type_fields_.OutputYaml());
+      map.Add("types", types_.OutputYaml());
+      map.Add("facet_types", facet_types_.OutputYaml());
+      map.Add("insts", Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+        for (auto [id, inst] : insts_.enumerate()) {
+          inst.CacheBundleDebugKinds(bundles_);
+          if (!include_singletons && IsSingletonInstId(id)) {
+            continue;
+          }
+          map.Add(PrintToString(id), Yaml::OutputScalar(inst));
+        }
+      }));
+      map.Add("bundles", bundles_.OutputYaml());
+      map.Add("constant_values",
+              constant_values_.OutputYaml(include_singletons));
+      map.Add("inst_blocks", inst_blocks_.OutputYaml());
+      map.Add("value_stores", value_stores_->OutputYaml());
+    }));
   });
 }
 

--- a/toolchain/sem_ir/generic.cpp
+++ b/toolchain/sem_ir/generic.cpp
@@ -34,13 +34,10 @@ auto SpecificStore::GetOrAdd(GenericId generic_id, InstBlockId args_id)
     -> SpecificId {
   CARBON_CHECK(generic_id.has_value());
   return lookup_table_
-      .Insert(
-          KeyContext::Key{.generic_id = generic_id, .args_id = args_id},
-          [&] {
-            return specifics_.Add(
-                {.generic_id = generic_id, .args_id = args_id});
-          },
-          KeyContext(&specifics_))
+      .Insert(KeyContext::Key{.generic_id = generic_id, .args_id = args_id},
+              [&] {
+    return specifics_.Add({.generic_id = generic_id, .args_id = args_id});
+  }, KeyContext(&specifics_))
       .key();
 }
 

--- a/toolchain/sem_ir/id_kind.h
+++ b/toolchain/sem_ir/id_kind.h
@@ -145,14 +145,14 @@ class IdAndKind {
     static constexpr std::array<DispatchFnT<R, F>*, TypeEnum<Ids...>::NumValues>
         Table = {
             [](F&& f, int32_t id) -> R {
-              return std::forward<F>(f)(SemIR::FromRaw<Ids>(id));
-            }...,
+      return std::forward<F>(f)(SemIR::FromRaw<Ids>(id));
+    }...,
             [](F&& f, int32_t /*id*/) -> R {
-              return std::forward<F>(f)(InvalidType{});
-            },
+      return std::forward<F>(f)(InvalidType{});
+    },
             [](F&& f, int32_t /*id*/) -> R {
-              return std::forward<F>(f)(NoneType{});
-            },
+      return std::forward<F>(f)(NoneType{});
+    },
         };
     return Table[id_kind.ToIndex()];
   }

--- a/toolchain/sem_ir/impl.cpp
+++ b/toolchain/sem_ir/impl.cpp
@@ -34,9 +34,9 @@ auto ImplStore::GetOrAddLookupBucket(const Impl& impl) -> LookupBucketRef {
   }
   return LookupBucketRef(
       *this, lookup_
-                 .Insert(std::pair{self_const_id, impl_as_interface},
-                         [] { return ImplOrLookupBucketId::None; })
-                 .value());
+                 .Insert(std::pair{self_const_id, impl_as_interface}, [] {
+    return ImplOrLookupBucketId::None;
+  }).value());
 }
 
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -262,21 +262,18 @@ class TypeStore : public Yaml::Printable<TypeStore> {
         auto info = GetCompleteTypeInfo(type_id);
         map.Add(PrintToString(type_id),
                 Yaml::OutputMapping([&](Yaml::OutputMapping::Map map2) {
-                  map2.Add("value_repr", Yaml::OutputScalar(info.value_repr));
-                  map2.Add(
-                      "object_layout",
-                      Yaml::OutputMapping([&](Yaml::OutputMapping::Map map3) {
-                        map3.Add("size",
-                                 Yaml::OutputScalar(info.object_layout.size));
-                        map3.Add(
-                            "alignment",
-                            Yaml::OutputScalar(info.object_layout.alignment));
-                      }));
-                  if (info.abstract_class_id.has_value()) {
-                    map2.Add("abstract_class_id",
-                             Yaml::OutputScalar(info.abstract_class_id));
-                  }
-                }));
+          map2.Add("value_repr", Yaml::OutputScalar(info.value_repr));
+          map2.Add("object_layout",
+                   Yaml::OutputMapping([&](Yaml::OutputMapping::Map map3) {
+            map3.Add("size", Yaml::OutputScalar(info.object_layout.size));
+            map3.Add("alignment",
+                     Yaml::OutputScalar(info.object_layout.alignment));
+          }));
+          if (info.abstract_class_id.has_value()) {
+            map2.Add("abstract_class_id",
+                     Yaml::OutputScalar(info.abstract_class_id));
+          }
+        }));
       }
     });
   }

--- a/toolchain/testing/file_test.cpp
+++ b/toolchain/testing/file_test.cpp
@@ -199,10 +199,10 @@ auto ToolchainFileTest::Run(
   // the prelude. Note this can empty out the list.
   llvm::erase_if(result.per_file_success,
                  [&](std::pair<llvm::StringRef, bool> entry) {
-                   return entry.first == "." || entry.first == "-" ||
-                          entry.first.starts_with("not_file") ||
-                          llvm::is_contained(data_->prelude_files, entry.first);
-                 });
+    return entry.first == "." || entry.first == "-" ||
+           entry.first.starts_with("not_file") ||
+           llvm::is_contained(data_->prelude_files, entry.first);
+  });
 
   if (component_ == "language_server") {
     // The language server doesn't always add a suffix newline, so add one for

--- a/toolchain/testing/yaml_test_helpers.cpp
+++ b/toolchain/testing/yaml_test_helpers.cpp
@@ -68,14 +68,12 @@ static auto Parse(llvm::yaml::Node* node) -> Value {
 auto Value::FromText(llvm::StringRef text) -> ErrorOr<SequenceValue> {
   llvm::SourceMgr sm;
   std::optional<std::string> error_message;
-  sm.setDiagHandler(
-      [](const llvm::SMDiagnostic& diag, void* context) -> void {
-        auto* error_message = static_cast<std::optional<std::string>*>(context);
-        RawStringOstream stream;
-        diag.print(/*ProgName=*/nullptr, stream, /*ShowColors=*/false);
-        *error_message = stream.TakeStr();
-      },
-      &error_message);
+  sm.setDiagHandler([](const llvm::SMDiagnostic& diag, void* context) -> void {
+    auto* error_message = static_cast<std::optional<std::string>*>(context);
+    RawStringOstream stream;
+    diag.print(/*ProgName=*/nullptr, stream, /*ShowColors=*/false);
+    *error_message = stream.TakeStr();
+  }, &error_message);
   llvm::yaml::Stream yaml_stream(text, sm);
 
   SequenceValue result;


### PR DESCRIPTION
Avoids formatting lambdas with a large amount of indentation, as this leaves few columns for the lambda body, which hurts readability.