### PR TITLE
Explicitly escape leading `-`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -220,7 +220,7 @@ repos:
           - --custom_format
           - '\.lua$'
           - ''
-          - '-- '
+          - '\-- '
           - ''
         exclude: |
           (?x)^(


### PR DESCRIPTION
Previously, this relied on the subtlety that `-- ` (with the trailing space) didn't get parsed as a flag. But there is support already for escaping a leading `-` in a format argument, so use that to make the code more obviously correct.

Assisted-by: Antigravity with Gemini