### PR TITLE
Make `Optional(T)` copyable. 

### DIFF
--- a/core/prelude/types/optional.carbon
+++ b/core/prelude/types/optional.carbon
@@ -19,6 +19,9 @@ private interface OptionalStorage {
   fn Some[self: Self]() -> Type;
   fn Has(value: Type) -> bool;
   fn Get(value: Type) -> Self;
+  // Copying can also be performed by Get(value).Some(), but Get returns by
+  // copy, so that performs two copies.
+  fn Copy(value: Type) -> Type;
 }
 
 // TODO: We don't have an approved design for an `Optional` type yet, but it's
@@ -42,6 +45,12 @@ class Optional(T:! OptionalStorage) {
 }
 
 impl forall [T:! OptionalStorage & UnformedInit] Optional(T) as UnformedInit {}
+
+impl forall [T:! OptionalStorage] Optional(T) as Copy {
+  fn Op[self: Self]() -> Self {
+    return T.Copy(self as T.Type) as Optional(T);
+  }
+}
 
 // Support for converting a `T` to an `Optional(U)` if `T` converts to `U`.
 // Once we have match_first, this can be rewritten more simply as:
@@ -135,6 +144,13 @@ impl forall [T:! Copy & Destroy] T as OptionalStorage
   fn Get(value: DefaultOptionalStorage(T)) -> T {
     return value.value unsafe as T;
   }
+  fn Copy(value: DefaultOptionalStorage(T)) -> DefaultOptionalStorage(T) {
+    if (Has(value)) {
+      return (value.value unsafe as T).(Some)();
+    } else {
+      return None();
+    }
+  }
 }
 
 private fn PointerIsNull[T:! type](value: MaybeUnformed(T*)) -> bool = "pointer.is_null";
@@ -159,4 +175,5 @@ final impl forall [T:! type] T* as OptionalStorage
   fn Get(value: MaybeUnformed(T*)) -> T* {
     return value unsafe as T*;
   }
+  fn Copy(value: MaybeUnformed(T*)) -> MaybeUnformed(T*) = "primitive_copy";
 }

--- a/toolchain/check/testdata/for/actual.carbon
+++ b/toolchain/check/testdata/for/actual.carbon
@@ -216,7 +216,7 @@ fn Read(y:! Core.IntLiteral()) {
 // CHECK:STDOUT:     .Int = %Core.Int
 // CHECK:STDOUT:     .Iterate = %Core.Iterate
 // CHECK:STDOUT:     .Optional = %Core.Optional
-// CHECK:STDOUT:     .Copy = %Core.Copy
+// CHECK:STDOUT:     .Copy = %Core.Copy.326
 // CHECK:STDOUT:     .OrderedWith = %Core.OrderedWith
 // CHECK:STDOUT:     .Inc = %Core.Inc
 // CHECK:STDOUT:     .Destroy = %Core.Destroy
@@ -238,7 +238,7 @@ fn Read(y:! Core.IntLiteral()) {
 // CHECK:STDOUT:   %Core.import_ref.d9d: @Int.as.Copy.impl.%Int.as.Copy.impl.Op.type (%Int.as.Copy.impl.Op.type.b5d) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.Copy.impl.%Int.as.Copy.impl.Op (constants.%Int.as.Copy.impl.Op.c85)]
 // CHECK:STDOUT:   %Copy.impl_witness_table.193 = impl_witness_table (%Core.import_ref.d9d), @Int.as.Copy.impl [concrete]
 // CHECK:STDOUT:   %Core.Optional: %Optional.type = import_ref Core//prelude/types/optional, Optional, loaded [concrete = constants.%Optional.generic]
-// CHECK:STDOUT:   %Core.Copy: type = import_ref Core//prelude/copy, Copy, loaded [concrete = constants.%Copy.type]
+// CHECK:STDOUT:   %Core.Copy.326: type = import_ref Core//prelude/copy, Copy, loaded [concrete = constants.%Copy.type]
 // CHECK:STDOUT:   %Core.OrderedWith: %OrderedWith.type.9f4 = import_ref Core//prelude/operators/comparison, OrderedWith, loaded [concrete = constants.%OrderedWith.generic]
 // CHECK:STDOUT:   %Core.import_ref.08c: @OrderedWith.WithSelf.%OrderedWith.assoc_type (%OrderedWith.assoc_type.72f) = import_ref Core//prelude/operators/comparison, loc{{\d+_\d+}}, loaded [symbolic = @OrderedWith.WithSelf.%assoc0 (constants.%assoc0.d47)]
 // CHECK:STDOUT:   %Core.import_ref.250: @OrderedWith.WithSelf.%OrderedWith.WithSelf.Less.type (%OrderedWith.WithSelf.Less.type.010) = import_ref Core//prelude/operators/comparison, loc{{\d+_\d+}}, loaded [symbolic = @OrderedWith.WithSelf.%OrderedWith.WithSelf.Less (constants.%OrderedWith.WithSelf.Less.828)]

--- a/toolchain/check/testdata/interop/cpp/class/import/field.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/import/field.carbon
@@ -212,8 +212,8 @@ fn Test(m: Cpp.UnsupportedMembers*) {
 // CHECK:STDOUT:   %T.390: %OptionalStorage.type = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %Optional.Get.type.dbe: type = fn_type @Optional.Get, @Optional(%T.390) [symbolic]
 // CHECK:STDOUT:   %Optional.Get.25b: %Optional.Get.type.dbe = struct_value () [symbolic]
-// CHECK:STDOUT:   %Copy.type: type = facet_type <@Copy> [concrete]
 // CHECK:STDOUT:   %Destroy.type: type = facet_type <@Destroy> [concrete]
+// CHECK:STDOUT:   %Copy.type: type = facet_type <@Copy> [concrete]
 // CHECK:STDOUT:   %T.67d: type = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %ptr.e8f: type = ptr_type %T.67d [symbolic]
 // CHECK:STDOUT:   %Destroy.lookup_impl_witness.310: <witness> = lookup_impl_witness %ptr.e8f, @Destroy [symbolic]
@@ -221,15 +221,15 @@ fn Test(m: Cpp.UnsupportedMembers*) {
 // CHECK:STDOUT:   %MaybeUnformed.4fe: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.0b6) [symbolic]
 // CHECK:STDOUT:   %ptr.as.OptionalStorage.impl.Get.type.890: type = fn_type @ptr.as.OptionalStorage.impl.Get, @ptr.as.OptionalStorage.impl(%T.67d) [symbolic]
 // CHECK:STDOUT:   %ptr.as.OptionalStorage.impl.Get.1b0: %ptr.as.OptionalStorage.impl.Get.type.890 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.d9b: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.1a1, @ptr.as.OptionalStorage.impl(%i32) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.143, (%OptionalStorage.impl_witness.d9b) [concrete]
-// CHECK:STDOUT:   %Optional.e54: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %Struct.elem.480: type = unbound_element_type %Struct, %Optional.e54 [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.477: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.b80, @ptr.as.OptionalStorage.impl(%i32) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.143, (%OptionalStorage.impl_witness.477) [concrete]
+// CHECK:STDOUT:   %Optional.efe: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Struct.elem.373: type = unbound_element_type %Struct, %Optional.efe [concrete]
 // CHECK:STDOUT:   %const.d48: type = const_type %ptr.143 [concrete]
 // CHECK:STDOUT:   %Struct.elem.169: type = unbound_element_type %Struct, %const.d48 [concrete]
-// CHECK:STDOUT:   %Optional.Get.type.6e7: type = fn_type @Optional.Get, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %Optional.Get.6e5: %Optional.Get.type.6e7 = struct_value () [concrete]
-// CHECK:STDOUT:   %Optional.Get.specific_fn: <specific function> = specific_function %Optional.Get.6e5, @Optional.Get(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Optional.Get.type.114: type = fn_type @Optional.Get, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Optional.Get.fdc: %Optional.Get.type.114 = struct_value () [concrete]
+// CHECK:STDOUT:   %Optional.Get.specific_fn: <specific function> = specific_function %Optional.Get.fdc, @Optional.Get(%OptionalStorage.facet) [concrete]
 // CHECK:STDOUT:   %Int.as.Copy.impl.Op.type.b5d: type = fn_type @Int.as.Copy.impl.Op, @Int.as.Copy.impl(%N) [symbolic]
 // CHECK:STDOUT:   %Int.as.Copy.impl.Op.c85: %Int.as.Copy.impl.Op.type.b5d = struct_value () [symbolic]
 // CHECK:STDOUT:   %Copy.impl_witness.ab4: <witness> = impl_witness imports.%Copy.impl_witness_table.193, @Int.as.Copy.impl(%int_32) [concrete]
@@ -248,7 +248,8 @@ fn Test(m: Cpp.UnsupportedMembers*) {
 // CHECK:STDOUT:   %Core.import_ref.5aa = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.37b8: @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Get.type (%ptr.as.OptionalStorage.impl.Get.type.890) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Get (constants.%ptr.as.OptionalStorage.impl.Get.1b0)]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.1a1 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.37b8), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.b80 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.37b8, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %Core.import_ref.d9d: @Int.as.Copy.impl.%Int.as.Copy.impl.Op.type (%Int.as.Copy.impl.Op.type.b5d) = import_ref Core//prelude/types/int, loc{{\d+_\d+}}, loaded [symbolic = @Int.as.Copy.impl.%Int.as.Copy.impl.Op (constants.%Int.as.Copy.impl.Op.c85)]
 // CHECK:STDOUT:   %Copy.impl_witness_table.193 = impl_witness_table (%Core.import_ref.d9d), @Int.as.Copy.impl [concrete]
 // CHECK:STDOUT: }
@@ -269,11 +270,11 @@ fn Test(m: Cpp.UnsupportedMembers*) {
 // CHECK:STDOUT:   %.loc8_23.2: %ptr.143 = acquire_value %.loc8_23.1
 // CHECK:STDOUT:   %.loc8_21.1: ref %i32 = deref %.loc8_23.2
 // CHECK:STDOUT:   %s.ref.loc8_28: %Struct = name_ref s, %s
-// CHECK:STDOUT:   %q.ref: %Struct.elem.480 = name_ref q, @Struct.%.5 [concrete = @Struct.%.5]
-// CHECK:STDOUT:   %.loc8_29.1: ref %Optional.e54 = class_element_access %s.ref.loc8_28, element3
-// CHECK:STDOUT:   %.loc8_29.2: %Optional.e54 = acquire_value %.loc8_29.1
-// CHECK:STDOUT:   %.loc8_31: %Optional.Get.type.6e7 = specific_constant imports.%Core.import_ref.2ae, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.Get.6e5]
-// CHECK:STDOUT:   %Get.ref: %Optional.Get.type.6e7 = name_ref Get, %.loc8_31 [concrete = constants.%Optional.Get.6e5]
+// CHECK:STDOUT:   %q.ref: %Struct.elem.373 = name_ref q, @Struct.%.5 [concrete = @Struct.%.5]
+// CHECK:STDOUT:   %.loc8_29.1: ref %Optional.efe = class_element_access %s.ref.loc8_28, element3
+// CHECK:STDOUT:   %.loc8_29.2: %Optional.efe = acquire_value %.loc8_29.1
+// CHECK:STDOUT:   %.loc8_31: %Optional.Get.type.114 = specific_constant imports.%Core.import_ref.2ae, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.Get.fdc]
+// CHECK:STDOUT:   %Get.ref: %Optional.Get.type.114 = name_ref Get, %.loc8_31 [concrete = constants.%Optional.Get.fdc]
 // CHECK:STDOUT:   %Optional.Get.bound: <bound method> = bound_method %.loc8_29.2, %Get.ref
 // CHECK:STDOUT:   %Optional.Get.specific_fn: <specific function> = specific_function %Get.ref, @Optional.Get(constants.%OptionalStorage.facet) [concrete = constants.%Optional.Get.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc8_36: <bound method> = bound_method %.loc8_29.2, %Optional.Get.specific_fn

--- a/toolchain/check/testdata/interop/cpp/function/import/decayed_param.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/import/decayed_param.carbon
@@ -131,41 +131,41 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.959: %Destroy.type = facet_value %ptr.143, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.5a6: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.959) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.1b4: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.1fd, @ptr.as.OptionalStorage.impl(%i32) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet.5c5: %OptionalStorage.type = facet_value %ptr.143, (%OptionalStorage.impl_witness.1b4) [concrete]
-// CHECK:STDOUT:   %Optional.ab2: type = class_type @Optional, @Optional(%OptionalStorage.facet.5c5) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.2c2: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.1a6, @ptr.as.OptionalStorage.impl(%i32) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet.7bd: %OptionalStorage.type = facet_value %ptr.143, (%OptionalStorage.impl_witness.2c2) [concrete]
+// CHECK:STDOUT:   %Optional.08a: type = class_type @Optional, @Optional(%OptionalStorage.facet.7bd) [concrete]
 // CHECK:STDOUT:   %TakesArray.type: type = fn_type @TakesArray [concrete]
 // CHECK:STDOUT:   %TakesArray: %TakesArray.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.type.535: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.ab2)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.1a6: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.08a)> [concrete]
 // CHECK:STDOUT:   %OptionalAs.type.c8f: type = facet_type <@OptionalAs, @OptionalAs(%T.390)> [symbolic]
 // CHECK:STDOUT:   %U.00a: %OptionalAs.type.c8f = symbolic_binding U, 1 [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.ba3: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%T.390, %U.00a) [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.7c5: %U.as_type.as.ImplicitAs.impl.Convert.type.ba3 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.type.5d0: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.5c5)> [concrete]
+// CHECK:STDOUT:   %OptionalAs.type.edd: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.7bd)> [concrete]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.type.135: type = fn_type @T.as_type.as.OptionalAs.impl.Convert, @T.as_type.as.OptionalAs.impl(%T.390) [symbolic]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.8c2: %T.as_type.as.OptionalAs.impl.Convert.type.135 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.impl_witness.334: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.5c5) [concrete]
-// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.5d0 = facet_value %ptr.143, (%OptionalAs.impl_witness.334) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.c80: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.5c5, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.3fc: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.5c5, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.22a: %U.as_type.as.ImplicitAs.impl.Convert.type.3fc = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.974: %ImplicitAs.type.535 = facet_value %ptr.143, (%ImplicitAs.impl_witness.c80) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.811: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.ab2, %ImplicitAs.facet.974) [concrete]
-// CHECK:STDOUT:   %.3bb: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.811, %ImplicitAs.facet.974 [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.22a, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.5c5, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %OptionalAs.impl_witness.28e: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.7bd) [concrete]
+// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.edd = facet_value %ptr.143, (%OptionalAs.impl_witness.28e) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.60c: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.7bd, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.f8c: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.7bd, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.457: %U.as_type.as.ImplicitAs.impl.Convert.type.f8c = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.9dd: %ImplicitAs.type.1a6 = facet_value %ptr.143, (%ImplicitAs.impl_witness.60c) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.ce5: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.08a, %ImplicitAs.facet.9dd) [concrete]
+// CHECK:STDOUT:   %.e8b: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.ce5, %ImplicitAs.facet.9dd [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.457, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.7bd, %OptionalAs.facet) [concrete]
 // CHECK:STDOUT:   %Cpp.nullptr_t: type = class_type @NullptrT [concrete]
 // CHECK:STDOUT:   %uninit: %Cpp.nullptr_t = uninitialized_value [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.f80: type = fn_type @Cpp.nullptr_t.as.ImplicitAs.impl.Convert, @Cpp.nullptr_t.as.ImplicitAs.impl(%T.67d) [symbolic]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.005: %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.f80 = struct_value () [symbolic]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.54e: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.e9c, @Cpp.nullptr_t.as.ImplicitAs.impl(%i32) [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.bb8: type = fn_type @Cpp.nullptr_t.as.ImplicitAs.impl.Convert, @Cpp.nullptr_t.as.ImplicitAs.impl(%i32) [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.779: %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.bb8 = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.e01: %ImplicitAs.type.535 = facet_value %Cpp.nullptr_t, (%ImplicitAs.impl_witness.54e) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.515: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.ab2, %ImplicitAs.facet.e01) [concrete]
-// CHECK:STDOUT:   %.108: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.515, %ImplicitAs.facet.e01 [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %uninit, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.779 [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.779, @Cpp.nullptr_t.as.ImplicitAs.impl.Convert(%i32) [concrete]
-// CHECK:STDOUT:   %bound_method.c21: <bound method> = bound_method %uninit, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.4ab: type = fn_type @Cpp.nullptr_t.as.ImplicitAs.impl.Convert, @Cpp.nullptr_t.as.ImplicitAs.impl(%T.67d) [symbolic]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.912: %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.4ab = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.731: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.1d0, @Cpp.nullptr_t.as.ImplicitAs.impl(%i32) [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.372: type = fn_type @Cpp.nullptr_t.as.ImplicitAs.impl.Convert, @Cpp.nullptr_t.as.ImplicitAs.impl(%i32) [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.a4b: %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.372 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.4a4: %ImplicitAs.type.1a6 = facet_value %Cpp.nullptr_t, (%ImplicitAs.impl_witness.731) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.073: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.08a, %ImplicitAs.facet.4a4) [concrete]
+// CHECK:STDOUT:   %.d17: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.073, %ImplicitAs.facet.4a4 [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %uninit, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.a4b [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.a4b, @Cpp.nullptr_t.as.ImplicitAs.impl.Convert(%i32) [concrete]
+// CHECK:STDOUT:   %bound_method.54c: <bound method> = bound_method %uninit, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.4: type = fn_type @Destroy.Op.loc13_21.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1dc86d.4: %Destroy.Op.type.af7ec0.4 = struct_value () [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.7: type = fn_type @Destroy.Op.loc10_3.3 [concrete]
@@ -190,16 +190,17 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6a0: @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some.type (%ptr.as.OptionalStorage.impl.Some.type.876) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some (constants.%ptr.as.OptionalStorage.impl.Some.0f5)]
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.1fd = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.f1b, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.1a6 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.f1b, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %TakesArray.decl: %TakesArray.type = fn_decl @TakesArray [concrete = constants.%TakesArray] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc11_23.1: type = splice_block %Optional [concrete = constants.%Optional.ab2] {
+// CHECK:STDOUT:     %.loc11_23.1: type = splice_block %Optional [concrete = constants.%Optional.08a] {
 // CHECK:STDOUT:       <elided>
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.143, (constants.%OptionalStorage.impl_witness.1b4) [concrete = constants.%OptionalStorage.facet.5c5]
-// CHECK:STDOUT:       %.loc11_23.2: %OptionalStorage.type = converted constants.%ptr.143, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.5c5]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.5c5) [concrete = constants.%Optional.ab2]
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.143, (constants.%OptionalStorage.impl_witness.2c2) [concrete = constants.%OptionalStorage.facet.7bd]
+// CHECK:STDOUT:       %.loc11_23.2: %OptionalStorage.type = converted constants.%ptr.143, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.7bd]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.7bd) [concrete = constants.%Optional.08a]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -207,8 +208,8 @@ fn F() {
 // CHECK:STDOUT:   %ImplicitAs.impl_witness_table.d00 = impl_witness_table (%Core.import_ref.0bb), @U.as_type.as.ImplicitAs.impl.20a [concrete]
 // CHECK:STDOUT:   %Core.import_ref.1a5: @T.as_type.as.OptionalAs.impl.%T.as_type.as.OptionalAs.impl.Convert.type (%T.as_type.as.OptionalAs.impl.Convert.type.135) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @T.as_type.as.OptionalAs.impl.%T.as_type.as.OptionalAs.impl.Convert (constants.%T.as_type.as.OptionalAs.impl.Convert.8c2)]
 // CHECK:STDOUT:   %OptionalAs.impl_witness_table.d46 = impl_witness_table (%Core.import_ref.1a5), @T.as_type.as.OptionalAs.impl [concrete]
-// CHECK:STDOUT:   %Core.import_ref.ce7: @Cpp.nullptr_t.as.ImplicitAs.impl.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type (%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.f80) = import_ref Core//prelude/types/cpp/nullptr, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.nullptr_t.as.ImplicitAs.impl.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert (constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.005)]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.e9c = impl_witness_table (%Core.import_ref.ce7), @Cpp.nullptr_t.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.89d: @Cpp.nullptr_t.as.ImplicitAs.impl.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type (%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.4ab) = import_ref Core//prelude/types/cpp/nullptr, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.nullptr_t.as.ImplicitAs.impl.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert (constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.912)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.1d0 = impl_witness_table (%Core.import_ref.89d), @Cpp.nullptr_t.as.ImplicitAs.impl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -245,30 +246,30 @@ fn F() {
 // CHECK:STDOUT:   %.loc11_21.2: %i32 = converted %int_0, %.loc11_21.1 [concrete = constants.%int_0.155]
 // CHECK:STDOUT:   %.loc11_22: ref %i32 = array_index %n.ref, %.loc11_21.2
 // CHECK:STDOUT:   %addr: %ptr.143 = addr_of %.loc11_22
-// CHECK:STDOUT:   %impl.elem0.loc11_18: %.3bb = impl_witness_access constants.%ImplicitAs.impl_witness.c80, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.22a]
+// CHECK:STDOUT:   %impl.elem0.loc11_18: %.e8b = impl_witness_access constants.%ImplicitAs.impl_witness.60c, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.457]
 // CHECK:STDOUT:   %bound_method.loc11_18.1: <bound method> = bound_method %addr, %impl.elem0.loc11_18
-// CHECK:STDOUT:   %specific_fn.loc11_18: <specific function> = specific_function %impl.elem0.loc11_18, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.5c5, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %specific_fn.loc11_18: <specific function> = specific_function %impl.elem0.loc11_18, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.7bd, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc11_18.2: <bound method> = bound_method %addr, %specific_fn.loc11_18
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.ab2 = call %bound_method.loc11_18.2(%addr)
-// CHECK:STDOUT:   %.loc11_18.1: init %Optional.ab2 = converted %addr, %U.as_type.as.ImplicitAs.impl.Convert.call
-// CHECK:STDOUT:   %.loc11_18.2: ref %Optional.ab2 = temporary_storage
-// CHECK:STDOUT:   %.loc11_18.3: ref %Optional.ab2 = temporary %.loc11_18.2, %.loc11_18.1
-// CHECK:STDOUT:   %.loc11_18.4: %Optional.ab2 = acquire_value %.loc11_18.3
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.08a = call %bound_method.loc11_18.2(%addr)
+// CHECK:STDOUT:   %.loc11_18.1: init %Optional.08a = converted %addr, %U.as_type.as.ImplicitAs.impl.Convert.call
+// CHECK:STDOUT:   %.loc11_18.2: ref %Optional.08a = temporary_storage
+// CHECK:STDOUT:   %.loc11_18.3: ref %Optional.08a = temporary %.loc11_18.2, %.loc11_18.1
+// CHECK:STDOUT:   %.loc11_18.4: %Optional.08a = acquire_value %.loc11_18.3
 // CHECK:STDOUT:   %TakesArray.call.loc11: init %empty_tuple.type = call imports.%TakesArray.decl(%.loc11_18.4)
 // CHECK:STDOUT:   %Cpp.ref.loc13_3: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %TakesArray.ref.loc13: %TakesArray.cpp_overload_set.type = name_ref TakesArray, imports.%TakesArray.cpp_overload_set.value [concrete = constants.%TakesArray.cpp_overload_set.value]
 // CHECK:STDOUT:   %Cpp.ref.loc13_18: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %nullptr.ref: %Cpp.nullptr_t = name_ref nullptr, %uninit [concrete = constants.%uninit]
-// CHECK:STDOUT:   %impl.elem0.loc13: %.108 = impl_witness_access constants.%ImplicitAs.impl_witness.54e, element0 [concrete = constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.779]
+// CHECK:STDOUT:   %impl.elem0.loc13: %.d17 = impl_witness_access constants.%ImplicitAs.impl_witness.731, element0 [concrete = constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.a4b]
 // CHECK:STDOUT:   %bound_method.loc13_21.1: <bound method> = bound_method %nullptr.ref, %impl.elem0.loc13 [concrete = constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.bound]
 // CHECK:STDOUT:   %specific_fn.loc13: <specific function> = specific_function %impl.elem0.loc13, @Cpp.nullptr_t.as.ImplicitAs.impl.Convert(constants.%i32) [concrete = constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn]
-// CHECK:STDOUT:   %bound_method.loc13_21.2: <bound method> = bound_method %nullptr.ref, %specific_fn.loc13 [concrete = constants.%bound_method.c21]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call: init %Optional.ab2 = call %bound_method.loc13_21.2(%nullptr.ref)
-// CHECK:STDOUT:   %.loc13_21.1: init %Optional.ab2 = converted %nullptr.ref, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call
-// CHECK:STDOUT:   %.loc13_21.2: ref %Optional.ab2 = temporary_storage
-// CHECK:STDOUT:   %.loc13_21.3: ref %Optional.ab2 = temporary %.loc13_21.2, %.loc13_21.1
-// CHECK:STDOUT:   %.loc13_21.4: %Optional.ab2 = acquire_value %.loc13_21.3
+// CHECK:STDOUT:   %bound_method.loc13_21.2: <bound method> = bound_method %nullptr.ref, %specific_fn.loc13 [concrete = constants.%bound_method.54c]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call: init %Optional.08a = call %bound_method.loc13_21.2(%nullptr.ref)
+// CHECK:STDOUT:   %.loc13_21.1: init %Optional.08a = converted %nullptr.ref, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call
+// CHECK:STDOUT:   %.loc13_21.2: ref %Optional.08a = temporary_storage
+// CHECK:STDOUT:   %.loc13_21.3: ref %Optional.08a = temporary %.loc13_21.2, %.loc13_21.1
+// CHECK:STDOUT:   %.loc13_21.4: %Optional.08a = acquire_value %.loc13_21.3
 // CHECK:STDOUT:   %TakesArray.call.loc13: init %empty_tuple.type = call imports.%TakesArray.decl(%.loc13_21.4)
 // CHECK:STDOUT:   %Destroy.Op.bound.loc13: <bound method> = bound_method %.loc13_21.3, constants.%Destroy.Op.1dc86d.4
 // CHECK:STDOUT:   %Destroy.Op.call.loc13: init %empty_tuple.type = call %Destroy.Op.bound.loc13(%.loc13_21.3)
@@ -284,7 +285,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc13_21.2(%self.param: ref %Optional.ab2) {
+// CHECK:STDOUT: fn @Destroy.Op.loc13_21.2(%self.param: ref %Optional.08a) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interop/cpp/function/import/pointer.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/import/pointer.carbon
@@ -937,12 +937,12 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.489: %Destroy.type = facet_value %ptr.9e9, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.cc9: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.489) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.e57: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.d60, @ptr.as.OptionalStorage.impl(%S) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet.844: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.e57) [concrete]
-// CHECK:STDOUT:   %Optional.ff6: type = class_type @Optional, @Optional(%OptionalStorage.facet.844) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.5b4: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.8c8, @ptr.as.OptionalStorage.impl(%S) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet.71f: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.5b4) [concrete]
+// CHECK:STDOUT:   %Optional.9fa: type = class_type @Optional, @Optional(%OptionalStorage.facet.71f) [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
 // CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.type.86a: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.ff6)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.e84: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.9fa)> [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.0b443a.2: type = facet_type <@ImplicitAs, @ImplicitAs(%T.67d)> [symbolic]
 // CHECK:STDOUT:   %U.2dd: %ImplicitAs.type.0b443a.2 = symbolic_binding U, 1 [symbolic]
 // CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.type.74b: type = fn_type @const.as.ImplicitAs.impl.Convert, @const.as.ImplicitAs.impl(%T.67d, %U.2dd) [symbolic]
@@ -951,20 +951,20 @@ fn F() {
 // CHECK:STDOUT:   %U.00a: %OptionalAs.type.c8f = symbolic_binding U, 1 [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.ba3: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%T.390, %U.00a) [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.7c5: %U.as_type.as.ImplicitAs.impl.Convert.type.ba3 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.type.949: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.844)> [concrete]
+// CHECK:STDOUT:   %OptionalAs.type.608: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.71f)> [concrete]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.type.135: type = fn_type @T.as_type.as.OptionalAs.impl.Convert, @T.as_type.as.OptionalAs.impl(%T.390) [symbolic]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.8c2: %T.as_type.as.OptionalAs.impl.Convert.type.135 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.impl_witness.eb3: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.844) [concrete]
-// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.949 = facet_value %ptr.9e9, (%OptionalAs.impl_witness.eb3) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.b04: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.d36: %ImplicitAs.type.86a = facet_value %ptr.9e9, (%ImplicitAs.impl_witness.b04) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.76d: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.e4b, @const.as.ImplicitAs.impl(%Optional.ff6, %ImplicitAs.facet.d36) [concrete]
-// CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.type.7c5: type = fn_type @const.as.ImplicitAs.impl.Convert, @const.as.ImplicitAs.impl(%Optional.ff6, %ImplicitAs.facet.d36) [concrete]
-// CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.97f: %const.as.ImplicitAs.impl.Convert.type.7c5 = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.e6a: %ImplicitAs.type.86a = facet_value %const.1f8, (%ImplicitAs.impl_witness.76d) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.c59: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.ff6, %ImplicitAs.facet.e6a) [concrete]
-// CHECK:STDOUT:   %.58c: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.c59, %ImplicitAs.facet.e6a [concrete]
-// CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %const.as.ImplicitAs.impl.Convert.97f, @const.as.ImplicitAs.impl.Convert(%Optional.ff6, %ImplicitAs.facet.d36) [concrete]
+// CHECK:STDOUT:   %OptionalAs.impl_witness.7c4: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.71f) [concrete]
+// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.608 = facet_value %ptr.9e9, (%OptionalAs.impl_witness.7c4) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.810: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.a0a: %ImplicitAs.type.e84 = facet_value %ptr.9e9, (%ImplicitAs.impl_witness.810) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.d62: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.e4b, @const.as.ImplicitAs.impl(%Optional.9fa, %ImplicitAs.facet.a0a) [concrete]
+// CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.type.a2c: type = fn_type @const.as.ImplicitAs.impl.Convert, @const.as.ImplicitAs.impl(%Optional.9fa, %ImplicitAs.facet.a0a) [concrete]
+// CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.819: %const.as.ImplicitAs.impl.Convert.type.a2c = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.56b: %ImplicitAs.type.e84 = facet_value %const.1f8, (%ImplicitAs.impl_witness.d62) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.d43: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.9fa, %ImplicitAs.facet.56b) [concrete]
+// CHECK:STDOUT:   %.a78: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.d43, %ImplicitAs.facet.56b [concrete]
+// CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %const.as.ImplicitAs.impl.Convert.819, @const.as.ImplicitAs.impl.Convert(%Optional.9fa, %ImplicitAs.facet.a0a) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.3: type = fn_type @Destroy.Op.loc11_11.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1dc86d.3: %Destroy.Op.type.af7ec0.3 = struct_value () [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.4: type = fn_type @Destroy.Op.loc10 [concrete]
@@ -984,15 +984,16 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6a0: @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some.type (%ptr.as.OptionalStorage.impl.Some.type.876) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some (constants.%ptr.as.OptionalStorage.impl.Some.0f5)]
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.d60 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.8c8 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc11_12.1: type = splice_block %Optional [concrete = constants.%Optional.ff6] {
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:       %.loc11_12.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.844) [concrete = constants.%Optional.ff6]
+// CHECK:STDOUT:     %.loc11_12.1: type = splice_block %Optional [concrete = constants.%Optional.9fa] {
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:       %.loc11_12.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.71f) [concrete = constants.%Optional.9fa]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -1024,16 +1025,16 @@ fn F() {
 // CHECK:STDOUT:   %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %foo.ref: %foo.cpp_overload_set.type = name_ref foo, imports.%foo.cpp_overload_set.value [concrete = constants.%foo.cpp_overload_set.value]
 // CHECK:STDOUT:   %p.ref: ref %const.1f8 = name_ref p, %p
-// CHECK:STDOUT:   %impl.elem0: %.58c = impl_witness_access constants.%ImplicitAs.impl_witness.76d, element0 [concrete = constants.%const.as.ImplicitAs.impl.Convert.97f]
+// CHECK:STDOUT:   %impl.elem0: %.a78 = impl_witness_access constants.%ImplicitAs.impl_witness.d62, element0 [concrete = constants.%const.as.ImplicitAs.impl.Convert.819]
 // CHECK:STDOUT:   %bound_method.loc11_11.1: <bound method> = bound_method %p.ref, %impl.elem0
-// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @const.as.ImplicitAs.impl.Convert(constants.%Optional.ff6, constants.%ImplicitAs.facet.d36) [concrete = constants.%const.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @const.as.ImplicitAs.impl.Convert(constants.%Optional.9fa, constants.%ImplicitAs.facet.a0a) [concrete = constants.%const.as.ImplicitAs.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc11_11.2: <bound method> = bound_method %p.ref, %specific_fn
 // CHECK:STDOUT:   %.loc11_11.1: %const.1f8 = acquire_value %p.ref
-// CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.call: init %Optional.ff6 = call %bound_method.loc11_11.2(%.loc11_11.1)
-// CHECK:STDOUT:   %.loc11_11.2: init %Optional.ff6 = converted %p.ref, %const.as.ImplicitAs.impl.Convert.call
-// CHECK:STDOUT:   %.loc11_11.3: ref %Optional.ff6 = temporary_storage
-// CHECK:STDOUT:   %.loc11_11.4: ref %Optional.ff6 = temporary %.loc11_11.3, %.loc11_11.2
-// CHECK:STDOUT:   %.loc11_11.5: %Optional.ff6 = acquire_value %.loc11_11.4
+// CHECK:STDOUT:   %const.as.ImplicitAs.impl.Convert.call: init %Optional.9fa = call %bound_method.loc11_11.2(%.loc11_11.1)
+// CHECK:STDOUT:   %.loc11_11.2: init %Optional.9fa = converted %p.ref, %const.as.ImplicitAs.impl.Convert.call
+// CHECK:STDOUT:   %.loc11_11.3: ref %Optional.9fa = temporary_storage
+// CHECK:STDOUT:   %.loc11_11.4: ref %Optional.9fa = temporary %.loc11_11.3, %.loc11_11.2
+// CHECK:STDOUT:   %.loc11_11.5: %Optional.9fa = acquire_value %.loc11_11.4
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc11_11.5)
 // CHECK:STDOUT:   %Destroy.Op.bound.loc11: <bound method> = bound_method %.loc11_11.4, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call.loc11: init %empty_tuple.type = call %Destroy.Op.bound.loc11(%.loc11_11.4)
@@ -1047,7 +1048,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc11_11.2(%self.param: ref %Optional.ff6) {
+// CHECK:STDOUT: fn @Destroy.Op.loc11_11.2(%self.param: ref %Optional.9fa) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -1083,28 +1084,28 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.489: %Destroy.type = facet_value %ptr.9e9, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.cc9: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.489) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.e57: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.d60, @ptr.as.OptionalStorage.impl(%S) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet.844: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.e57) [concrete]
-// CHECK:STDOUT:   %Optional.ff6: type = class_type @Optional, @Optional(%OptionalStorage.facet.844) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.5b4: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.8c8, @ptr.as.OptionalStorage.impl(%S) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet.71f: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.5b4) [concrete]
+// CHECK:STDOUT:   %Optional.9fa: type = class_type @Optional, @Optional(%OptionalStorage.facet.71f) [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
 // CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.type.86a: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.ff6)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.e84: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.9fa)> [concrete]
 // CHECK:STDOUT:   %OptionalAs.type.c8f: type = facet_type <@OptionalAs, @OptionalAs(%T.390)> [symbolic]
 // CHECK:STDOUT:   %U.00a: %OptionalAs.type.c8f = symbolic_binding U, 1 [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.ba3: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%T.390, %U.00a) [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.7c5: %U.as_type.as.ImplicitAs.impl.Convert.type.ba3 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.type.949: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.844)> [concrete]
+// CHECK:STDOUT:   %OptionalAs.type.608: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.71f)> [concrete]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.type.135: type = fn_type @T.as_type.as.OptionalAs.impl.Convert, @T.as_type.as.OptionalAs.impl(%T.390) [symbolic]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.8c2: %T.as_type.as.OptionalAs.impl.Convert.type.135 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.impl_witness.eb3: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.844) [concrete]
-// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.949 = facet_value %ptr.9e9, (%OptionalAs.impl_witness.eb3) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.b04: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.8e7: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.105: %U.as_type.as.ImplicitAs.impl.Convert.type.8e7 = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.d36: %ImplicitAs.type.86a = facet_value %ptr.9e9, (%ImplicitAs.impl_witness.b04) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.337: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.ff6, %ImplicitAs.facet.d36) [concrete]
-// CHECK:STDOUT:   %.add: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.337, %ImplicitAs.facet.d36 [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.105, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %OptionalAs.impl_witness.7c4: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.71f) [concrete]
+// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.608 = facet_value %ptr.9e9, (%OptionalAs.impl_witness.7c4) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.810: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.b75: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.506: %U.as_type.as.ImplicitAs.impl.Convert.type.b75 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.a0a: %ImplicitAs.type.e84 = facet_value %ptr.9e9, (%ImplicitAs.impl_witness.810) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.71d: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.9fa, %ImplicitAs.facet.a0a) [concrete]
+// CHECK:STDOUT:   %.820: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.71d, %ImplicitAs.facet.a0a [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.506, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.3: type = fn_type @Destroy.Op.loc11_11.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1dc86d.3: %Destroy.Op.type.af7ec0.3 = struct_value () [concrete]
 // CHECK:STDOUT: }
@@ -1122,15 +1123,16 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6a0: @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some.type (%ptr.as.OptionalStorage.impl.Some.type.876) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some (constants.%ptr.as.OptionalStorage.impl.Some.0f5)]
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.d60 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.8c8 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc11_12.1: type = splice_block %Optional [concrete = constants.%Optional.ff6] {
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:       %.loc11_12.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.844) [concrete = constants.%Optional.ff6]
+// CHECK:STDOUT:     %.loc11_12.1: type = splice_block %Optional [concrete = constants.%Optional.9fa] {
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:       %.loc11_12.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.71f) [concrete = constants.%Optional.9fa]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -1159,16 +1161,16 @@ fn F() {
 // CHECK:STDOUT:   %Cpp.ref.loc11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %foo.ref: %foo.cpp_overload_set.type = name_ref foo, imports.%foo.cpp_overload_set.value [concrete = constants.%foo.cpp_overload_set.value]
 // CHECK:STDOUT:   %p.ref: ref %ptr.9e9 = name_ref p, %p
-// CHECK:STDOUT:   %impl.elem0: %.add = impl_witness_access constants.%ImplicitAs.impl_witness.b04, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.105]
+// CHECK:STDOUT:   %impl.elem0: %.820 = impl_witness_access constants.%ImplicitAs.impl_witness.810, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.506]
 // CHECK:STDOUT:   %bound_method.loc11_11.1: <bound method> = bound_method %p.ref, %impl.elem0
-// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.844, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.71f, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc11_11.2: <bound method> = bound_method %p.ref, %specific_fn
 // CHECK:STDOUT:   %.loc11_11.1: %ptr.9e9 = acquire_value %p.ref
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.ff6 = call %bound_method.loc11_11.2(%.loc11_11.1)
-// CHECK:STDOUT:   %.loc11_11.2: init %Optional.ff6 = converted %p.ref, %U.as_type.as.ImplicitAs.impl.Convert.call
-// CHECK:STDOUT:   %.loc11_11.3: ref %Optional.ff6 = temporary_storage
-// CHECK:STDOUT:   %.loc11_11.4: ref %Optional.ff6 = temporary %.loc11_11.3, %.loc11_11.2
-// CHECK:STDOUT:   %.loc11_11.5: %Optional.ff6 = acquire_value %.loc11_11.4
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.9fa = call %bound_method.loc11_11.2(%.loc11_11.1)
+// CHECK:STDOUT:   %.loc11_11.2: init %Optional.9fa = converted %p.ref, %U.as_type.as.ImplicitAs.impl.Convert.call
+// CHECK:STDOUT:   %.loc11_11.3: ref %Optional.9fa = temporary_storage
+// CHECK:STDOUT:   %.loc11_11.4: ref %Optional.9fa = temporary %.loc11_11.3, %.loc11_11.2
+// CHECK:STDOUT:   %.loc11_11.5: %Optional.9fa = acquire_value %.loc11_11.4
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc11_11.5)
 // CHECK:STDOUT:   %Destroy.Op.bound.loc11: <bound method> = bound_method %.loc11_11.4, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call.loc11: init %empty_tuple.type = call %Destroy.Op.bound.loc11(%.loc11_11.4)
@@ -1182,7 +1184,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc11_11.2(%self.param: ref %Optional.ff6) {
+// CHECK:STDOUT: fn @Destroy.Op.loc11_11.2(%self.param: ref %Optional.9fa) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -1348,28 +1350,28 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.489: %Destroy.type = facet_value %ptr.9e9, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.cc9: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.489) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.e57: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.d60, @ptr.as.OptionalStorage.impl(%S) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet.844: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.e57) [concrete]
-// CHECK:STDOUT:   %Optional.ff6: type = class_type @Optional, @Optional(%OptionalStorage.facet.844) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.5b4: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.8c8, @ptr.as.OptionalStorage.impl(%S) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet.71f: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.5b4) [concrete]
+// CHECK:STDOUT:   %Optional.9fa: type = class_type @Optional, @Optional(%OptionalStorage.facet.71f) [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
 // CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.type.86a: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.ff6)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.e84: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.9fa)> [concrete]
 // CHECK:STDOUT:   %OptionalAs.type.c8f: type = facet_type <@OptionalAs, @OptionalAs(%T.390)> [symbolic]
 // CHECK:STDOUT:   %U.00a: %OptionalAs.type.c8f = symbolic_binding U, 1 [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.ba3: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%T.390, %U.00a) [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.7c5: %U.as_type.as.ImplicitAs.impl.Convert.type.ba3 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.type.949: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.844)> [concrete]
+// CHECK:STDOUT:   %OptionalAs.type.608: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.71f)> [concrete]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.type.135: type = fn_type @T.as_type.as.OptionalAs.impl.Convert, @T.as_type.as.OptionalAs.impl(%T.390) [symbolic]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.8c2: %T.as_type.as.OptionalAs.impl.Convert.type.135 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.impl_witness.eb3: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.844) [concrete]
-// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.949 = facet_value %ptr.9e9, (%OptionalAs.impl_witness.eb3) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.b04: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.8e7: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.105: %U.as_type.as.ImplicitAs.impl.Convert.type.8e7 = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.d36: %ImplicitAs.type.86a = facet_value %ptr.9e9, (%ImplicitAs.impl_witness.b04) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.337: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.ff6, %ImplicitAs.facet.d36) [concrete]
-// CHECK:STDOUT:   %.add: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.337, %ImplicitAs.facet.d36 [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.105, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %OptionalAs.impl_witness.7c4: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.71f) [concrete]
+// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.608 = facet_value %ptr.9e9, (%OptionalAs.impl_witness.7c4) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.810: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.b75: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.506: %U.as_type.as.ImplicitAs.impl.Convert.type.b75 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.a0a: %ImplicitAs.type.e84 = facet_value %ptr.9e9, (%ImplicitAs.impl_witness.810) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.71d: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.9fa, %ImplicitAs.facet.a0a) [concrete]
+// CHECK:STDOUT:   %.820: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.71d, %ImplicitAs.facet.a0a [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.506, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.3: type = fn_type @Destroy.Op.loc9_11.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1dc86d.3: %Destroy.Op.type.af7ec0.3 = struct_value () [concrete]
 // CHECK:STDOUT:   %S.cpp_destructor.type: type = fn_type @S.cpp_destructor [concrete]
@@ -1389,15 +1391,16 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6a0: @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some.type (%ptr.as.OptionalStorage.impl.Some.type.876) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some (constants.%ptr.as.OptionalStorage.impl.Some.0f5)]
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.d60 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.8c8 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc9_13.1: type = splice_block %Optional [concrete = constants.%Optional.ff6] {
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:       %.loc9_13.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.844) [concrete = constants.%Optional.ff6]
+// CHECK:STDOUT:     %.loc9_13.1: type = splice_block %Optional [concrete = constants.%Optional.9fa] {
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:       %.loc9_13.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.71f) [concrete = constants.%Optional.9fa]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -1427,15 +1430,15 @@ fn F() {
 // CHECK:STDOUT:   %foo.ref: %foo.cpp_overload_set.type = name_ref foo, imports.%foo.cpp_overload_set.value [concrete = constants.%foo.cpp_overload_set.value]
 // CHECK:STDOUT:   %s.ref: ref %S = name_ref s, %s
 // CHECK:STDOUT:   %addr: %ptr.9e9 = addr_of %s.ref
-// CHECK:STDOUT:   %impl.elem0: %.add = impl_witness_access constants.%ImplicitAs.impl_witness.b04, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.105]
+// CHECK:STDOUT:   %impl.elem0: %.820 = impl_witness_access constants.%ImplicitAs.impl_witness.810, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.506]
 // CHECK:STDOUT:   %bound_method.loc9_11.1: <bound method> = bound_method %addr, %impl.elem0
-// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.844, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.71f, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc9_11.2: <bound method> = bound_method %addr, %specific_fn
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.ff6 = call %bound_method.loc9_11.2(%addr)
-// CHECK:STDOUT:   %.loc9_11.1: init %Optional.ff6 = converted %addr, %U.as_type.as.ImplicitAs.impl.Convert.call
-// CHECK:STDOUT:   %.loc9_11.2: ref %Optional.ff6 = temporary_storage
-// CHECK:STDOUT:   %.loc9_11.3: ref %Optional.ff6 = temporary %.loc9_11.2, %.loc9_11.1
-// CHECK:STDOUT:   %.loc9_11.4: %Optional.ff6 = acquire_value %.loc9_11.3
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.9fa = call %bound_method.loc9_11.2(%addr)
+// CHECK:STDOUT:   %.loc9_11.1: init %Optional.9fa = converted %addr, %U.as_type.as.ImplicitAs.impl.Convert.call
+// CHECK:STDOUT:   %.loc9_11.2: ref %Optional.9fa = temporary_storage
+// CHECK:STDOUT:   %.loc9_11.3: ref %Optional.9fa = temporary %.loc9_11.2, %.loc9_11.1
+// CHECK:STDOUT:   %.loc9_11.4: %Optional.9fa = acquire_value %.loc9_11.3
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc9_11.4)
 // CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc9_11.3, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc9_11.3)
@@ -1449,7 +1452,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc9_11.2(%self.param: ref %Optional.ff6) {
+// CHECK:STDOUT: fn @Destroy.Op.loc9_11.2(%self.param: ref %Optional.9fa) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -1481,12 +1484,12 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.489: %Destroy.type = facet_value %ptr.9e9, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.cc9: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.489) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.6e7: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.698, @ptr.as.OptionalStorage.impl(%S) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.6e7) [concrete]
-// CHECK:STDOUT:   %Optional.99b: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %Optional.None.type.f55: type = fn_type @Optional.None, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %Optional.None.ccc: %Optional.None.type.f55 = struct_value () [concrete]
-// CHECK:STDOUT:   %Optional.None.specific_fn: <specific function> = specific_function %Optional.None.ccc, @Optional.None(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.657: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.e4f, @ptr.as.OptionalStorage.impl(%S) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.657) [concrete]
+// CHECK:STDOUT:   %Optional.bf0: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Optional.None.type.175: type = fn_type @Optional.None, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Optional.None.540: %Optional.None.type.175 = struct_value () [concrete]
+// CHECK:STDOUT:   %Optional.None.specific_fn: <specific function> = specific_function %Optional.None.540, @Optional.None(%OptionalStorage.facet) [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
 // CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.3: type = fn_type @Destroy.Op.loc8_38.2 [concrete]
@@ -1514,15 +1517,16 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.5aa = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.698 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.f1b, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.e4f = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.f1b, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc8_39.1: type = splice_block %Optional [concrete = constants.%Optional.99b] {
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.6e7) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:     %.loc8_39.1: type = splice_block %Optional [concrete = constants.%Optional.bf0] {
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.657) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:       %.loc8_39.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.99b]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.bf0]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -1538,16 +1542,16 @@ fn F() {
 // CHECK:STDOUT:   %Cpp.ref.loc8_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %S.ref: type = name_ref S, imports.%S.decl [concrete = constants.%S]
 // CHECK:STDOUT:   %ptr: type = ptr_type %S.ref [concrete = constants.%ptr.9e9]
-// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.6e7) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.657) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:   %.loc8_31: %OptionalStorage.type = converted %ptr, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:   %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.99b]
-// CHECK:STDOUT:   %.loc8_32: %Optional.None.type.f55 = specific_constant imports.%Core.import_ref.bd6, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.None.ccc]
-// CHECK:STDOUT:   %None.ref: %Optional.None.type.f55 = name_ref None, %.loc8_32 [concrete = constants.%Optional.None.ccc]
+// CHECK:STDOUT:   %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.bf0]
+// CHECK:STDOUT:   %.loc8_32: %Optional.None.type.175 = specific_constant imports.%Core.import_ref.bd6, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.None.540]
+// CHECK:STDOUT:   %None.ref: %Optional.None.type.175 = name_ref None, %.loc8_32 [concrete = constants.%Optional.None.540]
 // CHECK:STDOUT:   %Optional.None.specific_fn: <specific function> = specific_function %None.ref, @Optional.None(constants.%OptionalStorage.facet) [concrete = constants.%Optional.None.specific_fn]
-// CHECK:STDOUT:   %Optional.None.call: init %Optional.99b = call %Optional.None.specific_fn()
-// CHECK:STDOUT:   %.loc8_38.1: ref %Optional.99b = temporary_storage
-// CHECK:STDOUT:   %.loc8_38.2: ref %Optional.99b = temporary %.loc8_38.1, %Optional.None.call
-// CHECK:STDOUT:   %.loc8_38.3: %Optional.99b = acquire_value %.loc8_38.2
+// CHECK:STDOUT:   %Optional.None.call: init %Optional.bf0 = call %Optional.None.specific_fn()
+// CHECK:STDOUT:   %.loc8_38.1: ref %Optional.bf0 = temporary_storage
+// CHECK:STDOUT:   %.loc8_38.2: ref %Optional.bf0 = temporary %.loc8_38.1, %Optional.None.call
+// CHECK:STDOUT:   %.loc8_38.3: %Optional.bf0 = acquire_value %.loc8_38.2
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc8_38.3)
 // CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc8_38.2, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc8_38.2)
@@ -1559,7 +1563,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc8_38.2(%self.param: ref %Optional.99b) {
+// CHECK:STDOUT: fn @Destroy.Op.loc8_38.2(%self.param: ref %Optional.bf0) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -1595,12 +1599,12 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.489: %Destroy.type = facet_value %ptr.9e9, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.cc9: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.489) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.e57: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.d60, @ptr.as.OptionalStorage.impl(%S) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.e57) [concrete]
-// CHECK:STDOUT:   %Optional.ff6: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %Optional.Some.type.d88: type = fn_type @Optional.Some, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %Optional.Some.fba: %Optional.Some.type.d88 = struct_value () [concrete]
-// CHECK:STDOUT:   %Optional.Some.specific_fn: <specific function> = specific_function %Optional.Some.fba, @Optional.Some(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.5b4: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.8c8, @ptr.as.OptionalStorage.impl(%S) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.5b4) [concrete]
+// CHECK:STDOUT:   %Optional.9fa: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Optional.Some.type.367: type = fn_type @Optional.Some, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Optional.Some.6f2: %Optional.Some.type.367 = struct_value () [concrete]
+// CHECK:STDOUT:   %Optional.Some.specific_fn: <specific function> = specific_function %Optional.Some.6f2, @Optional.Some(%OptionalStorage.facet) [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
 // CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.3: type = fn_type @Destroy.Op.loc9_40.2 [concrete]
@@ -1630,15 +1634,16 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6a0: @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some.type (%ptr.as.OptionalStorage.impl.Some.type.876) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some (constants.%ptr.as.OptionalStorage.impl.Some.0f5)]
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.d60 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.8c8 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc9_41.1: type = splice_block %Optional [concrete = constants.%Optional.ff6] {
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:     %.loc9_41.1: type = splice_block %Optional [concrete = constants.%Optional.9fa] {
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:       %.loc9_41.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.ff6]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.9fa]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -1668,20 +1673,20 @@ fn F() {
 // CHECK:STDOUT:   %Cpp.ref.loc9_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %S.ref.loc9: type = name_ref S, imports.%S.decl [concrete = constants.%S]
 // CHECK:STDOUT:   %ptr: type = ptr_type %S.ref.loc9 [concrete = constants.%ptr.9e9]
-// CHECK:STDOUT:   %OptionalStorage.facet.loc9_31: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:   %OptionalStorage.facet.loc9_31: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:   %.loc9_31: %OptionalStorage.type = converted %ptr, %OptionalStorage.facet.loc9_31 [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:   %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.ff6]
-// CHECK:STDOUT:   %.loc9_32: %Optional.Some.type.d88 = specific_constant imports.%Core.import_ref.8ae4, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.Some.fba]
-// CHECK:STDOUT:   %Some.ref: %Optional.Some.type.d88 = name_ref Some, %.loc9_32 [concrete = constants.%Optional.Some.fba]
+// CHECK:STDOUT:   %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.9fa]
+// CHECK:STDOUT:   %.loc9_32: %Optional.Some.type.367 = specific_constant imports.%Core.import_ref.8ae4, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.Some.6f2]
+// CHECK:STDOUT:   %Some.ref: %Optional.Some.type.367 = name_ref Some, %.loc9_32 [concrete = constants.%Optional.Some.6f2]
 // CHECK:STDOUT:   %s.ref: ref %S = name_ref s, %s
 // CHECK:STDOUT:   %addr: %ptr.9e9 = addr_of %s.ref
-// CHECK:STDOUT:   %OptionalStorage.facet.loc9_40: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:   %OptionalStorage.facet.loc9_40: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:   %.loc9_40.1: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet.loc9_40 [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:   %Optional.Some.specific_fn: <specific function> = specific_function %Some.ref, @Optional.Some(constants.%OptionalStorage.facet) [concrete = constants.%Optional.Some.specific_fn]
-// CHECK:STDOUT:   %Optional.Some.call: init %Optional.ff6 = call %Optional.Some.specific_fn(%addr)
-// CHECK:STDOUT:   %.loc9_40.2: ref %Optional.ff6 = temporary_storage
-// CHECK:STDOUT:   %.loc9_40.3: ref %Optional.ff6 = temporary %.loc9_40.2, %Optional.Some.call
-// CHECK:STDOUT:   %.loc9_40.4: %Optional.ff6 = acquire_value %.loc9_40.3
+// CHECK:STDOUT:   %Optional.Some.call: init %Optional.9fa = call %Optional.Some.specific_fn(%addr)
+// CHECK:STDOUT:   %.loc9_40.2: ref %Optional.9fa = temporary_storage
+// CHECK:STDOUT:   %.loc9_40.3: ref %Optional.9fa = temporary %.loc9_40.2, %Optional.Some.call
+// CHECK:STDOUT:   %.loc9_40.4: %Optional.9fa = acquire_value %.loc9_40.3
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc9_40.4)
 // CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc9_40.3, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc9_40.3)
@@ -1695,7 +1700,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc9_40.2(%self.param: ref %Optional.ff6) {
+// CHECK:STDOUT: fn @Destroy.Op.loc9_40.2(%self.param: ref %Optional.9fa) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -1722,9 +1727,9 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.489: %Destroy.type = facet_value %ptr.9e9, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.cc9: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.489) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.c1e: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.b94, @ptr.as.OptionalStorage.impl(%S) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.c1e) [concrete]
-// CHECK:STDOUT:   %Optional.33a: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.968: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.54e, @ptr.as.OptionalStorage.impl(%S) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.968) [concrete]
+// CHECK:STDOUT:   %Optional.3df: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
 // CHECK:STDOUT:   %get.type: type = fn_type @get [concrete]
 // CHECK:STDOUT:   %get: %get.type = struct_value () [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
@@ -1746,23 +1751,24 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.5aa = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.b94 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.54e = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %get.decl: %get.type = fn_decl @get [concrete = constants.%get] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.c1e) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.968) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:     %.loc8: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.33a]
+// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.3df]
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc8_20.1: type = splice_block %Optional [concrete = constants.%Optional.33a] {
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.c1e) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:     %.loc8_20.1: type = splice_block %Optional [concrete = constants.%Optional.3df] {
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.968) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:       %.loc8_20.2: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.33a]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.3df]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -1774,10 +1780,10 @@ fn F() {
 // CHECK:STDOUT:   %foo.ref: %foo.cpp_overload_set.type = name_ref foo, imports.%foo.cpp_overload_set.value [concrete = constants.%foo.cpp_overload_set.value]
 // CHECK:STDOUT:   %Cpp.ref.loc8_11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %get.ref: %get.cpp_overload_set.type = name_ref get, imports.%get.cpp_overload_set.value [concrete = constants.%get.cpp_overload_set.value]
-// CHECK:STDOUT:   %get.call: init %Optional.33a = call imports.%get.decl()
-// CHECK:STDOUT:   %.loc8_19.1: ref %Optional.33a = temporary_storage
-// CHECK:STDOUT:   %.loc8_19.2: ref %Optional.33a = temporary %.loc8_19.1, %get.call
-// CHECK:STDOUT:   %.loc8_19.3: %Optional.33a = acquire_value %.loc8_19.2
+// CHECK:STDOUT:   %get.call: init %Optional.3df = call imports.%get.decl()
+// CHECK:STDOUT:   %.loc8_19.1: ref %Optional.3df = temporary_storage
+// CHECK:STDOUT:   %.loc8_19.2: ref %Optional.3df = temporary %.loc8_19.1, %get.call
+// CHECK:STDOUT:   %.loc8_19.3: %Optional.3df = acquire_value %.loc8_19.2
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc8_19.3)
 // CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc8_19.2, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc8_19.2)
@@ -1789,7 +1795,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc8_19.2(%self.param: ref %Optional.33a) {
+// CHECK:STDOUT: fn @Destroy.Op.loc8_19.2(%self.param: ref %Optional.3df) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -1894,31 +1900,31 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.489: %Destroy.type = facet_value %ptr.9e9, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.cc9: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.489) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.e57: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.d60, @ptr.as.OptionalStorage.impl(%S) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet.844: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.e57) [concrete]
-// CHECK:STDOUT:   %Optional.ff6: type = class_type @Optional, @Optional(%OptionalStorage.facet.844) [concrete]
-// CHECK:STDOUT:   %pattern_type.02a: type = pattern_type %Optional.ff6 [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.5b4: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.8c8, @ptr.as.OptionalStorage.impl(%S) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet.71f: %OptionalStorage.type = facet_value %ptr.9e9, (%OptionalStorage.impl_witness.5b4) [concrete]
+// CHECK:STDOUT:   %Optional.9fa: type = class_type @Optional, @Optional(%OptionalStorage.facet.71f) [concrete]
+// CHECK:STDOUT:   %pattern_type.2d0: type = pattern_type %Optional.9fa [concrete]
 // CHECK:STDOUT:   %Direct.type: type = fn_type @Direct [concrete]
 // CHECK:STDOUT:   %Direct: %Direct.type = struct_value () [concrete]
 // CHECK:STDOUT:   %ImplicitAs.type.649: type = generic_interface_type @ImplicitAs [concrete]
 // CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.649 = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.type.86a: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.ff6)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.e84: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.9fa)> [concrete]
 // CHECK:STDOUT:   %OptionalAs.type.c8f: type = facet_type <@OptionalAs, @OptionalAs(%T.390)> [symbolic]
 // CHECK:STDOUT:   %U.00a: %OptionalAs.type.c8f = symbolic_binding U, 1 [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.ba3: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%T.390, %U.00a) [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.7c5: %U.as_type.as.ImplicitAs.impl.Convert.type.ba3 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.type.949: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.844)> [concrete]
+// CHECK:STDOUT:   %OptionalAs.type.608: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.71f)> [concrete]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.type.135: type = fn_type @T.as_type.as.OptionalAs.impl.Convert, @T.as_type.as.OptionalAs.impl(%T.390) [symbolic]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.8c2: %T.as_type.as.OptionalAs.impl.Convert.type.135 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.impl_witness.eb3: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.844) [concrete]
-// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.949 = facet_value %ptr.9e9, (%OptionalAs.impl_witness.eb3) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.b04: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.8e7: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.105: %U.as_type.as.ImplicitAs.impl.Convert.type.8e7 = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.d36: %ImplicitAs.type.86a = facet_value %ptr.9e9, (%ImplicitAs.impl_witness.b04) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.337: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.ff6, %ImplicitAs.facet.d36) [concrete]
-// CHECK:STDOUT:   %.add: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.337, %ImplicitAs.facet.d36 [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.105, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.844, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %OptionalAs.impl_witness.7c4: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.71f) [concrete]
+// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.608 = facet_value %ptr.9e9, (%OptionalAs.impl_witness.7c4) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.810: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.b75: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.506: %U.as_type.as.ImplicitAs.impl.Convert.type.b75 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.a0a: %ImplicitAs.type.e84 = facet_value %ptr.9e9, (%ImplicitAs.impl_witness.810) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.71d: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.9fa, %ImplicitAs.facet.a0a) [concrete]
+// CHECK:STDOUT:   %.820: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.71d, %ImplicitAs.facet.a0a [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.506, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.71f, %OptionalAs.facet) [concrete]
 // CHECK:STDOUT:   %Indirect.cpp_overload_set.type: type = cpp_overload_set_type @Indirect.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %Indirect.cpp_overload_set.value: %Indirect.cpp_overload_set.type = cpp_overload_set_value @Indirect.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %Indirect__carbon_thunk.type: type = fn_type @Indirect__carbon_thunk [concrete]
@@ -1952,18 +1958,19 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6a0: @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some.type (%ptr.as.OptionalStorage.impl.Some.type.876) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some (constants.%ptr.as.OptionalStorage.impl.Some.0f5)]
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.d60 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.8c8 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %Direct.decl: %Direct.type = fn_decl @Direct [concrete = constants.%Direct] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %OptionalStorage.facet.loc11_16.1: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:     %.loc11_16.1: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet.loc11_16.1 [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:     %Optional.loc11_16.1: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.844) [concrete = constants.%Optional.ff6]
+// CHECK:STDOUT:     %OptionalStorage.facet.loc11_16.1: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:     %.loc11_16.1: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet.loc11_16.1 [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:     %Optional.loc11_16.1: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.71f) [concrete = constants.%Optional.9fa]
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc11_16.2: type = splice_block %Optional.loc11_16.2 [concrete = constants.%Optional.ff6] {
-// CHECK:STDOUT:       %OptionalStorage.facet.loc11_16.2: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:       %.loc11_16.3: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet.loc11_16.2 [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:       %Optional.loc11_16.2: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.844) [concrete = constants.%Optional.ff6]
+// CHECK:STDOUT:     %.loc11_16.2: type = splice_block %Optional.loc11_16.2 [concrete = constants.%Optional.9fa] {
+// CHECK:STDOUT:       %OptionalStorage.facet.loc11_16.2: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:       %.loc11_16.3: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet.loc11_16.2 [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:       %Optional.loc11_16.2: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.71f) [concrete = constants.%Optional.9fa]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -1976,9 +1983,9 @@ fn F() {
 // CHECK:STDOUT:   %Indirect__carbon_thunk.decl: %Indirect__carbon_thunk.type = fn_decl @Indirect__carbon_thunk [concrete = constants.%Indirect__carbon_thunk] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:     %.loc13: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.844) [concrete = constants.%Optional.ff6]
+// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.9e9, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:     %.loc13: %OptionalStorage.type = converted constants.%ptr.9e9, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.71f) [concrete = constants.%Optional.9fa]
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.Destroy: type = import_ref Core//prelude/destroy, Destroy, loaded [concrete = constants.%Destroy.type]
@@ -2004,18 +2011,18 @@ fn F() {
 // CHECK:STDOUT:   %Direct.ref: %Direct.cpp_overload_set.type = name_ref Direct, imports.%Direct.cpp_overload_set.value [concrete = constants.%Direct.cpp_overload_set.value]
 // CHECK:STDOUT:   %s.ref: ref %S = name_ref s, %s
 // CHECK:STDOUT:   %addr.loc11: %ptr.9e9 = addr_of %s.ref
-// CHECK:STDOUT:   %impl.elem0: %.add = impl_witness_access constants.%ImplicitAs.impl_witness.b04, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.105]
+// CHECK:STDOUT:   %impl.elem0: %.820 = impl_witness_access constants.%ImplicitAs.impl_witness.810, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.506]
 // CHECK:STDOUT:   %bound_method.loc11_14.1: <bound method> = bound_method %addr.loc11, %impl.elem0
-// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.844, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.71f, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc11_14.2: <bound method> = bound_method %addr.loc11, %specific_fn
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.ff6 = call %bound_method.loc11_14.2(%addr.loc11)
-// CHECK:STDOUT:   %.loc11_14.1: init %Optional.ff6 = converted %addr.loc11, %U.as_type.as.ImplicitAs.impl.Convert.call
-// CHECK:STDOUT:   %.loc11_14.2: ref %Optional.ff6 = temporary_storage
-// CHECK:STDOUT:   %.loc11_14.3: ref %Optional.ff6 = temporary %.loc11_14.2, %.loc11_14.1
-// CHECK:STDOUT:   %.loc11_14.4: %Optional.ff6 = acquire_value %.loc11_14.3
-// CHECK:STDOUT:   %Direct.call: init %Optional.ff6 = call imports.%Direct.decl(%.loc11_14.4)
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.9fa = call %bound_method.loc11_14.2(%addr.loc11)
+// CHECK:STDOUT:   %.loc11_14.1: init %Optional.9fa = converted %addr.loc11, %U.as_type.as.ImplicitAs.impl.Convert.call
+// CHECK:STDOUT:   %.loc11_14.2: ref %Optional.9fa = temporary_storage
+// CHECK:STDOUT:   %.loc11_14.3: ref %Optional.9fa = temporary %.loc11_14.2, %.loc11_14.1
+// CHECK:STDOUT:   %.loc11_14.4: %Optional.9fa = acquire_value %.loc11_14.3
+// CHECK:STDOUT:   %Direct.call: init %Optional.9fa = call imports.%Direct.decl(%.loc11_14.4)
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %a.patt: %pattern_type.02a = value_binding_pattern a [concrete]
+// CHECK:STDOUT:     %a.patt: %pattern_type.2d0 = value_binding_pattern a [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc13_41: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %Indirect.ref: %Indirect.cpp_overload_set.type = name_ref Indirect, imports.%Indirect.cpp_overload_set.value [concrete = constants.%Indirect.cpp_overload_set.value]
@@ -2029,21 +2036,21 @@ fn F() {
 // CHECK:STDOUT:   %.loc13_57.3: %S = acquire_value %.loc13_57.2 [concrete = constants.%S.val]
 // CHECK:STDOUT:   %.loc13_57.4: ref %S = value_as_ref %.loc13_57.3
 // CHECK:STDOUT:   %addr.loc13: %ptr.9e9 = addr_of %.loc13_57.4
-// CHECK:STDOUT:   %Indirect__carbon_thunk.call: init %Optional.ff6 = call imports.%Indirect__carbon_thunk.decl(%addr.loc13)
-// CHECK:STDOUT:   %.loc13_37.1: type = splice_block %Optional [concrete = constants.%Optional.ff6] {
+// CHECK:STDOUT:   %Indirect__carbon_thunk.call: init %Optional.9fa = call imports.%Indirect__carbon_thunk.decl(%addr.loc13)
+// CHECK:STDOUT:   %.loc13_37.1: type = splice_block %Optional [concrete = constants.%Optional.9fa] {
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, imports.%Core [concrete = imports.%Core]
 // CHECK:STDOUT:     %Optional.ref: %Optional.type = name_ref Optional, imports.%Core.Optional [concrete = constants.%Optional.generic]
 // CHECK:STDOUT:     %Cpp.ref.loc13_31: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %S.ref.loc13_34: type = name_ref S, imports.%S.decl [concrete = constants.%S]
 // CHECK:STDOUT:     %ptr: type = ptr_type %S.ref.loc13_34 [concrete = constants.%ptr.9e9]
-// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.e57) [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:     %.loc13_37.2: %OptionalStorage.type = converted %ptr, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.844]
-// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.844) [concrete = constants.%Optional.ff6]
+// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.5b4) [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:     %.loc13_37.2: %OptionalStorage.type = converted %ptr, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.71f]
+// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.71f) [concrete = constants.%Optional.9fa]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc13_65.1: ref %Optional.ff6 = temporary_storage
-// CHECK:STDOUT:   %.loc13_65.2: ref %Optional.ff6 = temporary %.loc13_65.1, %Indirect__carbon_thunk.call
-// CHECK:STDOUT:   %.loc13_65.3: %Optional.ff6 = acquire_value %.loc13_65.2
-// CHECK:STDOUT:   %a: %Optional.ff6 = value_binding a, %.loc13_65.3
+// CHECK:STDOUT:   %.loc13_65.1: ref %Optional.9fa = temporary_storage
+// CHECK:STDOUT:   %.loc13_65.2: ref %Optional.9fa = temporary %.loc13_65.1, %Indirect__carbon_thunk.call
+// CHECK:STDOUT:   %.loc13_65.3: %Optional.9fa = acquire_value %.loc13_65.2
+// CHECK:STDOUT:   %a: %Optional.9fa = value_binding a, %.loc13_65.3
 // CHECK:STDOUT:   %Destroy.Op.bound.loc13: <bound method> = bound_method %.loc13_65.2, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call.loc13: init %empty_tuple.type = call %Destroy.Op.bound.loc13(%.loc13_65.2)
 // CHECK:STDOUT:   %Destroy.Op.bound.loc11: <bound method> = bound_method %.loc11_14.3, constants.%Destroy.Op.1dc86d.3
@@ -2058,7 +2065,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc13_65.2(%self.param: ref %Optional.ff6) {
+// CHECK:STDOUT: fn @Destroy.Op.loc13_65.2(%self.param: ref %Optional.9fa) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interop/cpp/function/import/void_pointer.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/import/void_pointer.carbon
@@ -215,28 +215,28 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.b18: %Destroy.type = facet_value %ptr.838, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.b5e: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.b18) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.002: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.d60, @ptr.as.OptionalStorage.impl(%Cpp.void) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet.57b: %OptionalStorage.type = facet_value %ptr.838, (%OptionalStorage.impl_witness.002) [concrete]
-// CHECK:STDOUT:   %Optional.17a: type = class_type @Optional, @Optional(%OptionalStorage.facet.57b) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.b00: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.8c8, @ptr.as.OptionalStorage.impl(%Cpp.void) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet.011: %OptionalStorage.type = facet_value %ptr.838, (%OptionalStorage.impl_witness.b00) [concrete]
+// CHECK:STDOUT:   %Optional.f8a: type = class_type @Optional, @Optional(%OptionalStorage.facet.011) [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
 // CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.type.170: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.17a)> [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.7aa: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.f8a)> [concrete]
 // CHECK:STDOUT:   %OptionalAs.type.c8f: type = facet_type <@OptionalAs, @OptionalAs(%T.390)> [symbolic]
 // CHECK:STDOUT:   %U.00a: %OptionalAs.type.c8f = symbolic_binding U, 1 [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.ba3: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%T.390, %U.00a) [symbolic]
 // CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.7c5: %U.as_type.as.ImplicitAs.impl.Convert.type.ba3 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.type.fa5: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.57b)> [concrete]
+// CHECK:STDOUT:   %OptionalAs.type.066: type = facet_type <@OptionalAs, @OptionalAs(%OptionalStorage.facet.011)> [concrete]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.type.135: type = fn_type @T.as_type.as.OptionalAs.impl.Convert, @T.as_type.as.OptionalAs.impl(%T.390) [symbolic]
 // CHECK:STDOUT:   %T.as_type.as.OptionalAs.impl.Convert.8c2: %T.as_type.as.OptionalAs.impl.Convert.type.135 = struct_value () [symbolic]
-// CHECK:STDOUT:   %OptionalAs.impl_witness.a19: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.57b) [concrete]
-// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.fa5 = facet_value %ptr.838, (%OptionalAs.impl_witness.a19) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.63c: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.57b, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.b0a: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.57b, %OptionalAs.facet) [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.c22: %U.as_type.as.ImplicitAs.impl.Convert.type.b0a = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet.e0c: %ImplicitAs.type.170 = facet_value %ptr.838, (%ImplicitAs.impl_witness.63c) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.2b3: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.17a, %ImplicitAs.facet.e0c) [concrete]
-// CHECK:STDOUT:   %.fdb: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.2b3, %ImplicitAs.facet.e0c [concrete]
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.c22, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.57b, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %OptionalAs.impl_witness.dfe: <witness> = impl_witness imports.%OptionalAs.impl_witness_table.d46, @T.as_type.as.OptionalAs.impl(%OptionalStorage.facet.011) [concrete]
+// CHECK:STDOUT:   %OptionalAs.facet: %OptionalAs.type.066 = facet_value %ptr.838, (%OptionalAs.impl_witness.dfe) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.2d3: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.d00, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.011, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.type.7d8: type = fn_type @U.as_type.as.ImplicitAs.impl.Convert.2, @U.as_type.as.ImplicitAs.impl.20a(%OptionalStorage.facet.011, %OptionalAs.facet) [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.7ae: %U.as_type.as.ImplicitAs.impl.Convert.type.7d8 = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet.04c: %ImplicitAs.type.7aa = facet_value %ptr.838, (%ImplicitAs.impl_witness.2d3) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.a8d: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.f8a, %ImplicitAs.facet.04c) [concrete]
+// CHECK:STDOUT:   %.78a: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.a8d, %ImplicitAs.facet.04c [concrete]
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %U.as_type.as.ImplicitAs.impl.Convert.7ae, @U.as_type.as.ImplicitAs.impl.Convert.2(%OptionalStorage.facet.011, %OptionalAs.facet) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.3: type = fn_type @Destroy.Op.loc10_11.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1dc86d.3: %Destroy.Op.type.af7ec0.3 = struct_value () [concrete]
 // CHECK:STDOUT: }
@@ -253,15 +253,16 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.6a0: @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some.type (%ptr.as.OptionalStorage.impl.Some.type.876) = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, loaded [symbolic = @ptr.as.OptionalStorage.impl.%ptr.as.OptionalStorage.impl.Some (constants.%ptr.as.OptionalStorage.impl.Some.0f5)]
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.d60 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.8c8 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.6a0, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc10_16.1: type = splice_block %Optional [concrete = constants.%Optional.17a] {
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.838, (constants.%OptionalStorage.impl_witness.002) [concrete = constants.%OptionalStorage.facet.57b]
-// CHECK:STDOUT:       %.loc10_16.2: %OptionalStorage.type = converted constants.%ptr.838, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.57b]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.57b) [concrete = constants.%Optional.17a]
+// CHECK:STDOUT:     %.loc10_16.1: type = splice_block %Optional [concrete = constants.%Optional.f8a] {
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.838, (constants.%OptionalStorage.impl_witness.b00) [concrete = constants.%OptionalStorage.facet.011]
+// CHECK:STDOUT:       %.loc10_16.2: %OptionalStorage.type = converted constants.%ptr.838, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.011]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.011) [concrete = constants.%Optional.f8a]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -276,15 +277,15 @@ fn F() {
 // CHECK:STDOUT:   %Cpp.ref.loc10: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %foo.ref: %foo.cpp_overload_set.type = name_ref foo, imports.%foo.cpp_overload_set.value [concrete = constants.%foo.cpp_overload_set.value]
 // CHECK:STDOUT:   %input.ref: %ptr.838 = name_ref input, %input
-// CHECK:STDOUT:   %impl.elem0: %.fdb = impl_witness_access constants.%ImplicitAs.impl_witness.63c, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.c22]
+// CHECK:STDOUT:   %impl.elem0: %.78a = impl_witness_access constants.%ImplicitAs.impl_witness.2d3, element0 [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.7ae]
 // CHECK:STDOUT:   %bound_method.loc10_11.1: <bound method> = bound_method %input.ref, %impl.elem0
-// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.57b, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
+// CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @U.as_type.as.ImplicitAs.impl.Convert.2(constants.%OptionalStorage.facet.011, constants.%OptionalAs.facet) [concrete = constants.%U.as_type.as.ImplicitAs.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc10_11.2: <bound method> = bound_method %input.ref, %specific_fn
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.17a = call %bound_method.loc10_11.2(%input.ref)
-// CHECK:STDOUT:   %.loc10_11.1: init %Optional.17a = converted %input.ref, %U.as_type.as.ImplicitAs.impl.Convert.call
-// CHECK:STDOUT:   %.loc10_11.2: ref %Optional.17a = temporary_storage
-// CHECK:STDOUT:   %.loc10_11.3: ref %Optional.17a = temporary %.loc10_11.2, %.loc10_11.1
-// CHECK:STDOUT:   %.loc10_11.4: %Optional.17a = acquire_value %.loc10_11.3
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call: init %Optional.f8a = call %bound_method.loc10_11.2(%input.ref)
+// CHECK:STDOUT:   %.loc10_11.1: init %Optional.f8a = converted %input.ref, %U.as_type.as.ImplicitAs.impl.Convert.call
+// CHECK:STDOUT:   %.loc10_11.2: ref %Optional.f8a = temporary_storage
+// CHECK:STDOUT:   %.loc10_11.3: ref %Optional.f8a = temporary %.loc10_11.2, %.loc10_11.1
+// CHECK:STDOUT:   %.loc10_11.4: %Optional.f8a = acquire_value %.loc10_11.3
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc10_11.4)
 // CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc10_11.3, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc10_11.3)
@@ -296,7 +297,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc10_11.2(%self.param: ref %Optional.17a) {
+// CHECK:STDOUT: fn @Destroy.Op.loc10_11.2(%self.param: ref %Optional.f8a) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -328,12 +329,12 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.b18: %Destroy.type = facet_value %ptr.838, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.b5e: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.b18) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.183: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.698, @ptr.as.OptionalStorage.impl(%Cpp.void) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.838, (%OptionalStorage.impl_witness.183) [concrete]
-// CHECK:STDOUT:   %Optional.075: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %Optional.None.type.cd7: type = fn_type @Optional.None, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %Optional.None.52c: %Optional.None.type.cd7 = struct_value () [concrete]
-// CHECK:STDOUT:   %Optional.None.specific_fn: <specific function> = specific_function %Optional.None.52c, @Optional.None(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.2cf: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.e4f, @ptr.as.OptionalStorage.impl(%Cpp.void) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.838, (%OptionalStorage.impl_witness.2cf) [concrete]
+// CHECK:STDOUT:   %Optional.e33: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Optional.None.type.a54: type = fn_type @Optional.None, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %Optional.None.c01: %Optional.None.type.a54 = struct_value () [concrete]
+// CHECK:STDOUT:   %Optional.None.specific_fn: <specific function> = specific_function %Optional.None.c01, @Optional.None(%OptionalStorage.facet) [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
 // CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.3: type = fn_type @Destroy.Op.loc10_41.2 [concrete]
@@ -368,15 +369,16 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.5aa = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.698 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.f1b, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.e4f = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.f1b, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc10_42.1: type = splice_block %Optional [concrete = constants.%Optional.075] {
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.838, (constants.%OptionalStorage.impl_witness.183) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:     %.loc10_42.1: type = splice_block %Optional [concrete = constants.%Optional.e33] {
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.838, (constants.%OptionalStorage.impl_witness.2cf) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:       %.loc10_42.2: %OptionalStorage.type = converted constants.%ptr.838, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.075]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.e33]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
@@ -392,16 +394,16 @@ fn F() {
 // CHECK:STDOUT:   %Cpp.ref.loc10_25: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %void.ref: type = name_ref void, constants.%Cpp.void [concrete = constants.%Cpp.void]
 // CHECK:STDOUT:   %ptr: type = ptr_type %void.ref [concrete = constants.%ptr.838]
-// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.183) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.2cf) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:   %.loc10_34: %OptionalStorage.type = converted %ptr, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:   %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.075]
-// CHECK:STDOUT:   %.loc10_35: %Optional.None.type.cd7 = specific_constant imports.%Core.import_ref.bd6, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.None.52c]
-// CHECK:STDOUT:   %None.ref: %Optional.None.type.cd7 = name_ref None, %.loc10_35 [concrete = constants.%Optional.None.52c]
+// CHECK:STDOUT:   %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.e33]
+// CHECK:STDOUT:   %.loc10_35: %Optional.None.type.a54 = specific_constant imports.%Core.import_ref.bd6, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.None.c01]
+// CHECK:STDOUT:   %None.ref: %Optional.None.type.a54 = name_ref None, %.loc10_35 [concrete = constants.%Optional.None.c01]
 // CHECK:STDOUT:   %Optional.None.specific_fn: <specific function> = specific_function %None.ref, @Optional.None(constants.%OptionalStorage.facet) [concrete = constants.%Optional.None.specific_fn]
-// CHECK:STDOUT:   %Optional.None.call: init %Optional.075 = call %Optional.None.specific_fn()
-// CHECK:STDOUT:   %.loc10_41.1: ref %Optional.075 = temporary_storage
-// CHECK:STDOUT:   %.loc10_41.2: ref %Optional.075 = temporary %.loc10_41.1, %Optional.None.call
-// CHECK:STDOUT:   %.loc10_41.3: %Optional.075 = acquire_value %.loc10_41.2
+// CHECK:STDOUT:   %Optional.None.call: init %Optional.e33 = call %Optional.None.specific_fn()
+// CHECK:STDOUT:   %.loc10_41.1: ref %Optional.e33 = temporary_storage
+// CHECK:STDOUT:   %.loc10_41.2: ref %Optional.e33 = temporary %.loc10_41.1, %Optional.None.call
+// CHECK:STDOUT:   %.loc10_41.3: %Optional.e33 = acquire_value %.loc10_41.2
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc10_41.3)
 // CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc10_41.2, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc10_41.2)
@@ -413,7 +415,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc10_41.2(%self.param: ref %Optional.075) {
+// CHECK:STDOUT: fn @Destroy.Op.loc10_41.2(%self.param: ref %Optional.e33) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
@@ -438,10 +440,10 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.1: <witness> = custom_witness (%Destroy.Op.1dc86d.1), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.b18: %Destroy.type = facet_value %ptr.838, (%custom_witness.340963.1) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.b5e: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.b18) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.be6: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.b94, @ptr.as.OptionalStorage.impl(%Cpp.void) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.838, (%OptionalStorage.impl_witness.be6) [concrete]
-// CHECK:STDOUT:   %Optional.46b: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
-// CHECK:STDOUT:   %pattern_type.dbc: type = pattern_type %Optional.46b [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.595: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.54e, @ptr.as.OptionalStorage.impl(%Cpp.void) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr.838, (%OptionalStorage.impl_witness.595) [concrete]
+// CHECK:STDOUT:   %Optional.bcc: type = class_type @Optional, @Optional(%OptionalStorage.facet) [concrete]
+// CHECK:STDOUT:   %pattern_type.690: type = pattern_type %Optional.bcc [concrete]
 // CHECK:STDOUT:   %foo.cpp_overload_set.type: type = cpp_overload_set_type @foo.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %foo.cpp_overload_set.value: %foo.cpp_overload_set.type = cpp_overload_set_value @foo.cpp_overload_set [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
@@ -476,14 +478,15 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.5aa = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.b94 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.54e = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.efd, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.cpp_overload_set.value: %foo.cpp_overload_set.type = cpp_overload_set_value @foo.cpp_overload_set [concrete = constants.%foo.cpp_overload_set.value]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.838, (constants.%OptionalStorage.impl_witness.be6) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.838, (constants.%OptionalStorage.impl_witness.595) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:     %.loc10: %OptionalStorage.type = converted constants.%ptr.838, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.46b]
+// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.bcc]
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Core.Destroy: type = import_ref Core//prelude/destroy, Destroy, loaded [concrete = constants.%Destroy.type]
@@ -492,25 +495,25 @@ fn F() {
 // CHECK:STDOUT: fn @F() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   name_binding_decl {
-// CHECK:STDOUT:     %output.patt: %pattern_type.dbc = value_binding_pattern output [concrete]
+// CHECK:STDOUT:     %output.patt: %pattern_type.690 = value_binding_pattern output [concrete]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref.loc10_49: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   %foo.ref: %foo.cpp_overload_set.type = name_ref foo, imports.%foo.cpp_overload_set.value [concrete = constants.%foo.cpp_overload_set.value]
-// CHECK:STDOUT:   %foo.call: init %Optional.46b = call imports.%foo.decl()
-// CHECK:STDOUT:   %.loc10_45.1: type = splice_block %Optional [concrete = constants.%Optional.46b] {
+// CHECK:STDOUT:   %foo.call: init %Optional.bcc = call imports.%foo.decl()
+// CHECK:STDOUT:   %.loc10_45.1: type = splice_block %Optional [concrete = constants.%Optional.bcc] {
 // CHECK:STDOUT:     %Core.ref: <namespace> = name_ref Core, imports.%Core [concrete = imports.%Core]
 // CHECK:STDOUT:     %Optional.ref: %Optional.type = name_ref Optional, imports.%Core.Optional [concrete = constants.%Optional.generic]
 // CHECK:STDOUT:     %Cpp.ref.loc10_36: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:     %void.ref: type = name_ref void, constants.%Cpp.void [concrete = constants.%Cpp.void]
 // CHECK:STDOUT:     %ptr: type = ptr_type %void.ref [concrete = constants.%ptr.838]
-// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.be6) [concrete = constants.%OptionalStorage.facet]
+// CHECK:STDOUT:     %OptionalStorage.facet: %OptionalStorage.type = facet_value %ptr, (constants.%OptionalStorage.impl_witness.595) [concrete = constants.%OptionalStorage.facet]
 // CHECK:STDOUT:     %.loc10_45.2: %OptionalStorage.type = converted %ptr, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet]
-// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.46b]
+// CHECK:STDOUT:     %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet) [concrete = constants.%Optional.bcc]
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %.loc10_57.1: ref %Optional.46b = temporary_storage
-// CHECK:STDOUT:   %.loc10_57.2: ref %Optional.46b = temporary %.loc10_57.1, %foo.call
-// CHECK:STDOUT:   %.loc10_57.3: %Optional.46b = acquire_value %.loc10_57.2
-// CHECK:STDOUT:   %output: %Optional.46b = value_binding output, %.loc10_57.3
+// CHECK:STDOUT:   %.loc10_57.1: ref %Optional.bcc = temporary_storage
+// CHECK:STDOUT:   %.loc10_57.2: ref %Optional.bcc = temporary %.loc10_57.1, %foo.call
+// CHECK:STDOUT:   %.loc10_57.3: %Optional.bcc = acquire_value %.loc10_57.2
+// CHECK:STDOUT:   %output: %Optional.bcc = value_binding output, %.loc10_57.3
 // CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc10_57.2, constants.%Destroy.Op.1dc86d.3
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc10_57.2)
 // CHECK:STDOUT:   <elided>
@@ -521,7 +524,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc10_57.2(%self.param: ref %Optional.46b) {
+// CHECK:STDOUT: fn @Destroy.Op.loc10_57.2(%self.param: ref %Optional.bcc) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/check/testdata/interop/cpp/macros/macros.carbon
+++ b/toolchain/check/testdata/interop/cpp/macros/macros.carbon
@@ -1762,22 +1762,22 @@ fn F() {
 // CHECK:STDOUT:   %custom_witness.340963.2: <witness> = custom_witness (%Destroy.Op.1dc86d.2), @Destroy [concrete]
 // CHECK:STDOUT:   %Destroy.facet.959: %Destroy.type = facet_value %ptr.143, (%custom_witness.340963.2) [concrete]
 // CHECK:STDOUT:   %MaybeUnformed.5a6: type = class_type @MaybeUnformed, @MaybeUnformed(%Destroy.facet.959) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.impl_witness.15a: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.698, @ptr.as.OptionalStorage.impl(%i32) [concrete]
-// CHECK:STDOUT:   %OptionalStorage.facet.f48: %OptionalStorage.type = facet_value %ptr.143, (%OptionalStorage.impl_witness.15a) [concrete]
-// CHECK:STDOUT:   %Optional.45b: type = class_type @Optional, @Optional(%OptionalStorage.facet.f48) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.impl_witness.426: <witness> = impl_witness imports.%OptionalStorage.impl_witness_table.e4f, @ptr.as.OptionalStorage.impl(%i32) [concrete]
+// CHECK:STDOUT:   %OptionalStorage.facet.2b7: %OptionalStorage.type = facet_value %ptr.143, (%OptionalStorage.impl_witness.426) [concrete]
+// CHECK:STDOUT:   %Optional.65a: type = class_type @Optional, @Optional(%OptionalStorage.facet.2b7) [concrete]
 // CHECK:STDOUT:   %foo.type: type = fn_type @foo [concrete]
 // CHECK:STDOUT:   %foo: %foo.type = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.type.3ad: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.45b)> [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.418: type = fn_type @Cpp.nullptr_t.as.ImplicitAs.impl.Convert, @Cpp.nullptr_t.as.ImplicitAs.impl(%T.67d) [symbolic]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.1c6: %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.418 = struct_value () [symbolic]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness.bea: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.a9f, @Cpp.nullptr_t.as.ImplicitAs.impl(%i32) [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.6d3: type = fn_type @Cpp.nullptr_t.as.ImplicitAs.impl.Convert, @Cpp.nullptr_t.as.ImplicitAs.impl(%i32) [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.f94: %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.6d3 = struct_value () [concrete]
-// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.3ad = facet_value %Cpp.nullptr_t, (%ImplicitAs.impl_witness.bea) [concrete]
-// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.073: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.45b, %ImplicitAs.facet) [concrete]
-// CHECK:STDOUT:   %.a4e: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.073, %ImplicitAs.facet [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %uninit, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.f94 [concrete]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.f94, @Cpp.nullptr_t.as.ImplicitAs.impl.Convert(%i32) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.8c3: type = facet_type <@ImplicitAs, @ImplicitAs(%Optional.65a)> [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.36e: type = fn_type @Cpp.nullptr_t.as.ImplicitAs.impl.Convert, @Cpp.nullptr_t.as.ImplicitAs.impl(%T.67d) [symbolic]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.999: %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.36e = struct_value () [symbolic]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness.c26: <witness> = impl_witness imports.%ImplicitAs.impl_witness_table.8d5, @Cpp.nullptr_t.as.ImplicitAs.impl(%i32) [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.eec: type = fn_type @Cpp.nullptr_t.as.ImplicitAs.impl.Convert, @Cpp.nullptr_t.as.ImplicitAs.impl(%i32) [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.ee2: %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.eec = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.facet: %ImplicitAs.type.8c3 = facet_value %Cpp.nullptr_t, (%ImplicitAs.impl_witness.c26) [concrete]
+// CHECK:STDOUT:   %ImplicitAs.WithSelf.Convert.type.7f2: type = fn_type @ImplicitAs.WithSelf.Convert, @ImplicitAs.WithSelf(%Optional.65a, %ImplicitAs.facet) [concrete]
+// CHECK:STDOUT:   %.6bc: type = fn_type_with_self_type %ImplicitAs.WithSelf.Convert.type.7f2, %ImplicitAs.facet [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.bound: <bound method> = bound_method %uninit, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.ee2 [concrete]
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn: <specific function> = specific_function %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.ee2, @Cpp.nullptr_t.as.ImplicitAs.impl.Convert(%i32) [concrete]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %uninit, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.af7ec0.4: type = fn_type @Destroy.Op.loc11_14.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1dc86d.4: %Destroy.Op.type.af7ec0.4 = struct_value () [concrete]
@@ -1795,21 +1795,22 @@ fn F() {
 // CHECK:STDOUT:   %Core.import_ref.5aa = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.4ad = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
 // CHECK:STDOUT:   %Core.import_ref.291 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
-// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.698 = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.f1b, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291), @ptr.as.OptionalStorage.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.6b0 = import_ref Core//prelude/types/optional, loc{{\d+_\d+}}, unloaded
+// CHECK:STDOUT:   %OptionalStorage.impl_witness_table.e4f = impl_witness_table (%Core.import_ref.7ae, %Core.import_ref.f1b, %Core.import_ref.5aa, %Core.import_ref.4ad, %Core.import_ref.291, %Core.import_ref.6b0), @ptr.as.OptionalStorage.impl [concrete]
 // CHECK:STDOUT:   %foo.decl: %foo.type = fn_decl @foo [concrete = constants.%foo] {
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     <elided>
-// CHECK:STDOUT:     %.loc11_24.1: type = splice_block %Optional [concrete = constants.%Optional.45b] {
+// CHECK:STDOUT:     %.loc11_24.1: type = splice_block %Optional [concrete = constants.%Optional.65a] {
 // CHECK:STDOUT:       <elided>
-// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.143, (constants.%OptionalStorage.impl_witness.15a) [concrete = constants.%OptionalStorage.facet.f48]
-// CHECK:STDOUT:       %.loc11_24.2: %OptionalStorage.type = converted constants.%ptr.143, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.f48]
-// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.f48) [concrete = constants.%Optional.45b]
+// CHECK:STDOUT:       %OptionalStorage.facet: %OptionalStorage.type = facet_value constants.%ptr.143, (constants.%OptionalStorage.impl_witness.426) [concrete = constants.%OptionalStorage.facet.2b7]
+// CHECK:STDOUT:       %.loc11_24.2: %OptionalStorage.type = converted constants.%ptr.143, %OptionalStorage.facet [concrete = constants.%OptionalStorage.facet.2b7]
+// CHECK:STDOUT:       %Optional: type = class_type @Optional, @Optional(constants.%OptionalStorage.facet.2b7) [concrete = constants.%Optional.65a]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     <elided>
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %Core.import_ref.f7a: @Cpp.nullptr_t.as.ImplicitAs.impl.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type (%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.418) = import_ref Core//prelude/types/cpp/nullptr, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.nullptr_t.as.ImplicitAs.impl.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert (constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.1c6)]
-// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.a9f = impl_witness_table (%Core.import_ref.f7a), @Cpp.nullptr_t.as.ImplicitAs.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.cd4: @Cpp.nullptr_t.as.ImplicitAs.impl.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type (%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.type.36e) = import_ref Core//prelude/types/cpp/nullptr, loc{{\d+_\d+}}, loaded [symbolic = @Cpp.nullptr_t.as.ImplicitAs.impl.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert (constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.999)]
+// CHECK:STDOUT:   %ImplicitAs.impl_witness_table.8d5 = impl_witness_table (%Core.import_ref.cd4), @Cpp.nullptr_t.as.ImplicitAs.impl [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @F() {
@@ -1819,15 +1820,15 @@ fn F() {
 // CHECK:STDOUT:   %Cpp.ref.loc11_11: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
 // CHECK:STDOUT:   <elided>
 // CHECK:STDOUT:   %MyNullPtr.ref: %Cpp.nullptr_t = name_ref MyNullPtr, %uninit [concrete = constants.%uninit]
-// CHECK:STDOUT:   %impl.elem0: %.a4e = impl_witness_access constants.%ImplicitAs.impl_witness.bea, element0 [concrete = constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.f94]
+// CHECK:STDOUT:   %impl.elem0: %.6bc = impl_witness_access constants.%ImplicitAs.impl_witness.c26, element0 [concrete = constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.ee2]
 // CHECK:STDOUT:   %bound_method.loc11_14.1: <bound method> = bound_method %MyNullPtr.ref, %impl.elem0 [concrete = constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.bound]
 // CHECK:STDOUT:   %specific_fn: <specific function> = specific_function %impl.elem0, @Cpp.nullptr_t.as.ImplicitAs.impl.Convert(constants.%i32) [concrete = constants.%Cpp.nullptr_t.as.ImplicitAs.impl.Convert.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc11_14.2: <bound method> = bound_method %MyNullPtr.ref, %specific_fn [concrete = constants.%bound_method]
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call: init %Optional.45b = call %bound_method.loc11_14.2(%MyNullPtr.ref)
-// CHECK:STDOUT:   %.loc11_14.1: init %Optional.45b = converted %MyNullPtr.ref, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call
-// CHECK:STDOUT:   %.loc11_14.2: ref %Optional.45b = temporary_storage
-// CHECK:STDOUT:   %.loc11_14.3: ref %Optional.45b = temporary %.loc11_14.2, %.loc11_14.1
-// CHECK:STDOUT:   %.loc11_14.4: %Optional.45b = acquire_value %.loc11_14.3
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call: init %Optional.65a = call %bound_method.loc11_14.2(%MyNullPtr.ref)
+// CHECK:STDOUT:   %.loc11_14.1: init %Optional.65a = converted %MyNullPtr.ref, %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call
+// CHECK:STDOUT:   %.loc11_14.2: ref %Optional.65a = temporary_storage
+// CHECK:STDOUT:   %.loc11_14.3: ref %Optional.65a = temporary %.loc11_14.2, %.loc11_14.1
+// CHECK:STDOUT:   %.loc11_14.4: %Optional.65a = acquire_value %.loc11_14.3
 // CHECK:STDOUT:   %foo.call: init %empty_tuple.type = call imports.%foo.decl(%.loc11_14.4)
 // CHECK:STDOUT:   %Destroy.Op.bound: <bound method> = bound_method %.loc11_14.3, constants.%Destroy.Op.1dc86d.4
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %Destroy.Op.bound(%.loc11_14.3)
@@ -1839,7 +1840,7 @@ fn F() {
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc11_14.2(%self.param: ref %Optional.45b) {
+// CHECK:STDOUT: fn @Destroy.Op.loc11_14.2(%self.param: ref %Optional.65a) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }

--- a/toolchain/lower/testdata/array/iterate.carbon
+++ b/toolchain/lower/testdata/array/iterate.carbon
@@ -48,16 +48,16 @@ fn F() {
 // CHECK:STDOUT: for.next:                                         ; preds = %for.body, %entry
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_19.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_CNext.b8111087f462a219:Iterate.Core.50a5645d0fe1902e"(ptr %.loc17_19.1.temp, ptr @array.loc16_43.24, ptr %var), !dbg !8
-// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.e68f4e2e18b45e10(ptr %.loc17_19.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.9d6f831f9a08a854(ptr %.loc17_19.1.temp), !dbg !8
 // CHECK:STDOUT:   br i1 %Optional.HasValue.call, label %for.body, label %for.done, !dbg !8
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.body:                                         ; preds = %for.next
-// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.e68f4e2e18b45e10(ptr %.loc17_19.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.9d6f831f9a08a854(ptr %.loc17_19.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @_CG.Main(i32 %Optional.Get.call), !dbg !9
 // CHECK:STDOUT:   br label %for.next, !dbg !10
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.done:                                         ; preds = %for.next
-// CHECK:STDOUT:   call void @"_COp.7b8d9716e42f3972:core.Destroy.Core"(ptr %.loc17_19.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_COp.fb3a1b9ee3968ef1:core.Destroy.Core"(ptr %.loc17_19.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %var), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.8ee2ca6e48da1a18:core.Destroy.Core"(ptr @array), !dbg !7
 // CHECK:STDOUT:   ret void, !dbg !11
@@ -88,7 +88,7 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.7b8d9716e42f3972:core.Destroy.Core"(ptr %self) #0 !dbg !34 {
+// CHECK:STDOUT: define weak_odr void @"_COp.fb3a1b9ee3968ef1:core.Destroy.Core"(ptr %self) #0 !dbg !34 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !37
 // CHECK:STDOUT: }
@@ -119,22 +119,22 @@ fn F() {
 // CHECK:STDOUT:   %5 = sub i32 %4, 1, !dbg !58
 // CHECK:STDOUT:   %array.index = getelementptr inbounds [6 x i32], ptr %self, i32 0, i32 %5, !dbg !59
 // CHECK:STDOUT:   %6 = load i32, ptr %array.index, align 4, !dbg !59
-// CHECK:STDOUT:   call void @_CSome.Optional.Core.e68f4e2e18b45e10(ptr %return, i32 %6), !dbg !60
+// CHECK:STDOUT:   call void @_CSome.Optional.Core.9d6f831f9a08a854(ptr %return, i32 %6), !dbg !60
 // CHECK:STDOUT:   ret void, !dbg !61
 // CHECK:STDOUT:
 // CHECK:STDOUT: 7:                                                ; preds = %0
-// CHECK:STDOUT:   call void @_CNone.Optional.Core.e68f4e2e18b45e10(ptr %return), !dbg !62
+// CHECK:STDOUT:   call void @_CNone.Optional.Core.9d6f831f9a08a854(ptr %return), !dbg !62
 // CHECK:STDOUT:   ret void, !dbg !63
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.e68f4e2e18b45e10(ptr %self) #0 !dbg !64 {
+// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.9d6f831f9a08a854(ptr %self) #0 !dbg !64 {
 // CHECK:STDOUT:   %1 = call i1 @"_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085"(ptr %self), !dbg !70
 // CHECK:STDOUT:   ret i1 %1, !dbg !71
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CGet.Optional.Core.e68f4e2e18b45e10(ptr %self) #0 !dbg !72 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CGet.Optional.Core.9d6f831f9a08a854(ptr %self) #0 !dbg !72 {
 // CHECK:STDOUT:   %1 = call i32 @"_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085"(ptr %self), !dbg !75
 // CHECK:STDOUT:   ret i32 %1, !dbg !76
 // CHECK:STDOUT: }
@@ -146,13 +146,13 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.e68f4e2e18b45e10(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !83 {
+// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.9d6f831f9a08a854(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !83 {
 // CHECK:STDOUT:   call void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085"(ptr %return, i32 %value), !dbg !88
 // CHECK:STDOUT:   ret void, !dbg !89
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.e68f4e2e18b45e10(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !90 {
+// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.9d6f831f9a08a854(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !90 {
 // CHECK:STDOUT:   call void @"_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085"(ptr %return), !dbg !93
 // CHECK:STDOUT:   ret void, !dbg !94
 // CHECK:STDOUT: }
@@ -252,7 +252,7 @@ fn F() {
 // CHECK:STDOUT: !31 = !{!32}
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !30, type: !26)
 // CHECK:STDOUT: !33 = !DILocation(line: 17, column: 7, scope: !30)
-// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "Op", linkageName: "_COp.7b8d9716e42f3972:core.Destroy.Core", scope: null, file: !3, line: 17, type: !24, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !35)
+// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "Op", linkageName: "_COp.fb3a1b9ee3968ef1:core.Destroy.Core", scope: null, file: !3, line: 17, type: !24, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !35)
 // CHECK:STDOUT: !35 = !{!36}
 // CHECK:STDOUT: !36 = !DILocalVariable(arg: 1, scope: !34, type: !26)
 // CHECK:STDOUT: !37 = !DILocation(line: 17, column: 7, scope: !34)
@@ -282,47 +282,47 @@ fn F() {
 // CHECK:STDOUT: !61 = !DILocation(line: 27, column: 7, scope: !49)
 // CHECK:STDOUT: !62 = !DILocation(line: 29, column: 14, scope: !49)
 // CHECK:STDOUT: !63 = !DILocation(line: 29, column: 7, scope: !49)
-// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.e68f4e2e18b45e10", scope: null, file: !65, line: 33, type: !66, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !68)
+// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.9d6f831f9a08a854", scope: null, file: !65, line: 36, type: !66, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !68)
 // CHECK:STDOUT: !65 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !66 = !DISubroutineType(types: !67)
 // CHECK:STDOUT: !67 = !{!26, !26}
 // CHECK:STDOUT: !68 = !{!69}
 // CHECK:STDOUT: !69 = !DILocalVariable(arg: 1, scope: !64, type: !26)
-// CHECK:STDOUT: !70 = !DILocation(line: 34, column: 12, scope: !64)
-// CHECK:STDOUT: !71 = !DILocation(line: 34, column: 5, scope: !64)
-// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.e68f4e2e18b45e10", scope: null, file: !65, line: 36, type: !44, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !73)
+// CHECK:STDOUT: !70 = !DILocation(line: 37, column: 12, scope: !64)
+// CHECK:STDOUT: !71 = !DILocation(line: 37, column: 5, scope: !64)
+// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.9d6f831f9a08a854", scope: null, file: !65, line: 39, type: !44, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !73)
 // CHECK:STDOUT: !73 = !{!74}
 // CHECK:STDOUT: !74 = !DILocalVariable(arg: 1, scope: !72, type: !26)
-// CHECK:STDOUT: !75 = !DILocation(line: 37, column: 12, scope: !72)
-// CHECK:STDOUT: !76 = !DILocation(line: 37, column: 5, scope: !72)
+// CHECK:STDOUT: !75 = !DILocation(line: 40, column: 12, scope: !72)
+// CHECK:STDOUT: !76 = !DILocation(line: 40, column: 5, scope: !72)
 // CHECK:STDOUT: !77 = distinct !DISubprogram(name: "Op", linkageName: "_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8", scope: null, file: !78, line: 363, type: !13, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !79)
 // CHECK:STDOUT: !78 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
 // CHECK:STDOUT: !79 = !{!80}
 // CHECK:STDOUT: !80 = !DILocalVariable(arg: 1, scope: !77, type: !15)
 // CHECK:STDOUT: !81 = !DILocation(line: 365, column: 5, scope: !77)
 // CHECK:STDOUT: !82 = !DILocation(line: 363, column: 3, scope: !77)
-// CHECK:STDOUT: !83 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.e68f4e2e18b45e10", scope: null, file: !65, line: 30, type: !84, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !86)
+// CHECK:STDOUT: !83 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.9d6f831f9a08a854", scope: null, file: !65, line: 33, type: !84, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !86)
 // CHECK:STDOUT: !84 = !DISubroutineType(types: !85)
 // CHECK:STDOUT: !85 = !{!26, !15}
 // CHECK:STDOUT: !86 = !{!87}
 // CHECK:STDOUT: !87 = !DILocalVariable(arg: 1, scope: !83, type: !15)
-// CHECK:STDOUT: !88 = !DILocation(line: 31, column: 12, scope: !83)
-// CHECK:STDOUT: !89 = !DILocation(line: 31, column: 5, scope: !83)
-// CHECK:STDOUT: !90 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.e68f4e2e18b45e10", scope: null, file: !65, line: 27, type: !91, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !88 = !DILocation(line: 34, column: 12, scope: !83)
+// CHECK:STDOUT: !89 = !DILocation(line: 34, column: 5, scope: !83)
+// CHECK:STDOUT: !90 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.9d6f831f9a08a854", scope: null, file: !65, line: 30, type: !91, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !91 = !DISubroutineType(types: !92)
 // CHECK:STDOUT: !92 = !{!26}
-// CHECK:STDOUT: !93 = !DILocation(line: 28, column: 12, scope: !90)
-// CHECK:STDOUT: !94 = !DILocation(line: 28, column: 5, scope: !90)
-// CHECK:STDOUT: !95 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !65, line: 132, type: !66, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !96)
+// CHECK:STDOUT: !93 = !DILocation(line: 31, column: 12, scope: !90)
+// CHECK:STDOUT: !94 = !DILocation(line: 31, column: 5, scope: !90)
+// CHECK:STDOUT: !95 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !65, line: 141, type: !66, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !96)
 // CHECK:STDOUT: !96 = !{!97}
 // CHECK:STDOUT: !97 = !DILocalVariable(arg: 1, scope: !95, type: !26)
-// CHECK:STDOUT: !98 = !DILocation(line: 133, column: 12, scope: !95)
-// CHECK:STDOUT: !99 = !DILocation(line: 133, column: 5, scope: !95)
-// CHECK:STDOUT: !100 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !65, line: 135, type: !44, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !101)
+// CHECK:STDOUT: !98 = !DILocation(line: 142, column: 12, scope: !95)
+// CHECK:STDOUT: !99 = !DILocation(line: 142, column: 5, scope: !95)
+// CHECK:STDOUT: !100 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !65, line: 144, type: !44, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !101)
 // CHECK:STDOUT: !101 = !{!102}
 // CHECK:STDOUT: !102 = !DILocalVariable(arg: 1, scope: !100, type: !26)
-// CHECK:STDOUT: !103 = !DILocation(line: 136, column: 12, scope: !100)
-// CHECK:STDOUT: !104 = !DILocation(line: 136, column: 5, scope: !100)
+// CHECK:STDOUT: !103 = !DILocation(line: 145, column: 12, scope: !100)
+// CHECK:STDOUT: !104 = !DILocation(line: 145, column: 5, scope: !100)
 // CHECK:STDOUT: !105 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:AddAssignWith.5e64a0d5d6c6f700.Core:Int.9452f4c51951679b.Core:AddAssignWith.4fe8b3905f8c6cd6.Core.d8796c5c9758c898", scope: null, file: !78, line: 299, type: !106, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !108)
 // CHECK:STDOUT: !106 = !DISubroutineType(types: !107)
 // CHECK:STDOUT: !107 = !{null, !15, !15}
@@ -331,15 +331,15 @@ fn F() {
 // CHECK:STDOUT: !110 = !DILocalVariable(arg: 2, scope: !105, type: !15)
 // CHECK:STDOUT: !111 = !DILocation(line: 4294967295, scope: !105)
 // CHECK:STDOUT: !112 = !DILocation(line: 299, column: 3, scope: !105)
-// CHECK:STDOUT: !113 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !65, line: 122, type: !84, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !114)
+// CHECK:STDOUT: !113 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !65, line: 131, type: !84, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !114)
 // CHECK:STDOUT: !114 = !{!115}
 // CHECK:STDOUT: !115 = !DILocalVariable(arg: 1, scope: !113, type: !15)
-// CHECK:STDOUT: !116 = !DILocation(line: 128, column: 5, scope: !113)
-// CHECK:STDOUT: !117 = !DILocation(line: 129, column: 5, scope: !113)
-// CHECK:STDOUT: !118 = !DILocation(line: 130, column: 5, scope: !113)
-// CHECK:STDOUT: !119 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !65, line: 116, type: !91, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !120 = !DILocation(line: 119, column: 5, scope: !119)
-// CHECK:STDOUT: !121 = !DILocation(line: 120, column: 5, scope: !119)
+// CHECK:STDOUT: !116 = !DILocation(line: 137, column: 5, scope: !113)
+// CHECK:STDOUT: !117 = !DILocation(line: 138, column: 5, scope: !113)
+// CHECK:STDOUT: !118 = !DILocation(line: 139, column: 5, scope: !113)
+// CHECK:STDOUT: !119 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !65, line: 125, type: !91, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !120 = !DILocation(line: 128, column: 5, scope: !119)
+// CHECK:STDOUT: !121 = !DILocation(line: 129, column: 5, scope: !119)
 // CHECK:STDOUT: !122 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.c87c855149fb259e:ImplicitAs.e4ded66cc6bddc4a.Core.1bcae782b458290d", scope: null, file: !78, line: 62, type: !123, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !125)
 // CHECK:STDOUT: !123 = !DISubroutineType(types: !124)
 // CHECK:STDOUT: !124 = !{!15, !15}

--- a/toolchain/lower/testdata/for/bindings.carbon
+++ b/toolchain/lower/testdata/for/bindings.carbon
@@ -55,13 +55,13 @@ fn For() {
 // CHECK:STDOUT: for.next:                                         ; preds = %for.body, %entry
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc29_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_CNext.EmptyRange.7920d9939e32908d.Main:Iterate.Core.9de724674fdcc2fc"(ptr %.loc29_33.1.temp, ptr %r.var, ptr %var), !dbg !8
-// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.7fd008914520c891(ptr %.loc29_33.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.5455c160079333a5(ptr %.loc29_33.1.temp), !dbg !8
 // CHECK:STDOUT:   br i1 %Optional.HasValue.call, label %for.body, label %for.done, !dbg !8
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.body:                                         ; preds = %for.next
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc29_33.8.temp), !dbg !8
-// CHECK:STDOUT:   call void @_CGet.Optional.Core.7fd008914520c891(ptr %.loc29_33.8.temp, ptr %.loc29_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @_CGet.Optional.Core.5455c160079333a5(ptr %.loc29_33.8.temp, ptr %.loc29_33.1.temp), !dbg !8
 // CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc29_33.8.temp, i32 0, i32 0, !dbg !8
 // CHECK:STDOUT:   %tuple.elem1.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %.loc29_33.8.temp, i32 0, i32 1, !dbg !8
 // CHECK:STDOUT:   %.loc29_33.11 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !8
@@ -73,7 +73,7 @@ fn For() {
 // CHECK:STDOUT: for.done:                                         ; preds = %for.next
 // CHECK:STDOUT:   call void @"_COp.26f166843e861eec:core.Destroy.Core"(ptr %.loc29_33.8.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %n.var), !dbg !9
-// CHECK:STDOUT:   call void @"_COp.04e4e2b9096f3443:core.Destroy.Core"(ptr %.loc29_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_COp.682544221c1ca4a5:core.Destroy.Core"(ptr %.loc29_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.c249106e7f336249:core.Destroy.Core"(ptr %r.var), !dbg !7
 // CHECK:STDOUT:   ret void, !dbg !12
 // CHECK:STDOUT: }
@@ -109,7 +109,7 @@ fn For() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.04e4e2b9096f3443:core.Destroy.Core"(ptr %self) #0 !dbg !39 {
+// CHECK:STDOUT: define weak_odr void @"_COp.682544221c1ca4a5:core.Destroy.Core"(ptr %self) #0 !dbg !39 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !42
 // CHECK:STDOUT: }
@@ -135,24 +135,24 @@ fn For() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @"_CNext.EmptyRange.7920d9939e32908d.Main:Iterate.Core.9de724674fdcc2fc"(ptr sret(<{ { i32, i32 }, i1 }>) %return, ptr %self, ptr %_) #0 !dbg !51 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @_CNone.Optional.Core.7fd008914520c891(ptr %return), !dbg !57
+// CHECK:STDOUT:   call void @_CNone.Optional.Core.5455c160079333a5(ptr %return), !dbg !57
 // CHECK:STDOUT:   ret void, !dbg !58
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.7fd008914520c891(ptr %self) #0 !dbg !59 {
+// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.5455c160079333a5(ptr %self) #0 !dbg !59 {
 // CHECK:STDOUT:   %1 = call i1 @"_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc"(ptr %self), !dbg !65
 // CHECK:STDOUT:   ret i1 %1, !dbg !66
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CGet.Optional.Core.7fd008914520c891(ptr sret({ i32, i32 }) %return, ptr %self) #0 !dbg !67 {
+// CHECK:STDOUT: define linkonce_odr void @_CGet.Optional.Core.5455c160079333a5(ptr sret({ i32, i32 }) %return, ptr %self) #0 !dbg !67 {
 // CHECK:STDOUT:   call void @"_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc"(ptr %return, ptr %self), !dbg !70
 // CHECK:STDOUT:   ret void, !dbg !71
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.7fd008914520c891(ptr sret(<{ { i32, i32 }, i1 }>) %return) #0 !dbg !72 {
+// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.5455c160079333a5(ptr sret(<{ { i32, i32 }, i1 }>) %return) #0 !dbg !72 {
 // CHECK:STDOUT:   call void @"_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc"(ptr %return), !dbg !75
 // CHECK:STDOUT:   ret void, !dbg !76
 // CHECK:STDOUT: }
@@ -240,7 +240,7 @@ fn For() {
 // CHECK:STDOUT: !36 = !{!37}
 // CHECK:STDOUT: !37 = !DILocalVariable(arg: 1, scope: !35, type: !23)
 // CHECK:STDOUT: !38 = !DILocation(line: 29, column: 7, scope: !35)
-// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "Op", linkageName: "_COp.04e4e2b9096f3443:core.Destroy.Core", scope: null, file: !3, line: 29, type: !21, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !40)
+// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "Op", linkageName: "_COp.682544221c1ca4a5:core.Destroy.Core", scope: null, file: !3, line: 29, type: !21, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !40)
 // CHECK:STDOUT: !40 = !{!41}
 // CHECK:STDOUT: !41 = !DILocalVariable(arg: 1, scope: !39, type: !23)
 // CHECK:STDOUT: !42 = !DILocation(line: 29, column: 7, scope: !39)
@@ -260,37 +260,37 @@ fn For() {
 // CHECK:STDOUT: !56 = !DILocalVariable(arg: 2, scope: !51, type: !23)
 // CHECK:STDOUT: !57 = !DILocation(line: 19, column: 14, scope: !51)
 // CHECK:STDOUT: !58 = !DILocation(line: 19, column: 7, scope: !51)
-// CHECK:STDOUT: !59 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.7fd008914520c891", scope: null, file: !60, line: 33, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !63)
+// CHECK:STDOUT: !59 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.5455c160079333a5", scope: null, file: !60, line: 36, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !63)
 // CHECK:STDOUT: !60 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !61 = !DISubroutineType(types: !62)
 // CHECK:STDOUT: !62 = !{!23, !23}
 // CHECK:STDOUT: !63 = !{!64}
 // CHECK:STDOUT: !64 = !DILocalVariable(arg: 1, scope: !59, type: !23)
-// CHECK:STDOUT: !65 = !DILocation(line: 34, column: 12, scope: !59)
-// CHECK:STDOUT: !66 = !DILocation(line: 34, column: 5, scope: !59)
-// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.7fd008914520c891", scope: null, file: !60, line: 36, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !68)
+// CHECK:STDOUT: !65 = !DILocation(line: 37, column: 12, scope: !59)
+// CHECK:STDOUT: !66 = !DILocation(line: 37, column: 5, scope: !59)
+// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.5455c160079333a5", scope: null, file: !60, line: 39, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !68)
 // CHECK:STDOUT: !68 = !{!69}
 // CHECK:STDOUT: !69 = !DILocalVariable(arg: 1, scope: !67, type: !23)
-// CHECK:STDOUT: !70 = !DILocation(line: 37, column: 12, scope: !67)
-// CHECK:STDOUT: !71 = !DILocation(line: 37, column: 5, scope: !67)
-// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.7fd008914520c891", scope: null, file: !60, line: 27, type: !73, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !70 = !DILocation(line: 40, column: 12, scope: !67)
+// CHECK:STDOUT: !71 = !DILocation(line: 40, column: 5, scope: !67)
+// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.5455c160079333a5", scope: null, file: !60, line: 30, type: !73, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !73 = !DISubroutineType(types: !74)
 // CHECK:STDOUT: !74 = !{!23}
-// CHECK:STDOUT: !75 = !DILocation(line: 28, column: 12, scope: !72)
-// CHECK:STDOUT: !76 = !DILocation(line: 28, column: 5, scope: !72)
-// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc", scope: null, file: !60, line: 132, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !78)
+// CHECK:STDOUT: !75 = !DILocation(line: 31, column: 12, scope: !72)
+// CHECK:STDOUT: !76 = !DILocation(line: 31, column: 5, scope: !72)
+// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc", scope: null, file: !60, line: 141, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !78)
 // CHECK:STDOUT: !78 = !{!79}
 // CHECK:STDOUT: !79 = !DILocalVariable(arg: 1, scope: !77, type: !23)
-// CHECK:STDOUT: !80 = !DILocation(line: 133, column: 12, scope: !77)
-// CHECK:STDOUT: !81 = !DILocation(line: 133, column: 5, scope: !77)
-// CHECK:STDOUT: !82 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc", scope: null, file: !60, line: 135, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !83)
+// CHECK:STDOUT: !80 = !DILocation(line: 142, column: 12, scope: !77)
+// CHECK:STDOUT: !81 = !DILocation(line: 142, column: 5, scope: !77)
+// CHECK:STDOUT: !82 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc", scope: null, file: !60, line: 144, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !83)
 // CHECK:STDOUT: !83 = !{!84}
 // CHECK:STDOUT: !84 = !DILocalVariable(arg: 1, scope: !82, type: !23)
-// CHECK:STDOUT: !85 = !DILocation(line: 136, column: 12, scope: !82)
-// CHECK:STDOUT: !86 = !DILocation(line: 136, column: 5, scope: !82)
-// CHECK:STDOUT: !87 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc", scope: null, file: !60, line: 116, type: !73, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !88 = !DILocation(line: 119, column: 5, scope: !87)
-// CHECK:STDOUT: !89 = !DILocation(line: 120, column: 5, scope: !87)
+// CHECK:STDOUT: !85 = !DILocation(line: 145, column: 12, scope: !82)
+// CHECK:STDOUT: !86 = !DILocation(line: 145, column: 5, scope: !82)
+// CHECK:STDOUT: !87 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.9de724674fdcc2fc", scope: null, file: !60, line: 125, type: !73, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !88 = !DILocation(line: 128, column: 5, scope: !87)
+// CHECK:STDOUT: !89 = !DILocation(line: 129, column: 5, scope: !87)
 // CHECK:STDOUT: !90 = distinct !DISubprogram(name: "Op", linkageName: "_COp.2ebefcbfae1e57a1:Copy.Core.487289465e254743", scope: null, file: !91, line: 58, type: !61, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !92)
 // CHECK:STDOUT: !91 = !DIFile(filename: "{{.*}}/prelude/copy.carbon", directory: "")
 // CHECK:STDOUT: !92 = !{!93}

--- a/toolchain/lower/testdata/for/break_continue.carbon
+++ b/toolchain/lower/testdata/for/break_continue.carbon
@@ -49,11 +49,11 @@ fn For() {
 // CHECK:STDOUT: for.next:                                         ; preds = %if.else.loc22, %if.then.loc22, %entry
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc20_33.1.temp, ptr %.loc20_32.1.temp, ptr %var), !dbg !8
-// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.c1adf80abd305b7a(ptr %.loc20_33.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.40650089e390248d(ptr %.loc20_33.1.temp), !dbg !8
 // CHECK:STDOUT:   br i1 %Optional.HasValue.call, label %for.body, label %for.done, !dbg !8
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.body:                                         ; preds = %for.next
-// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.c1adf80abd305b7a(ptr %.loc20_33.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.40650089e390248d(ptr %.loc20_33.1.temp), !dbg !8
 // CHECK:STDOUT:   %F.call = call i1 @_CF.Main(), !dbg !9
 // CHECK:STDOUT:   br i1 %F.call, label %if.then.loc21, label %if.else.loc21, !dbg !10
 // CHECK:STDOUT:
@@ -72,7 +72,7 @@ fn For() {
 // CHECK:STDOUT:   br label %for.next, !dbg !16
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.done:                                         ; preds = %if.then.loc21, %for.next
-// CHECK:STDOUT:   call void @"_COp.1fe223c145fbb742:core.Destroy.Core"(ptr %.loc20_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_COp.901773399a281d04:core.Destroy.Core"(ptr %.loc20_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %var), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.d99cd304dde232b0:core.Destroy.Core"(ptr %.loc20_32.1.temp), !dbg !7
 // CHECK:STDOUT:   ret void, !dbg !17
@@ -105,7 +105,7 @@ fn For() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.1fe223c145fbb742:core.Destroy.Core"(ptr %self) #0 !dbg !41 {
+// CHECK:STDOUT: define weak_odr void @"_COp.901773399a281d04:core.Destroy.Core"(ptr %self) #0 !dbg !41 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !44
 // CHECK:STDOUT: }
@@ -147,24 +147,24 @@ fn For() {
 // CHECK:STDOUT: 6:                                                ; preds = %0
 // CHECK:STDOUT:   call void @"_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8"(ptr %cursor), !dbg !71
 // CHECK:STDOUT:   %7 = load i32, ptr %1, align 4, !dbg !72
-// CHECK:STDOUT:   call void @_CSome.Optional.Core.c1adf80abd305b7a(ptr %return, i32 %7), !dbg !73
+// CHECK:STDOUT:   call void @_CSome.Optional.Core.40650089e390248d(ptr %return, i32 %7), !dbg !73
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %1), !dbg !66
 // CHECK:STDOUT:   ret void, !dbg !74
 // CHECK:STDOUT:
 // CHECK:STDOUT: 8:                                                ; preds = %0
-// CHECK:STDOUT:   call void @_CNone.Optional.Core.c1adf80abd305b7a(ptr %return), !dbg !75
+// CHECK:STDOUT:   call void @_CNone.Optional.Core.40650089e390248d(ptr %return), !dbg !75
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %1), !dbg !66
 // CHECK:STDOUT:   ret void, !dbg !76
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.c1adf80abd305b7a(ptr %self) #0 !dbg !77 {
+// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.40650089e390248d(ptr %self) #0 !dbg !77 {
 // CHECK:STDOUT:   %1 = call i1 @"_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447"(ptr %self), !dbg !83
 // CHECK:STDOUT:   ret i1 %1, !dbg !84
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CGet.Optional.Core.c1adf80abd305b7a(ptr %self) #0 !dbg !85 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CGet.Optional.Core.40650089e390248d(ptr %self) #0 !dbg !85 {
 // CHECK:STDOUT:   %1 = call i32 @"_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447"(ptr %self), !dbg !88
 // CHECK:STDOUT:   ret i32 %1, !dbg !89
 // CHECK:STDOUT: }
@@ -178,13 +178,13 @@ fn For() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.c1adf80abd305b7a(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !96 {
+// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.40650089e390248d(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !96 {
 // CHECK:STDOUT:   call void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447"(ptr %return, i32 %value), !dbg !101
 // CHECK:STDOUT:   ret void, !dbg !102
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.c1adf80abd305b7a(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !103 {
+// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.40650089e390248d(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !103 {
 // CHECK:STDOUT:   call void @"_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447"(ptr %return), !dbg !106
 // CHECK:STDOUT:   ret void, !dbg !107
 // CHECK:STDOUT: }
@@ -291,7 +291,7 @@ fn For() {
 // CHECK:STDOUT: !38 = !{!39}
 // CHECK:STDOUT: !39 = !DILocalVariable(arg: 1, scope: !37, type: !33)
 // CHECK:STDOUT: !40 = !DILocation(line: 20, column: 7, scope: !37)
-// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.1fe223c145fbb742:core.Destroy.Core", scope: null, file: !3, line: 20, type: !31, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
+// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.901773399a281d04:core.Destroy.Core", scope: null, file: !3, line: 20, type: !31, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !41, type: !33)
 // CHECK:STDOUT: !44 = !DILocation(line: 20, column: 7, scope: !41)
@@ -327,47 +327,47 @@ fn For() {
 // CHECK:STDOUT: !74 = !DILocation(line: 30, column: 9, scope: !60)
 // CHECK:STDOUT: !75 = !DILocation(line: 32, column: 16, scope: !60)
 // CHECK:STDOUT: !76 = !DILocation(line: 32, column: 9, scope: !60)
-// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.c1adf80abd305b7a", scope: null, file: !78, line: 33, type: !79, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !81)
+// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.40650089e390248d", scope: null, file: !78, line: 36, type: !79, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !81)
 // CHECK:STDOUT: !78 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !79 = !DISubroutineType(types: !80)
 // CHECK:STDOUT: !80 = !{!33, !33}
 // CHECK:STDOUT: !81 = !{!82}
 // CHECK:STDOUT: !82 = !DILocalVariable(arg: 1, scope: !77, type: !33)
-// CHECK:STDOUT: !83 = !DILocation(line: 34, column: 12, scope: !77)
-// CHECK:STDOUT: !84 = !DILocation(line: 34, column: 5, scope: !77)
-// CHECK:STDOUT: !85 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.c1adf80abd305b7a", scope: null, file: !78, line: 36, type: !54, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !86)
+// CHECK:STDOUT: !83 = !DILocation(line: 37, column: 12, scope: !77)
+// CHECK:STDOUT: !84 = !DILocation(line: 37, column: 5, scope: !77)
+// CHECK:STDOUT: !85 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.40650089e390248d", scope: null, file: !78, line: 39, type: !54, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !86)
 // CHECK:STDOUT: !86 = !{!87}
 // CHECK:STDOUT: !87 = !DILocalVariable(arg: 1, scope: !85, type: !33)
-// CHECK:STDOUT: !88 = !DILocation(line: 37, column: 12, scope: !85)
-// CHECK:STDOUT: !89 = !DILocation(line: 37, column: 5, scope: !85)
+// CHECK:STDOUT: !88 = !DILocation(line: 40, column: 12, scope: !85)
+// CHECK:STDOUT: !89 = !DILocation(line: 40, column: 5, scope: !85)
 // CHECK:STDOUT: !90 = distinct !DISubprogram(name: "Op", linkageName: "_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8", scope: null, file: !91, line: 363, type: !20, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !92)
 // CHECK:STDOUT: !91 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
 // CHECK:STDOUT: !92 = !{!93}
 // CHECK:STDOUT: !93 = !DILocalVariable(arg: 1, scope: !90, type: !22)
 // CHECK:STDOUT: !94 = !DILocation(line: 365, column: 5, scope: !90)
 // CHECK:STDOUT: !95 = !DILocation(line: 363, column: 3, scope: !90)
-// CHECK:STDOUT: !96 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.c1adf80abd305b7a", scope: null, file: !78, line: 30, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !99)
+// CHECK:STDOUT: !96 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.40650089e390248d", scope: null, file: !78, line: 33, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !99)
 // CHECK:STDOUT: !97 = !DISubroutineType(types: !98)
 // CHECK:STDOUT: !98 = !{!33, !22}
 // CHECK:STDOUT: !99 = !{!100}
 // CHECK:STDOUT: !100 = !DILocalVariable(arg: 1, scope: !96, type: !22)
-// CHECK:STDOUT: !101 = !DILocation(line: 31, column: 12, scope: !96)
-// CHECK:STDOUT: !102 = !DILocation(line: 31, column: 5, scope: !96)
-// CHECK:STDOUT: !103 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.c1adf80abd305b7a", scope: null, file: !78, line: 27, type: !104, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !101 = !DILocation(line: 34, column: 12, scope: !96)
+// CHECK:STDOUT: !102 = !DILocation(line: 34, column: 5, scope: !96)
+// CHECK:STDOUT: !103 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.40650089e390248d", scope: null, file: !78, line: 30, type: !104, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !104 = !DISubroutineType(types: !105)
 // CHECK:STDOUT: !105 = !{!33}
-// CHECK:STDOUT: !106 = !DILocation(line: 28, column: 12, scope: !103)
-// CHECK:STDOUT: !107 = !DILocation(line: 28, column: 5, scope: !103)
-// CHECK:STDOUT: !108 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !78, line: 132, type: !79, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !109)
+// CHECK:STDOUT: !106 = !DILocation(line: 31, column: 12, scope: !103)
+// CHECK:STDOUT: !107 = !DILocation(line: 31, column: 5, scope: !103)
+// CHECK:STDOUT: !108 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !78, line: 141, type: !79, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !109)
 // CHECK:STDOUT: !109 = !{!110}
 // CHECK:STDOUT: !110 = !DILocalVariable(arg: 1, scope: !108, type: !33)
-// CHECK:STDOUT: !111 = !DILocation(line: 133, column: 12, scope: !108)
-// CHECK:STDOUT: !112 = !DILocation(line: 133, column: 5, scope: !108)
-// CHECK:STDOUT: !113 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !78, line: 135, type: !54, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !114)
+// CHECK:STDOUT: !111 = !DILocation(line: 142, column: 12, scope: !108)
+// CHECK:STDOUT: !112 = !DILocation(line: 142, column: 5, scope: !108)
+// CHECK:STDOUT: !113 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !78, line: 144, type: !54, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !114)
 // CHECK:STDOUT: !114 = !{!115}
 // CHECK:STDOUT: !115 = !DILocalVariable(arg: 1, scope: !113, type: !33)
-// CHECK:STDOUT: !116 = !DILocation(line: 136, column: 12, scope: !113)
-// CHECK:STDOUT: !117 = !DILocation(line: 136, column: 5, scope: !113)
+// CHECK:STDOUT: !116 = !DILocation(line: 145, column: 12, scope: !113)
+// CHECK:STDOUT: !117 = !DILocation(line: 145, column: 5, scope: !113)
 // CHECK:STDOUT: !118 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:AddAssignWith.ad7ccd31b6bdf5c9.Core:Int.9452f4c51951679b.Core:AddAssignWith.78e744410a40fd74.Core.9c83a169ad974fa6", scope: null, file: !91, line: 299, type: !119, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !121)
 // CHECK:STDOUT: !119 = !DISubroutineType(types: !120)
 // CHECK:STDOUT: !120 = !{null, !22, !22}
@@ -376,15 +376,15 @@ fn For() {
 // CHECK:STDOUT: !123 = !DILocalVariable(arg: 2, scope: !118, type: !22)
 // CHECK:STDOUT: !124 = !DILocation(line: 4294967295, scope: !118)
 // CHECK:STDOUT: !125 = !DILocation(line: 299, column: 3, scope: !118)
-// CHECK:STDOUT: !126 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !78, line: 122, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !127)
+// CHECK:STDOUT: !126 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !78, line: 131, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !127)
 // CHECK:STDOUT: !127 = !{!128}
 // CHECK:STDOUT: !128 = !DILocalVariable(arg: 1, scope: !126, type: !22)
-// CHECK:STDOUT: !129 = !DILocation(line: 128, column: 5, scope: !126)
-// CHECK:STDOUT: !130 = !DILocation(line: 129, column: 5, scope: !126)
-// CHECK:STDOUT: !131 = !DILocation(line: 130, column: 5, scope: !126)
-// CHECK:STDOUT: !132 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !78, line: 116, type: !104, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !133 = !DILocation(line: 119, column: 5, scope: !132)
-// CHECK:STDOUT: !134 = !DILocation(line: 120, column: 5, scope: !132)
+// CHECK:STDOUT: !129 = !DILocation(line: 137, column: 5, scope: !126)
+// CHECK:STDOUT: !130 = !DILocation(line: 138, column: 5, scope: !126)
+// CHECK:STDOUT: !131 = !DILocation(line: 139, column: 5, scope: !126)
+// CHECK:STDOUT: !132 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !78, line: 125, type: !104, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !133 = !DILocation(line: 128, column: 5, scope: !132)
+// CHECK:STDOUT: !134 = !DILocation(line: 129, column: 5, scope: !132)
 // CHECK:STDOUT: !135 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.b912251d28f69b6d:ImplicitAs.a629ad9d3aac3895.Core.245bb80fde7c8401", scope: null, file: !91, line: 62, type: !136, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !138)
 // CHECK:STDOUT: !136 = !DISubroutineType(types: !137)
 // CHECK:STDOUT: !137 = !{!22, !22}

--- a/toolchain/lower/testdata/for/for.carbon
+++ b/toolchain/lower/testdata/for/for.carbon
@@ -50,17 +50,17 @@ fn For() {
 // CHECK:STDOUT: for.next:                                         ; preds = %for.body, %entry
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc21_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc21_33.1.temp, ptr %.loc21_32.1.temp, ptr %var), !dbg !8
-// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.c1adf80abd305b7a(ptr %.loc21_33.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.40650089e390248d(ptr %.loc21_33.1.temp), !dbg !8
 // CHECK:STDOUT:   br i1 %Optional.HasValue.call, label %for.body, label %for.done, !dbg !8
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.body:                                         ; preds = %for.next
-// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.c1adf80abd305b7a(ptr %.loc21_33.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.40650089e390248d(ptr %.loc21_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @_CG.Main(), !dbg !10
 // CHECK:STDOUT:   br label %for.next, !dbg !11
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.done:                                         ; preds = %for.next
 // CHECK:STDOUT:   call void @_CH.Main(), !dbg !12
-// CHECK:STDOUT:   call void @"_COp.1fe223c145fbb742:core.Destroy.Core"(ptr %.loc21_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_COp.901773399a281d04:core.Destroy.Core"(ptr %.loc21_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %var), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.d99cd304dde232b0:core.Destroy.Core"(ptr %.loc21_32.1.temp), !dbg !7
 // CHECK:STDOUT:   ret void, !dbg !13
@@ -93,7 +93,7 @@ fn For() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.1fe223c145fbb742:core.Destroy.Core"(ptr %self) #0 !dbg !37 {
+// CHECK:STDOUT: define weak_odr void @"_COp.901773399a281d04:core.Destroy.Core"(ptr %self) #0 !dbg !37 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !40
 // CHECK:STDOUT: }
@@ -135,24 +135,24 @@ fn For() {
 // CHECK:STDOUT: 6:                                                ; preds = %0
 // CHECK:STDOUT:   call void @"_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8"(ptr %cursor), !dbg !67
 // CHECK:STDOUT:   %7 = load i32, ptr %1, align 4, !dbg !68
-// CHECK:STDOUT:   call void @_CSome.Optional.Core.c1adf80abd305b7a(ptr %return, i32 %7), !dbg !69
+// CHECK:STDOUT:   call void @_CSome.Optional.Core.40650089e390248d(ptr %return, i32 %7), !dbg !69
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %1), !dbg !62
 // CHECK:STDOUT:   ret void, !dbg !70
 // CHECK:STDOUT:
 // CHECK:STDOUT: 8:                                                ; preds = %0
-// CHECK:STDOUT:   call void @_CNone.Optional.Core.c1adf80abd305b7a(ptr %return), !dbg !71
+// CHECK:STDOUT:   call void @_CNone.Optional.Core.40650089e390248d(ptr %return), !dbg !71
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %1), !dbg !62
 // CHECK:STDOUT:   ret void, !dbg !72
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.c1adf80abd305b7a(ptr %self) #0 !dbg !73 {
+// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.40650089e390248d(ptr %self) #0 !dbg !73 {
 // CHECK:STDOUT:   %1 = call i1 @"_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447"(ptr %self), !dbg !79
 // CHECK:STDOUT:   ret i1 %1, !dbg !80
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i32 @_CGet.Optional.Core.c1adf80abd305b7a(ptr %self) #0 !dbg !81 {
+// CHECK:STDOUT: define linkonce_odr i32 @_CGet.Optional.Core.40650089e390248d(ptr %self) #0 !dbg !81 {
 // CHECK:STDOUT:   %1 = call i32 @"_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447"(ptr %self), !dbg !84
 // CHECK:STDOUT:   ret i32 %1, !dbg !85
 // CHECK:STDOUT: }
@@ -166,13 +166,13 @@ fn For() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.c1adf80abd305b7a(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !92 {
+// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.40650089e390248d(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !92 {
 // CHECK:STDOUT:   call void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447"(ptr %return, i32 %value), !dbg !97
 // CHECK:STDOUT:   ret void, !dbg !98
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.c1adf80abd305b7a(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !99 {
+// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.40650089e390248d(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !99 {
 // CHECK:STDOUT:   call void @"_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447"(ptr %return), !dbg !102
 // CHECK:STDOUT:   ret void, !dbg !103
 // CHECK:STDOUT: }
@@ -275,7 +275,7 @@ fn For() {
 // CHECK:STDOUT: !34 = !{!35}
 // CHECK:STDOUT: !35 = !DILocalVariable(arg: 1, scope: !33, type: !29)
 // CHECK:STDOUT: !36 = !DILocation(line: 21, column: 7, scope: !33)
-// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "Op", linkageName: "_COp.1fe223c145fbb742:core.Destroy.Core", scope: null, file: !3, line: 21, type: !27, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !38)
+// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "Op", linkageName: "_COp.901773399a281d04:core.Destroy.Core", scope: null, file: !3, line: 21, type: !27, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !38)
 // CHECK:STDOUT: !38 = !{!39}
 // CHECK:STDOUT: !39 = !DILocalVariable(arg: 1, scope: !37, type: !29)
 // CHECK:STDOUT: !40 = !DILocation(line: 21, column: 7, scope: !37)
@@ -311,47 +311,47 @@ fn For() {
 // CHECK:STDOUT: !70 = !DILocation(line: 30, column: 9, scope: !56)
 // CHECK:STDOUT: !71 = !DILocation(line: 32, column: 16, scope: !56)
 // CHECK:STDOUT: !72 = !DILocation(line: 32, column: 9, scope: !56)
-// CHECK:STDOUT: !73 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.c1adf80abd305b7a", scope: null, file: !74, line: 33, type: !75, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !77)
+// CHECK:STDOUT: !73 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.40650089e390248d", scope: null, file: !74, line: 36, type: !75, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !77)
 // CHECK:STDOUT: !74 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !75 = !DISubroutineType(types: !76)
 // CHECK:STDOUT: !76 = !{!29, !29}
 // CHECK:STDOUT: !77 = !{!78}
 // CHECK:STDOUT: !78 = !DILocalVariable(arg: 1, scope: !73, type: !29)
-// CHECK:STDOUT: !79 = !DILocation(line: 34, column: 12, scope: !73)
-// CHECK:STDOUT: !80 = !DILocation(line: 34, column: 5, scope: !73)
-// CHECK:STDOUT: !81 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.c1adf80abd305b7a", scope: null, file: !74, line: 36, type: !50, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !82)
+// CHECK:STDOUT: !79 = !DILocation(line: 37, column: 12, scope: !73)
+// CHECK:STDOUT: !80 = !DILocation(line: 37, column: 5, scope: !73)
+// CHECK:STDOUT: !81 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.40650089e390248d", scope: null, file: !74, line: 39, type: !50, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !82)
 // CHECK:STDOUT: !82 = !{!83}
 // CHECK:STDOUT: !83 = !DILocalVariable(arg: 1, scope: !81, type: !29)
-// CHECK:STDOUT: !84 = !DILocation(line: 37, column: 12, scope: !81)
-// CHECK:STDOUT: !85 = !DILocation(line: 37, column: 5, scope: !81)
+// CHECK:STDOUT: !84 = !DILocation(line: 40, column: 12, scope: !81)
+// CHECK:STDOUT: !85 = !DILocation(line: 40, column: 5, scope: !81)
 // CHECK:STDOUT: !86 = distinct !DISubprogram(name: "Op", linkageName: "_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8", scope: null, file: !87, line: 363, type: !16, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !88)
 // CHECK:STDOUT: !87 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
 // CHECK:STDOUT: !88 = !{!89}
 // CHECK:STDOUT: !89 = !DILocalVariable(arg: 1, scope: !86, type: !18)
 // CHECK:STDOUT: !90 = !DILocation(line: 365, column: 5, scope: !86)
 // CHECK:STDOUT: !91 = !DILocation(line: 363, column: 3, scope: !86)
-// CHECK:STDOUT: !92 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.c1adf80abd305b7a", scope: null, file: !74, line: 30, type: !93, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !95)
+// CHECK:STDOUT: !92 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.40650089e390248d", scope: null, file: !74, line: 33, type: !93, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !95)
 // CHECK:STDOUT: !93 = !DISubroutineType(types: !94)
 // CHECK:STDOUT: !94 = !{!29, !18}
 // CHECK:STDOUT: !95 = !{!96}
 // CHECK:STDOUT: !96 = !DILocalVariable(arg: 1, scope: !92, type: !18)
-// CHECK:STDOUT: !97 = !DILocation(line: 31, column: 12, scope: !92)
-// CHECK:STDOUT: !98 = !DILocation(line: 31, column: 5, scope: !92)
-// CHECK:STDOUT: !99 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.c1adf80abd305b7a", scope: null, file: !74, line: 27, type: !100, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !97 = !DILocation(line: 34, column: 12, scope: !92)
+// CHECK:STDOUT: !98 = !DILocation(line: 34, column: 5, scope: !92)
+// CHECK:STDOUT: !99 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.40650089e390248d", scope: null, file: !74, line: 30, type: !100, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !100 = !DISubroutineType(types: !101)
 // CHECK:STDOUT: !101 = !{!29}
-// CHECK:STDOUT: !102 = !DILocation(line: 28, column: 12, scope: !99)
-// CHECK:STDOUT: !103 = !DILocation(line: 28, column: 5, scope: !99)
-// CHECK:STDOUT: !104 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !74, line: 132, type: !75, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !105)
+// CHECK:STDOUT: !102 = !DILocation(line: 31, column: 12, scope: !99)
+// CHECK:STDOUT: !103 = !DILocation(line: 31, column: 5, scope: !99)
+// CHECK:STDOUT: !104 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !74, line: 141, type: !75, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !105)
 // CHECK:STDOUT: !105 = !{!106}
 // CHECK:STDOUT: !106 = !DILocalVariable(arg: 1, scope: !104, type: !29)
-// CHECK:STDOUT: !107 = !DILocation(line: 133, column: 12, scope: !104)
-// CHECK:STDOUT: !108 = !DILocation(line: 133, column: 5, scope: !104)
-// CHECK:STDOUT: !109 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !74, line: 135, type: !50, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !110)
+// CHECK:STDOUT: !107 = !DILocation(line: 142, column: 12, scope: !104)
+// CHECK:STDOUT: !108 = !DILocation(line: 142, column: 5, scope: !104)
+// CHECK:STDOUT: !109 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !74, line: 144, type: !50, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !110)
 // CHECK:STDOUT: !110 = !{!111}
 // CHECK:STDOUT: !111 = !DILocalVariable(arg: 1, scope: !109, type: !29)
-// CHECK:STDOUT: !112 = !DILocation(line: 136, column: 12, scope: !109)
-// CHECK:STDOUT: !113 = !DILocation(line: 136, column: 5, scope: !109)
+// CHECK:STDOUT: !112 = !DILocation(line: 145, column: 12, scope: !109)
+// CHECK:STDOUT: !113 = !DILocation(line: 145, column: 5, scope: !109)
 // CHECK:STDOUT: !114 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:AddAssignWith.ad7ccd31b6bdf5c9.Core:Int.9452f4c51951679b.Core:AddAssignWith.78e744410a40fd74.Core.9c83a169ad974fa6", scope: null, file: !87, line: 299, type: !115, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !117)
 // CHECK:STDOUT: !115 = !DISubroutineType(types: !116)
 // CHECK:STDOUT: !116 = !{null, !18, !18}
@@ -360,15 +360,15 @@ fn For() {
 // CHECK:STDOUT: !119 = !DILocalVariable(arg: 2, scope: !114, type: !18)
 // CHECK:STDOUT: !120 = !DILocation(line: 4294967295, scope: !114)
 // CHECK:STDOUT: !121 = !DILocation(line: 299, column: 3, scope: !114)
-// CHECK:STDOUT: !122 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !74, line: 122, type: !93, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !123)
+// CHECK:STDOUT: !122 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !74, line: 131, type: !93, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !123)
 // CHECK:STDOUT: !123 = !{!124}
 // CHECK:STDOUT: !124 = !DILocalVariable(arg: 1, scope: !122, type: !18)
-// CHECK:STDOUT: !125 = !DILocation(line: 128, column: 5, scope: !122)
-// CHECK:STDOUT: !126 = !DILocation(line: 129, column: 5, scope: !122)
-// CHECK:STDOUT: !127 = !DILocation(line: 130, column: 5, scope: !122)
-// CHECK:STDOUT: !128 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !74, line: 116, type: !100, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !129 = !DILocation(line: 119, column: 5, scope: !128)
-// CHECK:STDOUT: !130 = !DILocation(line: 120, column: 5, scope: !128)
+// CHECK:STDOUT: !125 = !DILocation(line: 137, column: 5, scope: !122)
+// CHECK:STDOUT: !126 = !DILocation(line: 138, column: 5, scope: !122)
+// CHECK:STDOUT: !127 = !DILocation(line: 139, column: 5, scope: !122)
+// CHECK:STDOUT: !128 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.df89832508ab6447", scope: null, file: !74, line: 125, type: !100, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !129 = !DILocation(line: 128, column: 5, scope: !128)
+// CHECK:STDOUT: !130 = !DILocation(line: 129, column: 5, scope: !128)
 // CHECK:STDOUT: !131 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.b912251d28f69b6d:ImplicitAs.a629ad9d3aac3895.Core.245bb80fde7c8401", scope: null, file: !87, line: 62, type: !132, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !134)
 // CHECK:STDOUT: !132 = !DISubroutineType(types: !133)
 // CHECK:STDOUT: !133 = !{!18, !18}

--- a/toolchain/lower/testdata/interop/cpp/nullptr.carbon
+++ b/toolchain/lower/testdata/interop/cpp/nullptr.carbon
@@ -59,7 +59,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc12_18.2.temp = alloca ptr, align 8, !dbg !14
 // CHECK:STDOUT:   %.loc14_22.1.temp = alloca ptr, align 8, !dbg !15
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.7b6a382d04a36247.Core.c8fd090a2e741f70"(ptr poison), !dbg !14
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.5e80ad62f480057c.Core.c8fd090a2e741f70"(ptr poison), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc12_18.2.temp), !dbg !14
 // CHECK:STDOUT:   store ptr %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call, ptr %.loc12_18.2.temp, align 8, !dbg !14
 // CHECK:STDOUT:   %.loc12_18.4 = load ptr, ptr %.loc12_18.2.temp, align 8, !dbg !14
@@ -69,7 +69,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT:   store ptr %Cpp.nullptr_t.as.Copy.impl.Op.call, ptr %.loc14_22.1.temp, align 8, !dbg !15
 // CHECK:STDOUT:   call void @_Z11TakeNullptrDn.carbon_thunk._(ptr %.loc14_22.1.temp), !dbg !17
 // CHECK:STDOUT:   call void @"_COp.5f1c33499946866e:core.Destroy.Core"(ptr %.loc14_22.1.temp), !dbg !15
-// CHECK:STDOUT:   call void @"_COp.ffb455139f965851:core.Destroy.Core"(ptr %.loc12_18.2.temp), !dbg !14
+// CHECK:STDOUT:   call void @"_COp.30d8820b488e450b:core.Destroy.Core"(ptr %.loc12_18.2.temp), !dbg !14
 // CHECK:STDOUT:   ret void, !dbg !18
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -100,7 +100,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.ffb455139f965851:core.Destroy.Core"(ptr %self) #0 !dbg !33 {
+// CHECK:STDOUT: define weak_odr void @"_COp.30d8820b488e450b:core.Destroy.Core"(ptr %self) #0 !dbg !33 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !36
 // CHECK:STDOUT: }
@@ -132,7 +132,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !48
 // CHECK:STDOUT:   call void @_Z13ReturnNullptrv.carbon_thunk.(ptr %a.var), !dbg !49
 // CHECK:STDOUT:   %.loc28_10 = load ptr, ptr %a.var, align 8, !dbg !50
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.7b6a382d04a36247.Core.c8fd090a2e741f70"(ptr %.loc28_10), !dbg !51
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.5e80ad62f480057c.Core.c8fd090a2e741f70"(ptr %.loc28_10), !dbg !51
 // CHECK:STDOUT:   call void @"_COp.5f1c33499946866e:core.Destroy.Core"(ptr %a.var), !dbg !48
 // CHECK:STDOUT:   ret ptr %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call, !dbg !51
 // CHECK:STDOUT: }
@@ -155,7 +155,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc32_28.1.temp), !dbg !55
 // CHECK:STDOUT:   call void @_Z13ReturnNullptrv.carbon_thunk.(ptr %.loc32_28.1.temp), !dbg !55
 // CHECK:STDOUT:   %.loc32_28.4 = load ptr, ptr %.loc32_28.1.temp, align 8, !dbg !55
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.7b6a382d04a36247.Core.c8fd090a2e741f70"(ptr %.loc32_28.4), !dbg !56
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.5e80ad62f480057c.Core.c8fd090a2e741f70"(ptr %.loc32_28.4), !dbg !56
 // CHECK:STDOUT:   call void @"_COp.5f1c33499946866e:core.Destroy.Core"(ptr %.loc32_28.1.temp), !dbg !55
 // CHECK:STDOUT:   ret ptr %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call, !dbg !56
 // CHECK:STDOUT: }
@@ -163,13 +163,13 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define ptr @_CConvertNullptrConstant.Main() #0 !dbg !57 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.7b6a382d04a36247.Core.c8fd090a2e741f70"(ptr poison), !dbg !58
+// CHECK:STDOUT:   %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.5e80ad62f480057c.Core.c8fd090a2e741f70"(ptr poison), !dbg !58
 // CHECK:STDOUT:   ret ptr %Cpp.nullptr_t.as.ImplicitAs.impl.Convert.call, !dbg !58
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.7b6a382d04a36247.Core.c8fd090a2e741f70"(ptr %self) #0 !dbg !59 {
-// CHECK:STDOUT:   %1 = call ptr @_CNone.Optional.Core.e51fa37fd255d8de(), !dbg !65
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.5e80ad62f480057c.Core.c8fd090a2e741f70"(ptr %self) #0 !dbg !59 {
+// CHECK:STDOUT:   %1 = call ptr @_CNone.Optional.Core.f86670471c077286(), !dbg !65
 // CHECK:STDOUT:   ret ptr %1, !dbg !66
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -179,7 +179,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: declare ptr @_CMake.NullptrT.CppCompat.Core()
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CNone.Optional.Core.e51fa37fd255d8de() #0 !dbg !67 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CNone.Optional.Core.f86670471c077286() #0 !dbg !67 {
 // CHECK:STDOUT:   ret ptr null, !dbg !69
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -188,7 +188,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: declare ptr @_Z13ReturnNullptrv() #1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.7b6a382d04a36247.Core.c8fd090a2e741f70", { 3, 2, 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @"_CConvert.NullptrT.CppCompat.Core:ImplicitAs.5e80ad62f480057c.Core.c8fd090a2e741f70", { 3, 2, 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 4, 3, 2, 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
@@ -233,7 +233,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: !30 = !{!31}
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !25)
 // CHECK:STDOUT: !32 = !DILocation(line: 12, column: 15, scope: !29)
-// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "Op", linkageName: "_COp.ffb455139f965851:core.Destroy.Core", scope: null, file: !6, line: 12, type: !23, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !34)
+// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "Op", linkageName: "_COp.30d8820b488e450b:core.Destroy.Core", scope: null, file: !6, line: 12, type: !23, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !34)
 // CHECK:STDOUT: !34 = !{!35}
 // CHECK:STDOUT: !35 = !DILocalVariable(arg: 1, scope: !33, type: !25)
 // CHECK:STDOUT: !36 = !DILocation(line: 12, column: 15, scope: !33)
@@ -259,7 +259,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: !56 = !DILocation(line: 32, column: 3, scope: !54)
 // CHECK:STDOUT: !57 = distinct !DISubprogram(name: "ConvertNullptrConstant", linkageName: "_CConvertNullptrConstant.Main", scope: null, file: !6, line: 35, type: !38, spFlags: DISPFlagDefinition, unit: !5)
 // CHECK:STDOUT: !58 = !DILocation(line: 36, column: 3, scope: !57)
-// CHECK:STDOUT: !59 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.NullptrT.CppCompat.Core:ImplicitAs.7b6a382d04a36247.Core.c8fd090a2e741f70", scope: null, file: !60, line: 51, type: !61, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !63)
+// CHECK:STDOUT: !59 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.NullptrT.CppCompat.Core:ImplicitAs.5e80ad62f480057c.Core.c8fd090a2e741f70", scope: null, file: !60, line: 51, type: !61, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !63)
 // CHECK:STDOUT: !60 = !DIFile(filename: "{{.*}}/prelude/types/cpp/nullptr.carbon", directory: "")
 // CHECK:STDOUT: !61 = !DISubroutineType(types: !62)
 // CHECK:STDOUT: !62 = !{!25, !25}
@@ -267,6 +267,6 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: !64 = !DILocalVariable(arg: 1, scope: !59, type: !25)
 // CHECK:STDOUT: !65 = !DILocation(line: 52, column: 14, scope: !59)
 // CHECK:STDOUT: !66 = !DILocation(line: 52, column: 7, scope: !59)
-// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.e51fa37fd255d8de", scope: null, file: !68, line: 27, type: !38, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.f86670471c077286", scope: null, file: !68, line: 30, type: !38, spFlags: DISPFlagDefinition, unit: !5)
 // CHECK:STDOUT: !68 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
-// CHECK:STDOUT: !69 = !DILocation(line: 28, column: 5, scope: !67)
+// CHECK:STDOUT: !69 = !DILocation(line: 31, column: 5, scope: !67)

--- a/toolchain/lower/testdata/interop/cpp/pointer.carbon
+++ b/toolchain/lower/testdata/interop/cpp/pointer.carbon
@@ -218,12 +218,12 @@ fn Convert() {
 // CHECK:STDOUT: define void @_CPassNonnullPtr.Main(ptr %p) #0 !dbg !18 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc22_15.2.temp = alloca ptr, align 8, !dbg !21
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.b425d6bf10aac33d"(ptr %p), !dbg !21
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.7ca8ed081f5d7ff7"(ptr %p), !dbg !21
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_15.2.temp), !dbg !21
 // CHECK:STDOUT:   store ptr %U.as_type.as.ImplicitAs.impl.Convert.call, ptr %.loc22_15.2.temp, align 8, !dbg !21
 // CHECK:STDOUT:   %.loc22_15.4 = load ptr, ptr %.loc22_15.2.temp, align 8, !dbg !21
 // CHECK:STDOUT:   call void @_Z7TakePtrP1C(ptr %.loc22_15.4), !dbg !22
-// CHECK:STDOUT:   call void @"_COp.129c8ad8f31c07e1:core.Destroy.Core"(ptr %.loc22_15.2.temp), !dbg !21
+// CHECK:STDOUT:   call void @"_COp.357c5945ee623cad:core.Destroy.Core"(ptr %.loc22_15.2.temp), !dbg !21
 // CHECK:STDOUT:   ret void, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -236,7 +236,7 @@ fn Convert() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.129c8ad8f31c07e1:core.Destroy.Core"(ptr %self) #0 !dbg !28 {
+// CHECK:STDOUT: define weak_odr void @"_COp.357c5945ee623cad:core.Destroy.Core"(ptr %self) #0 !dbg !28 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !31
 // CHECK:STDOUT: }
@@ -260,12 +260,12 @@ fn Convert() {
 // CHECK:STDOUT: define void @_CPassNonnullPtrWithThunk.Main(ptr %p) #0 !dbg !41 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc35_24.2.temp = alloca ptr, align 8, !dbg !44
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.b425d6bf10aac33d"(ptr %p), !dbg !44
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.7ca8ed081f5d7ff7"(ptr %p), !dbg !44
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc35_24.2.temp), !dbg !44
 // CHECK:STDOUT:   store ptr %U.as_type.as.ImplicitAs.impl.Convert.call, ptr %.loc35_24.2.temp, align 8, !dbg !44
 // CHECK:STDOUT:   %.loc35_24.4 = load ptr, ptr %.loc35_24.2.temp, align 8, !dbg !44
 // CHECK:STDOUT:   call void @_Z16TakePtrWithThunkP1Ci.carbon_thunk._(ptr %.loc35_24.4), !dbg !45
-// CHECK:STDOUT:   call void @"_COp.129c8ad8f31c07e1:core.Destroy.Core"(ptr %.loc35_24.2.temp), !dbg !44
+// CHECK:STDOUT:   call void @"_COp.357c5945ee623cad:core.Destroy.Core"(ptr %.loc35_24.2.temp), !dbg !44
 // CHECK:STDOUT:   ret void, !dbg !46
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -294,8 +294,8 @@ fn Convert() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.b425d6bf10aac33d"(ptr %self) #0 !dbg !53 {
-// CHECK:STDOUT:   %1 = call ptr @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.3dfa3b552b212aa8"(ptr %self), !dbg !59
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.7ca8ed081f5d7ff7"(ptr %self) #0 !dbg !53 {
+// CHECK:STDOUT:   %1 = call ptr @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.63998780806c7fd2"(ptr %self), !dbg !59
 // CHECK:STDOUT:   ret ptr %1, !dbg !60
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -303,13 +303,13 @@ fn Convert() {
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #3
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.3dfa3b552b212aa8"(ptr %self) #0 !dbg !61 {
-// CHECK:STDOUT:   %1 = call ptr @_CSome.Optional.Core.3dfa3b552b212aa8(ptr %self), !dbg !64
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.63998780806c7fd2"(ptr %self) #0 !dbg !61 {
+// CHECK:STDOUT:   %1 = call ptr @_CSome.Optional.Core.63998780806c7fd2(ptr %self), !dbg !64
 // CHECK:STDOUT:   ret ptr %1, !dbg !65
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CSome.Optional.Core.3dfa3b552b212aa8(ptr %value) #0 !dbg !66 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CSome.Optional.Core.63998780806c7fd2(ptr %value) #0 !dbg !66 {
 // CHECK:STDOUT:   %1 = call ptr @"_CSome.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690"(ptr %value), !dbg !69
 // CHECK:STDOUT:   ret ptr %1, !dbg !70
 // CHECK:STDOUT: }
@@ -330,7 +330,7 @@ fn Convert() {
 // CHECK:STDOUT: declare noundef ptr @_Z18ReturnPtrWithThunki(i32 noundef) #1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.b425d6bf10aac33d", { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.7ca8ed081f5d7ff7", { 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 0, 2, 1 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
@@ -370,7 +370,7 @@ fn Convert() {
 // CHECK:STDOUT: !25 = !{!26}
 // CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !24, type: !14)
 // CHECK:STDOUT: !27 = !DILocation(line: 22, column: 15, scope: !24)
-// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "Op", linkageName: "_COp.129c8ad8f31c07e1:core.Destroy.Core", scope: null, file: !6, line: 22, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !29)
+// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "Op", linkageName: "_COp.357c5945ee623cad:core.Destroy.Core", scope: null, file: !6, line: 22, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !29)
 // CHECK:STDOUT: !29 = !{!30}
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !28, type: !14)
 // CHECK:STDOUT: !31 = !DILocation(line: 22, column: 15, scope: !28)
@@ -395,31 +395,31 @@ fn Convert() {
 // CHECK:STDOUT: !50 = distinct !DISubprogram(name: "ReturnPtrWithThunk", linkageName: "_CReturnPtrWithThunk.Main", scope: null, file: !6, line: 38, type: !33, spFlags: DISPFlagDefinition, unit: !5)
 // CHECK:STDOUT: !51 = !DILocation(line: 39, column: 10, scope: !50)
 // CHECK:STDOUT: !52 = !DILocation(line: 39, column: 3, scope: !50)
-// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.b425d6bf10aac33d", scope: null, file: !54, line: 96, type: !55, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !57)
+// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.7ca8ed081f5d7ff7", scope: null, file: !54, line: 105, type: !55, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !57)
 // CHECK:STDOUT: !54 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !55 = !DISubroutineType(types: !56)
 // CHECK:STDOUT: !56 = !{!14, !14}
 // CHECK:STDOUT: !57 = !{!58}
 // CHECK:STDOUT: !58 = !DILocalVariable(arg: 1, scope: !53, type: !14)
-// CHECK:STDOUT: !59 = !DILocation(line: 97, column: 12, scope: !53)
-// CHECK:STDOUT: !60 = !DILocation(line: 97, column: 5, scope: !53)
-// CHECK:STDOUT: !61 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.3dfa3b552b212aa8", scope: null, file: !54, line: 71, type: !55, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !62)
+// CHECK:STDOUT: !59 = !DILocation(line: 106, column: 12, scope: !53)
+// CHECK:STDOUT: !60 = !DILocation(line: 106, column: 5, scope: !53)
+// CHECK:STDOUT: !61 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.63998780806c7fd2", scope: null, file: !54, line: 80, type: !55, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !62)
 // CHECK:STDOUT: !62 = !{!63}
 // CHECK:STDOUT: !63 = !DILocalVariable(arg: 1, scope: !61, type: !14)
-// CHECK:STDOUT: !64 = !DILocation(line: 72, column: 12, scope: !61)
-// CHECK:STDOUT: !65 = !DILocation(line: 72, column: 5, scope: !61)
-// CHECK:STDOUT: !66 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.3dfa3b552b212aa8", scope: null, file: !54, line: 30, type: !55, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !67)
+// CHECK:STDOUT: !64 = !DILocation(line: 81, column: 12, scope: !61)
+// CHECK:STDOUT: !65 = !DILocation(line: 81, column: 5, scope: !61)
+// CHECK:STDOUT: !66 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.63998780806c7fd2", scope: null, file: !54, line: 33, type: !55, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !67)
 // CHECK:STDOUT: !67 = !{!68}
 // CHECK:STDOUT: !68 = !DILocalVariable(arg: 1, scope: !66, type: !14)
-// CHECK:STDOUT: !69 = !DILocation(line: 31, column: 12, scope: !66)
-// CHECK:STDOUT: !70 = !DILocation(line: 31, column: 5, scope: !66)
-// CHECK:STDOUT: !71 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690", scope: null, file: !54, line: 150, type: !55, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !72)
+// CHECK:STDOUT: !69 = !DILocation(line: 34, column: 12, scope: !66)
+// CHECK:STDOUT: !70 = !DILocation(line: 34, column: 5, scope: !66)
+// CHECK:STDOUT: !71 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690", scope: null, file: !54, line: 166, type: !55, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !72)
 // CHECK:STDOUT: !72 = !{!73}
 // CHECK:STDOUT: !73 = !DILocalVariable(arg: 1, scope: !71, type: !14)
-// CHECK:STDOUT: !74 = !DILocation(line: 151, column: 14, scope: !71)
-// CHECK:STDOUT: !75 = !DILocation(line: 153, column: 5, scope: !71)
-// CHECK:STDOUT: !76 = !DILocation(line: 151, column: 18, scope: !71)
-// CHECK:STDOUT: !77 = !DILocation(line: 154, column: 5, scope: !71)
+// CHECK:STDOUT: !74 = !DILocation(line: 167, column: 14, scope: !71)
+// CHECK:STDOUT: !75 = !DILocation(line: 169, column: 5, scope: !71)
+// CHECK:STDOUT: !76 = !DILocation(line: 167, column: 18, scope: !71)
+// CHECK:STDOUT: !77 = !DILocation(line: 170, column: 5, scope: !71)
 // CHECK:STDOUT: ; ModuleID = 'add_const.carbon'
 // CHECK:STDOUT: source_filename = "add_const.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -434,13 +434,13 @@ fn Convert() {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_21.1.temp), !dbg !14
 // CHECK:STDOUT:   store ptr %make.call, ptr %.loc9_21.1.temp, align 8, !dbg !14
 // CHECK:STDOUT:   %.loc9_21.3 = load ptr, ptr %.loc9_21.1.temp, align 8, !dbg !14
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.8c78338db8262399"(ptr %.loc9_21.3), !dbg !14
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.db0c0c062ccbeee2"(ptr %.loc9_21.3), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_21.5.temp), !dbg !14
 // CHECK:STDOUT:   store ptr %U.as_type.as.ImplicitAs.impl.Convert.call, ptr %.loc9_21.5.temp, align 8, !dbg !14
 // CHECK:STDOUT:   %.loc9_21.7 = load ptr, ptr %.loc9_21.5.temp, align 8, !dbg !14
 // CHECK:STDOUT:   call void @_Z4takePK1C(ptr %.loc9_21.7), !dbg !15
-// CHECK:STDOUT:   call void @"_COp.ce10e9f6ae2a5326:core.Destroy.Core"(ptr %.loc9_21.5.temp), !dbg !14
-// CHECK:STDOUT:   call void @"_COp.02e5976f4da6b54a:core.Destroy.Core"(ptr %.loc9_21.1.temp), !dbg !14
+// CHECK:STDOUT:   call void @"_COp.70b543b9054a214c:core.Destroy.Core"(ptr %.loc9_21.5.temp), !dbg !14
+// CHECK:STDOUT:   call void @"_COp.3c4756f6f67440bc:core.Destroy.Core"(ptr %.loc9_21.1.temp), !dbg !14
 // CHECK:STDOUT:   ret void, !dbg !16
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -455,7 +455,7 @@ fn Convert() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.ce10e9f6ae2a5326:core.Destroy.Core"(ptr %self) #0 !dbg !24 {
+// CHECK:STDOUT: define weak_odr void @"_COp.70b543b9054a214c:core.Destroy.Core"(ptr %self) #0 !dbg !24 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !27
 // CHECK:STDOUT: }
@@ -467,7 +467,7 @@ fn Convert() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.02e5976f4da6b54a:core.Destroy.Core"(ptr %self) #0 !dbg !32 {
+// CHECK:STDOUT: define weak_odr void @"_COp.3c4756f6f67440bc:core.Destroy.Core"(ptr %self) #0 !dbg !32 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !35
 // CHECK:STDOUT: }
@@ -476,54 +476,54 @@ fn Convert() {
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.8c78338db8262399"(ptr %self) #0 !dbg !36 {
-// CHECK:STDOUT:   %1 = call ptr @"_CConvert.Optional.5dca1548b0a7c023.Core:OptionalAs.f5e7d4305ac1f327.Core.393d60e97ff65cbb"(ptr %self), !dbg !42
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.db0c0c062ccbeee2"(ptr %self) #0 !dbg !36 {
+// CHECK:STDOUT:   %1 = call ptr @"_CConvert.Optional.5dca1548b0a7c023.Core:OptionalAs.f5e7d4305ac1f327.Core.dcb11ca5ddf1633f"(ptr %self), !dbg !42
 // CHECK:STDOUT:   ret ptr %1, !dbg !43
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.Optional.5dca1548b0a7c023.Core:OptionalAs.f5e7d4305ac1f327.Core.393d60e97ff65cbb"(ptr %self) #0 !dbg !44 {
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.Optional.5dca1548b0a7c023.Core:OptionalAs.f5e7d4305ac1f327.Core.dcb11ca5ddf1633f"(ptr %self) #0 !dbg !44 {
 // CHECK:STDOUT:   %temp = alloca ptr, align 8, !dbg !47
 // CHECK:STDOUT:   %temp1 = alloca ptr, align 8, !dbg !47
-// CHECK:STDOUT:   %1 = call i1 @_CHasValue.Optional.Core.63099895f5fdc5b3(ptr %self), !dbg !48
+// CHECK:STDOUT:   %1 = call i1 @_CHasValue.Optional.Core.2b3974338accec9e(ptr %self), !dbg !48
 // CHECK:STDOUT:   br i1 %1, label %2, label %7, !dbg !49
 // CHECK:STDOUT:
 // CHECK:STDOUT: 2:                                                ; preds = %0
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %temp), !dbg !47
-// CHECK:STDOUT:   %3 = call ptr @_CGet.Optional.Core.63099895f5fdc5b3(ptr %self), !dbg !47
+// CHECK:STDOUT:   %3 = call ptr @_CGet.Optional.Core.2b3974338accec9e(ptr %self), !dbg !47
 // CHECK:STDOUT:   store ptr %3, ptr %temp, align 8, !dbg !47
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %temp1), !dbg !47
 // CHECK:STDOUT:   %4 = load ptr, ptr %temp, align 8, !dbg !47
 // CHECK:STDOUT:   store ptr %4, ptr %temp1, align 8, !dbg !47
 // CHECK:STDOUT:   %5 = load ptr, ptr %temp1, align 8, !dbg !47
-// CHECK:STDOUT:   %6 = call ptr @_CSome.Optional.Core.24cf9e6f9173c4f1(ptr %5), !dbg !50
+// CHECK:STDOUT:   %6 = call ptr @_CSome.Optional.Core.428663f04d56e65c(ptr %5), !dbg !50
 // CHECK:STDOUT:   ret ptr %6, !dbg !51
 // CHECK:STDOUT:
 // CHECK:STDOUT: 7:                                                ; preds = %0
-// CHECK:STDOUT:   %8 = call ptr @_CNone.Optional.Core.24cf9e6f9173c4f1(), !dbg !52
+// CHECK:STDOUT:   %8 = call ptr @_CNone.Optional.Core.428663f04d56e65c(), !dbg !52
 // CHECK:STDOUT:   ret ptr %8, !dbg !53
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.63099895f5fdc5b3(ptr %self) #0 !dbg !54 {
+// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.2b3974338accec9e(ptr %self) #0 !dbg !54 {
 // CHECK:STDOUT:   %1 = call i1 @"_CHas.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690"(ptr %self), !dbg !57
 // CHECK:STDOUT:   ret i1 %1, !dbg !58
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CGet.Optional.Core.63099895f5fdc5b3(ptr %self) #0 !dbg !59 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CGet.Optional.Core.2b3974338accec9e(ptr %self) #0 !dbg !59 {
 // CHECK:STDOUT:   %1 = call ptr @"_CGet.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690"(ptr %self), !dbg !62
 // CHECK:STDOUT:   ret ptr %1, !dbg !63
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CSome.Optional.Core.24cf9e6f9173c4f1(ptr %value) #0 !dbg !64 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CSome.Optional.Core.428663f04d56e65c(ptr %value) #0 !dbg !64 {
 // CHECK:STDOUT:   %1 = call ptr @"_CSome.e8f8f92d3d08d149:OptionalStorage.Core.11944b9073985c4a"(ptr %value), !dbg !67
 // CHECK:STDOUT:   ret ptr %1, !dbg !68
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CNone.Optional.Core.24cf9e6f9173c4f1() #0 !dbg !69 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CNone.Optional.Core.428663f04d56e65c() #0 !dbg !69 {
 // CHECK:STDOUT:   ret ptr null, !dbg !72
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -585,7 +585,7 @@ fn Convert() {
 // CHECK:STDOUT: !21 = !{!22}
 // CHECK:STDOUT: !22 = !DILocalVariable(arg: 1, scope: !17, type: !20)
 // CHECK:STDOUT: !23 = !DILocation(line: 9, column: 12, scope: !17)
-// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "Op", linkageName: "_COp.ce10e9f6ae2a5326:core.Destroy.Core", scope: null, file: !6, line: 9, type: !18, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !25)
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "Op", linkageName: "_COp.70b543b9054a214c:core.Destroy.Core", scope: null, file: !6, line: 9, type: !18, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !25)
 // CHECK:STDOUT: !25 = !{!26}
 // CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !24, type: !20)
 // CHECK:STDOUT: !27 = !DILocation(line: 9, column: 12, scope: !24)
@@ -593,61 +593,61 @@ fn Convert() {
 // CHECK:STDOUT: !29 = !{!30}
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !28, type: !20)
 // CHECK:STDOUT: !31 = !DILocation(line: 9, column: 12, scope: !28)
-// CHECK:STDOUT: !32 = distinct !DISubprogram(name: "Op", linkageName: "_COp.02e5976f4da6b54a:core.Destroy.Core", scope: null, file: !6, line: 9, type: !18, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !33)
+// CHECK:STDOUT: !32 = distinct !DISubprogram(name: "Op", linkageName: "_COp.3c4756f6f67440bc:core.Destroy.Core", scope: null, file: !6, line: 9, type: !18, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !33)
 // CHECK:STDOUT: !33 = !{!34}
 // CHECK:STDOUT: !34 = !DILocalVariable(arg: 1, scope: !32, type: !20)
 // CHECK:STDOUT: !35 = !DILocation(line: 9, column: 12, scope: !32)
-// CHECK:STDOUT: !36 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.8c78338db8262399", scope: null, file: !37, line: 96, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !40)
+// CHECK:STDOUT: !36 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.db0c0c062ccbeee2", scope: null, file: !37, line: 105, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !40)
 // CHECK:STDOUT: !37 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !38 = !DISubroutineType(types: !39)
 // CHECK:STDOUT: !39 = !{!20, !20}
 // CHECK:STDOUT: !40 = !{!41}
 // CHECK:STDOUT: !41 = !DILocalVariable(arg: 1, scope: !36, type: !20)
-// CHECK:STDOUT: !42 = !DILocation(line: 97, column: 12, scope: !36)
-// CHECK:STDOUT: !43 = !DILocation(line: 97, column: 5, scope: !36)
-// CHECK:STDOUT: !44 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.Optional.5dca1548b0a7c023.Core:OptionalAs.f5e7d4305ac1f327.Core.393d60e97ff65cbb", scope: null, file: !37, line: 86, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !45)
+// CHECK:STDOUT: !42 = !DILocation(line: 106, column: 12, scope: !36)
+// CHECK:STDOUT: !43 = !DILocation(line: 106, column: 5, scope: !36)
+// CHECK:STDOUT: !44 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.Optional.5dca1548b0a7c023.Core:OptionalAs.f5e7d4305ac1f327.Core.dcb11ca5ddf1633f", scope: null, file: !37, line: 95, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !45)
 // CHECK:STDOUT: !45 = !{!46}
 // CHECK:STDOUT: !46 = !DILocalVariable(arg: 1, scope: !44, type: !20)
-// CHECK:STDOUT: !47 = !DILocation(line: 88, column: 31, scope: !44)
-// CHECK:STDOUT: !48 = !DILocation(line: 87, column: 9, scope: !44)
-// CHECK:STDOUT: !49 = !DILocation(line: 87, column: 8, scope: !44)
-// CHECK:STDOUT: !50 = !DILocation(line: 88, column: 14, scope: !44)
-// CHECK:STDOUT: !51 = !DILocation(line: 88, column: 7, scope: !44)
-// CHECK:STDOUT: !52 = !DILocation(line: 90, column: 12, scope: !44)
-// CHECK:STDOUT: !53 = !DILocation(line: 90, column: 5, scope: !44)
-// CHECK:STDOUT: !54 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.63099895f5fdc5b3", scope: null, file: !37, line: 33, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !55)
+// CHECK:STDOUT: !47 = !DILocation(line: 97, column: 31, scope: !44)
+// CHECK:STDOUT: !48 = !DILocation(line: 96, column: 9, scope: !44)
+// CHECK:STDOUT: !49 = !DILocation(line: 96, column: 8, scope: !44)
+// CHECK:STDOUT: !50 = !DILocation(line: 97, column: 14, scope: !44)
+// CHECK:STDOUT: !51 = !DILocation(line: 97, column: 7, scope: !44)
+// CHECK:STDOUT: !52 = !DILocation(line: 99, column: 12, scope: !44)
+// CHECK:STDOUT: !53 = !DILocation(line: 99, column: 5, scope: !44)
+// CHECK:STDOUT: !54 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.2b3974338accec9e", scope: null, file: !37, line: 36, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !55)
 // CHECK:STDOUT: !55 = !{!56}
 // CHECK:STDOUT: !56 = !DILocalVariable(arg: 1, scope: !54, type: !20)
-// CHECK:STDOUT: !57 = !DILocation(line: 34, column: 12, scope: !54)
-// CHECK:STDOUT: !58 = !DILocation(line: 34, column: 5, scope: !54)
-// CHECK:STDOUT: !59 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.63099895f5fdc5b3", scope: null, file: !37, line: 36, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !60)
+// CHECK:STDOUT: !57 = !DILocation(line: 37, column: 12, scope: !54)
+// CHECK:STDOUT: !58 = !DILocation(line: 37, column: 5, scope: !54)
+// CHECK:STDOUT: !59 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.2b3974338accec9e", scope: null, file: !37, line: 39, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !60)
 // CHECK:STDOUT: !60 = !{!61}
 // CHECK:STDOUT: !61 = !DILocalVariable(arg: 1, scope: !59, type: !20)
-// CHECK:STDOUT: !62 = !DILocation(line: 37, column: 12, scope: !59)
-// CHECK:STDOUT: !63 = !DILocation(line: 37, column: 5, scope: !59)
-// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.24cf9e6f9173c4f1", scope: null, file: !37, line: 30, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !65)
+// CHECK:STDOUT: !62 = !DILocation(line: 40, column: 12, scope: !59)
+// CHECK:STDOUT: !63 = !DILocation(line: 40, column: 5, scope: !59)
+// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.428663f04d56e65c", scope: null, file: !37, line: 33, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !65)
 // CHECK:STDOUT: !65 = !{!66}
 // CHECK:STDOUT: !66 = !DILocalVariable(arg: 1, scope: !64, type: !20)
-// CHECK:STDOUT: !67 = !DILocation(line: 31, column: 12, scope: !64)
-// CHECK:STDOUT: !68 = !DILocation(line: 31, column: 5, scope: !64)
-// CHECK:STDOUT: !69 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.24cf9e6f9173c4f1", scope: null, file: !37, line: 27, type: !70, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !67 = !DILocation(line: 34, column: 12, scope: !64)
+// CHECK:STDOUT: !68 = !DILocation(line: 34, column: 5, scope: !64)
+// CHECK:STDOUT: !69 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.428663f04d56e65c", scope: null, file: !37, line: 30, type: !70, spFlags: DISPFlagDefinition, unit: !5)
 // CHECK:STDOUT: !70 = !DISubroutineType(types: !71)
 // CHECK:STDOUT: !71 = !{!20}
-// CHECK:STDOUT: !72 = !DILocation(line: 28, column: 5, scope: !69)
-// CHECK:STDOUT: !73 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690", scope: null, file: !37, line: 156, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !74)
+// CHECK:STDOUT: !72 = !DILocation(line: 31, column: 5, scope: !69)
+// CHECK:STDOUT: !73 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690", scope: null, file: !37, line: 172, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !74)
 // CHECK:STDOUT: !74 = !{!75}
 // CHECK:STDOUT: !75 = !DILocalVariable(arg: 1, scope: !73, type: !20)
-// CHECK:STDOUT: !76 = !DILocation(line: 157, column: 16, scope: !73)
-// CHECK:STDOUT: !77 = !DILocation(line: 157, column: 12, scope: !73)
-// CHECK:STDOUT: !78 = !DILocation(line: 157, column: 5, scope: !73)
-// CHECK:STDOUT: !79 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690", scope: null, file: !37, line: 159, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !80)
+// CHECK:STDOUT: !76 = !DILocation(line: 173, column: 16, scope: !73)
+// CHECK:STDOUT: !77 = !DILocation(line: 173, column: 12, scope: !73)
+// CHECK:STDOUT: !78 = !DILocation(line: 173, column: 5, scope: !73)
+// CHECK:STDOUT: !79 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.e8f8f92d3d08d149:OptionalStorage.Core.908e8f868f225690", scope: null, file: !37, line: 175, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !80)
 // CHECK:STDOUT: !80 = !{!81}
 // CHECK:STDOUT: !81 = !DILocalVariable(arg: 1, scope: !79, type: !20)
-// CHECK:STDOUT: !82 = !DILocation(line: 160, column: 5, scope: !79)
-// CHECK:STDOUT: !83 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.e8f8f92d3d08d149:OptionalStorage.Core.11944b9073985c4a", scope: null, file: !37, line: 150, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !84)
+// CHECK:STDOUT: !82 = !DILocation(line: 176, column: 5, scope: !79)
+// CHECK:STDOUT: !83 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.e8f8f92d3d08d149:OptionalStorage.Core.11944b9073985c4a", scope: null, file: !37, line: 166, type: !38, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !84)
 // CHECK:STDOUT: !84 = !{!85}
 // CHECK:STDOUT: !85 = !DILocalVariable(arg: 1, scope: !83, type: !20)
-// CHECK:STDOUT: !86 = !DILocation(line: 151, column: 14, scope: !83)
-// CHECK:STDOUT: !87 = !DILocation(line: 153, column: 5, scope: !83)
-// CHECK:STDOUT: !88 = !DILocation(line: 151, column: 18, scope: !83)
-// CHECK:STDOUT: !89 = !DILocation(line: 154, column: 5, scope: !83)
+// CHECK:STDOUT: !86 = !DILocation(line: 167, column: 14, scope: !83)
+// CHECK:STDOUT: !87 = !DILocation(line: 169, column: 5, scope: !83)
+// CHECK:STDOUT: !88 = !DILocation(line: 167, column: 18, scope: !83)
+// CHECK:STDOUT: !89 = !DILocation(line: 170, column: 5, scope: !83)

--- a/toolchain/lower/testdata/interop/cpp/void.carbon
+++ b/toolchain/lower/testdata/interop/cpp/void.carbon
@@ -65,12 +65,12 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: define void @_CPassVoidPtr.Main(ptr %a) #0 !dbg !11 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc7_21.2.temp = alloca ptr, align 8, !dbg !17
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.bc8a88dae0c7117a"(ptr %a), !dbg !17
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.5cb3be840dc534b9"(ptr %a), !dbg !17
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_21.2.temp), !dbg !17
 // CHECK:STDOUT:   store ptr %U.as_type.as.ImplicitAs.impl.Convert.call, ptr %.loc7_21.2.temp, align 8, !dbg !17
 // CHECK:STDOUT:   %.loc7_21.4 = load ptr, ptr %.loc7_21.2.temp, align 8, !dbg !17
 // CHECK:STDOUT:   call void @_Z13take_void_ptrPv(ptr %.loc7_21.4), !dbg !18
-// CHECK:STDOUT:   call void @"_COp.29cb36961ff3e7a9:core.Destroy.Core"(ptr %.loc7_21.2.temp), !dbg !17
+// CHECK:STDOUT:   call void @"_COp.246ed33979ddb7a6:core.Destroy.Core"(ptr %.loc7_21.2.temp), !dbg !17
 // CHECK:STDOUT:   ret void, !dbg !19
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -83,7 +83,7 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.29cb36961ff3e7a9:core.Destroy.Core"(ptr %self) #0 !dbg !24 {
+// CHECK:STDOUT: define weak_odr void @"_COp.246ed33979ddb7a6:core.Destroy.Core"(ptr %self) #0 !dbg !24 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !27
 // CHECK:STDOUT: }
@@ -92,12 +92,12 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: define void @_CPassIntPtr.Main(ptr %a) #0 !dbg !28 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc11_21.2.temp = alloca ptr, align 8, !dbg !31
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.a84fab117d3c0ee6"(ptr %a), !dbg !31
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.768fc8296e1e36ca"(ptr %a), !dbg !31
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc11_21.2.temp), !dbg !31
 // CHECK:STDOUT:   store ptr %U.as_type.as.ImplicitAs.impl.Convert.call, ptr %.loc11_21.2.temp, align 8, !dbg !31
 // CHECK:STDOUT:   %.loc11_21.4 = load ptr, ptr %.loc11_21.2.temp, align 8, !dbg !31
 // CHECK:STDOUT:   call void @_Z13take_void_ptrPv(ptr %.loc11_21.4), !dbg !32
-// CHECK:STDOUT:   call void @"_COp.29cb36961ff3e7a9:core.Destroy.Core"(ptr %.loc11_21.2.temp), !dbg !31
+// CHECK:STDOUT:   call void @"_COp.246ed33979ddb7a6:core.Destroy.Core"(ptr %.loc11_21.2.temp), !dbg !31
 // CHECK:STDOUT:   ret void, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -105,12 +105,12 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: define void @_CPassIntPtrToConstVoidPtr.Main(ptr %a) #0 !dbg !34 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc15_27.2.temp = alloca ptr, align 8, !dbg !37
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.aed2bb692dd6cdfe"(ptr %a), !dbg !37
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.bedbcdacb285d12b"(ptr %a), !dbg !37
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc15_27.2.temp), !dbg !37
 // CHECK:STDOUT:   store ptr %U.as_type.as.ImplicitAs.impl.Convert.call, ptr %.loc15_27.2.temp, align 8, !dbg !37
 // CHECK:STDOUT:   %.loc15_27.4 = load ptr, ptr %.loc15_27.2.temp, align 8, !dbg !37
 // CHECK:STDOUT:   call void @_Z19take_const_void_ptrPKv(ptr %.loc15_27.4), !dbg !38
-// CHECK:STDOUT:   call void @"_COp.8aa3827fca3a355d:core.Destroy.Core"(ptr %.loc15_27.2.temp), !dbg !37
+// CHECK:STDOUT:   call void @"_COp.728380d5ff77eadd:core.Destroy.Core"(ptr %.loc15_27.2.temp), !dbg !37
 // CHECK:STDOUT:   ret void, !dbg !39
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -123,7 +123,7 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.8aa3827fca3a355d:core.Destroy.Core"(ptr %self) #0 !dbg !44 {
+// CHECK:STDOUT: define weak_odr void @"_COp.728380d5ff77eadd:core.Destroy.Core"(ptr %self) #0 !dbg !44 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !47
 // CHECK:STDOUT: }
@@ -132,18 +132,18 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: define void @_CPassConstIntPtrToConstVoidPtr.Main(ptr %a) #0 !dbg !48 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc19_27.2.temp = alloca ptr, align 8, !dbg !51
-// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.aed2bb692dd6cdfe"(ptr %a), !dbg !51
+// CHECK:STDOUT:   %U.as_type.as.ImplicitAs.impl.Convert.call = call ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.bedbcdacb285d12b"(ptr %a), !dbg !51
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc19_27.2.temp), !dbg !51
 // CHECK:STDOUT:   store ptr %U.as_type.as.ImplicitAs.impl.Convert.call, ptr %.loc19_27.2.temp, align 8, !dbg !51
 // CHECK:STDOUT:   %.loc19_27.4 = load ptr, ptr %.loc19_27.2.temp, align 8, !dbg !51
 // CHECK:STDOUT:   call void @_Z19take_const_void_ptrPKv(ptr %.loc19_27.4), !dbg !52
-// CHECK:STDOUT:   call void @"_COp.8aa3827fca3a355d:core.Destroy.Core"(ptr %.loc19_27.2.temp), !dbg !51
+// CHECK:STDOUT:   call void @"_COp.728380d5ff77eadd:core.Destroy.Core"(ptr %.loc19_27.2.temp), !dbg !51
 // CHECK:STDOUT:   ret void, !dbg !53
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.bc8a88dae0c7117a"(ptr %self) #0 !dbg !54 {
-// CHECK:STDOUT:   %1 = call ptr @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.58daef9740f71e43"(ptr %self), !dbg !60
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.5cb3be840dc534b9"(ptr %self) #0 !dbg !54 {
+// CHECK:STDOUT:   %1 = call ptr @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.1f340f4ca78e6045"(ptr %self), !dbg !60
 // CHECK:STDOUT:   ret ptr %1, !dbg !61
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -151,46 +151,46 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #2
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.a84fab117d3c0ee6"(ptr %self) #0 !dbg !62 {
-// CHECK:STDOUT:   %1 = call ptr @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.598d3d2f1309c543"(ptr %self), !dbg !65
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.768fc8296e1e36ca"(ptr %self) #0 !dbg !62 {
+// CHECK:STDOUT:   %1 = call ptr @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.fbd613f85778f3e8"(ptr %self), !dbg !65
 // CHECK:STDOUT:   ret ptr %1, !dbg !66
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.aed2bb692dd6cdfe"(ptr %self) #0 !dbg !67 {
-// CHECK:STDOUT:   %1 = call ptr @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.5cd669b97de7611a"(ptr %self), !dbg !70
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.bedbcdacb285d12b"(ptr %self) #0 !dbg !67 {
+// CHECK:STDOUT:   %1 = call ptr @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.358bb0df88a4e672"(ptr %self), !dbg !70
 // CHECK:STDOUT:   ret ptr %1, !dbg !71
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.58daef9740f71e43"(ptr %self) #0 !dbg !72 {
-// CHECK:STDOUT:   %1 = call ptr @_CSome.Optional.Core.58daef9740f71e43(ptr %self), !dbg !75
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.1f340f4ca78e6045"(ptr %self) #0 !dbg !72 {
+// CHECK:STDOUT:   %1 = call ptr @_CSome.Optional.Core.1f340f4ca78e6045(ptr %self), !dbg !75
 // CHECK:STDOUT:   ret ptr %1, !dbg !76
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.598d3d2f1309c543"(ptr %self) #0 !dbg !77 {
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.fbd613f85778f3e8"(ptr %self) #0 !dbg !77 {
 // CHECK:STDOUT:   %temp = alloca ptr, align 8, !dbg !80
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %temp), !dbg !80
 // CHECK:STDOUT:   store ptr %self, ptr %temp, align 8, !dbg !80
 // CHECK:STDOUT:   %1 = load ptr, ptr %temp, align 8, !dbg !80
-// CHECK:STDOUT:   %2 = call ptr @_CSome.Optional.Core.58daef9740f71e43(ptr %1), !dbg !81
+// CHECK:STDOUT:   %2 = call ptr @_CSome.Optional.Core.1f340f4ca78e6045(ptr %1), !dbg !81
 // CHECK:STDOUT:   ret ptr %2, !dbg !82
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.5cd669b97de7611a"(ptr %self) #0 !dbg !83 {
+// CHECK:STDOUT: define linkonce_odr ptr @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.358bb0df88a4e672"(ptr %self) #0 !dbg !83 {
 // CHECK:STDOUT:   %temp = alloca ptr, align 8, !dbg !86
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %temp), !dbg !86
 // CHECK:STDOUT:   %1 = call ptr @"_CConvert:thunk:ImplicitAs.18b29766acf27da3.Core:e8f8f92d3d08d149:ImplicitAs.c8091dc115c4eb3f.Core.c8fd090a2e741f70"(ptr %self), !dbg !86
 // CHECK:STDOUT:   store ptr %1, ptr %temp, align 8, !dbg !86
 // CHECK:STDOUT:   %2 = load ptr, ptr %temp, align 8, !dbg !86
-// CHECK:STDOUT:   %3 = call ptr @_CSome.Optional.Core.6be97cf0783728aa(ptr %2), !dbg !87
+// CHECK:STDOUT:   %3 = call ptr @_CSome.Optional.Core.352135a287b6dfbe(ptr %2), !dbg !87
 // CHECK:STDOUT:   ret ptr %3, !dbg !88
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CSome.Optional.Core.58daef9740f71e43(ptr %value) #0 !dbg !89 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CSome.Optional.Core.1f340f4ca78e6045(ptr %value) #0 !dbg !89 {
 // CHECK:STDOUT:   %1 = call ptr @"_CSome.e8f8f92d3d08d149:OptionalStorage.Core.e002d6765e4506fc"(ptr %value), !dbg !92
 // CHECK:STDOUT:   ret ptr %1, !dbg !93
 // CHECK:STDOUT: }
@@ -201,7 +201,7 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CSome.Optional.Core.6be97cf0783728aa(ptr %value) #0 !dbg !99 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CSome.Optional.Core.352135a287b6dfbe(ptr %value) #0 !dbg !99 {
 // CHECK:STDOUT:   %1 = call ptr @"_CSome.e8f8f92d3d08d149:OptionalStorage.Core.de7664f1c7ce4d43"(ptr %value), !dbg !102
 // CHECK:STDOUT:   ret ptr %1, !dbg !103
 // CHECK:STDOUT: }
@@ -230,8 +230,8 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
 // CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 0, 1, 2, 3, 7, 6, 5, 4 }
-// CHECK:STDOUT: uselistorder ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.aed2bb692dd6cdfe", { 1, 0 }
-// CHECK:STDOUT: uselistorder ptr @_CSome.Optional.Core.58daef9740f71e43, { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.bedbcdacb285d12b", { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @_CSome.Optional.Core.1f340f4ca78e6045, { 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
 // CHECK:STDOUT: attributes #1 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
@@ -266,7 +266,7 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: !21 = !{!22}
 // CHECK:STDOUT: !22 = !DILocalVariable(arg: 1, scope: !20, type: !14)
 // CHECK:STDOUT: !23 = !DILocation(line: 7, column: 21, scope: !20)
-// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "Op", linkageName: "_COp.29cb36961ff3e7a9:core.Destroy.Core", scope: null, file: !6, line: 7, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !25)
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "Op", linkageName: "_COp.246ed33979ddb7a6:core.Destroy.Core", scope: null, file: !6, line: 7, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !25)
 // CHECK:STDOUT: !25 = !{!26}
 // CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !24, type: !14)
 // CHECK:STDOUT: !27 = !DILocation(line: 7, column: 21, scope: !24)
@@ -286,7 +286,7 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: !41 = !{!42}
 // CHECK:STDOUT: !42 = !DILocalVariable(arg: 1, scope: !40, type: !14)
 // CHECK:STDOUT: !43 = !DILocation(line: 15, column: 27, scope: !40)
-// CHECK:STDOUT: !44 = distinct !DISubprogram(name: "Op", linkageName: "_COp.8aa3827fca3a355d:core.Destroy.Core", scope: null, file: !6, line: 15, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !45)
+// CHECK:STDOUT: !44 = distinct !DISubprogram(name: "Op", linkageName: "_COp.728380d5ff77eadd:core.Destroy.Core", scope: null, file: !6, line: 15, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !45)
 // CHECK:STDOUT: !45 = !{!46}
 // CHECK:STDOUT: !46 = !DILocalVariable(arg: 1, scope: !44, type: !14)
 // CHECK:STDOUT: !47 = !DILocation(line: 15, column: 27, scope: !44)
@@ -296,70 +296,70 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: !51 = !DILocation(line: 19, column: 27, scope: !48)
 // CHECK:STDOUT: !52 = !DILocation(line: 19, column: 3, scope: !48)
 // CHECK:STDOUT: !53 = !DILocation(line: 18, column: 1, scope: !48)
-// CHECK:STDOUT: !54 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.bc8a88dae0c7117a", scope: null, file: !55, line: 96, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !58)
+// CHECK:STDOUT: !54 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.5cb3be840dc534b9", scope: null, file: !55, line: 105, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !58)
 // CHECK:STDOUT: !55 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !56 = !DISubroutineType(types: !57)
 // CHECK:STDOUT: !57 = !{!14, !14}
 // CHECK:STDOUT: !58 = !{!59}
 // CHECK:STDOUT: !59 = !DILocalVariable(arg: 1, scope: !54, type: !14)
-// CHECK:STDOUT: !60 = !DILocation(line: 97, column: 12, scope: !54)
-// CHECK:STDOUT: !61 = !DILocation(line: 97, column: 5, scope: !54)
-// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.a84fab117d3c0ee6", scope: null, file: !55, line: 96, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !63)
+// CHECK:STDOUT: !60 = !DILocation(line: 106, column: 12, scope: !54)
+// CHECK:STDOUT: !61 = !DILocation(line: 106, column: 5, scope: !54)
+// CHECK:STDOUT: !62 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.768fc8296e1e36ca", scope: null, file: !55, line: 105, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !63)
 // CHECK:STDOUT: !63 = !{!64}
 // CHECK:STDOUT: !64 = !DILocalVariable(arg: 1, scope: !62, type: !14)
-// CHECK:STDOUT: !65 = !DILocation(line: 97, column: 12, scope: !62)
-// CHECK:STDOUT: !66 = !DILocation(line: 97, column: 5, scope: !62)
-// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.aed2bb692dd6cdfe", scope: null, file: !55, line: 96, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !68)
+// CHECK:STDOUT: !65 = !DILocation(line: 106, column: 12, scope: !62)
+// CHECK:STDOUT: !66 = !DILocation(line: 106, column: 5, scope: !62)
+// CHECK:STDOUT: !67 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.bedbcdacb285d12b", scope: null, file: !55, line: 105, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !68)
 // CHECK:STDOUT: !68 = !{!69}
 // CHECK:STDOUT: !69 = !DILocalVariable(arg: 1, scope: !67, type: !14)
-// CHECK:STDOUT: !70 = !DILocation(line: 97, column: 12, scope: !67)
-// CHECK:STDOUT: !71 = !DILocation(line: 97, column: 5, scope: !67)
-// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.58daef9740f71e43", scope: null, file: !55, line: 71, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !73)
+// CHECK:STDOUT: !70 = !DILocation(line: 106, column: 12, scope: !67)
+// CHECK:STDOUT: !71 = !DILocation(line: 106, column: 5, scope: !67)
+// CHECK:STDOUT: !72 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.1f340f4ca78e6045", scope: null, file: !55, line: 80, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !73)
 // CHECK:STDOUT: !73 = !{!74}
 // CHECK:STDOUT: !74 = !DILocalVariable(arg: 1, scope: !72, type: !14)
-// CHECK:STDOUT: !75 = !DILocation(line: 72, column: 12, scope: !72)
-// CHECK:STDOUT: !76 = !DILocation(line: 72, column: 5, scope: !72)
-// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.598d3d2f1309c543", scope: null, file: !55, line: 78, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !78)
+// CHECK:STDOUT: !75 = !DILocation(line: 81, column: 12, scope: !72)
+// CHECK:STDOUT: !76 = !DILocation(line: 81, column: 5, scope: !72)
+// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.fbd613f85778f3e8", scope: null, file: !55, line: 87, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !78)
 // CHECK:STDOUT: !78 = !{!79}
 // CHECK:STDOUT: !79 = !DILocalVariable(arg: 1, scope: !77, type: !14)
-// CHECK:STDOUT: !80 = !DILocation(line: 79, column: 29, scope: !77)
-// CHECK:STDOUT: !81 = !DILocation(line: 79, column: 12, scope: !77)
-// CHECK:STDOUT: !82 = !DILocation(line: 79, column: 5, scope: !77)
-// CHECK:STDOUT: !83 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.5cd669b97de7611a", scope: null, file: !55, line: 78, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !84)
+// CHECK:STDOUT: !80 = !DILocation(line: 88, column: 29, scope: !77)
+// CHECK:STDOUT: !81 = !DILocation(line: 88, column: 12, scope: !77)
+// CHECK:STDOUT: !82 = !DILocation(line: 88, column: 5, scope: !77)
+// CHECK:STDOUT: !83 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.358bb0df88a4e672", scope: null, file: !55, line: 87, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !84)
 // CHECK:STDOUT: !84 = !{!85}
 // CHECK:STDOUT: !85 = !DILocalVariable(arg: 1, scope: !83, type: !14)
-// CHECK:STDOUT: !86 = !DILocation(line: 79, column: 29, scope: !83)
-// CHECK:STDOUT: !87 = !DILocation(line: 79, column: 12, scope: !83)
-// CHECK:STDOUT: !88 = !DILocation(line: 79, column: 5, scope: !83)
-// CHECK:STDOUT: !89 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.58daef9740f71e43", scope: null, file: !55, line: 30, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !90)
+// CHECK:STDOUT: !86 = !DILocation(line: 88, column: 29, scope: !83)
+// CHECK:STDOUT: !87 = !DILocation(line: 88, column: 12, scope: !83)
+// CHECK:STDOUT: !88 = !DILocation(line: 88, column: 5, scope: !83)
+// CHECK:STDOUT: !89 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.1f340f4ca78e6045", scope: null, file: !55, line: 33, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !90)
 // CHECK:STDOUT: !90 = !{!91}
 // CHECK:STDOUT: !91 = !DILocalVariable(arg: 1, scope: !89, type: !14)
-// CHECK:STDOUT: !92 = !DILocation(line: 31, column: 12, scope: !89)
-// CHECK:STDOUT: !93 = !DILocation(line: 31, column: 5, scope: !89)
+// CHECK:STDOUT: !92 = !DILocation(line: 34, column: 12, scope: !89)
+// CHECK:STDOUT: !93 = !DILocation(line: 34, column: 5, scope: !89)
 // CHECK:STDOUT: !94 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert:thunk:ImplicitAs.18b29766acf27da3.Core:e8f8f92d3d08d149:ImplicitAs.c8091dc115c4eb3f.Core.c8fd090a2e741f70", scope: null, file: !95, line: 40, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !96)
 // CHECK:STDOUT: !95 = !DIFile(filename: "{{.*}}/prelude/types/cpp/void.carbon", directory: "")
 // CHECK:STDOUT: !96 = !{!97}
 // CHECK:STDOUT: !97 = !DILocalVariable(arg: 1, scope: !94, type: !14)
 // CHECK:STDOUT: !98 = !DILocation(line: 40, column: 3, scope: !94)
-// CHECK:STDOUT: !99 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.6be97cf0783728aa", scope: null, file: !55, line: 30, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !100)
+// CHECK:STDOUT: !99 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.352135a287b6dfbe", scope: null, file: !55, line: 33, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !100)
 // CHECK:STDOUT: !100 = !{!101}
 // CHECK:STDOUT: !101 = !DILocalVariable(arg: 1, scope: !99, type: !14)
-// CHECK:STDOUT: !102 = !DILocation(line: 31, column: 12, scope: !99)
-// CHECK:STDOUT: !103 = !DILocation(line: 31, column: 5, scope: !99)
-// CHECK:STDOUT: !104 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.e8f8f92d3d08d149:OptionalStorage.Core.e002d6765e4506fc", scope: null, file: !55, line: 150, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !105)
+// CHECK:STDOUT: !102 = !DILocation(line: 34, column: 12, scope: !99)
+// CHECK:STDOUT: !103 = !DILocation(line: 34, column: 5, scope: !99)
+// CHECK:STDOUT: !104 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.e8f8f92d3d08d149:OptionalStorage.Core.e002d6765e4506fc", scope: null, file: !55, line: 166, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !105)
 // CHECK:STDOUT: !105 = !{!106}
 // CHECK:STDOUT: !106 = !DILocalVariable(arg: 1, scope: !104, type: !14)
-// CHECK:STDOUT: !107 = !DILocation(line: 151, column: 14, scope: !104)
-// CHECK:STDOUT: !108 = !DILocation(line: 153, column: 5, scope: !104)
-// CHECK:STDOUT: !109 = !DILocation(line: 151, column: 18, scope: !104)
-// CHECK:STDOUT: !110 = !DILocation(line: 154, column: 5, scope: !104)
-// CHECK:STDOUT: !111 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.e8f8f92d3d08d149:OptionalStorage.Core.de7664f1c7ce4d43", scope: null, file: !55, line: 150, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !112)
+// CHECK:STDOUT: !107 = !DILocation(line: 167, column: 14, scope: !104)
+// CHECK:STDOUT: !108 = !DILocation(line: 169, column: 5, scope: !104)
+// CHECK:STDOUT: !109 = !DILocation(line: 167, column: 18, scope: !104)
+// CHECK:STDOUT: !110 = !DILocation(line: 170, column: 5, scope: !104)
+// CHECK:STDOUT: !111 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.e8f8f92d3d08d149:OptionalStorage.Core.de7664f1c7ce4d43", scope: null, file: !55, line: 166, type: !56, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !112)
 // CHECK:STDOUT: !112 = !{!113}
 // CHECK:STDOUT: !113 = !DILocalVariable(arg: 1, scope: !111, type: !14)
-// CHECK:STDOUT: !114 = !DILocation(line: 151, column: 14, scope: !111)
-// CHECK:STDOUT: !115 = !DILocation(line: 153, column: 5, scope: !111)
-// CHECK:STDOUT: !116 = !DILocation(line: 151, column: 18, scope: !111)
-// CHECK:STDOUT: !117 = !DILocation(line: 154, column: 5, scope: !111)
+// CHECK:STDOUT: !114 = !DILocation(line: 167, column: 14, scope: !111)
+// CHECK:STDOUT: !115 = !DILocation(line: 169, column: 5, scope: !111)
+// CHECK:STDOUT: !116 = !DILocation(line: 167, column: 18, scope: !111)
+// CHECK:STDOUT: !117 = !DILocation(line: 170, column: 5, scope: !111)
 // CHECK:STDOUT: ; ModuleID = 'receive.carbon'
 // CHECK:STDOUT: source_filename = "receive.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"

--- a/toolchain/lower/testdata/primitives/optional.carbon
+++ b/toolchain/lower/testdata/primitives/optional.carbon
@@ -13,6 +13,9 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/primitives/optional.carbon
 
+// --- convert.carbon
+library "[[@TEST_NAME]]";
+
 fn Convert(o: Core.Optional(i32*)) -> Core.Optional(i32) {
   if (o.HasValue()) {
     return *o.Get();
@@ -31,8 +34,31 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
   var _: const Core.Optional(const i32) = b;
 }
 
-// CHECK:STDOUT: ; ModuleID = 'optional.carbon'
-// CHECK:STDOUT: source_filename = "optional.carbon"
+// --- copy.carbon
+library "[[@TEST_NAME]]";
+
+class Copyable {
+  impl as Core.Copy {
+    fn Op[self: Self]() -> Self;
+  }
+}
+
+fn F(c: Core.Optional(Copyable)) -> Core.Optional(Copyable) {
+  // Should only perform one copy.
+  return c;
+}
+
+// --- copy_pointer.carbon
+library "[[@TEST_NAME]]";
+
+class C {}
+
+fn F(c: Core.Optional(C*)) -> Core.Optional(C*) {
+  return c;
+}
+
+// CHECK:STDOUT: ; ModuleID = 'convert.carbon'
+// CHECK:STDOUT: source_filename = "convert.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define weak_odr void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %self) #0 !dbg !4 {
@@ -43,55 +69,55 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CConvert.Main(ptr sret(<{ i32, i1 }>) %return, ptr %o) #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.c2b2aa7ce9960f99(ptr %o), !dbg !17
+// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.36b54e287793a2ba(ptr %o), !dbg !17
 // CHECK:STDOUT:   br i1 %Optional.HasValue.call, label %if.then, label %if.else, !dbg !18
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.then:                                          ; preds = %entry
-// CHECK:STDOUT:   %Optional.Get.call = call ptr @_CGet.Optional.Core.c2b2aa7ce9960f99(ptr %o), !dbg !19
-// CHECK:STDOUT:   %.loc18_12.2 = load i32, ptr %Optional.Get.call, align 4, !dbg !20
-// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.67d5e332e5dc0930"(ptr %return, i32 %.loc18_12.2), !dbg !21
+// CHECK:STDOUT:   %Optional.Get.call = call ptr @_CGet.Optional.Core.36b54e287793a2ba(ptr %o), !dbg !19
+// CHECK:STDOUT:   %.loc5_12.2 = load i32, ptr %Optional.Get.call, align 4, !dbg !20
+// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.d356e073ce1a5b35"(ptr %return, i32 %.loc5_12.2), !dbg !21
 // CHECK:STDOUT:   ret void, !dbg !21
 // CHECK:STDOUT:
 // CHECK:STDOUT: if.else:                                          ; preds = %entry
-// CHECK:STDOUT:   call void @_CNone.Optional.Core.474385511948e0a9(ptr %return), !dbg !22
+// CHECK:STDOUT:   call void @_CNone.Optional.Core.cf11014f74122042(ptr %return), !dbg !22
 // CHECK:STDOUT:   ret void, !dbg !23
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CAddOrRemoveConst.Main(i32 %a, i32 %b) #0 !dbg !24 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var.loc24 = alloca <{ i32, i1 }>, align 8, !dbg !30
-// CHECK:STDOUT:   %_.var.loc25 = alloca <{ i32, i1 }>, align 8, !dbg !31
-// CHECK:STDOUT:   %_.var.loc26 = alloca <{ i32, i1 }>, align 8, !dbg !32
-// CHECK:STDOUT:   %_.var.loc27 = alloca <{ i32, i1 }>, align 8, !dbg !33
-// CHECK:STDOUT:   %_.var.loc28 = alloca <{ i32, i1 }>, align 8, !dbg !34
-// CHECK:STDOUT:   %_.var.loc29 = alloca <{ i32, i1 }>, align 8, !dbg !35
-// CHECK:STDOUT:   %_.var.loc30 = alloca <{ i32, i1 }>, align 8, !dbg !36
-// CHECK:STDOUT:   %_.var.loc31 = alloca <{ i32, i1 }>, align 8, !dbg !37
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc24), !dbg !30
-// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.67d5e332e5dc0930"(ptr %_.var.loc24, i32 %a), !dbg !30
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc25), !dbg !31
-// CHECK:STDOUT:   call void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.2f9aa43bda454fff"(ptr %_.var.loc25, i32 %a), !dbg !31
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc26), !dbg !32
-// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.8b1f639410c6fca3"(ptr %_.var.loc26, i32 %a), !dbg !32
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc27), !dbg !33
-// CHECK:STDOUT:   call void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.a1638d31d24cfbda"(ptr %_.var.loc27, i32 %a), !dbg !33
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc28), !dbg !34
-// CHECK:STDOUT:   call void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.2f9aa43bda454fff"(ptr %_.var.loc28, i32 %b), !dbg !34
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc29), !dbg !35
-// CHECK:STDOUT:   call void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.1aa01ee321663405"(ptr %_.var.loc29, i32 %b), !dbg !35
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc30), !dbg !36
-// CHECK:STDOUT:   call void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.a1638d31d24cfbda"(ptr %_.var.loc30, i32 %b), !dbg !36
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc31), !dbg !37
-// CHECK:STDOUT:   call void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.8e46e1cf04c82a78"(ptr %_.var.loc31, i32 %b), !dbg !37
-// CHECK:STDOUT:   call void @"_COp.069a47fa3ad2e3b5:core.Destroy.Core"(ptr %_.var.loc31), !dbg !37
-// CHECK:STDOUT:   call void @"_COp.6266a7d1b07e8fb0:core.Destroy.Core"(ptr %_.var.loc30), !dbg !36
-// CHECK:STDOUT:   call void @"_COp.0d6434e377e7c428:core.Destroy.Core"(ptr %_.var.loc29), !dbg !35
-// CHECK:STDOUT:   call void @"_COp.b815f2fb59516ce9:core.Destroy.Core"(ptr %_.var.loc28), !dbg !34
-// CHECK:STDOUT:   call void @"_COp.069a47fa3ad2e3b5:core.Destroy.Core"(ptr %_.var.loc27), !dbg !33
-// CHECK:STDOUT:   call void @"_COp.6266a7d1b07e8fb0:core.Destroy.Core"(ptr %_.var.loc26), !dbg !32
-// CHECK:STDOUT:   call void @"_COp.0d6434e377e7c428:core.Destroy.Core"(ptr %_.var.loc25), !dbg !31
-// CHECK:STDOUT:   call void @"_COp.b815f2fb59516ce9:core.Destroy.Core"(ptr %_.var.loc24), !dbg !30
+// CHECK:STDOUT:   %_.var.loc11 = alloca <{ i32, i1 }>, align 8, !dbg !30
+// CHECK:STDOUT:   %_.var.loc12 = alloca <{ i32, i1 }>, align 8, !dbg !31
+// CHECK:STDOUT:   %_.var.loc13 = alloca <{ i32, i1 }>, align 8, !dbg !32
+// CHECK:STDOUT:   %_.var.loc14 = alloca <{ i32, i1 }>, align 8, !dbg !33
+// CHECK:STDOUT:   %_.var.loc15 = alloca <{ i32, i1 }>, align 8, !dbg !34
+// CHECK:STDOUT:   %_.var.loc16 = alloca <{ i32, i1 }>, align 8, !dbg !35
+// CHECK:STDOUT:   %_.var.loc17 = alloca <{ i32, i1 }>, align 8, !dbg !36
+// CHECK:STDOUT:   %_.var.loc18 = alloca <{ i32, i1 }>, align 8, !dbg !37
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc11), !dbg !30
+// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.d356e073ce1a5b35"(ptr %_.var.loc11, i32 %a), !dbg !30
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc12), !dbg !31
+// CHECK:STDOUT:   call void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.93e3eaa0d3eea476"(ptr %_.var.loc12, i32 %a), !dbg !31
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc13), !dbg !32
+// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.a06e83c323a306da"(ptr %_.var.loc13, i32 %a), !dbg !32
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc14), !dbg !33
+// CHECK:STDOUT:   call void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.183173080affdcb8"(ptr %_.var.loc14, i32 %a), !dbg !33
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc15), !dbg !34
+// CHECK:STDOUT:   call void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.93e3eaa0d3eea476"(ptr %_.var.loc15, i32 %b), !dbg !34
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc16), !dbg !35
+// CHECK:STDOUT:   call void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.54bcc98de4b4d68e"(ptr %_.var.loc16, i32 %b), !dbg !35
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc17), !dbg !36
+// CHECK:STDOUT:   call void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.183173080affdcb8"(ptr %_.var.loc17, i32 %b), !dbg !36
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc18), !dbg !37
+// CHECK:STDOUT:   call void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.53171a0379a201a0"(ptr %_.var.loc18, i32 %b), !dbg !37
+// CHECK:STDOUT:   call void @"_COp.adbfbb7b79f63468:core.Destroy.Core"(ptr %_.var.loc18), !dbg !37
+// CHECK:STDOUT:   call void @"_COp.8ed16437b3e9f3a5:core.Destroy.Core"(ptr %_.var.loc17), !dbg !36
+// CHECK:STDOUT:   call void @"_COp.01d632db26744f11:core.Destroy.Core"(ptr %_.var.loc16), !dbg !35
+// CHECK:STDOUT:   call void @"_COp.2867d2b01356b3cb:core.Destroy.Core"(ptr %_.var.loc15), !dbg !34
+// CHECK:STDOUT:   call void @"_COp.adbfbb7b79f63468:core.Destroy.Core"(ptr %_.var.loc14), !dbg !33
+// CHECK:STDOUT:   call void @"_COp.8ed16437b3e9f3a5:core.Destroy.Core"(ptr %_.var.loc13), !dbg !32
+// CHECK:STDOUT:   call void @"_COp.01d632db26744f11:core.Destroy.Core"(ptr %_.var.loc12), !dbg !31
+// CHECK:STDOUT:   call void @"_COp.2867d2b01356b3cb:core.Destroy.Core"(ptr %_.var.loc11), !dbg !30
 // CHECK:STDOUT:   ret void, !dbg !38
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -114,19 +140,19 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.4e20543cf8f2965d:core.Destroy.Core"(ptr %self) #0 !dbg !53 {
+// CHECK:STDOUT: define weak_odr void @"_COp.83837874cf69a650:core.Destroy.Core"(ptr %self) #0 !dbg !53 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !56
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.6266a7d1b07e8fb0:core.Destroy.Core"(ptr %self) #0 !dbg !57 {
+// CHECK:STDOUT: define weak_odr void @"_COp.8ed16437b3e9f3a5:core.Destroy.Core"(ptr %self) #0 !dbg !57 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !60
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.069a47fa3ad2e3b5:core.Destroy.Core"(ptr %self) #0 !dbg !61 {
+// CHECK:STDOUT: define weak_odr void @"_COp.adbfbb7b79f63468:core.Destroy.Core"(ptr %self) #0 !dbg !61 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !64
 // CHECK:STDOUT: }
@@ -144,44 +170,44 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.1bc1533dda6a5e5d:core.Destroy.Core"(ptr %self) #0 !dbg !73 {
+// CHECK:STDOUT: define weak_odr void @"_COp.57bd9f6c8b0ddceb:core.Destroy.Core"(ptr %self) #0 !dbg !73 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !76
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.b815f2fb59516ce9:core.Destroy.Core"(ptr %self) #0 !dbg !77 {
+// CHECK:STDOUT: define weak_odr void @"_COp.2867d2b01356b3cb:core.Destroy.Core"(ptr %self) #0 !dbg !77 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !80
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define weak_odr void @"_COp.0d6434e377e7c428:core.Destroy.Core"(ptr %self) #0 !dbg !81 {
+// CHECK:STDOUT: define weak_odr void @"_COp.01d632db26744f11:core.Destroy.Core"(ptr %self) #0 !dbg !81 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !84
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.c2b2aa7ce9960f99(ptr %self) #0 !dbg !85 {
+// CHECK:STDOUT: define linkonce_odr i1 @_CHasValue.Optional.Core.36b54e287793a2ba(ptr %self) #0 !dbg !85 {
 // CHECK:STDOUT:   %1 = call i1 @"_CHas.e8f8f92d3d08d149:OptionalStorage.Core.c8fd090a2e741f70"(ptr %self), !dbg !89
 // CHECK:STDOUT:   ret i1 %1, !dbg !90
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr ptr @_CGet.Optional.Core.c2b2aa7ce9960f99(ptr %self) #0 !dbg !91 {
+// CHECK:STDOUT: define linkonce_odr ptr @_CGet.Optional.Core.36b54e287793a2ba(ptr %self) #0 !dbg !91 {
 // CHECK:STDOUT:   %1 = call ptr @"_CGet.e8f8f92d3d08d149:OptionalStorage.Core.c8fd090a2e741f70"(ptr %self), !dbg !94
 // CHECK:STDOUT:   ret ptr %1, !dbg !95
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.67d5e332e5dc0930"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !96 {
-// CHECK:STDOUT:   call void @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.474385511948e0a9"(ptr %return, i32 %self), !dbg !101
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.d356e073ce1a5b35"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !96 {
+// CHECK:STDOUT:   call void @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.cf11014f74122042"(ptr %return, i32 %self), !dbg !101
 // CHECK:STDOUT:   ret void, !dbg !102
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.474385511948e0a9(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !103 {
-// CHECK:STDOUT:   call void @"_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085"(ptr %return), !dbg !106
+// CHECK:STDOUT: define linkonce_odr void @_CNone.Optional.Core.cf11014f74122042(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !103 {
+// CHECK:STDOUT:   call void @"_CNone.4f9853132d866dc6:OptionalStorage.Core.fe1b3f265f915ed6"(ptr %return), !dbg !106
 // CHECK:STDOUT:   ret void, !dbg !107
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -189,44 +215,44 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.2f9aa43bda454fff"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !108 {
-// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.67d5e332e5dc0930"(ptr %return, i32 %self), !dbg !112
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.93e3eaa0d3eea476"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !108 {
+// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.d356e073ce1a5b35"(ptr %return, i32 %self), !dbg !112
 // CHECK:STDOUT:   ret void, !dbg !113
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.8b1f639410c6fca3"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !114 {
-// CHECK:STDOUT:   call void @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.9b89437b60c764fb"(ptr %return, i32 %self), !dbg !117
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.a06e83c323a306da"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !114 {
+// CHECK:STDOUT:   call void @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.359fad345e4cc188"(ptr %return, i32 %self), !dbg !117
 // CHECK:STDOUT:   ret void, !dbg !118
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.a1638d31d24cfbda"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !119 {
-// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.8b1f639410c6fca3"(ptr %return, i32 %self), !dbg !122
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.183173080affdcb8"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !119 {
+// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.a06e83c323a306da"(ptr %return, i32 %self), !dbg !122
 // CHECK:STDOUT:   ret void, !dbg !123
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.2f9aa43bda454fff"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !124 {
-// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.67d5e332e5dc0930"(ptr %return, i32 %self), !dbg !127
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.93e3eaa0d3eea476"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !124 {
+// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.d356e073ce1a5b35"(ptr %return, i32 %self), !dbg !127
 // CHECK:STDOUT:   ret void, !dbg !128
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.1aa01ee321663405"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !129 {
-// CHECK:STDOUT:   call void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.2f9aa43bda454fff"(ptr %return, i32 %self), !dbg !132
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.54bcc98de4b4d68e"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !129 {
+// CHECK:STDOUT:   call void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.93e3eaa0d3eea476"(ptr %return, i32 %self), !dbg !132
 // CHECK:STDOUT:   ret void, !dbg !133
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.a1638d31d24cfbda"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !134 {
-// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.8b1f639410c6fca3"(ptr %return, i32 %self), !dbg !137
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.183173080affdcb8"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !134 {
+// CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.a06e83c323a306da"(ptr %return, i32 %self), !dbg !137
 // CHECK:STDOUT:   ret void, !dbg !138
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.8e46e1cf04c82a78"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !139 {
-// CHECK:STDOUT:   call void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.a1638d31d24cfbda"(ptr %return, i32 %self), !dbg !142
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.53171a0379a201a0"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !139 {
+// CHECK:STDOUT:   call void @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.183173080affdcb8"(ptr %return, i32 %self), !dbg !142
 // CHECK:STDOUT:   ret void, !dbg !143
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -243,33 +269,33 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.474385511948e0a9"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !154 {
-// CHECK:STDOUT:   call void @_CSome.Optional.Core.474385511948e0a9(ptr %return, i32 %self), !dbg !157
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.cf11014f74122042"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !154 {
+// CHECK:STDOUT:   call void @_CSome.Optional.Core.cf11014f74122042(ptr %return, i32 %self), !dbg !157
 // CHECK:STDOUT:   ret void, !dbg !158
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085"(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !159 {
+// CHECK:STDOUT: define linkonce_odr void @"_CNone.4f9853132d866dc6:OptionalStorage.Core.fe1b3f265f915ed6"(ptr sret(<{ i32, i1 }>) %return) #0 !dbg !159 {
 // CHECK:STDOUT:   %has_value = getelementptr inbounds nuw <{ i32, i1 }>, ptr %return, i32 0, i32 1, !dbg !160
 // CHECK:STDOUT:   store i8 0, ptr %has_value, align 1, !dbg !160
 // CHECK:STDOUT:   ret void, !dbg !161
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.9b89437b60c764fb"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !162 {
+// CHECK:STDOUT: define linkonce_odr void @"_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.359fad345e4cc188"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !162 {
 // CHECK:STDOUT:   %temp = alloca i32, align 4, !dbg !165
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %temp), !dbg !165
 // CHECK:STDOUT:   %1 = call i32 @"_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.3d03a93e76942d8a"(i32 %self), !dbg !165
 // CHECK:STDOUT:   store i32 %1, ptr %temp, align 4, !dbg !165
 // CHECK:STDOUT:   %2 = load i32, ptr %temp, align 4, !dbg !165
-// CHECK:STDOUT:   call void @_CSome.Optional.Core.3f4ee3c720c792b2(ptr %return, i32 %2), !dbg !166
+// CHECK:STDOUT:   call void @_CSome.Optional.Core.50482747a823e073(ptr %return, i32 %2), !dbg !166
 // CHECK:STDOUT:   call void @"_COp.cf0fdf6659baaa34:core.Destroy.Core"(ptr %temp), !dbg !165
 // CHECK:STDOUT:   ret void, !dbg !167
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.474385511948e0a9(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !168 {
-// CHECK:STDOUT:   call void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085"(ptr %return, i32 %value), !dbg !171
+// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.cf11014f74122042(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !168 {
+// CHECK:STDOUT:   call void @"_CSome.4f9853132d866dc6:OptionalStorage.Core.fe1b3f265f915ed6"(ptr %return, i32 %value), !dbg !171
 // CHECK:STDOUT:   ret void, !dbg !172
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -280,13 +306,13 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.3f4ee3c720c792b2(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !178 {
-// CHECK:STDOUT:   call void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.73173aebc8a6c2aa"(ptr %return, i32 %value), !dbg !181
+// CHECK:STDOUT: define linkonce_odr void @_CSome.Optional.Core.50482747a823e073(ptr sret(<{ i32, i1 }>) %return, i32 %value) #0 !dbg !178 {
+// CHECK:STDOUT:   call void @"_CSome.4f9853132d866dc6:OptionalStorage.Core.9078267c53e6931d"(ptr %return, i32 %value), !dbg !181
 // CHECK:STDOUT:   ret void, !dbg !182
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !183 {
+// CHECK:STDOUT: define linkonce_odr void @"_CSome.4f9853132d866dc6:OptionalStorage.Core.fe1b3f265f915ed6"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !183 {
 // CHECK:STDOUT:   %value = getelementptr inbounds nuw <{ i32, i1 }>, ptr %return, i32 0, i32 0, !dbg !186
 // CHECK:STDOUT:   store i32 %self, ptr %value, align 4, !dbg !186
 // CHECK:STDOUT:   %has_value = getelementptr inbounds nuw <{ i32, i1 }>, ptr %return, i32 0, i32 1, !dbg !187
@@ -301,7 +327,7 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
-// CHECK:STDOUT: define linkonce_odr void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.73173aebc8a6c2aa"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !197 {
+// CHECK:STDOUT: define linkonce_odr void @"_CSome.4f9853132d866dc6:OptionalStorage.Core.9078267c53e6931d"(ptr sret(<{ i32, i1 }>) %return, i32 %self) #0 !dbg !197 {
 // CHECK:STDOUT:   %value = getelementptr inbounds nuw <{ i32, i1 }>, ptr %return, i32 0, i32 0, !dbg !200
 // CHECK:STDOUT:   %1 = call i32 @"_COp.c4bf98205baa6bbe:Copy.Core.986e4fbf737c841b"(i32 %self), !dbg !201
 // CHECK:STDOUT:   store i32 %1, ptr %value, align 4, !dbg !200
@@ -321,11 +347,11 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @"_COp.6266a7d1b07e8fb0:core.Destroy.Core", { 1, 0 }
-// CHECK:STDOUT: uselistorder ptr @"_COp.069a47fa3ad2e3b5:core.Destroy.Core", { 1, 0 }
-// CHECK:STDOUT: uselistorder ptr @"_COp.b815f2fb59516ce9:core.Destroy.Core", { 1, 0 }
-// CHECK:STDOUT: uselistorder ptr @"_COp.0d6434e377e7c428:core.Destroy.Core", { 1, 0 }
-// CHECK:STDOUT: uselistorder ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.67d5e332e5dc0930", { 0, 1, 3, 2 }
+// CHECK:STDOUT: uselistorder ptr @"_COp.8ed16437b3e9f3a5:core.Destroy.Core", { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @"_COp.adbfbb7b79f63468:core.Destroy.Core", { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @"_COp.2867d2b01356b3cb:core.Destroy.Core", { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @"_COp.01d632db26744f11:core.Destroy.Core", { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.d356e073ce1a5b35", { 0, 1, 3, 2 }
 // CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 0, 8, 7, 6, 5, 4, 3, 2, 1 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
@@ -337,192 +363,192 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !3 = !DIFile(filename: "optional.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Op", linkageName: "_COp.94e3ca86614aba5d:core.Destroy.Core", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !8)
+// CHECK:STDOUT: !3 = !DIFile(filename: "convert.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Op", linkageName: "_COp.94e3ca86614aba5d:core.Destroy.Core", scope: null, file: !3, line: 3, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !8)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null, !7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !{!9}
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
-// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 39, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.Main", scope: null, file: !3, line: 16, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !15)
+// CHECK:STDOUT: !10 = !DILocation(line: 3, column: 39, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.Main", scope: null, file: !3, line: 3, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !15)
 // CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
 // CHECK:STDOUT: !13 = !{!14, !14}
 // CHECK:STDOUT: !14 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !15 = !{!16}
 // CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !11, type: !14)
-// CHECK:STDOUT: !17 = !DILocation(line: 17, column: 7, scope: !11)
-// CHECK:STDOUT: !18 = !DILocation(line: 17, column: 6, scope: !11)
-// CHECK:STDOUT: !19 = !DILocation(line: 18, column: 13, scope: !11)
-// CHECK:STDOUT: !20 = !DILocation(line: 18, column: 12, scope: !11)
-// CHECK:STDOUT: !21 = !DILocation(line: 18, column: 5, scope: !11)
-// CHECK:STDOUT: !22 = !DILocation(line: 20, column: 10, scope: !11)
-// CHECK:STDOUT: !23 = !DILocation(line: 20, column: 3, scope: !11)
-// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "AddOrRemoveConst", linkageName: "_CAddOrRemoveConst.Main", scope: null, file: !3, line: 23, type: !25, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !27)
+// CHECK:STDOUT: !17 = !DILocation(line: 4, column: 7, scope: !11)
+// CHECK:STDOUT: !18 = !DILocation(line: 4, column: 6, scope: !11)
+// CHECK:STDOUT: !19 = !DILocation(line: 5, column: 13, scope: !11)
+// CHECK:STDOUT: !20 = !DILocation(line: 5, column: 12, scope: !11)
+// CHECK:STDOUT: !21 = !DILocation(line: 5, column: 5, scope: !11)
+// CHECK:STDOUT: !22 = !DILocation(line: 7, column: 10, scope: !11)
+// CHECK:STDOUT: !23 = !DILocation(line: 7, column: 3, scope: !11)
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "AddOrRemoveConst", linkageName: "_CAddOrRemoveConst.Main", scope: null, file: !3, line: 10, type: !25, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !27)
 // CHECK:STDOUT: !25 = !DISubroutineType(types: !26)
 // CHECK:STDOUT: !26 = !{null, !7, !7}
 // CHECK:STDOUT: !27 = !{!28, !29}
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 1, scope: !24, type: !7)
 // CHECK:STDOUT: !29 = !DILocalVariable(arg: 2, scope: !24, type: !7)
-// CHECK:STDOUT: !30 = !DILocation(line: 24, column: 3, scope: !24)
-// CHECK:STDOUT: !31 = !DILocation(line: 25, column: 3, scope: !24)
-// CHECK:STDOUT: !32 = !DILocation(line: 26, column: 3, scope: !24)
-// CHECK:STDOUT: !33 = !DILocation(line: 27, column: 3, scope: !24)
-// CHECK:STDOUT: !34 = !DILocation(line: 28, column: 3, scope: !24)
-// CHECK:STDOUT: !35 = !DILocation(line: 29, column: 3, scope: !24)
-// CHECK:STDOUT: !36 = !DILocation(line: 30, column: 3, scope: !24)
-// CHECK:STDOUT: !37 = !DILocation(line: 31, column: 3, scope: !24)
-// CHECK:STDOUT: !38 = !DILocation(line: 23, column: 1, scope: !24)
-// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "Op", linkageName: "_COp.cf0fdf6659baaa34:core.Destroy.Core", scope: null, file: !3, line: 26, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
+// CHECK:STDOUT: !30 = !DILocation(line: 11, column: 3, scope: !24)
+// CHECK:STDOUT: !31 = !DILocation(line: 12, column: 3, scope: !24)
+// CHECK:STDOUT: !32 = !DILocation(line: 13, column: 3, scope: !24)
+// CHECK:STDOUT: !33 = !DILocation(line: 14, column: 3, scope: !24)
+// CHECK:STDOUT: !34 = !DILocation(line: 15, column: 3, scope: !24)
+// CHECK:STDOUT: !35 = !DILocation(line: 16, column: 3, scope: !24)
+// CHECK:STDOUT: !36 = !DILocation(line: 17, column: 3, scope: !24)
+// CHECK:STDOUT: !37 = !DILocation(line: 18, column: 3, scope: !24)
+// CHECK:STDOUT: !38 = !DILocation(line: 10, column: 1, scope: !24)
+// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "Op", linkageName: "_COp.cf0fdf6659baaa34:core.Destroy.Core", scope: null, file: !3, line: 13, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
 // CHECK:STDOUT: !40 = !DISubroutineType(types: !41)
 // CHECK:STDOUT: !41 = !{null, !14}
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !39, type: !14)
-// CHECK:STDOUT: !44 = !DILocation(line: 26, column: 10, scope: !39)
-// CHECK:STDOUT: !45 = distinct !DISubprogram(name: "Op", linkageName: "_COp.6d0c6cfaed549004:core.Destroy.Core", scope: null, file: !3, line: 31, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !46)
+// CHECK:STDOUT: !44 = !DILocation(line: 13, column: 10, scope: !39)
+// CHECK:STDOUT: !45 = distinct !DISubprogram(name: "Op", linkageName: "_COp.6d0c6cfaed549004:core.Destroy.Core", scope: null, file: !3, line: 18, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !46)
 // CHECK:STDOUT: !46 = !{!47}
 // CHECK:STDOUT: !47 = !DILocalVariable(arg: 1, scope: !45, type: !14)
-// CHECK:STDOUT: !48 = !DILocation(line: 31, column: 3, scope: !45)
-// CHECK:STDOUT: !49 = distinct !DISubprogram(name: "Op", linkageName: "_COp.ff8e65f476832154:core.Destroy.Core", scope: null, file: !3, line: 31, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !50)
+// CHECK:STDOUT: !48 = !DILocation(line: 18, column: 3, scope: !45)
+// CHECK:STDOUT: !49 = distinct !DISubprogram(name: "Op", linkageName: "_COp.ff8e65f476832154:core.Destroy.Core", scope: null, file: !3, line: 18, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !50)
 // CHECK:STDOUT: !50 = !{!51}
 // CHECK:STDOUT: !51 = !DILocalVariable(arg: 1, scope: !49, type: !14)
-// CHECK:STDOUT: !52 = !DILocation(line: 31, column: 3, scope: !49)
-// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "Op", linkageName: "_COp.4e20543cf8f2965d:core.Destroy.Core", scope: null, file: !3, line: 31, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !54)
+// CHECK:STDOUT: !52 = !DILocation(line: 18, column: 3, scope: !49)
+// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "Op", linkageName: "_COp.83837874cf69a650:core.Destroy.Core", scope: null, file: !3, line: 18, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !54)
 // CHECK:STDOUT: !54 = !{!55}
 // CHECK:STDOUT: !55 = !DILocalVariable(arg: 1, scope: !53, type: !14)
-// CHECK:STDOUT: !56 = !DILocation(line: 31, column: 3, scope: !53)
-// CHECK:STDOUT: !57 = distinct !DISubprogram(name: "Op", linkageName: "_COp.6266a7d1b07e8fb0:core.Destroy.Core", scope: null, file: !3, line: 31, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !58)
+// CHECK:STDOUT: !56 = !DILocation(line: 18, column: 3, scope: !53)
+// CHECK:STDOUT: !57 = distinct !DISubprogram(name: "Op", linkageName: "_COp.8ed16437b3e9f3a5:core.Destroy.Core", scope: null, file: !3, line: 18, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !58)
 // CHECK:STDOUT: !58 = !{!59}
 // CHECK:STDOUT: !59 = !DILocalVariable(arg: 1, scope: !57, type: !14)
-// CHECK:STDOUT: !60 = !DILocation(line: 31, column: 3, scope: !57)
-// CHECK:STDOUT: !61 = distinct !DISubprogram(name: "Op", linkageName: "_COp.069a47fa3ad2e3b5:core.Destroy.Core", scope: null, file: !3, line: 31, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !62)
+// CHECK:STDOUT: !60 = !DILocation(line: 18, column: 3, scope: !57)
+// CHECK:STDOUT: !61 = distinct !DISubprogram(name: "Op", linkageName: "_COp.adbfbb7b79f63468:core.Destroy.Core", scope: null, file: !3, line: 18, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !62)
 // CHECK:STDOUT: !62 = !{!63}
 // CHECK:STDOUT: !63 = !DILocalVariable(arg: 1, scope: !61, type: !14)
-// CHECK:STDOUT: !64 = !DILocation(line: 31, column: 3, scope: !61)
-// CHECK:STDOUT: !65 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5d78bb11848724da:core.Destroy.Core", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !66)
+// CHECK:STDOUT: !64 = !DILocation(line: 18, column: 3, scope: !61)
+// CHECK:STDOUT: !65 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5d78bb11848724da:core.Destroy.Core", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !66)
 // CHECK:STDOUT: !66 = !{!67}
 // CHECK:STDOUT: !67 = !DILocalVariable(arg: 1, scope: !65, type: !7)
-// CHECK:STDOUT: !68 = !DILocation(line: 29, column: 3, scope: !65)
-// CHECK:STDOUT: !69 = distinct !DISubprogram(name: "Op", linkageName: "_COp.e6bd9626cf45e979:core.Destroy.Core", scope: null, file: !3, line: 29, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !70)
+// CHECK:STDOUT: !68 = !DILocation(line: 16, column: 3, scope: !65)
+// CHECK:STDOUT: !69 = distinct !DISubprogram(name: "Op", linkageName: "_COp.e6bd9626cf45e979:core.Destroy.Core", scope: null, file: !3, line: 16, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !70)
 // CHECK:STDOUT: !70 = !{!71}
 // CHECK:STDOUT: !71 = !DILocalVariable(arg: 1, scope: !69, type: !14)
-// CHECK:STDOUT: !72 = !DILocation(line: 29, column: 3, scope: !69)
-// CHECK:STDOUT: !73 = distinct !DISubprogram(name: "Op", linkageName: "_COp.1bc1533dda6a5e5d:core.Destroy.Core", scope: null, file: !3, line: 29, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !74)
+// CHECK:STDOUT: !72 = !DILocation(line: 16, column: 3, scope: !69)
+// CHECK:STDOUT: !73 = distinct !DISubprogram(name: "Op", linkageName: "_COp.57bd9f6c8b0ddceb:core.Destroy.Core", scope: null, file: !3, line: 16, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !74)
 // CHECK:STDOUT: !74 = !{!75}
 // CHECK:STDOUT: !75 = !DILocalVariable(arg: 1, scope: !73, type: !14)
-// CHECK:STDOUT: !76 = !DILocation(line: 29, column: 3, scope: !73)
-// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "Op", linkageName: "_COp.b815f2fb59516ce9:core.Destroy.Core", scope: null, file: !3, line: 29, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !78)
+// CHECK:STDOUT: !76 = !DILocation(line: 16, column: 3, scope: !73)
+// CHECK:STDOUT: !77 = distinct !DISubprogram(name: "Op", linkageName: "_COp.2867d2b01356b3cb:core.Destroy.Core", scope: null, file: !3, line: 16, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !78)
 // CHECK:STDOUT: !78 = !{!79}
 // CHECK:STDOUT: !79 = !DILocalVariable(arg: 1, scope: !77, type: !14)
-// CHECK:STDOUT: !80 = !DILocation(line: 29, column: 3, scope: !77)
-// CHECK:STDOUT: !81 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0d6434e377e7c428:core.Destroy.Core", scope: null, file: !3, line: 29, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !82)
+// CHECK:STDOUT: !80 = !DILocation(line: 16, column: 3, scope: !77)
+// CHECK:STDOUT: !81 = distinct !DISubprogram(name: "Op", linkageName: "_COp.01d632db26744f11:core.Destroy.Core", scope: null, file: !3, line: 16, type: !40, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !82)
 // CHECK:STDOUT: !82 = !{!83}
 // CHECK:STDOUT: !83 = !DILocalVariable(arg: 1, scope: !81, type: !14)
-// CHECK:STDOUT: !84 = !DILocation(line: 29, column: 3, scope: !81)
-// CHECK:STDOUT: !85 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.c2b2aa7ce9960f99", scope: null, file: !86, line: 33, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !87)
+// CHECK:STDOUT: !84 = !DILocation(line: 16, column: 3, scope: !81)
+// CHECK:STDOUT: !85 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.36b54e287793a2ba", scope: null, file: !86, line: 36, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !87)
 // CHECK:STDOUT: !86 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !87 = !{!88}
 // CHECK:STDOUT: !88 = !DILocalVariable(arg: 1, scope: !85, type: !14)
-// CHECK:STDOUT: !89 = !DILocation(line: 34, column: 12, scope: !85)
-// CHECK:STDOUT: !90 = !DILocation(line: 34, column: 5, scope: !85)
-// CHECK:STDOUT: !91 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.c2b2aa7ce9960f99", scope: null, file: !86, line: 36, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !92)
+// CHECK:STDOUT: !89 = !DILocation(line: 37, column: 12, scope: !85)
+// CHECK:STDOUT: !90 = !DILocation(line: 37, column: 5, scope: !85)
+// CHECK:STDOUT: !91 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Optional.Core.36b54e287793a2ba", scope: null, file: !86, line: 39, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !92)
 // CHECK:STDOUT: !92 = !{!93}
 // CHECK:STDOUT: !93 = !DILocalVariable(arg: 1, scope: !91, type: !14)
-// CHECK:STDOUT: !94 = !DILocation(line: 37, column: 12, scope: !91)
-// CHECK:STDOUT: !95 = !DILocation(line: 37, column: 5, scope: !91)
-// CHECK:STDOUT: !96 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.67d5e332e5dc0930", scope: null, file: !86, line: 96, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !99)
+// CHECK:STDOUT: !94 = !DILocation(line: 40, column: 12, scope: !91)
+// CHECK:STDOUT: !95 = !DILocation(line: 40, column: 5, scope: !91)
+// CHECK:STDOUT: !96 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.d356e073ce1a5b35", scope: null, file: !86, line: 105, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !99)
 // CHECK:STDOUT: !97 = !DISubroutineType(types: !98)
 // CHECK:STDOUT: !98 = !{!14, !7}
 // CHECK:STDOUT: !99 = !{!100}
 // CHECK:STDOUT: !100 = !DILocalVariable(arg: 1, scope: !96, type: !7)
-// CHECK:STDOUT: !101 = !DILocation(line: 97, column: 12, scope: !96)
-// CHECK:STDOUT: !102 = !DILocation(line: 97, column: 5, scope: !96)
-// CHECK:STDOUT: !103 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.474385511948e0a9", scope: null, file: !86, line: 27, type: !104, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !101 = !DILocation(line: 106, column: 12, scope: !96)
+// CHECK:STDOUT: !102 = !DILocation(line: 106, column: 5, scope: !96)
+// CHECK:STDOUT: !103 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.cf11014f74122042", scope: null, file: !86, line: 30, type: !104, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !104 = !DISubroutineType(types: !105)
 // CHECK:STDOUT: !105 = !{!14}
-// CHECK:STDOUT: !106 = !DILocation(line: 28, column: 12, scope: !103)
-// CHECK:STDOUT: !107 = !DILocation(line: 28, column: 5, scope: !103)
-// CHECK:STDOUT: !108 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.2f9aa43bda454fff", scope: null, file: !109, line: 40, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !110)
+// CHECK:STDOUT: !106 = !DILocation(line: 31, column: 12, scope: !103)
+// CHECK:STDOUT: !107 = !DILocation(line: 31, column: 5, scope: !103)
+// CHECK:STDOUT: !108 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.93e3eaa0d3eea476", scope: null, file: !109, line: 40, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !110)
 // CHECK:STDOUT: !109 = !DIFile(filename: "{{.*}}/prelude/operators/as.carbon", directory: "")
 // CHECK:STDOUT: !110 = !{!111}
 // CHECK:STDOUT: !111 = !DILocalVariable(arg: 1, scope: !108, type: !7)
 // CHECK:STDOUT: !112 = !DILocation(line: 40, column: 45, scope: !108)
 // CHECK:STDOUT: !113 = !DILocation(line: 40, column: 38, scope: !108)
-// CHECK:STDOUT: !114 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.8b1f639410c6fca3", scope: null, file: !86, line: 96, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !115)
+// CHECK:STDOUT: !114 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.a06e83c323a306da", scope: null, file: !86, line: 105, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !115)
 // CHECK:STDOUT: !115 = !{!116}
 // CHECK:STDOUT: !116 = !DILocalVariable(arg: 1, scope: !114, type: !7)
-// CHECK:STDOUT: !117 = !DILocation(line: 97, column: 12, scope: !114)
-// CHECK:STDOUT: !118 = !DILocation(line: 97, column: 5, scope: !114)
-// CHECK:STDOUT: !119 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.a1638d31d24cfbda", scope: null, file: !109, line: 40, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !120)
+// CHECK:STDOUT: !117 = !DILocation(line: 106, column: 12, scope: !114)
+// CHECK:STDOUT: !118 = !DILocation(line: 106, column: 5, scope: !114)
+// CHECK:STDOUT: !119 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.183173080affdcb8", scope: null, file: !109, line: 40, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !120)
 // CHECK:STDOUT: !120 = !{!121}
 // CHECK:STDOUT: !121 = !DILocalVariable(arg: 1, scope: !119, type: !7)
 // CHECK:STDOUT: !122 = !DILocation(line: 40, column: 45, scope: !119)
 // CHECK:STDOUT: !123 = !DILocation(line: 40, column: 38, scope: !119)
-// CHECK:STDOUT: !124 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.2f9aa43bda454fff", scope: null, file: !109, line: 44, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !125)
+// CHECK:STDOUT: !124 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.93e3eaa0d3eea476", scope: null, file: !109, line: 44, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !125)
 // CHECK:STDOUT: !125 = !{!126}
 // CHECK:STDOUT: !126 = !DILocalVariable(arg: 1, scope: !124, type: !7)
 // CHECK:STDOUT: !127 = !DILocation(line: 44, column: 45, scope: !124)
 // CHECK:STDOUT: !128 = !DILocation(line: 44, column: 38, scope: !124)
-// CHECK:STDOUT: !129 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.1aa01ee321663405", scope: null, file: !109, line: 44, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !130)
+// CHECK:STDOUT: !129 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.54bcc98de4b4d68e", scope: null, file: !109, line: 44, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !130)
 // CHECK:STDOUT: !130 = !{!131}
 // CHECK:STDOUT: !131 = !DILocalVariable(arg: 1, scope: !129, type: !7)
 // CHECK:STDOUT: !132 = !DILocation(line: 44, column: 45, scope: !129)
 // CHECK:STDOUT: !133 = !DILocation(line: 44, column: 38, scope: !129)
-// CHECK:STDOUT: !134 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.a1638d31d24cfbda", scope: null, file: !109, line: 44, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !135)
+// CHECK:STDOUT: !134 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.183173080affdcb8", scope: null, file: !109, line: 44, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !135)
 // CHECK:STDOUT: !135 = !{!136}
 // CHECK:STDOUT: !136 = !DILocalVariable(arg: 1, scope: !134, type: !7)
 // CHECK:STDOUT: !137 = !DILocation(line: 44, column: 45, scope: !134)
 // CHECK:STDOUT: !138 = !DILocation(line: 44, column: 38, scope: !134)
-// CHECK:STDOUT: !139 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.8e46e1cf04c82a78", scope: null, file: !109, line: 44, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !140)
+// CHECK:STDOUT: !139 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.e767a09bf0821f52:ImplicitAs.eb057aa32837c84e.Core.53171a0379a201a0", scope: null, file: !109, line: 44, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !140)
 // CHECK:STDOUT: !140 = !{!141}
 // CHECK:STDOUT: !141 = !DILocalVariable(arg: 1, scope: !139, type: !7)
 // CHECK:STDOUT: !142 = !DILocation(line: 44, column: 45, scope: !139)
 // CHECK:STDOUT: !143 = !DILocation(line: 44, column: 38, scope: !139)
-// CHECK:STDOUT: !144 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.e8f8f92d3d08d149:OptionalStorage.Core.c8fd090a2e741f70", scope: null, file: !86, line: 156, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !145)
+// CHECK:STDOUT: !144 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.e8f8f92d3d08d149:OptionalStorage.Core.c8fd090a2e741f70", scope: null, file: !86, line: 172, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !145)
 // CHECK:STDOUT: !145 = !{!146}
 // CHECK:STDOUT: !146 = !DILocalVariable(arg: 1, scope: !144, type: !14)
-// CHECK:STDOUT: !147 = !DILocation(line: 157, column: 16, scope: !144)
-// CHECK:STDOUT: !148 = !DILocation(line: 157, column: 12, scope: !144)
-// CHECK:STDOUT: !149 = !DILocation(line: 157, column: 5, scope: !144)
-// CHECK:STDOUT: !150 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.e8f8f92d3d08d149:OptionalStorage.Core.c8fd090a2e741f70", scope: null, file: !86, line: 159, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !151)
+// CHECK:STDOUT: !147 = !DILocation(line: 173, column: 16, scope: !144)
+// CHECK:STDOUT: !148 = !DILocation(line: 173, column: 12, scope: !144)
+// CHECK:STDOUT: !149 = !DILocation(line: 173, column: 5, scope: !144)
+// CHECK:STDOUT: !150 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.e8f8f92d3d08d149:OptionalStorage.Core.c8fd090a2e741f70", scope: null, file: !86, line: 175, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !151)
 // CHECK:STDOUT: !151 = !{!152}
 // CHECK:STDOUT: !152 = !DILocalVariable(arg: 1, scope: !150, type: !14)
-// CHECK:STDOUT: !153 = !DILocation(line: 160, column: 5, scope: !150)
-// CHECK:STDOUT: !154 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.474385511948e0a9", scope: null, file: !86, line: 71, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !155)
+// CHECK:STDOUT: !153 = !DILocation(line: 176, column: 5, scope: !150)
+// CHECK:STDOUT: !154 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.ba9a17e320476215:OptionalAs.7eef99cd03a74de4.Core.cf11014f74122042", scope: null, file: !86, line: 80, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !155)
 // CHECK:STDOUT: !155 = !{!156}
 // CHECK:STDOUT: !156 = !DILocalVariable(arg: 1, scope: !154, type: !7)
-// CHECK:STDOUT: !157 = !DILocation(line: 72, column: 12, scope: !154)
-// CHECK:STDOUT: !158 = !DILocation(line: 72, column: 5, scope: !154)
-// CHECK:STDOUT: !159 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !86, line: 116, type: !104, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !160 = !DILocation(line: 119, column: 5, scope: !159)
-// CHECK:STDOUT: !161 = !DILocation(line: 120, column: 5, scope: !159)
-// CHECK:STDOUT: !162 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.9b89437b60c764fb", scope: null, file: !86, line: 78, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !163)
+// CHECK:STDOUT: !157 = !DILocation(line: 81, column: 12, scope: !154)
+// CHECK:STDOUT: !158 = !DILocation(line: 81, column: 5, scope: !154)
+// CHECK:STDOUT: !159 = distinct !DISubprogram(name: "None", linkageName: "_CNone.4f9853132d866dc6:OptionalStorage.Core.fe1b3f265f915ed6", scope: null, file: !86, line: 125, type: !104, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !160 = !DILocation(line: 128, column: 5, scope: !159)
+// CHECK:STDOUT: !161 = !DILocation(line: 129, column: 5, scope: !159)
+// CHECK:STDOUT: !162 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.62d55c5523334675:OptionalAs.f5e7d4305ac1f327.Core.359fad345e4cc188", scope: null, file: !86, line: 87, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !163)
 // CHECK:STDOUT: !163 = !{!164}
 // CHECK:STDOUT: !164 = !DILocalVariable(arg: 1, scope: !162, type: !7)
-// CHECK:STDOUT: !165 = !DILocation(line: 79, column: 29, scope: !162)
-// CHECK:STDOUT: !166 = !DILocation(line: 79, column: 12, scope: !162)
-// CHECK:STDOUT: !167 = !DILocation(line: 79, column: 5, scope: !162)
-// CHECK:STDOUT: !168 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.474385511948e0a9", scope: null, file: !86, line: 30, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !169)
+// CHECK:STDOUT: !165 = !DILocation(line: 88, column: 29, scope: !162)
+// CHECK:STDOUT: !166 = !DILocation(line: 88, column: 12, scope: !162)
+// CHECK:STDOUT: !167 = !DILocation(line: 88, column: 5, scope: !162)
+// CHECK:STDOUT: !168 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.cf11014f74122042", scope: null, file: !86, line: 33, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !169)
 // CHECK:STDOUT: !169 = !{!170}
 // CHECK:STDOUT: !170 = !DILocalVariable(arg: 1, scope: !168, type: !7)
-// CHECK:STDOUT: !171 = !DILocation(line: 31, column: 12, scope: !168)
-// CHECK:STDOUT: !172 = !DILocation(line: 31, column: 5, scope: !168)
+// CHECK:STDOUT: !171 = !DILocation(line: 34, column: 12, scope: !168)
+// CHECK:STDOUT: !172 = !DILocation(line: 34, column: 5, scope: !168)
 // CHECK:STDOUT: !173 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.68cbef1dbba6ee88:ImplicitAs.ad22d1bbc0605210.Core.3d03a93e76942d8a", scope: null, file: !109, line: 40, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !174)
 // CHECK:STDOUT: !174 = !{!175}
 // CHECK:STDOUT: !175 = !DILocalVariable(arg: 1, scope: !173, type: !7)
 // CHECK:STDOUT: !176 = !DILocation(line: 40, column: 45, scope: !173)
 // CHECK:STDOUT: !177 = !DILocation(line: 40, column: 38, scope: !173)
-// CHECK:STDOUT: !178 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.3f4ee3c720c792b2", scope: null, file: !86, line: 30, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !179)
+// CHECK:STDOUT: !178 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.Optional.Core.50482747a823e073", scope: null, file: !86, line: 33, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !179)
 // CHECK:STDOUT: !179 = !{!180}
 // CHECK:STDOUT: !180 = !DILocalVariable(arg: 1, scope: !178, type: !7)
-// CHECK:STDOUT: !181 = !DILocation(line: 31, column: 12, scope: !178)
-// CHECK:STDOUT: !182 = !DILocation(line: 31, column: 5, scope: !178)
-// CHECK:STDOUT: !183 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.6d535d38260d6085", scope: null, file: !86, line: 122, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !184)
+// CHECK:STDOUT: !181 = !DILocation(line: 34, column: 12, scope: !178)
+// CHECK:STDOUT: !182 = !DILocation(line: 34, column: 5, scope: !178)
+// CHECK:STDOUT: !183 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.4f9853132d866dc6:OptionalStorage.Core.fe1b3f265f915ed6", scope: null, file: !86, line: 131, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !184)
 // CHECK:STDOUT: !184 = !{!185}
 // CHECK:STDOUT: !185 = !DILocalVariable(arg: 1, scope: !183, type: !7)
-// CHECK:STDOUT: !186 = !DILocation(line: 128, column: 5, scope: !183)
-// CHECK:STDOUT: !187 = !DILocation(line: 129, column: 5, scope: !183)
-// CHECK:STDOUT: !188 = !DILocation(line: 130, column: 5, scope: !183)
+// CHECK:STDOUT: !186 = !DILocation(line: 137, column: 5, scope: !183)
+// CHECK:STDOUT: !187 = !DILocation(line: 138, column: 5, scope: !183)
+// CHECK:STDOUT: !188 = !DILocation(line: 139, column: 5, scope: !183)
 // CHECK:STDOUT: !189 = distinct !DISubprogram(name: "Convert", linkageName: "_CConvert.b912251d28f69b6d:ImplicitAs.a629ad9d3aac3895.Core.245bb80fde7c8401", scope: null, file: !190, line: 62, type: !191, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !193)
 // CHECK:STDOUT: !190 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
 // CHECK:STDOUT: !191 = !DISubroutineType(types: !192)
@@ -531,13 +557,13 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: !194 = !DILocalVariable(arg: 1, scope: !189, type: !7)
 // CHECK:STDOUT: !195 = !DILocation(line: 64, column: 17, scope: !189)
 // CHECK:STDOUT: !196 = !DILocation(line: 64, column: 5, scope: !189)
-// CHECK:STDOUT: !197 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.73173aebc8a6c2aa", scope: null, file: !86, line: 122, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !198)
+// CHECK:STDOUT: !197 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.4f9853132d866dc6:OptionalStorage.Core.9078267c53e6931d", scope: null, file: !86, line: 131, type: !97, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !198)
 // CHECK:STDOUT: !198 = !{!199}
 // CHECK:STDOUT: !199 = !DILocalVariable(arg: 1, scope: !197, type: !7)
-// CHECK:STDOUT: !200 = !DILocation(line: 128, column: 5, scope: !197)
-// CHECK:STDOUT: !201 = !DILocation(line: 128, column: 28, scope: !197)
-// CHECK:STDOUT: !202 = !DILocation(line: 129, column: 5, scope: !197)
-// CHECK:STDOUT: !203 = !DILocation(line: 130, column: 5, scope: !197)
+// CHECK:STDOUT: !200 = !DILocation(line: 137, column: 5, scope: !197)
+// CHECK:STDOUT: !201 = !DILocation(line: 137, column: 28, scope: !197)
+// CHECK:STDOUT: !202 = !DILocation(line: 138, column: 5, scope: !197)
+// CHECK:STDOUT: !203 = !DILocation(line: 139, column: 5, scope: !197)
 // CHECK:STDOUT: !204 = distinct !DISubprogram(name: "AsInt", linkageName: "_CAsInt.Int.9452f4c51951679b.Core:AnyInt.Core.be1e879c1ad406d8", scope: null, file: !190, line: 57, type: !191, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !205)
 // CHECK:STDOUT: !205 = !{!206}
 // CHECK:STDOUT: !206 = !DILocalVariable(arg: 1, scope: !204, type: !7)
@@ -547,3 +573,159 @@ fn AddOrRemoveConst(a: i32, b: const i32) {
 // CHECK:STDOUT: !210 = !{!211}
 // CHECK:STDOUT: !211 = !DILocalVariable(arg: 1, scope: !208, type: !7)
 // CHECK:STDOUT: !212 = !DILocation(line: 19, column: 33, scope: !208)
+// CHECK:STDOUT: ; ModuleID = 'copy.carbon'
+// CHECK:STDOUT: source_filename = "copy.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @"_COp.Copyable.Main:Copy.Core"(ptr sret({}), ptr)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define weak_odr void @"_COp.fc5284d8d58d5626:core.Destroy.Core"(ptr %self) #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !10
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CF.Main(ptr sret({ {}, i1 }) %return, ptr %c) #0 !dbg !11 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @"_COp.Optional.7eef99cd03a74de4.Core:Copy.Core.c9e30f6f9b477949"(ptr %return, ptr %c), !dbg !16
+// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @"_COp.Optional.7eef99cd03a74de4.Core:Copy.Core.c9e30f6f9b477949"(ptr sret({ {}, i1 }) %return, ptr %self) #0 !dbg !18 {
+// CHECK:STDOUT:   call void @"_CCopy.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a"(ptr %return, ptr %self), !dbg !22
+// CHECK:STDOUT:   ret void, !dbg !23
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @"_CCopy.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a"(ptr sret({ {}, i1 }) %return, ptr %value) #0 !dbg !24 {
+// CHECK:STDOUT:   %1 = call i1 @"_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a"(ptr %value), !dbg !27
+// CHECK:STDOUT:   br i1 %1, label %2, label %3, !dbg !28
+// CHECK:STDOUT:
+// CHECK:STDOUT: 2:                                                ; preds = %0
+// CHECK:STDOUT:   %value1 = getelementptr inbounds nuw { {}, i1 }, ptr %value, i32 0, i32 0, !dbg !29
+// CHECK:STDOUT:   call void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a"(ptr %return, ptr %value1), !dbg !30
+// CHECK:STDOUT:   ret void, !dbg !31
+// CHECK:STDOUT:
+// CHECK:STDOUT: 3:                                                ; preds = %0
+// CHECK:STDOUT:   call void @"_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a"(ptr %return), !dbg !32
+// CHECK:STDOUT:   ret void, !dbg !33
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr i1 @"_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a"(ptr %value) #0 !dbg !34 {
+// CHECK:STDOUT:   %has_value = getelementptr inbounds nuw { {}, i1 }, ptr %value, i32 0, i32 1, !dbg !37
+// CHECK:STDOUT:   %1 = load i8, ptr %has_value, align 1, !dbg !37
+// CHECK:STDOUT:   %2 = trunc i8 %1 to i1, !dbg !37
+// CHECK:STDOUT:   ret i1 %2, !dbg !38
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @"_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a"(ptr sret({ {}, i1 }) %return, ptr %self) #0 !dbg !39 {
+// CHECK:STDOUT:   %value = getelementptr inbounds nuw { {}, i1 }, ptr %return, i32 0, i32 0, !dbg !42
+// CHECK:STDOUT:   call void @"_COp.Copyable.Main:Copy.Core"(ptr %value, ptr %self), !dbg !43
+// CHECK:STDOUT:   %has_value = getelementptr inbounds nuw { {}, i1 }, ptr %return, i32 0, i32 1, !dbg !44
+// CHECK:STDOUT:   store i8 1, ptr %has_value, align 1, !dbg !44
+// CHECK:STDOUT:   ret void, !dbg !45
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @"_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a"(ptr sret({ {}, i1 }) %return) #0 !dbg !46 {
+// CHECK:STDOUT:   %has_value = getelementptr inbounds nuw { {}, i1 }, ptr %return, i32 0, i32 1, !dbg !49
+// CHECK:STDOUT:   store i8 0, ptr %has_value, align 1, !dbg !49
+// CHECK:STDOUT:   ret void, !dbg !50
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "copy.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Op", linkageName: "_COp.fc5284d8d58d5626:core.Destroy.Core", scope: null, file: !3, line: 9, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !8)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{null, !7}
+// CHECK:STDOUT: !7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !8 = !{!9}
+// CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
+// CHECK:STDOUT: !10 = !DILocation(line: 9, column: 9, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 9, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !14)
+// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
+// CHECK:STDOUT: !13 = !{!7, !7}
+// CHECK:STDOUT: !14 = !{!15}
+// CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !11, type: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 11, column: 10, scope: !11)
+// CHECK:STDOUT: !17 = !DILocation(line: 11, column: 3, scope: !11)
+// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "Op", linkageName: "_COp.Optional.7eef99cd03a74de4.Core:Copy.Core.c9e30f6f9b477949", scope: null, file: !19, line: 50, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)
+// CHECK:STDOUT: !19 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
+// CHECK:STDOUT: !20 = !{!21}
+// CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !18, type: !7)
+// CHECK:STDOUT: !22 = !DILocation(line: 51, column: 12, scope: !18)
+// CHECK:STDOUT: !23 = !DILocation(line: 51, column: 5, scope: !18)
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "Copy", linkageName: "_CCopy.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a", scope: null, file: !19, line: 147, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !25)
+// CHECK:STDOUT: !25 = !{!26}
+// CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !24, type: !7)
+// CHECK:STDOUT: !27 = !DILocation(line: 148, column: 9, scope: !24)
+// CHECK:STDOUT: !28 = !DILocation(line: 148, column: 8, scope: !24)
+// CHECK:STDOUT: !29 = !DILocation(line: 149, column: 15, scope: !24)
+// CHECK:STDOUT: !30 = !DILocation(line: 149, column: 14, scope: !24)
+// CHECK:STDOUT: !31 = !DILocation(line: 149, column: 7, scope: !24)
+// CHECK:STDOUT: !32 = !DILocation(line: 151, column: 14, scope: !24)
+// CHECK:STDOUT: !33 = !DILocation(line: 151, column: 7, scope: !24)
+// CHECK:STDOUT: !34 = distinct !DISubprogram(name: "Has", linkageName: "_CHas.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a", scope: null, file: !19, line: 141, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !35)
+// CHECK:STDOUT: !35 = !{!36}
+// CHECK:STDOUT: !36 = !DILocalVariable(arg: 1, scope: !34, type: !7)
+// CHECK:STDOUT: !37 = !DILocation(line: 142, column: 12, scope: !34)
+// CHECK:STDOUT: !38 = !DILocation(line: 142, column: 5, scope: !34)
+// CHECK:STDOUT: !39 = distinct !DISubprogram(name: "Some", linkageName: "_CSome.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a", scope: null, file: !19, line: 131, type: !12, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !40)
+// CHECK:STDOUT: !40 = !{!41}
+// CHECK:STDOUT: !41 = !DILocalVariable(arg: 1, scope: !39, type: !7)
+// CHECK:STDOUT: !42 = !DILocation(line: 137, column: 5, scope: !39)
+// CHECK:STDOUT: !43 = !DILocation(line: 137, column: 28, scope: !39)
+// CHECK:STDOUT: !44 = !DILocation(line: 138, column: 5, scope: !39)
+// CHECK:STDOUT: !45 = !DILocation(line: 139, column: 5, scope: !39)
+// CHECK:STDOUT: !46 = distinct !DISubprogram(name: "None", linkageName: "_CNone.ca6ae00af8d27ba2:OptionalStorage.Core.8e4d068dce7d104a", scope: null, file: !19, line: 125, type: !47, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !47 = !DISubroutineType(types: !48)
+// CHECK:STDOUT: !48 = !{!7}
+// CHECK:STDOUT: !49 = !DILocation(line: 128, column: 5, scope: !46)
+// CHECK:STDOUT: !50 = !DILocation(line: 129, column: 5, scope: !46)
+// CHECK:STDOUT: ; ModuleID = 'copy_pointer.carbon'
+// CHECK:STDOUT: source_filename = "copy_pointer.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define ptr @_CF.Main(ptr %c) #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Optional.as.Copy.impl.Op.call = call ptr @"_COp.Optional.7eef99cd03a74de4.Core:Copy.Core.051b3610b095ceee"(ptr %c), !dbg !10
+// CHECK:STDOUT:   ret ptr %Optional.as.Copy.impl.Op.call, !dbg !11
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr ptr @"_COp.Optional.7eef99cd03a74de4.Core:Copy.Core.051b3610b095ceee"(ptr %self) #0 !dbg !12 {
+// CHECK:STDOUT:   ret ptr %self, !dbg !16
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "copy_pointer.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main", scope: null, file: !3, line: 5, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !8)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{!7, !7}
+// CHECK:STDOUT: !7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !8 = !{!9}
+// CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
+// CHECK:STDOUT: !10 = !DILocation(line: 6, column: 10, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 6, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Op", linkageName: "_COp.Optional.7eef99cd03a74de4.Core:Copy.Core.051b3610b095ceee", scope: null, file: !13, line: 50, type: !5, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !14)
+// CHECK:STDOUT: !13 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
+// CHECK:STDOUT: !14 = !{!15}
+// CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !12, type: !7)
+// CHECK:STDOUT: !16 = !DILocation(line: 51, column: 5, scope: !12)


### PR DESCRIPTION
`Optional` is already restricted to only be able to store copyable
types, so it should always implement `Core.Copy`.