### PR TITLE
Optimize pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -246,6 +246,7 @@ repos:
         name: Check build graph
         entry: scripts/check_build_graph.py
         language: python
+        pass_filenames: false
         files: |
           (?x)^(
             .*BUILD.*|

--- a/scripts/bazel_mod_deps.py
+++ b/scripts/bazel_mod_deps.py
@@ -16,7 +16,7 @@ import scripts_utils
 def main() -> None:
     scripts_utils.chdir_repo_root()
     bazel = scripts_utils.locate_bazel()
-    subprocess.run([bazel, "mod", "deps"])
+    subprocess.run([bazel, "mod", "--curses=no", "deps"])
 
 
 if __name__ == "__main__":

--- a/scripts/check_build_graph.py
+++ b/scripts/check_build_graph.py
@@ -16,7 +16,7 @@ import scripts_utils
 def main() -> None:
     scripts_utils.chdir_repo_root()
     bazel = scripts_utils.locate_bazel()
-    subprocess.check_call([bazel, "build", "--nobuild", "//..."])
+    subprocess.check_call([bazel, "build", "--curses=no", "--nobuild", "//..."])
 
 
 if __name__ == "__main__":

--- a/scripts/fix_cc_deps.py
+++ b/scripts/fix_cc_deps.py
@@ -38,29 +38,38 @@ class RuleChoice(NamedTuple):
     rules: set[str]
 
 
+# Compiled regexes for external repo remapping.
+LLVM_PREFIX_REGEX = re.compile(r"^(.*:(lib|include))/")
+COLON_REGEX = re.compile(r":")
+GOOGLE_TEST_PREFIX_REGEX = re.compile(r":google(?:mock|test)/include/")
+BOOST_INCLUDE_PREFIX_REGEX = re.compile(r"^(.*:include)/")
+
+# Regex for finding #include directives.
+INCLUDE_REGEX = re.compile(r'^(#include (?:(["<])([^">]+)[">]))', re.MULTILINE)
+
 # Maps external repository names to a method translating bazel labels to file
 # paths for that repository.
 EXTERNAL_REPOS: dict[str, ExternalRepo] = {
     # llvm:include/llvm/Support/Error.h ->llvm/Support/Error.h
     # clang-tools-extra/clangd:URI.h -> clang-tools-extra/clangd/URI.h
     "@llvm-project": ExternalRepo(
-        lambda x: re.sub(":", "/", re.sub("^(.*:(lib|include))/", "", x)),
+        lambda x: COLON_REGEX.sub("/", LLVM_PREFIX_REGEX.sub("", x)),
         "...",
     ),
     # tools/cpp/runfiles:runfiles.h -> tools/cpp/runfiles/runfiles.h
-    "@bazel_tools": ExternalRepo(lambda x: re.sub(":", "/", x), "..."),
+    "@bazel_tools": ExternalRepo(lambda x: COLON_REGEX.sub("/", x), "..."),
     # absl/flags:flag.h -> absl/flags/flag.h
-    "@abseil-cpp": ExternalRepo(lambda x: re.sub(":", "/", x), "..."),
+    "@abseil-cpp": ExternalRepo(lambda x: COLON_REGEX.sub("/", x), "..."),
     # :re2/re2.h -> re2/re2.h
-    "@re2": ExternalRepo(lambda x: re.sub(":", "", x), ":re2"),
+    "@re2": ExternalRepo(lambda x: COLON_REGEX.sub("", x), ":re2"),
     # :googletest/include/gtest/gtest.h -> gtest/gtest.h
     "@googletest": ExternalRepo(
-        lambda x: re.sub(":google(?:mock|test)/include/", "", x),
+        lambda x: GOOGLE_TEST_PREFIX_REGEX.sub("", x),
         ":gtest",
         use_system_include=True,
     ),
     "@boost.unordered": ExternalRepo(
-        lambda x: re.sub("^(.*:include)/", "", x),
+        lambda x: BOOST_INCLUDE_PREFIX_REGEX.sub("", x),
         ":boost.unordered",
         use_system_include=True,
     ),
@@ -126,6 +135,7 @@ def get_rules(bazel: str, targets: str, keep_going: bool) -> dict[str, Rule]:
     args = [
         bazel,
         "query",
+        "--curses=no",
         "--output=xml",
         f"kind('(cc_binary|cc_library|cc_test|genrule)', set({targets}))",
     ]
@@ -222,12 +232,9 @@ def get_missing_deps(
             file_content = f.read()
         file_content_changed = False
 
-        for header_groups in re.findall(
-            r'^(#include (?:(["<])([^">]+)[">]))',
-            file_content,
-            re.MULTILINE,
+        for full_include, include_open, header in INCLUDE_REGEX.findall(
+            file_content
         ):
-            full_include, include_open, header = header_groups
             is_system_include = include_open == "<"
 
             if header in rule_files:


### PR DESCRIPTION
First, this makes the Bazel invocations not try to uses curses which prevents running them with `pre-commit run ... -v` showing the timings for each check. The curses display overwrote the output.

Second, this fixes the main slowdown I was seeing. Because we passed _all_ files to the check-build-graph hook and there are large number of files, pre-commit would run the tool over and over on a subset of the files. This is especially wasteful as the build graph check already doesn't do anything with the files, it just checks `//...` on each invocation. So this just added a (large) constant factor of cost.

Third, this tries to reduce the cost of `fix_cc_deps.py` in the case of large numbers of files. This still isn't _super_ fast -- but the rest of the cost is in running the `bazel query` and parsing the output. I tried switching it to jsonproto and it wasn't any faster. I think this would need to be in a non-Python language and use `proto` directly to significantly improve the cost here.

Assisted-by: Antigravity with Gemini