### PR TITLE
Support jj workspaces

### DIFF
--- a/scripts/workspace_status.py
+++ b/scripts/workspace_status.py
@@ -49,7 +49,7 @@ def jj_commit_sha() -> str:
 
 
 def jj_dirty_suffix() -> str:
-    # This `jj log` returns "true" if the current working copy is empty,
+    # This `jj log` template returns "true" if the current working copy is empty,
     # otherwise "false".
     status = subprocess.check_output(
         ["jj", "log", "-r", "@", "--no-graph", "-T", "empty"], encoding="utf-8"

--- a/scripts/workspace_status.py
+++ b/scripts/workspace_status.py
@@ -12,7 +12,18 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """
 
+import os
 import subprocess
+import sys
+
+
+def use_jj() -> bool:
+    if os.path.isdir(".jj"):
+        return True
+    elif os.path.exists(".git"):
+        return False
+    print("Can't tell whether to use jj or git:", os.getcwd())
+    sys.exit(1)
 
 
 def git_commit_sha() -> str:
@@ -28,9 +39,31 @@ def git_dirty_suffix() -> str:
     return ".dirty" if len(status) > 0 else ""
 
 
+def jj_commit_sha() -> str:
+    # Get the first 9 characters of the commit id of the parent of the current
+    # working copy.
+    return subprocess.check_output(
+        ["jj", "log", "-r", "@-", "--no-graph", "-T", "commit_id.shortest(9)"],
+        encoding="utf-8",
+    ).strip()
+
+
+def jj_dirty_suffix() -> str:
+    # This `jj log` returns "true" if the current working copy is empty,
+    # otherwise "false".
+    status = subprocess.check_output(
+        ["jj", "log", "-r", "@", "--no-graph", "-T", "empty"], encoding="utf-8"
+    ).strip()
+    return ".dirty" if status == "false" else ""
+
+
 def main() -> None:
-    print("STABLE_GIT_COMMIT_SHA " + git_commit_sha())
-    print("STABLE_GIT_DIRTY_SUFFIX " + git_dirty_suffix())
+    if use_jj():
+        print("STABLE_GIT_COMMIT_SHA " + jj_commit_sha())
+        print("STABLE_GIT_DIRTY_SUFFIX " + jj_dirty_suffix())
+    else:
+        print("STABLE_GIT_COMMIT_SHA " + git_commit_sha())
+        print("STABLE_GIT_DIRTY_SUFFIX " + git_dirty_suffix())
 
 
 if __name__ == "__main__":

--- a/scripts/workspace_status.py
+++ b/scripts/workspace_status.py
@@ -49,8 +49,8 @@ def jj_commit_sha() -> str:
 
 
 def jj_dirty_suffix() -> str:
-    # This `jj log` template returns "true" if the current working copy is empty,
-    # otherwise "false".
+    # This `jj log` template returns "true" if the current working copy is
+    # empty, otherwise "false".
     status = subprocess.check_output(
         ["jj", "log", "-r", "@", "--no-graph", "-T", "empty"], encoding="utf-8"
     ).strip()


### PR DESCRIPTION
In particular, bazel builds would previously fail in `workspace_status.py` if you didn't have a `.git` with this error:

> ```
> ERROR: <builtin>: BazelWorkspaceStatusAction stable-status.txt failed: Failed to determine workspace status: Process exited with status 1
> fatal: not a git repository (or any of the parent directories): .git
> ```

Assisted-by: Google Antigravity
