### PR TITLE
Support use of Carbon toolchain as a bazel module

### DIFF
--- a/bazel/carbon_rules/defs.bzl
+++ b/bazel/carbon_rules/defs.bzl
@@ -188,7 +188,7 @@ def carbon_binary(name, srcs, deps = [], flags = [], tags = []):
     _carbon_binary_internal(
         name = name,
         srcs = srcs,
-        prelude_srcs = ["//core:prelude_files"],
+        prelude_srcs = [Label("//core:prelude_files")],
         deps = deps,
         flags = flags,
         tags = tags,
@@ -198,27 +198,33 @@ def carbon_binary(name, srcs, deps = [], flags = [], tags = []):
         # but that isn't `select`-able. Instead, we have both attributes and
         # `select` which one we use.
         internal_exec_toolchain_driver = select({
-            "//bazel/carbon_rules:use_target_config_carbon_rules_config": None,
-            "//conditions:default": "//toolchain/install:carbon-busybox",
+            Label("//bazel/carbon_rules:use_target_config_carbon_rules_config"): None,
+            "//conditions:default": Label("//toolchain/install:carbon-busybox"),
         }),
         internal_exec_toolchain_data = select({
-            "//bazel/carbon_rules:use_target_config_carbon_rules_config": None,
-            "//conditions:default": "//toolchain/install:install_data",
+            Label("//bazel/carbon_rules:use_target_config_carbon_rules_config"): None,
+            "//conditions:default": Label("//toolchain/install:install_data"),
         }),
         internal_exec_prebuilt_runtimes = select({
-            "//bazel/carbon_rules:use_target_config_carbon_rules_config": None,
-            "//conditions:default": "//toolchain/install:built_runtimes",
+            Label("//bazel/carbon_rules:use_target_config_carbon_rules_config"): None,
+            "//conditions:default": Label("//toolchain/install:built_runtimes"),
         }),
         internal_target_toolchain_driver = select({
-            "//bazel/carbon_rules:use_target_config_carbon_rules_config": "//toolchain/install:carbon-busybox",
+            Label(
+                "//bazel/carbon_rules:use_target_config_carbon_rules_config",
+            ): Label("//toolchain/install:carbon-busybox"),
             "//conditions:default": None,
         }),
         internal_target_toolchain_data = select({
-            "//bazel/carbon_rules:use_target_config_carbon_rules_config": "//toolchain/install:install_data",
+            Label(
+                "//bazel/carbon_rules:use_target_config_carbon_rules_config",
+            ): Label("//toolchain/install:install_data"),
             "//conditions:default": None,
         }),
         internal_target_prebuilt_runtimes = select({
-            "//bazel/carbon_rules:use_target_config_carbon_rules_config": "//toolchain/install:built_runtimes",
+            Label(
+                "//bazel/carbon_rules:use_target_config_carbon_rules_config",
+            ): Label("//toolchain/install:built_runtimes"),
             "//conditions:default": None,
         }),
     )

--- a/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
+++ b/bazel/cc_toolchains/clang_cc_toolchain_config.bzl
@@ -6,6 +6,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 load(":cc_toolchain_carbon_project_features.bzl", "carbon_project_features")
 load(":cc_toolchain_cpp_features.bzl", "libcxx_feature")
 load(":cc_toolchain_features.bzl", "clang_cc_toolchain_features")

--- a/bazel/cc_toolchains/defs.bzl
+++ b/bazel/cc_toolchains/defs.bzl
@@ -41,6 +41,6 @@ def cc_env():
     macos_env = {"MallocNanoZone": "0"}
 
     return common_env | select({
-        "//bazel/cc_toolchains:macos_asan": macos_env,
+        Label("//bazel/cc_toolchains:macos_asan"): macos_env,
         "//conditions:default": {},
     })

--- a/bazel/manifest/defs.bzl
+++ b/bazel/manifest/defs.bzl
@@ -13,8 +13,16 @@ def _get_files(ctx):
         # Files may or may not be prefixed with the bin directory, and then
         # may or may not be prefixed with the package directory. Strip both.
         bin_dir = ctx.bin_dir.path + "/"
+        workspace_root = (
+            ctx.label.workspace_root + "/" if ctx.label.workspace_root else ""
+        )
         package_dir = ctx.label.package + "/"
-        files_stripped = [f.removeprefix(bin_dir).removeprefix(package_dir) for f in files]
+        files_stripped = [
+            f.removeprefix(bin_dir)
+                .removeprefix(workspace_root)
+                .removeprefix(package_dir)
+            for f in files
+        ]
     else:
         files_stripped = files
 

--- a/bazel/version/rules.bzl
+++ b/bazel/version/rules.bzl
@@ -135,7 +135,7 @@ def expand_version_build_info(name, **kwargs):
     expand_version_build_info_internal(
         name = name,
         internal_stamp_flag_detect = False if kwargs.get("stamp") == 0 else select({
-            "//bazel/version:internal_stamp_flag_detect": True,
+            Label("//bazel/version:internal_stamp_flag_detect"): True,
             "//conditions:default": False,
         }),
         **kwargs

--- a/testing/file_test/rules.bzl
+++ b/testing/file_test/rules.bzl
@@ -46,7 +46,7 @@ def file_test(
     cc_test(
         name = name,
         srcs = srcs + [":" + manifest_cpp],
-        deps = deps + ["//testing/file_test:manifest_impl"],
+        deps = deps + [Label("//testing/file_test:manifest_impl")],
         data = tests + data,
         args = args,
         **kwargs

--- a/toolchain/driver/prebuilt_runtimes.bzl
+++ b/toolchain/driver/prebuilt_runtimes.bzl
@@ -152,11 +152,11 @@ def prebuilt_runtimes(name, target = None, tags = []):
         # have different internal properties (that can't be `select`-ed) and we
         # can select between the attributes instead.
         internal_exec_runtimes_builder = select({
-            "//toolchain/driver:use_target_config_runtimes_builder_config": None,
-            "//conditions:default": "//toolchain/driver:bazel_build_clang_runtimes",
+            Label("//toolchain/driver:use_target_config_runtimes_builder_config"): None,
+            "//conditions:default": Label("//toolchain/driver:bazel_build_clang_runtimes"),
         }),
         internal_target_runtimes_builder = select({
-            "//toolchain/driver:use_target_config_runtimes_builder_config": "//toolchain/driver:bazel_build_clang_runtimes",
+            Label("//toolchain/driver:use_target_config_runtimes_builder_config"): Label("//toolchain/driver:bazel_build_clang_runtimes"),
             "//conditions:default": None,
         }),
     )


### PR DESCRIPTION
Use `Label` to mark labels that are local to this module. Remove workspace root when forming manifest. Add explicit import for name that is not available implicitly in an imported module.

Assisted-by: Gemini via Antigravity