### PR TITLE
Support jj workspaces in suggested jj abandon-untagged alias

### DIFF
--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -261,7 +261,7 @@ If you use `jj`, you may find the following configuration snippets (added to
 
 ```sh
 # Clean up untracked or abandoned commits.
-jj config set --user aliases.abandon-untagged '["abandon", "all() & ~ancestors(@ | bookmarks() | remote_bookmarks())"]'
+jj config set --user aliases.abandon-untagged '["abandon", "~ancestors(working_copies() | bookmarks() | remote_bookmarks())"]'
 
 # Use Git-style conflict markers, which VS Code can provide merge support for.
 jj config set --user ui.conflict-marker-style 'git'


### PR DESCRIPTION
`@` refers to the current workspace's working copy, but if we want the command to respect the working copies of other workspaces, we should use `working_copies()` instead; see https://docs.jj-vcs.dev/latest/revsets/#functions .

Also remove `all() &` while here, since it is always redundant.

Assisted-by: Google Antigravity