### PR TITLE
Fix crash if initializing Clang fails.

### DIFF
--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -882,6 +882,13 @@ auto GenerateAst(Context& context,
   context.sem_ir().set_cpp_file(std::make_unique<SemIR::CppFile>(
       std::move(clang_instance_ptr), llvm_context));
 
+  // Register an annotation scope to flush any Clang diagnostics when we return.
+  // This ensures C++ diagnostics get flushed before `diags` is destroyed, and
+  // that diagnostics created here don't interleave with later Carbon
+  // diagnostics.
+  Diagnostics::AnnotationScope annotate_diagnostics(&context.emitter(),
+                                                    [](auto& /*builder*/) {});
+
   clang_instance.setDiagnostics(diags);
   clang_instance.setVirtualFileSystem(fs);
   clang_instance.createFileManager();
@@ -914,10 +921,6 @@ auto GenerateAst(Context& context,
                                          llvm::toString(std::move(error)));
     return false;
   }
-
-  // Flush any diagnostics. We know we're not part-way through emitting a
-  // diagnostic now.
-  context.emitter().Flush();
 
   return true;
 }

--- a/toolchain/check/handle_inline_decl.cpp
+++ b/toolchain/check/handle_inline_decl.cpp
@@ -30,12 +30,23 @@ auto HandleParseNode(Context& context, Parse::InlineCppDeclId node_id) -> bool {
   // TODO: It'd be nice to produce a clearer error saying to insert an `import
   // Cpp` in a file that uses `inline Cpp` and doesn't otherwise import anything
   // from package `Cpp`.
-  if (context.constant_values().Get(
-          context.node_stack().Pop<Parse::NodeKind::CppNameExpr>()) ==
-      SemIR::ErrorInst::ConstantId) {
+  auto cpp_id = context.constant_values().Get(
+      context.node_stack().Pop<Parse::NodeKind::CppNameExpr>());
+  if (cpp_id == SemIR::ErrorInst::ConstantId) {
     return true;
   }
-  CARBON_CHECK(context.cpp_context(), "Have `Cpp` name but no Cpp context");
+
+  // If Clang initialization catastrophically failed, skip the inline fragment.
+  if (!context.cpp_context()) {
+    // We should have already diagnosed an error initializing Clang.
+    CARBON_CHECK(context.name_scopes()
+                     .Get(context.constant_values()
+                              .GetInstAs<SemIR::Namespace>(cpp_id)
+                              .name_scope_id)
+                     .has_error(),
+                 "Have valid `Cpp` scope but no Cpp context");
+    return true;
+  }
 
   auto string_token = context.parse_tree().node_token(body_id);
   auto string_value_id = context.tokens().GetStringLiteralValue(string_token);

--- a/toolchain/check/handle_inline_decl.cpp
+++ b/toolchain/check/handle_inline_decl.cpp
@@ -39,11 +39,10 @@ auto HandleParseNode(Context& context, Parse::InlineCppDeclId node_id) -> bool {
   // If Clang initialization catastrophically failed, skip the inline fragment.
   if (!context.cpp_context()) {
     // We should have already diagnosed an error initializing Clang.
-    CARBON_CHECK(context.name_scopes()
-                     .Get(context.constant_values()
-                              .GetInstAs<SemIR::Namespace>(cpp_id)
-                              .name_scope_id)
-                     .has_error(),
+    auto cpp_scope_id = context.constant_values()
+                            .GetInstAs<SemIR::Namespace>(cpp_id)
+                            .name_scope_id;
+    CARBON_CHECK(context.name_scopes().Get(cpp_scope_id).has_error(),
                  "Have valid `Cpp` scope but no Cpp context");
     return true;
   }

--- a/toolchain/check/testdata/interop/cpp/basics/import/bad_args.carbon
+++ b/toolchain/check/testdata/interop/cpp/basics/import/bad_args.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/none.carbon
+// EXTRA-ARGS: --clang-arg=-fmodules --clang-arg=-fmodule-file=nonexistent.pcm
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/interop/cpp/basics/import/bad_args.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/interop/cpp/basics/import/bad_args.carbon
+// CHECK:STDERR: error: module file 'nonexistent.pcm' not found [CppInteropParseError]
+// CHECK:STDERR:
+
+// --- fail_use_cpp.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+inline Cpp '''
+int n;
+''';


### PR DESCRIPTION
Flush diagnostics before destroying Clang. If we see an `inline Cpp` and `Cpp` initialization failed, recover by skipping the inline code rather than CHECK-failing.