### PR TITLE
WIP: fix `pre_commit.yaml` workflow vulnerability

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -5,7 +5,12 @@
 name: pre-commit
 
 on:
-  pull_request:
+  pull_request_target:
+    # It is possible to inject malicious commands into the this workflow by modifying
+    # the .pre-commit-config.yaml file to contain directives for reviewdog. To prevent
+    # this we ignore any workflows that include modifications to this file.
+    paths-ignore:
+      - '.pre-commit-config.yaml'
   merge_group:
   push:
     branches: [trunk]

--- a/.github/workflows/pre_commit_suggestions.yaml
+++ b/.github/workflows/pre_commit_suggestions.yaml
@@ -28,7 +28,7 @@ jobs:
     # Only generate suggestions if pre-commit for a PR failed.
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
This patch makes two changes to the GitHub `pre_commit` Workflow:
 - Changes the pre_commit hook from `pull_request` to `pull_request_target` so that a PR with a compromised `pre_commit` workflow will not execute the new changes to the workflow in the PR, because the workflow will source from the upstream file.
 - Adds a condition to not run the pre_commit workflow if the `.pre-commit-config.yaml` file has been modified, preventing malicious reviewdog configurations from automatically running.

To test I would like to merge this PR and then I will try a few other PRs to make sure the two changes have taken effect.