### PR TITLE
Use earlier `C(.Self) impls ...` and `.Self impls ...` constraints in a facet type

### DIFF
--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -365,6 +365,35 @@ static auto CollectFacetWitnessSources(
 
   llvm::SmallVector<FacetWitnessSource> witnesses;
 
+  auto push_early_impl = [&](SemIR::InstId facet,
+                             bool allow_partially_identified) {
+    if (context.where_stack().empty()) {
+      return;
+    }
+
+    auto facet_const_id = context.constant_values().Get(facet);
+
+    const auto& impls = context.where_stack().back().impls;
+    for (auto [self_const_id, facet_type_const_id] : impls) {
+      auto canon_self_const_id =
+          GetCanonicalFacetOrTypeValue(context, self_const_id);
+      if (canon_self_const_id != facet_const_id) {
+        continue;
+      }
+      // TypeType is never stored in the impls stack, so we always have a
+      // FacetType.
+      auto facet_type = context.constant_values().GetInstAs<SemIR::FacetType>(
+          facet_type_const_id);
+      auto identified_id =
+          TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
+                                 allow_partially_identified);
+      if (identified_id.has_value()) {
+        witnesses.push_back({.facet_const_id = facet_const_id,
+                             .identified_facet_type_id = identified_id});
+      }
+    }
+  };
+
   auto push_facet = [&](SemIR::InstId facet, bool allow_partially_identified) {
     auto facet_const_id = context.constant_values().Get(facet);
 
@@ -380,24 +409,19 @@ static auto CollectFacetWitnessSources(
       }
     }
 
-    if (!context.where_stack().empty()) {
-      const auto& impls = context.where_stack().back().impls;
-      for (auto [self_const_id, facet_type_const_id] : impls) {
-        if (self_const_id != facet_const_id) {
-          continue;
-        }
-        // TypeType is never stored in the impls stack, so we always have a
-        // FacetType.
-        auto facet_type = context.constant_values().GetInstAs<SemIR::FacetType>(
-            facet_type_const_id);
-        auto identified_id =
-            TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
-                                   allow_partially_identified);
-        if (identified_id.has_value()) {
-          witnesses.push_back({.facet_const_id = facet_const_id,
-                               .identified_facet_type_id = identified_id});
-        }
-      }
+    push_early_impl(facet, allow_partially_identified);
+  };
+
+  auto push_concrete = [&](SemIR::TypeId concrete,
+                           bool allow_partially_identified) {
+    auto concrete_const_id = context.types().GetTypeInstId(concrete);
+
+    // We only look for a witness for a concrete type if it's the root
+    // type of the query. An impls constraint in the current facet type
+    // may provide a witness for query. Other concrete types can't provide
+    // a useful witness for the query.
+    if (concrete_const_id == query_self_inst_id) {
+      push_early_impl(concrete_const_id, allow_partially_identified);
     }
   };
 
@@ -435,6 +459,30 @@ static auto CollectFacetWitnessSources(
           // FacetValue represents a conversion which can lose part of the facet
           // type.
           push_facet(symbolic.facet, allow_partially_identified);
+          break;
+        }
+        case CARBON_KIND(Step::ClassStart start): {
+          push_concrete(start.type_id, allow_partially_identified);
+          break;
+        }
+        case CARBON_KIND(Step::ClassStartOnly start): {
+          push_concrete(start.type_id, allow_partially_identified);
+          break;
+        }
+        case CARBON_KIND(Step::TupleStart start): {
+          push_concrete(start.type_id, allow_partially_identified);
+          break;
+        }
+        case CARBON_KIND(Step::TupleStartOnly start): {
+          push_concrete(start.type_id, allow_partially_identified);
+          break;
+        }
+        case CARBON_KIND(Step::StructStartOnly start): {
+          push_concrete(start.type_id, allow_partially_identified);
+          break;
+        }
+        case CARBON_KIND(Step::ConcreteType concrete): {
+          push_concrete(concrete.type_id, allow_partially_identified);
           break;
         }
         default:

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -365,35 +365,6 @@ static auto CollectFacetWitnessSources(
 
   llvm::SmallVector<FacetWitnessSource> witnesses;
 
-  auto push_early_impl = [&](SemIR::InstId facet,
-                             bool allow_partially_identified) {
-    if (context.where_stack().empty()) {
-      return;
-    }
-
-    auto facet_const_id = context.constant_values().Get(facet);
-
-    const auto& impls = context.where_stack().back().impls;
-    for (auto [self_const_id, facet_type_const_id] : impls) {
-      auto canon_self_const_id =
-          GetCanonicalFacetOrTypeValue(context, self_const_id);
-      if (canon_self_const_id != facet_const_id) {
-        continue;
-      }
-      // TypeType is never stored in the impls stack, so we always have a
-      // FacetType.
-      auto facet_type = context.constant_values().GetInstAs<SemIR::FacetType>(
-          facet_type_const_id);
-      auto identified_id =
-          TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
-                                 allow_partially_identified);
-      if (identified_id.has_value()) {
-        witnesses.push_back({.facet_const_id = facet_const_id,
-                             .identified_facet_type_id = identified_id});
-      }
-    }
-  };
-
   auto push_facet = [&](SemIR::InstId facet, bool allow_partially_identified) {
     auto facet_const_id = context.constant_values().Get(facet);
 
@@ -407,21 +378,6 @@ static auto CollectFacetWitnessSources(
         witnesses.push_back({.facet_const_id = facet_const_id,
                              .identified_facet_type_id = identified_id});
       }
-    }
-
-    push_early_impl(facet, allow_partially_identified);
-  };
-
-  auto push_concrete = [&](SemIR::TypeId concrete,
-                           bool allow_partially_identified) {
-    auto concrete_const_id = context.types().GetTypeInstId(concrete);
-
-    // We only look for a witness for a concrete type if it's the root
-    // type of the query. An impls constraint in the current facet type
-    // may provide a witness for query. Other concrete types can't provide
-    // a useful witness for the query.
-    if (concrete_const_id == query_self_inst_id) {
-      push_early_impl(concrete_const_id, allow_partially_identified);
     }
   };
 
@@ -461,30 +417,6 @@ static auto CollectFacetWitnessSources(
           push_facet(symbolic.facet, allow_partially_identified);
           break;
         }
-        case CARBON_KIND(Step::ClassStart start): {
-          push_concrete(start.type_id, allow_partially_identified);
-          break;
-        }
-        case CARBON_KIND(Step::ClassStartOnly start): {
-          push_concrete(start.type_id, allow_partially_identified);
-          break;
-        }
-        case CARBON_KIND(Step::TupleStart start): {
-          push_concrete(start.type_id, allow_partially_identified);
-          break;
-        }
-        case CARBON_KIND(Step::TupleStartOnly start): {
-          push_concrete(start.type_id, allow_partially_identified);
-          break;
-        }
-        case CARBON_KIND(Step::StructStartOnly start): {
-          push_concrete(start.type_id, allow_partially_identified);
-          break;
-        }
-        case CARBON_KIND(Step::ConcreteType concrete): {
-          push_concrete(concrete.type_id, allow_partially_identified);
-          break;
-        }
         default:
           break;
       }
@@ -501,6 +433,25 @@ static auto CollectFacetWitnessSources(
     SemIR::TypeIterator iter(&context.sem_ir());
     iter.Add(context.insts().GetAs<SemIR::FacetType>(query_facet_type_inst_id));
     collect_facets(iter, /*allow_partially_identified=*/false);
+  }
+
+  if (!context.where_stack().empty()) {
+    const auto& impls = context.where_stack().back().impls;
+    for (auto [self_const_id, facet_type_const_id] : impls) {
+      auto canon_self_const_id =
+          GetCanonicalFacetOrTypeValue(context, self_const_id);
+      // TypeType is never stored in the impls stack, so we always have a
+      // FacetType.
+      auto facet_type = context.constant_values().GetInstAs<SemIR::FacetType>(
+          facet_type_const_id);
+      auto identified_id = TryToIdentifyFacetType(
+          context, loc_id, canon_self_const_id, facet_type,
+          /*allow_partially_identified=*/true);
+      if (identified_id.has_value()) {
+        witnesses.push_back({.facet_const_id = canon_self_const_id,
+                             .identified_facet_type_id = identified_id});
+      }
+    }
   }
 
   return witnesses;

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -436,6 +436,13 @@ static auto CollectFacetWitnessSources(
   }
 
   if (!context.where_stack().empty()) {
+    // Grab witnesses from any `impls` constraints in the current `where`
+    // expression.
+    //
+    // The `where` expression may be nested inside another `where`, but the
+    // inner `where` expression is checked before the outer, so it needs to be
+    // self-consistent and provide any `impls` constraints required by other
+    // constraints.
     const auto& impls = context.where_stack().back().impls;
     for (auto [self_const_id, facet_type_const_id] : impls) {
       auto canon_self_const_id =

--- a/toolchain/check/testdata/facet/early_impls.carbon
+++ b/toolchain/check/testdata/facet/early_impls.carbon
@@ -72,24 +72,28 @@ interface X(U:! Y(.Self)) {
 }
 class C;
 
-// Needs to identify `C as Y(.Self)` without replacing this `.Self` with C,
-// since it refers to the top level facet.
-// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+4]]:45: error: cannot convert type `C` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
-// CHECK:STDERR: fn F(_:! Z where C impls Y(.Self) and .Z1 = C.(Y(.Self).Y1)) {}
-// CHECK:STDERR:                                             ^~~~~~~~~~~~~~~
+// Needs to identify `C as Y(.Self)` without replacing this `.Self` with `C`,
+// since it refers to `T`.
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+4]]:52: error: cannot convert type `C` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn F(unused T:! Z where C impls Y(.Self) and .Z1 = C.(Y(.Self).Y1)) {}
+// CHECK:STDERR:                                                    ^~~~~~~~~~~~~~~
 // CHECK:STDERR:
-fn F(_:! Z where C impls Y(.Self) and .Z1 = C.(Y(.Self).Y1)) {}
+fn F(unused T:! Z where C impls Y(.Self) and .Z1 = C.(Y(.Self).Y1)) {}
 
-// Needs to identify `C as Y(.Self)` but _does_ need to replace the `.Self` with
-// `C`, since it refers to `U` which is being replaced by `C` in this specific.
-// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+7]]:48: error: cannot convert type `C` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
-// CHECK:STDERR: fn G(_:! Z where C impls Y(.Self) and .Z1 = C.(X(C).X1)) {}
-// CHECK:STDERR:                                                ^~~~
-// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE-18]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
+class D(V:! type);
+
+// Needs to identify `D(.Self) as Y(D(.Self))` without replacing the argument
+// `.Self` to `D` since it refers to `T`. But we _do_ need to replace the
+// `.Self` in the type of `U`, since it refers to `U` which is being replaced by
+// `D(.Self)` in this specific.
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+7]]:72: error: cannot convert type `D(.Self)` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn G(unused T:! Z where D(.Self) impls Y(D(.Self)) and .Z1 = D(.Self).(X(D(.Self)).X1)) {}
+// CHECK:STDERR:                                                                        ^~~~~~~~~~~
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE-22]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
 // CHECK:STDERR: interface X(U:! Y(.Self)) {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
-fn G(_:! Z where C impls Y(.Self) and .Z1 = C.(X(C).X1)) {}
+fn G(unused T:! Z where D(.Self) impls Y(D(.Self)) and .Z1 = D(.Self).(X(D(.Self)).X1)) {}
 
 // --- fail_todo_early_class_impls_generic_interface_with_member_designator.carbon
 library "[[@TEST_NAME]]";
@@ -187,3 +191,58 @@ fn IntLiteral() -> type = "int_literal.make_type";
 // CHECK:STDERR:                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F(_:! Z where IntLiteral() impls Y(.Self) and .Z1 = IntLiteral().(Y(.Self).Y1)) {}
+
+// --- early_impl_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface Y {}
+interface Z {
+  let Z1:! type;
+  let Z2:! Y;
+}
+constraint N {
+  require impls Y;
+}
+
+fn F(_:! Z where .Z1 impls N and .Z2 = .Z1) {}
+
+// --- early_impl_named_constraint_gives_witness_for_different_self.carbon
+library "[[@TEST_NAME]]";
+
+class C;
+
+interface Y(T:! type) {}
+interface Z {
+  let Z1:! type;
+  let Z2:! type;
+}
+
+constraint N(V:! type) {
+  require V impls Y(Self);
+}
+
+// `C impls N(.Z1)` gives `.Z1 impls Y(C)`.
+fn F(_:! Z where C impls N(.Z1) and .Z2 = (.Z1 as Y(C))) {}
+
+// --- fail_early_impl_named_constraint_gives_wrong_witness_for_different_self.carbon
+library "[[@TEST_NAME]]";
+
+class C;
+
+interface Y(T:! type) {}
+interface Z(U:! type) {
+  let Z1:! type;
+  let Z2:! type;
+}
+
+constraint N(V:! type) {
+  require V impls Y(Self);
+}
+
+// `C impls N(.Z1)` gives `.Z1 impls Y(C)`.
+//
+// CHECK:STDERR: fail_early_impl_named_constraint_gives_wrong_witness_for_different_self.carbon:[[@LINE+4]]:51: error: cannot convert type `.(Z(.Self).Z1)` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn F(_:! Z(.Self) where C impls N(.Z1) and .Z2 = (.Z1 as Y(.Self))) {}
+// CHECK:STDERR:                                                   ^~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! Z(.Self) where C impls N(.Z1) and .Z2 = (.Z1 as Y(.Self))) {}

--- a/toolchain/check/testdata/facet/early_impls.carbon
+++ b/toolchain/check/testdata/facet/early_impls.carbon
@@ -64,21 +64,17 @@ library "[[@TEST_NAME]]";
 interface Z {
   let Z1:! type;
 }
-interface Y(T:! type) {
-  let Y1:! type;
-}
-interface X(U:! Y(.Self)) {
-  let X1:! type;
-}
+interface Y(T:! type) {}
+interface X(U:! Y(.Self)) {}
 class C;
 
 // Needs to identify `C as Y(.Self)` without replacing this `.Self` with `C`,
 // since it refers to `T`.
-// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+4]]:52: error: cannot convert type `C` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
-// CHECK:STDERR: fn F(unused T:! Z where C impls Y(.Self) and .Z1 = C.(Y(.Self).Y1)) {}
-// CHECK:STDERR:                                                    ^~~~~~~~~~~~~~~
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+4]]:53: error: cannot convert type `C` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn F(unused T:! Z where C impls Y(.Self) and .Z1 = (C as Y(.Self))) {}
+// CHECK:STDERR:                                                     ^~~~~~~~~~~~~
 // CHECK:STDERR:
-fn F(unused T:! Z where C impls Y(.Self) and .Z1 = C.(Y(.Self).Y1)) {}
+fn F(unused T:! Z where C impls Y(.Self) and .Z1 = (C as Y(.Self))) {}
 
 class D(V:! type);
 
@@ -86,14 +82,14 @@ class D(V:! type);
 // `.Self` to `D` since it refers to `T`. But we _do_ need to replace the
 // `.Self` in the type of `U`, since it refers to `U` which is being replaced by
 // `D(.Self)` in this specific.
-// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+7]]:72: error: cannot convert type `D(.Self)` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
-// CHECK:STDERR: fn G(unused T:! Z where D(.Self) impls Y(D(.Self)) and .Z1 = D(.Self).(X(D(.Self)).X1)) {}
-// CHECK:STDERR:                                                                        ^~~~~~~~~~~
-// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE-22]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
-// CHECK:STDERR: interface X(U:! Y(.Self)) {
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+7]]:71: error: cannot convert type `D(.Self)` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn G(unused T:! Z where D(.Self) impls Y(D(.Self)) and D(.Self) impls X(D(.Self))) {}
+// CHECK:STDERR:                                                                       ^~~~~~~~~~~
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE-20]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
+// CHECK:STDERR: interface X(U:! Y(.Self)) {}
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
-fn G(unused T:! Z where D(.Self) impls Y(D(.Self)) and .Z1 = D(.Self).(X(D(.Self)).X1)) {}
+fn G(unused T:! Z where D(.Self) impls Y(D(.Self)) and D(.Self) impls X(D(.Self))) {}
 
 // --- fail_todo_early_class_impls_generic_interface_with_member_designator.carbon
 library "[[@TEST_NAME]]";

--- a/toolchain/check/testdata/facet/early_impls.carbon
+++ b/toolchain/check/testdata/facet/early_impls.carbon
@@ -24,13 +24,166 @@ interface Y {
   let Y1:! type;
 }
 
-fn F(_:! Z where .Z1 impls Y and .Z2 = .Z1.(Y.Y1)) {
-}
+fn F(_:! Z where .Z1 impls Y and .Z2 = .Z1.(Y.Y1)) {}
 
 class C(T:! type);
 constraint X {
   require C(Self) impls Y;
 }
 
-fn G(_:! Z where .Z1 impls X and .Z2 = C(.Z1).(Y.Y1)) {
+fn G(_:! Z where .Z1 impls X and .Z2 = C(.Z1).(Y.Y1)) {}
+
+// --- early_self_impls.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
 }
+interface Y {
+  let Y1:! type;
+}
+
+fn F(_:! Z where .Self impls Y and .Z1 = .Self.(Y.Y1)) {}
+
+// --- early_generic_class_impls.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+interface Y {
+  let Y1:! type;
+}
+class C(T:! type);
+
+fn F(_:! Z where C(.Self) impls Y and .Z1 = C(.Self).(Y.Y1)) {}
+
+// --- fail_todo_early_class_impls_generic_interface.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+interface Y(T:! type) {
+  let Y1:! type;
+}
+interface X(U:! Y(.Self)) {
+  let X1:! type;
+}
+class C;
+
+// Needs to identify `C as Y(.Self)` without replacing this `.Self` with C,
+// since it refers to the top level facet.
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+4]]:45: error: cannot convert type `C` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn F(_:! Z where C impls Y(.Self) and .Z1 = C.(Y(.Self).Y1)) {}
+// CHECK:STDERR:                                             ^~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! Z where C impls Y(.Self) and .Z1 = C.(Y(.Self).Y1)) {}
+
+// Needs to identify `C as Y(.Self)` but _does_ need to replace the `.Self` with
+// `C`, since it refers to `U` which is being replaced by `C` in this specific.
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE+7]]:48: error: cannot convert type `C` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn G(_:! Z where C impls Y(.Self) and .Z1 = C.(X(C).X1)) {}
+// CHECK:STDERR:                                                ^~~~
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface.carbon:[[@LINE-18]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
+// CHECK:STDERR: interface X(U:! Y(.Self)) {
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn G(_:! Z where C impls Y(.Self) and .Z1 = C.(X(C).X1)) {}
+
+// --- fail_todo_early_class_impls_generic_interface_with_member_designator.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+  let Z2:! type;
+}
+interface Y(T:! type) {
+  let Y1:! type;
+}
+class C;
+
+// CHECK:STDERR: fail_todo_early_class_impls_generic_interface_with_member_designator.carbon:[[@LINE+4]]:43: error: cannot convert type `C` into type implementing `Y(.(Z.Z2))` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn F(_:! Z where C impls Y(.Z2) and .Z1 = C.(Y(.Z2).Y1)) {}
+// CHECK:STDERR:                                           ^~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! Z where C impls Y(.Z2) and .Z1 = C.(Y(.Z2).Y1)) {}
+
+// --- fail_todo_early_tuple_impls_generic_interface.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+interface Y(T:! type) {
+  let Y1:! type;
+}
+interface X {
+  let X1:! type;
+}
+class C;
+
+// CHECK:STDERR: fail_todo_early_tuple_impls_generic_interface.carbon:[[@LINE+4]]:46: error: cannot convert type `()` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn F(_:! Z where () impls Y(.Self) and .Z1 = ().(Y(.Self).Y1)) {}
+// CHECK:STDERR:                                              ^~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! Z where () impls Y(.Self) and .Z1 = ().(Y(.Self).Y1)) {}
+
+// CHECK:STDERR: fail_todo_early_tuple_impls_generic_interface.carbon:[[@LINE+4]]:49: error: cannot convert type `(C,)` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn G(_:! Z where (C, ) impls Y(.Self) and .Z1 = (C, ).(Y(.Self).Y1)) {}
+// CHECK:STDERR:                                                 ^~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn G(_:! Z where (C, ) impls Y(.Self) and .Z1 = (C, ).(Y(.Self).Y1)) {}
+
+// TODO: Can merge with the next test once they both pass.
+
+// --- early_tuple_impls.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+interface X {
+  let X1:! type;
+}
+
+fn H(_:! Z where (.Self, ) impls X and .Z1 = (.Self, ).(X.X1)) {}
+
+// --- fail_todo_early_struct_impls.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+interface Y(T:! type) {
+  let Y1:! type;
+}
+interface X {
+  let X1:! type;
+}
+class C;
+
+// CHECK:STDERR: fail_todo_early_struct_impls.carbon:[[@LINE+4]]:46: error: cannot convert type `{}` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn F(_:! Z where {} impls Y(.Self) and .Z1 = {}.(Y(.Self).Y1)) {}
+// CHECK:STDERR:                                              ^~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! Z where {} impls Y(.Self) and .Z1 = {}.(Y(.Self).Y1)) {}
+
+// --- fail_todo_early_concrete_impls.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+interface Y(T:! type) {
+  let Y1:! type;
+}
+
+// A concrete type that is not a class, tuple, or struct.
+fn IntLiteral() -> type = "int_literal.make_type";
+
+// CHECK:STDERR: fail_todo_early_concrete_impls.carbon:[[@LINE+4]]:56: error: cannot convert type `Core.IntLiteral` into type implementing `Y(.Self)` [ConversionFailureTypeToFacet]
+// CHECK:STDERR: fn F(_:! Z where IntLiteral() impls Y(.Self) and .Z1 = IntLiteral().(Y(.Self).Y1)) {}
+// CHECK:STDERR:                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! Z where IntLiteral() impls Y(.Self) and .Z1 = IntLiteral().(Y(.Self).Y1)) {}


### PR DESCRIPTION
The `.Self` needs to be canonicalized when recording the witness, since it will be a FacetAccessType in the `impls` clause.

Todo tests are also added for `C impls Y(.Self)`. The `.Self` in the interface specific breaks everything as we end up replacing the `.Self` with `C` in later `C as Y(.Self)` lookups, which then does not find the witness.

Pull all the witnesses from `impls` constraints so that we capture witnesses coming from named constraints on different self types, as `C impls N(.Self)` may give witnesses for `C` or for other self types.