### PR TITLE
Add `Core.Destroy` support for enums imported from C++

### DIFF
--- a/toolchain/check/cpp/impl_lookup.cpp
+++ b/toolchain/check/cpp/impl_lookup.cpp
@@ -245,11 +245,14 @@ static auto BuildDestroyWitness(
     SemIR::SpecificInterfaceId query_specific_interface_id) -> SemIR::InstId {
   auto& clang_sema = context.clang_sema();
 
-  // TODO: This should provide `Destroy` for enums and other trivially
-  // destructible types.
-  auto* class_decl = TypeAsClassDecl(context, query_self_const_id);
-  if (!class_decl) {
+  auto* tag_decl = TypeAsTagDecl(context, query_self_const_id);
+  if (!tag_decl) {
     return SemIR::InstId::None;
+  }
+  auto* class_decl = dyn_cast<clang::CXXRecordDecl>(tag_decl);
+  if (!class_decl) {
+    return BuildTrivialDestroyWitness(context, loc_id, query_self_const_id,
+                                      query_specific_interface_id);
   }
   SemIR::ClangDeclSignatureId signature_id = MakeSignature(context, {});
 

--- a/toolchain/check/custom_witness.cpp
+++ b/toolchain/check/custom_witness.cpp
@@ -584,6 +584,29 @@ auto BuildPrimitiveCopyWitness(
   return BuildCustomWitness(context, loc_id, query_self_const_id,
                             query_specific_interface_id, {op_id});
 }
+
+static auto BuildDestroyWitness(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::ConstantId query_self_const_id,
+    SemIR::SpecificInterfaceId query_specific_interface_id,
+    DestroyFormat format) -> SemIR::InstId {
+  CARBON_CHECK(format != DestroyFormat::NoDestroy);
+
+  // Mark functions with the interface's scope as a hint to mangling. This
+  // does not add them to the scope.
+  auto query_specific_interface =
+      context.specific_interfaces().Get(query_specific_interface_id);
+  auto parent_scope_id = context.interfaces()
+                             .Get(query_specific_interface.interface_id)
+                             .scope_without_self_id;
+
+  auto self_type_id = GetFacetAsType(context, query_self_const_id);
+  auto op_id = MakeDestroyOpFunction(context, loc_id, self_type_id,
+                                     parent_scope_id, format);
+  return BuildCustomWitness(context, loc_id, query_self_const_id,
+                            query_specific_interface_id, {op_id});
+}
+
 static auto MakeDestroyWitness(
     Context& context, SemIR::LocId loc_id,
     SemIR::ConstantId query_self_const_id,
@@ -600,19 +623,17 @@ static auto MakeDestroyWitness(
     return SemIR::InstId::None;
   }
 
-  // Mark functions with the interface's scope as a hint to mangling. This
-  // does not add them to the scope.
-  auto query_specific_interface =
-      context.specific_interfaces().Get(query_specific_interface_id);
-  auto parent_scope_id = context.interfaces()
-                             .Get(query_specific_interface.interface_id)
-                             .scope_without_self_id;
+  return BuildDestroyWitness(context, loc_id, query_self_const_id,
+                             query_specific_interface_id, format);
+}
 
-  auto self_type_id = GetFacetAsType(context, query_self_const_id);
-  auto op_id = MakeDestroyOpFunction(context, loc_id, self_type_id,
-                                     parent_scope_id, format);
-  return BuildCustomWitness(context, loc_id, query_self_const_id,
-                            query_specific_interface_id, {op_id});
+auto BuildTrivialDestroyWitness(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::ConstantId query_self_const_id,
+    SemIR::SpecificInterfaceId query_specific_interface_id) -> SemIR::InstId {
+  return BuildDestroyWitness(context, loc_id, query_self_const_id,
+                             query_specific_interface_id,
+                             DestroyFormat::Trivial);
 }
 
 static auto MakeIntFitsInWitness(

--- a/toolchain/check/custom_witness.cpp
+++ b/toolchain/check/custom_witness.cpp
@@ -585,6 +585,8 @@ auto BuildPrimitiveCopyWitness(
                             query_specific_interface_id, {op_id});
 }
 
+// Builds and returns a custom witness that performs the specified kind of
+// destruction for the given type.
 static auto BuildDestroyWitness(
     Context& context, SemIR::LocId loc_id,
     SemIR::ConstantId query_self_const_id,
@@ -607,7 +609,9 @@ static auto BuildDestroyWitness(
                             query_specific_interface_id, {op_id});
 }
 
-static auto MakeDestroyWitness(
+// Returns the custom witness to use for destruction of the given type. See
+// `LookupCustomWitness`.
+static auto LookupDestroyWitness(
     Context& context, SemIR::LocId loc_id,
     SemIR::ConstantId query_self_const_id,
     SemIR::SpecificInterfaceId query_specific_interface_id, bool build_witness)
@@ -717,8 +721,8 @@ auto LookupCustomWitness(Context& context, SemIR::LocId loc_id,
                          bool build_witness) -> std::optional<SemIR::InstId> {
   switch (core_interface) {
     case SemIR::CoreInterface::Destroy:
-      return MakeDestroyWitness(context, loc_id, query_self_const_id,
-                                query_specific_interface_id, build_witness);
+      return LookupDestroyWitness(context, loc_id, query_self_const_id,
+                                  query_specific_interface_id, build_witness);
     case SemIR::CoreInterface::IntFitsIn:
       return MakeIntFitsInWitness(context, loc_id, query_self_const_id,
                                   query_specific_interface_id, build_witness);

--- a/toolchain/check/custom_witness.h
+++ b/toolchain/check/custom_witness.h
@@ -25,6 +25,12 @@ auto BuildPrimitiveCopyWitness(
     SemIR::ConstantId query_self_const_id,
     SemIR::SpecificInterfaceId query_specific_interface_id) -> SemIR::InstId;
 
+// Builds a witness that the given type is trivially destroyable.
+auto BuildTrivialDestroyWitness(
+    Context& context, SemIR::LocId loc_id,
+    SemIR::ConstantId query_self_const_id,
+    SemIR::SpecificInterfaceId query_specific_interface_id) -> SemIR::InstId;
+
 // Given an interface, returns the corresponding enum if it's covered by
 // `CoreInterface`, or `Unknown` if it's some other interface.
 auto GetCoreInterface(Context& context, SemIR::InterfaceId interface_id)

--- a/toolchain/check/testdata/interop/cpp/enum/copy.carbon
+++ b/toolchain/check/testdata/interop/cpp/enum/copy.carbon
@@ -14,7 +14,7 @@
 
 enum Enum : short { a, b, c };
 
-// --- fail_todo_copy_enum.carbon
+// --- copy_enum.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -22,20 +22,17 @@ import Cpp library "enum.h";
 
 //@dump-sem-ir-begin
 fn F() {
-  // CHECK:STDERR: fail_todo_copy_enum.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Core.Destroy` in type `Cpp.Enum` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   var a: Cpp.Enum = Cpp.Enum.a;
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   var a: Cpp.Enum = Cpp.Enum.a;
 
   a = Cpp.Enum.b;
 }
 //@dump-sem-ir-end
 
-// CHECK:STDOUT: --- fail_todo_copy_enum.carbon
+// CHECK:STDOUT: --- copy_enum.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %Enum: type = class_type @Enum [concrete]
 // CHECK:STDOUT:   %pattern_type.9f7: type = pattern_type %Enum [concrete]
@@ -50,6 +47,8 @@ fn F() {
 // CHECK:STDOUT:   %Enum.Op.bound.7be: <bound method> = bound_method %int_0, %Enum.Op [concrete]
 // CHECK:STDOUT:   %int_1: %Enum = int_value 1 [concrete]
 // CHECK:STDOUT:   %Enum.Op.bound.c35: <bound method> = bound_method %int_1, %Enum.Op [concrete]
+// CHECK:STDOUT:   %Destroy.Op.type: type = fn_type @Destroy.Op [concrete]
+// CHECK:STDOUT:   %Destroy.Op: %Destroy.Op.type = struct_value () [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -73,28 +72,32 @@ fn F() {
 // CHECK:STDOUT:     %a.var_patt: %pattern_type.9f7 = var_pattern %a.patt [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a.var: ref %Enum = var %a.var_patt
-// CHECK:STDOUT:   %Cpp.ref.loc12_21: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %Enum.ref.loc12_24: type = name_ref Enum, imports.%Enum.decl [concrete = constants.%Enum]
-// CHECK:STDOUT:   %a.ref.loc12: %Enum = name_ref a, imports.%int_0 [concrete = constants.%int_0]
-// CHECK:STDOUT:   %impl.elem0.loc12: %.e06 = impl_witness_access constants.%custom_witness.b8d, element0 [concrete = constants.%Enum.Op]
-// CHECK:STDOUT:   %bound_method.loc12: <bound method> = bound_method %a.ref.loc12, %impl.elem0.loc12 [concrete = constants.%Enum.Op.bound.7be]
-// CHECK:STDOUT:   %Enum.Op.call.loc12: init %Enum = call %bound_method.loc12(%a.ref.loc12) [concrete = constants.%int_0]
-// CHECK:STDOUT:   assign %a.var, %Enum.Op.call.loc12
-// CHECK:STDOUT:   %.loc12: type = splice_block %Enum.ref.loc12_13 [concrete = constants.%Enum] {
-// CHECK:STDOUT:     %Cpp.ref.loc12_10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:     %Enum.ref.loc12_13: type = name_ref Enum, imports.%Enum.decl [concrete = constants.%Enum]
+// CHECK:STDOUT:   %Cpp.ref.loc8_21: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %Enum.ref.loc8_24: type = name_ref Enum, imports.%Enum.decl [concrete = constants.%Enum]
+// CHECK:STDOUT:   %a.ref.loc8: %Enum = name_ref a, imports.%int_0 [concrete = constants.%int_0]
+// CHECK:STDOUT:   %impl.elem0.loc8: %.e06 = impl_witness_access constants.%custom_witness.b8d, element0 [concrete = constants.%Enum.Op]
+// CHECK:STDOUT:   %bound_method.loc8: <bound method> = bound_method %a.ref.loc8, %impl.elem0.loc8 [concrete = constants.%Enum.Op.bound.7be]
+// CHECK:STDOUT:   %Enum.Op.call.loc8: init %Enum = call %bound_method.loc8(%a.ref.loc8) [concrete = constants.%int_0]
+// CHECK:STDOUT:   assign %a.var, %Enum.Op.call.loc8
+// CHECK:STDOUT:   %.loc8: type = splice_block %Enum.ref.loc8_13 [concrete = constants.%Enum] {
+// CHECK:STDOUT:     %Cpp.ref.loc8_10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %Enum.ref.loc8_13: type = name_ref Enum, imports.%Enum.decl [concrete = constants.%Enum]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %a: ref %Enum = ref_binding a, %a.var
-// CHECK:STDOUT:   %a.ref.loc14: ref %Enum = name_ref a, %a
-// CHECK:STDOUT:   %Cpp.ref.loc14: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %Enum.ref.loc14: type = name_ref Enum, imports.%Enum.decl [concrete = constants.%Enum]
+// CHECK:STDOUT:   %a.ref.loc10: ref %Enum = name_ref a, %a
+// CHECK:STDOUT:   %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:   %Enum.ref.loc10: type = name_ref Enum, imports.%Enum.decl [concrete = constants.%Enum]
 // CHECK:STDOUT:   %b.ref: %Enum = name_ref b, imports.%int_1 [concrete = constants.%int_1]
-// CHECK:STDOUT:   %impl.elem0.loc14: %.e06 = impl_witness_access constants.%custom_witness.b8d, element0 [concrete = constants.%Enum.Op]
-// CHECK:STDOUT:   %bound_method.loc14: <bound method> = bound_method %b.ref, %impl.elem0.loc14 [concrete = constants.%Enum.Op.bound.c35]
-// CHECK:STDOUT:   %Enum.Op.call.loc14: init %Enum = call %bound_method.loc14(%b.ref) [concrete = constants.%int_1]
-// CHECK:STDOUT:   assign %a.ref.loc14, %Enum.Op.call.loc14
+// CHECK:STDOUT:   %impl.elem0.loc10: %.e06 = impl_witness_access constants.%custom_witness.b8d, element0 [concrete = constants.%Enum.Op]
+// CHECK:STDOUT:   %bound_method.loc10: <bound method> = bound_method %b.ref, %impl.elem0.loc10 [concrete = constants.%Enum.Op.bound.c35]
+// CHECK:STDOUT:   %Enum.Op.call.loc10: init %Enum = call %bound_method.loc10(%b.ref) [concrete = constants.%int_1]
+// CHECK:STDOUT:   assign %a.ref.loc10, %Enum.Op.call.loc10
+// CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %a.var, constants.%Destroy.Op
+// CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%a.var)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Enum.Op(%self.param: %Enum) -> out %return.param: %Enum = "primitive_copy";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Destroy.Op(%self.param: ref %Enum) = "no_op";
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/enum.carbon
+++ b/toolchain/lower/testdata/interop/cpp/enum.carbon
@@ -22,7 +22,7 @@ struct C {
   static void F(E);
 };
 
-// --- fail_todo_pass_as_arg.carbon
+// --- pass_as_arg.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -35,38 +35,10 @@ fn Pass() {
   Cpp.C.F(Cpp.C.c);
   Cpp.C.F(Cpp.C.E.a);
   Cpp.C.F(Cpp.C.E.b);
-  // CHECK:STDERR: fail_todo_pass_as_arg.carbon:[[@LINE+28]]:11: error: cannot access member of interface `Core.Destroy` in type `Cpp.E` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.c);
-  // CHECK:STDERR:           ^~~~~~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_pass_as_arg.carbon:[[@LINE-5]]:11: error: cannot access member of interface `Core.Destroy` in type `Cpp.E` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.b);
-  // CHECK:STDERR:           ^~~~~~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_pass_as_arg.carbon:[[@LINE-10]]:11: error: cannot access member of interface `Core.Destroy` in type `Cpp.E` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.E.a);
-  // CHECK:STDERR:           ^~~~~~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_pass_as_arg.carbon:[[@LINE-15]]:11: error: cannot access member of interface `Core.Destroy` in type `Cpp.E` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.c);
-  // CHECK:STDERR:           ^~~~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_pass_as_arg.carbon:[[@LINE-20]]:11: error: cannot access member of interface `Core.Destroy` in type `Cpp.E` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.b);
-  // CHECK:STDERR:           ^~~~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_pass_as_arg.carbon:[[@LINE-25]]:11: error: cannot access member of interface `Core.Destroy` in type `Cpp.E` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.a);
-  // CHECK:STDERR:           ^~~~~~~
-  // CHECK:STDERR:
-  // CHECK:STDERR: fail_todo_pass_as_arg.carbon:[[@LINE-30]]:11: error: cannot access member of interface `Core.Destroy` in type `Cpp.E` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   Cpp.C.F(Cpp.C.a);
-  // CHECK:STDERR:           ^~~~~~~
-  // CHECK:STDERR:
   Cpp.C.F(Cpp.C.E.c);
 }
 
-// --- fail_todo_convert.carbon
+// --- convert.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -83,10 +55,6 @@ fn ConvertEnumToI16(e: Cpp.C.E) {
 }
 
 fn ConvertI16ToEnum(n: i16) {
-  // CHECK:STDERR: fail_todo_convert.carbon:[[@LINE+4]]:11: error: cannot access member of interface `Core.Destroy` in type `Cpp.E` that does not implement that interface [MissingImplInMemberAccess]
-  // CHECK:STDERR:   Cpp.C.F(n as Cpp.C.E);
-  // CHECK:STDERR:           ^~~~~~~~~~~~
-  // CHECK:STDERR:
   Cpp.C.F(n as Cpp.C.E);
 }
 
@@ -106,10 +74,235 @@ library "[[@TEST_NAME]]";
 
 import Cpp library "bitmask.h";
 
-// TODO: Once we support interop with C++-defined operators, we should be able
-// to use `|` below rather than declaring our own builtin.
+// TODO: We should be able to use `|` below rather than declaring our own builtin.
 fn BitOr(a: Cpp.Bits, b: Cpp.Bits) -> Cpp.Bits = "int.or";
 
 fn Call() {
   Cpp.Take(BitOr(Cpp.A, Cpp.C));
 }
+
+// CHECK:STDOUT: ; ModuleID = 'pass_as_arg.carbon'
+// CHECK:STDOUT: source_filename = "pass_as_arg.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @int_0 = internal constant i16 0
+// CHECK:STDOUT: @int_7 = internal constant i16 7
+// CHECK:STDOUT: @int_8 = internal constant i16 8
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CPass.Main() #0 !dbg !11 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc7_16.1.temp = alloca i16, align 2, !dbg !14
+// CHECK:STDOUT:   %.loc8_16.1.temp = alloca i16, align 2, !dbg !15
+// CHECK:STDOUT:   %.loc9_16.1.temp = alloca i16, align 2, !dbg !16
+// CHECK:STDOUT:   %.loc10_16.1.temp = alloca i16, align 2, !dbg !17
+// CHECK:STDOUT:   %.loc11_18.1.temp = alloca i16, align 2, !dbg !18
+// CHECK:STDOUT:   %.loc12_18.1.temp = alloca i16, align 2, !dbg !19
+// CHECK:STDOUT:   %.loc13_18.1.temp = alloca i16, align 2, !dbg !20
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_16.1.temp), !dbg !14
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk._(ptr @int_0), !dbg !21
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc8_16.1.temp), !dbg !15
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk._(ptr @int_0), !dbg !22
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_16.1.temp), !dbg !16
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk._(ptr @int_7), !dbg !23
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc10_16.1.temp), !dbg !17
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk._(ptr @int_8), !dbg !24
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc11_18.1.temp), !dbg !18
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk._(ptr @int_0), !dbg !25
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc12_18.1.temp), !dbg !19
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk._(ptr @int_7), !dbg !26
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc13_18.1.temp), !dbg !20
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk._(ptr @int_8), !dbg !27
+// CHECK:STDOUT:   ret void, !dbg !28
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress uwtable
+// CHECK:STDOUT: define internal void @_ZN1C1FENS_1EE.carbon_thunk._(ptr noundef %0) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8, !tbaa !29
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8, !tbaa !29
+// CHECK:STDOUT:   %2 = load i16, ptr %1, align 2, !tbaa !31
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE(i16 noundef signext %2)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_ZN1C1FENS_1EE(i16 noundef signext) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @_ZN1C1FENS_1EE.carbon_thunk._, { 6, 5, 4, 3, 2, 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 6, 5, 4, 3, 2, 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #3 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "pass_as_arg.carbon", directory: "")
+// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
+// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Pass", linkageName: "_CPass.Main", scope: null, file: !6, line: 6, type: !12, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
+// CHECK:STDOUT: !13 = !{null}
+// CHECK:STDOUT: !14 = !DILocation(line: 7, column: 11, scope: !11)
+// CHECK:STDOUT: !15 = !DILocation(line: 8, column: 11, scope: !11)
+// CHECK:STDOUT: !16 = !DILocation(line: 9, column: 11, scope: !11)
+// CHECK:STDOUT: !17 = !DILocation(line: 10, column: 11, scope: !11)
+// CHECK:STDOUT: !18 = !DILocation(line: 11, column: 11, scope: !11)
+// CHECK:STDOUT: !19 = !DILocation(line: 12, column: 11, scope: !11)
+// CHECK:STDOUT: !20 = !DILocation(line: 13, column: 11, scope: !11)
+// CHECK:STDOUT: !21 = !DILocation(line: 7, column: 3, scope: !11)
+// CHECK:STDOUT: !22 = !DILocation(line: 8, column: 3, scope: !11)
+// CHECK:STDOUT: !23 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !24 = !DILocation(line: 10, column: 3, scope: !11)
+// CHECK:STDOUT: !25 = !DILocation(line: 11, column: 3, scope: !11)
+// CHECK:STDOUT: !26 = !DILocation(line: 12, column: 3, scope: !11)
+// CHECK:STDOUT: !27 = !DILocation(line: 13, column: 3, scope: !11)
+// CHECK:STDOUT: !28 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT: !29 = !{!30, !30, i64 0}
+// CHECK:STDOUT: !30 = !{!"any pointer", !9, i64 0}
+// CHECK:STDOUT: !31 = !{!32, !32, i64 0}
+// CHECK:STDOUT: !32 = !{!"_ZTSN1C1EE", !9, i64 0}
+// CHECK:STDOUT: ; ModuleID = 'convert.carbon'
+// CHECK:STDOUT: source_filename = "convert.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_CTakeI16.Main(i16)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CPassEnum.Main() #0 !dbg !11 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CTakeI16.Main(i16 7), !dbg !14
+// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CConvertEnumToI16.Main(i16 %e) #0 !dbg !16 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CTakeI16.Main(i16 %e), !dbg !22
+// CHECK:STDOUT:   ret void, !dbg !23
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CConvertI16ToEnum.Main(i16 %n) #0 !dbg !24 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.loc17_13.3.temp = alloca i16, align 2, !dbg !27
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_13.3.temp), !dbg !27
+// CHECK:STDOUT:   store i16 %n, ptr %.loc17_13.3.temp, align 2, !dbg !27
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE.carbon_thunk._(ptr %.loc17_13.3.temp), !dbg !28
+// CHECK:STDOUT:   ret void, !dbg !29
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress uwtable
+// CHECK:STDOUT: define internal void @_ZN1C1FENS_1EE.carbon_thunk._(ptr noundef %0) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %0, ptr %.addr, align 8, !tbaa !30
+// CHECK:STDOUT:   %1 = load ptr, ptr %.addr, align 8, !tbaa !30
+// CHECK:STDOUT:   %2 = load i16, ptr %1, align 2, !tbaa !32
+// CHECK:STDOUT:   call void @_ZN1C1FENS_1EE(i16 noundef signext %2)
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #2
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_ZN1C1FENS_1EE(i16 noundef signext) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT: attributes #3 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "convert.carbon", directory: "")
+// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
+// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "PassEnum", linkageName: "_CPassEnum.Main", scope: null, file: !6, line: 8, type: !12, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
+// CHECK:STDOUT: !13 = !{null}
+// CHECK:STDOUT: !14 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !15 = !DILocation(line: 8, column: 1, scope: !11)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "ConvertEnumToI16", linkageName: "_CConvertEnumToI16.Main", scope: null, file: !6, line: 12, type: !17, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !20)
+// CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
+// CHECK:STDOUT: !18 = !{null, !19}
+// CHECK:STDOUT: !19 = !DIBasicType(name: "int", size: 16, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !20 = !{!21}
+// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !16, type: !19)
+// CHECK:STDOUT: !22 = !DILocation(line: 13, column: 3, scope: !16)
+// CHECK:STDOUT: !23 = !DILocation(line: 12, column: 1, scope: !16)
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "ConvertI16ToEnum", linkageName: "_CConvertI16ToEnum.Main", scope: null, file: !6, line: 16, type: !17, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !25)
+// CHECK:STDOUT: !25 = !{!26}
+// CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !24, type: !19)
+// CHECK:STDOUT: !27 = !DILocation(line: 17, column: 11, scope: !24)
+// CHECK:STDOUT: !28 = !DILocation(line: 17, column: 3, scope: !24)
+// CHECK:STDOUT: !29 = !DILocation(line: 16, column: 1, scope: !24)
+// CHECK:STDOUT: !30 = !{!31, !31, i64 0}
+// CHECK:STDOUT: !31 = !{!"any pointer", !9, i64 0}
+// CHECK:STDOUT: !32 = !{!33, !33, i64 0}
+// CHECK:STDOUT: !33 = !{!"_ZTSN1C1EE", !9, i64 0}
+// CHECK:STDOUT: ; ModuleID = 'use_bitmask.carbon'
+// CHECK:STDOUT: source_filename = "use_bitmask.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CCall.Main() #0 !dbg !11 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_Z4Take4Bits(i32 5), !dbg !14
+// CHECK:STDOUT:   ret void, !dbg !15
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z4Take4Bits(i32 noundef) #1
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "use_bitmask.carbon", directory: "")
+// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
+// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Call", linkageName: "_CCall.Main", scope: null, file: !6, line: 9, type: !12, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
+// CHECK:STDOUT: !13 = !{null}
+// CHECK:STDOUT: !14 = !DILocation(line: 10, column: 3, scope: !11)
+// CHECK:STDOUT: !15 = !DILocation(line: 9, column: 1, scope: !11)


### PR DESCRIPTION
We previously only supported values of enum type, as we did not find a suitable `Core.Destroy` implementation for enums.