### PR TITLE
Convert `TokenInfo::ResetAs...` functions to return new `TokenInfo`s.

### DIFF
--- a/toolchain/lex/lex.cpp
+++ b/toolchain/lex/lex.cpp
@@ -1574,7 +1574,7 @@ class Lexer::ErrorRecoveryBuffer {
   auto ReplaceWithError(TokenIndex token) -> void {
     auto& token_info = buffer_->token_infos_.Get(token);
     int error_length = buffer_->GetTokenText(token).size();
-    token_info.ResetAsError(error_length);
+    token_info = token_info.AsError(error_length);
     any_error_tokens_ = true;
   }
 

--- a/toolchain/lex/token_info.h
+++ b/toolchain/lex/token_info.h
@@ -123,23 +123,20 @@ class TokenInfo {
   // token as well.
   auto byte_offset() const -> int32_t { return byte_offset_; }
 
-  // Transforms the token into an error token of the given length but at its
-  // original position and with the same whitespace adjacency.
-  auto ResetAsError(int error_length) -> void {
-    // Construct a fresh token to establish any needed invariants and replace
-    // this token with it.
-    TokenInfo error(TokenKind::Error, has_leading_space(), error_length,
-                    byte_offset());
-    *this = error;
+  // Returns an error token of the given length with this token's position and
+  // whitespace adjacency.
+  [[nodiscard]] auto AsError(int error_length) const -> TokenInfo {
+    return TokenInfo(TokenKind::Error, has_leading_space(), error_length,
+                     byte_offset());
   }
 
-  // Resets the token to be an identifier with the given identifier id at its
-  // original position and with the same whitespace adjacency.
-  auto ResetAsErrorRecoveryIdentifier(IdentifierId id) -> void {
+  // Returns an identifier token with the given identifier id with this
+  // token's position and whitespace adjacency.
+  [[nodiscard]] auto AsErrorRecoveryIdentifier(IdentifierId id) const
+      -> TokenInfo {
     CARBON_CHECK(kind().is_word());
-    TokenInfo error(TokenKind::Identifier, has_leading_space(), id.index,
-                    byte_offset());
-    *this = error;
+    return TokenInfo(TokenKind::Identifier, has_leading_space(), id.index,
+                     byte_offset());
   }
 
  private:

--- a/toolchain/lex/tokenized_buffer.cpp
+++ b/toolchain/lex/tokenized_buffer.cpp
@@ -212,9 +212,8 @@ auto TokenizedBuffer::AddPostLexingRecoveryTokenAsIdentifier(TokenIndex token)
   CARBON_CHECK(kind != TokenKind::Identifier, "Recovery not required");
 
   auto identifier_id = value_stores_->identifiers().Add(GetTokenText(token));
-  auto info = token_infos_.Get(token);
-  info.ResetAsErrorRecoveryIdentifier(identifier_id);
-  return AddPostLexingRecoveryToken(info);
+  return AddPostLexingRecoveryToken(
+      token_infos_.Get(token).AsErrorRecoveryIdentifier(identifier_id));
 }
 
 auto TokenizedBuffer::AddPostLexingRecoveryToken(TokenInfo info) -> TokenIndex {


### PR DESCRIPTION
As requested in #7249.