### PR TITLE
Makes impls constraints available to use in later constraints within a facet type

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -252,21 +252,26 @@ class Context {
     return poisoned_concrete_impl_lookup_queries_;
   }
 
-  // A stack that tracks the rewrite constraints from a `where` expression being
-  // checked. The back of the stack is the currently checked `where` expression.
-  auto rewrites_stack()
-      -> llvm::SmallVector<Map<SemIR::ConstantId, SemIR::InstId>>& {
-    return rewrites_stack_;
-  }
+  // A stack that tracks constraints from a `where` expression being checked.
+  // The back of the stack is the currently checked `where` expression.
+  struct WhereStackEntry {
+    // A map from an ImplWitnessAccess on the LHS of a rewrite constraint to its
+    // value on the RHS. Used during checking of a `where` expression to allow
+    // constraints to access values from earlier constraints.
+    Map<SemIR::ConstantId, SemIR::InstId> rewrites;
 
-  // A stack of tracks the impls constraints from a `where` expression being
-  // checked. The back of the stack is the currently checked `where` expression.
-  struct ImplsStackEntry {
-    SemIR::ConstantId self_const_id;
-    SemIR::ConstantId facet_type_const_id;
+    // A collection of `A impls B` facts known about the current `where`
+    // expression being checked. Used to allow constraints to know about `impls`
+    // relationships from earlier constraints.
+    struct SelfImplsFacetType {
+      SemIR::ConstantId self_const_id;
+      SemIR::ConstantId facet_type_const_id;
+    };
+    llvm::SmallVector<SelfImplsFacetType> impls;
   };
-  auto impls_stack() -> llvm::SmallVector<llvm::SmallVector<ImplsStackEntry>>& {
-    return impls_stack_;
+
+  auto where_stack() -> llvm::SmallVector<WhereStackEntry>& {
+    return where_stack_;
   }
 
   // Data about a form expression.
@@ -543,15 +548,9 @@ class Context {
   llvm::SmallVector<PoisonedConcreteImplLookupQuery>
       poisoned_concrete_impl_lookup_queries_;
 
-  // A map from an ImplWitnessAccess on the LHS of a rewrite constraint to its
-  // value on the RHS. Used during checking of a `where` expression to allow
-  // constraints to access values from earlier constraints.
-  llvm::SmallVector<Map<SemIR::ConstantId, SemIR::InstId>> rewrites_stack_;
-
-  // A collection of `A impls B` facts known about the current `where`
-  // expression being checked. Used to allow constraints to know about `impls`
-  // relationships from earlier constraints.
-  llvm::SmallVector<llvm::SmallVector<ImplsStackEntry>> impls_stack_;
+  // Tracks information about constraints in the current `where` expression
+  // being checked so that they can be used by later constraints.
+  llvm::SmallVector<WhereStackEntry> where_stack_;
 
   // Declared return form for the in-progress function declaration, if any.
   std::optional<FormExpr> return_form_expr_;

--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -259,6 +259,16 @@ class Context {
     return rewrites_stack_;
   }
 
+  // A stack of tracks the impls constraints from a `where` expression being
+  // checked. The back of the stack is the currently checked `where` expression.
+  struct ImplsStackEntry {
+    SemIR::ConstantId self_const_id;
+    SemIR::ConstantId facet_type_const_id;
+  };
+  auto impls_stack() -> llvm::SmallVector<llvm::SmallVector<ImplsStackEntry>>& {
+    return impls_stack_;
+  }
+
   // Data about a form expression.
   //
   // TODO: consider moving this out of Context.
@@ -537,6 +547,11 @@ class Context {
   // value on the RHS. Used during checking of a `where` expression to allow
   // constraints to access values from earlier constraints.
   llvm::SmallVector<Map<SemIR::ConstantId, SemIR::InstId>> rewrites_stack_;
+
+  // A collection of `A impls B` facts known about the current `where`
+  // expression being checked. Used to allow constraints to know about `impls`
+  // relationships from earlier constraints.
+  llvm::SmallVector<llvm::SmallVector<ImplsStackEntry>> impls_stack_;
 
   // Declared return form for the in-progress function declaration, if any.
   std::optional<FormExpr> return_form_expr_;

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -20,6 +20,32 @@
 
 namespace Carbon::Check {
 
+static auto GetExtendedOnlyFacetType(Context& context,
+                                     const SemIR::FacetType& facet_type)
+    -> SemIR::TypeId {
+  const auto& info = context.facet_types().Get(facet_type.facet_type_id);
+  auto stripped_info = SemIR::FacetTypeInfo::ExtendedOnly(info);
+  stripped_info.Canonicalize();
+  return GetFacetType(context, stripped_info);
+}
+
+static auto GetPeriodSelfType(Context& context,
+                              SemIR::TypeId facet_type_type_id)
+    -> SemIR::TypeId {
+  if (auto facet_type =
+          context.types().TryGetAs<SemIR::FacetType>(facet_type_type_id)) {
+    return GetExtendedOnlyFacetType(context, *facet_type);
+  } else if (facet_type_type_id == SemIR::TypeType::TypeId) {
+    // The self may be `TypeType` in `type where X impls Y`, so we use an empty
+    // facet type.
+    return GetEmptyFacetType(context);
+  } else {
+    CARBON_CHECK(facet_type_type_id == SemIR::ErrorInst::TypeId,
+                 "unexpected .Self type {0}", facet_type_type_id);
+    return SemIR::ErrorInst::TypeId;
+  }
+}
+
 auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
   // The expression at the top of the stack represents a constraint type that
   // is being modified by the `where` operator. It would be `MyInterface` in
@@ -48,21 +74,8 @@ auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
   // Any references to `.Self` in constraints for the current `WhereExpr` will
   // not see constraints in the `Self` facet type, but they will resolve to
   // values through the constraints explicitly when they are combined together.
-  auto period_self_type_id = self_with_constraints_type_id;
-  if (auto facet_type =
-          context.types().TryGetAs<SemIR::FacetType>(period_self_type_id)) {
-    const auto& info = context.facet_types().Get(facet_type->facet_type_id);
-    auto stripped_info = SemIR::FacetTypeInfo::ExtendedOnly(info);
-    stripped_info.Canonicalize();
-    period_self_type_id = GetFacetType(context, stripped_info);
-  } else if (period_self_type_id == SemIR::TypeType::TypeId) {
-    // The self may be `TypeType` in `type where X impls Y`, so we use an empty
-    // facet type.
-    period_self_type_id = GetEmptyFacetType(context);
-  } else {
-    CARBON_CHECK(period_self_type_id == SemIR::ErrorInst::TypeId,
-                 "unexpected .Self type {0}", period_self_type_id);
-  }
+  auto period_self_type_id =
+      GetPeriodSelfType(context, self_with_constraints_type_id);
 
   // Introduce a name scope so that we can remove the `.Self` entry we are
   // adding to name lookup at the end of the `where` expression.
@@ -86,6 +99,7 @@ auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
   // Add a context stack for tracking rewrite constraints, that will be used to
   // allow later constraints to read from them eagerly.
   context.rewrites_stack().emplace_back();
+  context.impls_stack().emplace_back();
 
   // Make rewrite constraints from the self facet type available immediately to
   // expressions in rewrite constraints for this `where` expression.
@@ -160,6 +174,27 @@ auto HandleParseNode(Context& context, Parse::RequirementEqualEqualId node_id)
   return true;
 }
 
+static auto IsPeriodSelfAccess(Context& context, SemIR::InstId inst_id)
+    -> bool {
+  while (true) {
+    if (IsPeriodSelf(context, inst_id)) {
+      return true;
+    }
+    // Recurse through ImplWitnessAccess into the self type being accessed.
+    auto access = context.insts().TryGetAs<SemIR::ImplWitnessAccess>(
+        GetImplWitnessAccessWithoutSubstitution(context, inst_id));
+    if (!access) {
+      return false;
+    }
+    auto lookup =
+        context.insts().TryGetAs<SemIR::LookupImplWitness>(access->witness_id);
+    if (!lookup) {
+      return false;
+    }
+    inst_id = lookup->query_self_inst_id;
+  }
+}
+
 auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
     -> bool {
   auto [rhs_node, rhs_id] = context.node_stack().PopExprWithNodeId();
@@ -174,6 +209,7 @@ auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
         ImplsOnNonFacetType, Error,
         "right argument of `impls` requirement must be a facet type");
     context.emitter().Emit(rhs_node, ImplsOnNonFacetType);
+    rhs_as_type.type_id = SemIR::ErrorInst::TypeId;
     rhs_as_type.inst_id = SemIR::ErrorInst::TypeInstId;
   }
   // TODO: Require that at least one side uses a designator.
@@ -182,6 +218,7 @@ auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
 
   if (FindAndDiagnoseAmbiguousPeriodSelf(context, lhs_as_type.inst_id,
                                          rhs_id)) {
+    rhs_as_type.type_id = SemIR::ErrorInst::TypeId;
     rhs_as_type.inst_id = SemIR::ErrorInst::TypeInstId;
   }
 
@@ -190,6 +227,34 @@ auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
       AddInstInNoBlock<SemIR::RequirementImpls>(
           context, node_id,
           {.lhs_id = lhs_as_type.inst_id, .rhs_id = rhs_as_type.inst_id}));
+
+  if (lhs_as_type.inst_id != SemIR::ErrorInst::InstId &&
+      rhs_as_type.inst_id != SemIR::ErrorInst::InstId &&
+      rhs_as_type.inst_id != SemIR::TypeType::TypeInstId) {
+    // Track the impls relationship so further constraints can use it
+    // immediately, before they are evaluated. Impl lookup will search the top
+    // of the stack.
+    context.impls_stack().back().push_back({
+        context.constant_values().Get(lhs_as_type.inst_id),
+        context.constant_values().Get(rhs_as_type.inst_id),
+    });
+
+    // Track any rewrites that are inherited from the impls constraint as the
+    // LHS can be referring to `.Self` or a member of it, which makes those
+    // rewrites modification of this facet type's self.
+    if (IsPeriodSelfAccess(context, lhs_as_type.inst_id)) {
+      auto facet_type =
+          context.types().GetAs<SemIR::FacetType>(rhs_as_type.type_id);
+      const auto& facet_type_info =
+          context.facet_types().Get(facet_type.facet_type_id);
+      for (const auto& rewrite : facet_type_info.rewrite_constraints) {
+        auto lhs = SubstPeriodSelf(
+            context, rhs_node, context.constant_values().Get(rewrite.lhs_id),
+            context.constant_values().Get(lhs_as_type.inst_id));
+        context.rewrites_stack().back().Insert(lhs, rewrite.rhs_id);
+      }
+    }
+  }
   return true;
 }
 
@@ -343,6 +408,7 @@ static auto FindDesignator(Context& context,
 }
 
 auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
+  context.impls_stack().pop_back();
   context.rewrites_stack().pop_back();
   // Remove `PeriodSelf` from name lookup, undoing the `Push` done for the
   // `WhereOperand`.

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -228,9 +228,9 @@ auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
           context, node_id,
           {.lhs_id = lhs_as_type.inst_id, .rhs_id = rhs_as_type.inst_id}));
 
-  if (lhs_as_type.inst_id != SemIR::ErrorInst::InstId &&
-      rhs_as_type.inst_id != SemIR::ErrorInst::InstId &&
-      rhs_as_type.inst_id != SemIR::TypeType::TypeInstId) {
+  if (lhs_as_type.type_id != SemIR::ErrorInst::TypeId &&
+      rhs_as_type.type_id != SemIR::ErrorInst::TypeId &&
+      rhs_as_type.type_id != SemIR::TypeType::TypeId) {
     // Track the impls relationship so further constraints can use it
     // immediately, before they are evaluated. Impl lookup will search the top
     // of the stack.

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -96,10 +96,9 @@ auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
           context, SemIR::LocId(node_id),
           {.base_type_inst_id = context.types().GetAsTypeInstId(self_id)}));
 
-  // Add a context stack for tracking rewrite constraints, that will be used to
-  // allow later constraints to read from them eagerly.
-  context.rewrites_stack().emplace_back();
-  context.impls_stack().emplace_back();
+  // Add a context stack for tracking constraints, that will be used to allow
+  // later constraints to read from them eagerly.
+  context.where_stack().emplace_back();
 
   // Make rewrite constraints from the self facet type available immediately to
   // expressions in rewrite constraints for this `where` expression.
@@ -109,7 +108,7 @@ auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
         context.facet_types().Get(self_facet_type->facet_type_id);
     for (const auto& rewrite : base_facet_type_info.rewrite_constraints) {
       if (rewrite.lhs_id != SemIR::ErrorInst::InstId) {
-        context.rewrites_stack().back().Insert(
+        context.where_stack().back().rewrites.Insert(
             context.constant_values().Get(
                 GetImplWitnessAccessWithoutSubstitution(context,
                                                         rewrite.lhs_id)),
@@ -152,7 +151,7 @@ auto HandleParseNode(Context& context, Parse::RequirementEqualId node_id)
     // immediately, before they are evaluated. This happens directly where the
     // `ImplWitnessAccess` that refers to the rewrite constraint would have been
     // created, and the value of the constraint will be used instead.
-    context.rewrites_stack().back().Insert(
+    context.where_stack().back().rewrites.Insert(
         context.constant_values().Get(
             GetImplWitnessAccessWithoutSubstitution(context, lhs_id)),
         rhs_id);
@@ -174,8 +173,13 @@ auto HandleParseNode(Context& context, Parse::RequirementEqualEqualId node_id)
   return true;
 }
 
+// Returns whether `inst_id` is `.Self` or an access into `.Self`, possibly
+// nested.
 static auto IsPeriodSelfAccess(Context& context, SemIR::InstId inst_id)
     -> bool {
+  // Walks through nested `ImplWitnessAccess(LookupImplWitness(...))`
+  // instructions until it either finds `.Self` and returns true, or finds
+  // anything else and returns false.
   while (true) {
     if (IsPeriodSelf(context, inst_id)) {
       return true;
@@ -234,7 +238,7 @@ auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
     // Track the impls relationship so further constraints can use it
     // immediately, before they are evaluated. Impl lookup will search the top
     // of the stack.
-    context.impls_stack().back().push_back({
+    context.where_stack().back().impls.push_back({
         context.constant_values().Get(lhs_as_type.inst_id),
         context.constant_values().Get(rhs_as_type.inst_id),
     });
@@ -251,7 +255,7 @@ auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
         auto lhs = SubstPeriodSelf(
             context, rhs_node, context.constant_values().Get(rewrite.lhs_id),
             context.constant_values().Get(lhs_as_type.inst_id));
-        context.rewrites_stack().back().Insert(lhs, rewrite.rhs_id);
+        context.where_stack().back().rewrites.Insert(lhs, rewrite.rhs_id);
       }
     }
   }
@@ -408,8 +412,7 @@ static auto FindDesignator(Context& context,
 }
 
 auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
-  context.impls_stack().pop_back();
-  context.rewrites_stack().pop_back();
+  context.where_stack().pop_back();
   // Remove `PeriodSelf` from name lookup, undoing the `Push` done for the
   // `WhereOperand`.
   context.scope_stack().Pop(/*check_unused=*/true);

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -380,8 +380,8 @@ static auto CollectFacetWitnessSources(
       }
     }
 
-    if (!context.impls_stack().empty()) {
-      const auto& impls = context.impls_stack().back();
+    if (!context.where_stack().empty()) {
+      const auto& impls = context.where_stack().back().impls;
       for (auto [self_const_id, facet_type_const_id] : impls) {
         if (self_const_id != facet_const_id) {
           continue;

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -366,18 +366,38 @@ static auto CollectFacetWitnessSources(
   llvm::SmallVector<FacetWitnessSource> witnesses;
 
   auto push_facet = [&](SemIR::InstId facet, bool allow_partially_identified) {
-    auto type_id = context.insts().Get(facet).type_id();
-    if (type_id == SemIR::TypeType::TypeId) {
-      return;
-    }
     auto facet_const_id = context.constant_values().Get(facet);
-    auto facet_type = context.types().GetAs<SemIR::FacetType>(type_id);
-    auto identified_id =
-        TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
-                               allow_partially_identified);
-    if (identified_id.has_value()) {
-      witnesses.push_back({.facet_const_id = facet_const_id,
-                           .identified_facet_type_id = identified_id});
+
+    auto type_id = context.insts().Get(facet).type_id();
+    if (type_id != SemIR::TypeType::TypeId) {
+      auto facet_type = context.types().GetAs<SemIR::FacetType>(type_id);
+      auto identified_id =
+          TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
+                                 allow_partially_identified);
+      if (identified_id.has_value()) {
+        witnesses.push_back({.facet_const_id = facet_const_id,
+                             .identified_facet_type_id = identified_id});
+      }
+    }
+
+    if (!context.impls_stack().empty()) {
+      const auto& impls = context.impls_stack().back();
+      for (auto [self_const_id, facet_type_const_id] : impls) {
+        if (self_const_id != facet_const_id) {
+          continue;
+        }
+        // TypeType is never stored in the impls stack, so we always have a
+        // FacetType.
+        auto facet_type = context.constant_values().GetInstAs<SemIR::FacetType>(
+            facet_type_const_id);
+        auto identified_id =
+            TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
+                                   allow_partially_identified);
+        if (identified_id.has_value()) {
+          witnesses.push_back({.facet_const_id = facet_const_id,
+                               .identified_facet_type_id = identified_id});
+        }
+      }
     }
   };
 

--- a/toolchain/check/member_access.cpp
+++ b/toolchain/check/member_access.cpp
@@ -184,8 +184,8 @@ static auto PerformImplWitnessAccessAndSubstitute(
   auto access_id =
       GetOrAddInst<SemIR::ImplWitnessAccess>(context, loc_id, access);
 
-  if (!context.rewrites_stack().empty()) {
-    if (auto result = context.rewrites_stack().back().Lookup(
+  if (!context.where_stack().empty()) {
+    if (auto result = context.where_stack().back().rewrites.Lookup(
             context.constant_values().Get(access_id))) {
       return GetOrAddInst<SemIR::ImplWitnessAccessSubstituted>(
           context, loc_id,

--- a/toolchain/check/testdata/facet/early_impls.carbon
+++ b/toolchain/check/testdata/facet/early_impls.carbon
@@ -1,0 +1,36 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/convert.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/facet/early_impls.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/early_impls.carbon
+
+// Tests that `.X impls Y` in a facet type is available in later constraints of
+// the same facet type.
+
+// --- member_access_uses_impls_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+  let Z2:! type;
+}
+interface Y {
+  let Y1:! type;
+}
+
+fn F(_:! Z where .Z1 impls Y and .Z2 = .Z1.(Y.Y1)) {
+}
+
+class C(T:! type);
+constraint X {
+  require C(Self) impls Y;
+}
+
+fn G(_:! Z where .Z1 impls X and .Z2 = C(.Z1).(Y.Y1)) {
+}

--- a/toolchain/check/testdata/facet/early_rewrites.carbon
+++ b/toolchain/check/testdata/facet/early_rewrites.carbon
@@ -383,3 +383,18 @@ impl D as Z where .Z1 = .Self and .Z2 = () and .Z3 = C(()) {}
 fn G(T:! J where .J1 = D) {
   F(T);
 }
+
+// --- early_rewrite_from_previous_impls_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+  let Z2:! type;
+}
+interface Y {
+  let Y1:! type;
+}
+
+fn F(T:! Z where .Z1 impls (Y where .Y1 = ()) and .Z2 = .Z1.(Y.Y1)) -> T.Z2 {
+  return ();
+}


### PR DESCRIPTION
If a facet type contains `.X impls Y` then later references to `.X` should know that it impls `Y`. This is done through a stack on the context like for rewrites, where impl lookup can find constraints from the current `where` expression being checked.

Similarly, if a facet type contains `.X impls (Y where .Z = T)`, then `.X.(Y.Z) = T` should be available to later constraints in the facet type for early application of rewrite rules. We add these rewrites to the rewrite stack when handling the `impls` constraint