### PR TITLE
Find correct nested rewrite constraints

### DIFF
--- a/toolchain/check/eval_inst.cpp
+++ b/toolchain/check/eval_inst.cpp
@@ -281,6 +281,7 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
   if (witness_id.has_value()) {
     return ConstantEvalResult::Existing(witness_id);
   }
+
   // Try again when the query is modified by a specific.
   return ConstantEvalResult::NewSamePhase(inst);
 }
@@ -290,6 +291,7 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
 // the type of `search_facet`.
 static auto TryFindValueInRewriteConstraints(
     Context& context, SemIR::LocId loc_id,
+    llvm::ArrayRef<SemIR::ImplWitnessAccess> access_qualifiers,
     SemIR::SpecificInterfaceId specific_interface_id,
     SemIR::ElementIndex interface_index, SemIR::InstId search_facet)
     -> SemIR::ConstantId {
@@ -344,11 +346,71 @@ static auto TryFindValueInRewriteConstraints(
 
     auto self_const_id = context.constant_values().Get(search_facet);
 
-    // The LHS of the rewrite might be `.Self` or it could be one or more nested
-    // ImplWitnessAccess instructions that eventually bottom out in `.Self`.
-    // Rewrite constraints must modify `.Self` so we know the target of the
-    // rewrite is ultimately always `.Self` which refers to the `search_facet`.
-    // So we don't have to substitute the `.Self` and do any comparison.
+    // The LHS of a rewrite can be an arbitrary type. For example:
+    // ```
+    //   T:! Z where C impls (Y(.Self) where .Y1 = {})
+    // ```
+    // The rewrite in the facet type will be `(C as Y(T)).Y1 = {}`.
+    //
+    // It can also be another ImplWitnessAccess. For example:
+    // ```
+    //   T:! Z where .Z1 impls (Y where .Y1 = {})
+    // ```
+    // The rewrite in the facet type will be `((T as Z).Z1 as Y).Y1 = {}`.
+    //
+    // If the original access was `T.Z1.Y1`, by the time `search_facet` is `T`
+    // where we find the rewrite, we will have already tried and failed to find
+    // a witness in `T.Z1`. So now a rewrite must be `.Z1.Y1` not just `.Y1`.
+    // This is represented in the `access_qualifiers`, and we check that the LHS
+    // of the rewrite contains those qualifiers in its access self facets,
+    // requiring that they are accessing the same interface and element.
+    //
+    // The inner-most self facet in the rewrite must be `.Self` in order to be
+    // providing a value for `search_facet`.
+    //
+    // TODO: Requiring the rewrite to be against `.Self` is actually
+    // insufficient. For a facet like
+    // ```
+    // T:! type where C impls (Z(.Self) where .Z1 = ())
+    // ```
+    // and an access like `C.(Z(T).Z1)`, the root of the access is `C`. If we
+    // search `T` for a witness, we'd need the inner-most self facet to be `C`
+    // in the rewrite. This isn't an issue in the code right now, because we
+    // only ever search the facet type for the self facets in the
+    // ImplWitnessAccess. But we should also be searching facets in the specific
+    // interfaces that would be part of the type structure. That is, we should
+    // match the search in `CollectFacetWitnessSources()`.
+    auto rewrite_lhs_self = rewrite_lhs_witness.query_self_inst_id;
+    bool mismatching_qualifier = false;
+    for (auto qualifier : access_qualifiers) {
+      auto rewrite_lhs_access =
+          context.insts().TryGetAs<SemIR::ImplWitnessAccess>(rewrite_lhs_self);
+      if (!rewrite_lhs_access) {
+        mismatching_qualifier = true;
+        break;
+      }
+      if (rewrite_lhs_access->index != qualifier.index) {
+        mismatching_qualifier = true;
+        break;
+      }
+      auto rewrite_lhs_witness =
+          context.insts().GetAs<SemIR::LookupImplWitness>(
+              rewrite_lhs_access->witness_id);
+      auto qualifier_witness = context.insts().GetAs<SemIR::LookupImplWitness>(
+          rewrite_lhs_access->witness_id);
+      if (rewrite_lhs_witness.query_specific_interface_id !=
+          qualifier_witness.query_specific_interface_id) {
+        mismatching_qualifier = true;
+        break;
+      }
+      rewrite_lhs_self = rewrite_lhs_witness.query_self_inst_id;
+    }
+    if (mismatching_qualifier) {
+      continue;
+    }
+    if (!IsPeriodSelf(context, rewrite_lhs_self)) {
+      continue;
+    }
 
     auto rewrite_lhs_interface =
         SubstPeriodSelf(context, loc_id,
@@ -425,11 +487,12 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
       // If we have a nested `.X1.Y1.Z1` we start with the facet type of .Y1 to
       // look for a rewrite constraint that provides the value for .Z1. But if
       // we don't find it, we try .X1 and .Self.
+      llvm::SmallVector<SemIR::ImplWitnessAccess> access_qualifiers;
       auto search_facet = witness.query_self_inst_id;
       while (true) {
         auto const_id = TryFindValueInRewriteConstraints(
-            context, SemIR::LocId(inst_id), witness.query_specific_interface_id,
-            inst.index, search_facet);
+            context, SemIR::LocId(inst_id), access_qualifiers,
+            witness.query_specific_interface_id, inst.index, search_facet);
         if (const_id.has_value()) {
           return ConstantEvalResult::Existing(const_id);
         }
@@ -437,6 +500,7 @@ auto EvalConstantInst(Context& context, SemIR::InstId inst_id,
                 search_facet)) {
           auto witness = context.insts().GetAs<SemIR::LookupImplWitness>(
               access->witness_id);
+          access_qualifiers.push_back(*access);
           search_facet = witness.query_self_inst_id;
         } else {
           break;

--- a/toolchain/check/testdata/facet/access.carbon
+++ b/toolchain/check/testdata/facet/access.carbon
@@ -370,7 +370,7 @@ fn F(U:! W, V:! Z(.Self) where .Z1 impls Y(U)) {
   V.(Z(V).Z1).(Y(U).Y1).(X.X1) as W;
 }
 
-// --- fail_todo_find_access_value_in_second_nested_access.carbon
+// --- find_access_value_in_second_nested_access.carbon
 library "[[@TEST_NAME]]";
 
 interface W {}
@@ -383,8 +383,6 @@ interface Y(T:! type) {
   let Y2:! type;
 }
 interface Z(U:! type, PeriodSelf:! type) {
-  // TODO: When we look for .Y1.X1 we currently only look for a rewrite of .X1,
-  // but there are three, and we can pick the wrong one.
   let Z1:! Y(PeriodSelf) where .Y0 impls (X where .X1 = ())
                            and .Y1 impls (X where .X1 = U)
                            and .Y2 impls (X where .X1 = ()) ;
@@ -396,10 +394,6 @@ fn F(U:! W, V:! Z(U, .Self)) {
   // it finds the rewrite of `.Y1.X1 = U`.
   //
   // Only U impls W so we use `as W` to test that the LHS is U.
-  // CHECK:STDERR: fail_todo_find_access_value_in_second_nested_access.carbon:[[@LINE+4]]:3: error: cannot convert type `V.(Z(U, V).Z1).(Y(V).Y1).(X.X1)` into type implementing `W` [ConversionFailureTypeToFacet]
-  // CHECK:STDERR:   V.(Z(U, V).Z1).(Y(V).Y1).(X.X1) as W;
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   V.(Z(U, V).Z1).(Y(V).Y1).(X.X1) as W;
 }
 
@@ -414,13 +408,17 @@ interface Y {
   let Y1:! type;
 }
 interface Z(T:! type) {
+  let Z0:! type;
   let Z1:! type;
+  let Z2:! type;
 }
 
-fn F(U:! W, V:! Z(.Self) where .Z1 impls (Y where .Y1 impls (X where .X1 = U))) {
+fn F(U:! W, V:! Z(.Self) where .Z0 impls (Y where .Y1 impls (X where .X1 = ()))
+                           and .Z1 impls (Y where .Y1 impls (X where .X1 = U))
+                           and .Z2 impls (Y where .Y1 impls (X where .X1 = ()))) {
   // This has to search for a value for `.Z1.Y1.X1` in V. To do so it needs to
   // look for a rewrite of .X1. First it looks in `V.Z1.Y1`, then `V.Z1`, then
-  // `V` where it finds the rewrite of `.X1 = U`.
+  // `V` where it finds the rewrite of `.Z1.Y1.X1 = U`.
   //
   // Only U impls W so we use `as W` to test that the LHS is U.
   V.(Z(V).Z1).(Y.Y1).(X.X1) as W;

--- a/toolchain/check/testdata/facet/access.carbon
+++ b/toolchain/check/testdata/facet/access.carbon
@@ -370,7 +370,7 @@ fn F(U:! W, V:! Z(.Self) where .Z1 impls Y(U)) {
   V.(Z(V).Z1).(Y(U).Y1).(X.X1) as W;
 }
 
-// --- find_access_value_in_second_nested_access.carbon
+// --- fail_todo_find_access_value_in_second_nested_access.carbon
 library "[[@TEST_NAME]]";
 
 interface W {}
@@ -378,18 +378,28 @@ interface X {
   let X1:! type;
 }
 interface Y(T:! type) {
+  let Y0:! type;
   let Y1:! type;
+  let Y2:! type;
 }
 interface Z(U:! type, PeriodSelf:! type) {
-  let Z1:! Y(PeriodSelf) where .Y1 impls (X where .X1 = U);
+  // TODO: When we look for .Y1.X1 we currently only look for a rewrite of .X1,
+  // but there are three, and we can pick the wrong one.
+  let Z1:! Y(PeriodSelf) where .Y0 impls (X where .X1 = ())
+                           and .Y1 impls (X where .X1 = U)
+                           and .Y2 impls (X where .X1 = ()) ;
 }
 
 fn F(U:! W, V:! Z(U, .Self)) {
   // This has to search for a value for `.Z1.Y1.X1` in V. To do so it needs to
   // look for a rewrite of .X1. First it looks in `V.Z1.Y1`, then `V.Z1`, where
-  // it finds the rewrite of `.X1 = U`.
+  // it finds the rewrite of `.Y1.X1 = U`.
   //
   // Only U impls W so we use `as W` to test that the LHS is U.
+  // CHECK:STDERR: fail_todo_find_access_value_in_second_nested_access.carbon:[[@LINE+4]]:3: error: cannot convert type `V.(Z(U, V).Z1).(Y(V).Y1).(X.X1)` into type implementing `W` [ConversionFailureTypeToFacet]
+  // CHECK:STDERR:   V.(Z(U, V).Z1).(Y(V).Y1).(X.X1) as W;
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   V.(Z(U, V).Z1).(Y(V).Y1).(X.X1) as W;
 }
 

--- a/toolchain/check/testdata/facet/access.carbon
+++ b/toolchain/check/testdata/facet/access.carbon
@@ -105,27 +105,6 @@ fn F(U:! I where .I1 = .Self and .I2 = ()) {
   (U as type) as (I where .I1 = .Self);
 }
 
-// --- access_through_call_once.carbon
-library "[[@TEST_NAME]]";
-
-// TODO: Merge this test with the one below once it works.
-
-interface I {
-  let X:! type;
-  fn G() -> X*;
-}
-
-fn F2[U:! I](unused V: U*) {}
-
-fn F(U:! I where .X = .Self, unused V: U) {
-  // The returned value of `G` type `U` which has access to the methods of `I`.
-  U.G()->G();
-  (U as type).G()->G();
-
-  // The returned value of type `U` can be used as a value of type `U`.
-  F2(U.G());
-}
-
 // --- access_through_call.carbon
 library "[[@TEST_NAME]]";
 
@@ -289,13 +268,11 @@ interface J {
 // --- access_constant_in_self_facet.carbon
 library "[[@TEST_NAME]]";
 
-//@dump-sem-ir-begin
 interface A { let X:! type; }
 
 fn F(AA:! A where .X = ()) -> AA.X {
   return ();
 }
-//@dump-sem-ir-end
 
 // --- access_constant_in_self_facet_with_multiple_interfaces.carbon
 library "[[@TEST_NAME]]";
@@ -310,7 +287,6 @@ interface B { let Y:! type; }
 // an interface other than the one it is accessing before finding the correct
 // rewrite.
 
-//@dump-sem-ir-begin
 fn F(AB:! A & B where .X = () and .Y = {}) -> AB.X {
   return ();
 }
@@ -318,7 +294,28 @@ fn F(AB:! A & B where .X = () and .Y = {}) -> AB.X {
 fn G(AB:! A & B where .X = () and .Y = {}) -> AB.Y {
   return {};
 }
-//@dump-sem-ir-end
+
+// --- fail_todo_access_constant_through_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface A { let X:! type; }
+
+constraint N {
+  extend require impls A where .X = ();
+}
+
+fn F(AA:! N) {
+  // TODO: The identified facet type `N` includes `A` and should provide a
+  // same-type constraint `A.X == ()` which would allow this conversion.
+  // CHECK:STDERR: fail_todo_access_constant_through_named_constraint.carbon:[[@LINE+7]]:3: error: cannot convert expression of type `()` to `AA.(A.X)` with `as` [ConversionFailure]
+  // CHECK:STDERR:   () as AA.X;
+  // CHECK:STDERR:   ^~~~~~~~~~
+  // CHECK:STDERR: fail_todo_access_constant_through_named_constraint.carbon:[[@LINE+4]]:3: note: type `()` does not implement interface `Core.As(AA.(A.X))` [MissingImplInMemberAccessInContext]
+  // CHECK:STDERR:   () as AA.X;
+  // CHECK:STDERR:   ^~~~~~~~~~
+  // CHECK:STDERR:
+  () as AA.X;
+}
 
 // --- symbolic_binding_type_of_impl_witness_access.carbon
 
@@ -422,6 +419,85 @@ fn F(U:! W, V:! Z(.Self) where .Z0 impls (Y where .Y1 impls (X where .X1 = ()))
   //
   // Only U impls W so we use `as W` to test that the LHS is U.
   V.(Z(V).Z1).(Y.Y1).(X.X1) as W;
+}
+
+// --- fail_todo_find_access_value_in_second_nested_access_through_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface W {}
+interface X {
+  let X1:! type;
+}
+interface Y(T:! type) {
+  let Y0:! type;
+  let Y1:! type;
+  let Y2:! type;
+}
+
+constraint NX(V:! type) {
+  extend require impls X where .X1 = V;
+}
+
+interface Z(PeriodSelf:! type) {
+  let Z1:! Y(PeriodSelf) where .Y0 impls NX(())
+                           and .Y1 impls NX({})
+                           and .Y2 impls NX(());
+}
+
+fn F(V:! Z(.Self)) {
+  // This has to search for a value for `.Z1.Y1.X1` in V. To do so it needs to
+  // look for a rewrite of .X1. First it looks in `V.Z1.Y1`, then `V.Z1`, where
+  // it finds the rewrite of `.Y1.X1 = {}`.
+  //
+  // TODO: The identified facet type `NX` includes `X` and should provide a
+  // same-type constraint `X.X1 == {}` which would allow this conversion.
+  // CHECK:STDERR: fail_todo_find_access_value_in_second_nested_access_through_named_constraint.carbon:[[@LINE+7]]:3: error: cannot convert expression of type `{}` to `V.(Z(V).Z1).(Y(V).Y1).(X.X1)` with `as` [ConversionFailure]
+  // CHECK:STDERR:   {} as V.(Z(V).Z1).(Y(V).Y1).(X.X1);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_todo_find_access_value_in_second_nested_access_through_named_constraint.carbon:[[@LINE+4]]:3: note: type `{}` does not implement interface `Core.As(V.(Z(V).Z1).(Y(V).Y1).(X.X1))` [MissingImplInMemberAccessInContext]
+  // CHECK:STDERR:   {} as V.(Z(V).Z1).(Y(V).Y1).(X.X1);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  {} as V.(Z(V).Z1).(Y(V).Y1).(X.X1);
+}
+
+// --- fail_todo_find_access_value_in_third_nested_access_through_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface W {}
+interface X {
+  let X1:! type;
+}
+interface Y {
+  let Y1:! type;
+}
+interface Z(T:! type) {
+  let Z0:! type;
+  let Z1:! type;
+  let Z2:! type;
+}
+
+constraint NX(V:! type) {
+  extend require impls X where .X1 = V;
+}
+
+fn F(V:! Z(.Self) where .Z0 impls (Y where .Y1 impls NX(()))
+                    and .Z1 impls (Y where .Y1 impls NX({}))
+                    and .Z2 impls (Y where .Y1 impls NX(()))) {
+  // This has to search for a value for `.Z1.Y1.X1` in V. To do so it needs to
+  // look for a rewrite of .X1. First it looks in `V.Z1.Y1`, then `V.Z1`, then
+  // `V` where it finds the rewrite of `.Z1.Y1.X1 = {}`.
+  //
+  // TODO: The identified facet type `NX` includes `X` and should provide a
+  // same-type constraint `X.X1 == V` which would allow this conversion.
+  // CHECK:STDERR: fail_todo_find_access_value_in_third_nested_access_through_named_constraint.carbon:[[@LINE+7]]:3: error: cannot convert expression of type `{}` to `V.(Z(V).Z1).(Y.Y1).(X.X1)` with `as` [ConversionFailure]
+  // CHECK:STDERR:   {} as V.(Z(V).Z1).(Y.Y1).(X.X1);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR: fail_todo_find_access_value_in_third_nested_access_through_named_constraint.carbon:[[@LINE+4]]:3: note: type `{}` does not implement interface `Core.As(V.(Z(V).Z1).(Y.Y1).(X.X1))` [MissingImplInMemberAccessInContext]
+  // CHECK:STDERR:   {} as V.(Z(V).Z1).(Y.Y1).(X.X1);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  {} as V.(Z(V).Z1).(Y.Y1).(X.X1);
 }
 
 // --- fail_todo_find_access_value_in_facet_from_specific_interface.carbon
@@ -769,318 +845,5 @@ fn F(T:! Z where C impls (Y(.Self) where .Y1 = {})) -> C.(Y(T).Y1) {
 // CHECK:STDOUT:   %.loc8_32.2 => constants.%.0ce
 // CHECK:STDOUT:   %return.param_patt.loc8_32.2 => constants.%return.param_patt.b82
 // CHECK:STDOUT:   %return.patt.loc8_29.2 => constants.%return.patt.2e6
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- access_constant_in_self_facet.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %A.type: type = facet_type <@A> [concrete]
-// CHECK:STDOUT:   %Self: %A.type = symbolic_binding Self, 0 [symbolic]
-// CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A [concrete]
-// CHECK:STDOUT:   %assoc0: %A.assoc_type = assoc_entity element0, @A.WithSelf.%X [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self.c39: %type = symbolic_binding .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.dad: %A.type = symbolic_binding .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self.dad [symbolic_self]
-// CHECK:STDOUT:   %A.lookup_impl_witness.744: <witness> = lookup_impl_witness %.Self.dad, @A [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %A.lookup_impl_witness.744, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
-// CHECK:STDOUT:   %A_where.type: type = facet_type <@A where %impl.elem0 = %empty_tuple.type> [concrete]
-// CHECK:STDOUT:   %pattern_type.634: type = pattern_type %A_where.type [concrete]
-// CHECK:STDOUT:   %AA.patt: %pattern_type.634 = symbolic_binding_pattern AA, 0 [symbolic]
-// CHECK:STDOUT:   %AA: %A_where.type = symbolic_binding AA, 0 [symbolic]
-// CHECK:STDOUT:   %AA.as_type: type = facet_access_type %AA [symbolic]
-// CHECK:STDOUT:   %A.lookup_impl_witness.9cf: <witness> = lookup_impl_witness %AA, @A [symbolic]
-// CHECK:STDOUT:   %A.facet: %A.type = facet_value %AA.as_type, (%A.lookup_impl_witness.9cf) [symbolic]
-// CHECK:STDOUT:   %.262: Core.Form = init_form %empty_tuple.type [concrete]
-// CHECK:STDOUT:   %pattern_type.cb1: type = pattern_type %empty_tuple.type [concrete]
-// CHECK:STDOUT:   %return.param_patt: %pattern_type.cb1 = out_param_pattern [concrete]
-// CHECK:STDOUT:   %return.patt: %pattern_type.cb1 = return_slot_pattern %return.param_patt, %empty_tuple.type [concrete]
-// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
-// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   %A.decl: type = interface_decl @A [concrete = constants.%A.type] {} {}
-// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %AA.patt.loc6_8.1: %pattern_type.634 = symbolic_binding_pattern AA, 0 [symbolic = %AA.patt.loc6_8.2 (constants.%AA.patt)]
-// CHECK:STDOUT:     %return.param_patt: %pattern_type.cb1 = out_param_pattern [concrete = constants.%return.param_patt]
-// CHECK:STDOUT:     %return.patt: %pattern_type.cb1 = return_slot_pattern %return.param_patt, %impl.elem0.loc6_33 [concrete = constants.%return.patt]
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %AA.ref: %A_where.type = name_ref AA, %AA.loc6_8.2 [symbolic = %AA.loc6_8.1 (constants.%AA)]
-// CHECK:STDOUT:     %AA.as_type.loc6_33.2: type = facet_access_type %AA.ref [symbolic = %AA.as_type.loc6_33.1 (constants.%AA.as_type)]
-// CHECK:STDOUT:     %.loc6_33.1: type = converted %AA.ref, %AA.as_type.loc6_33.2 [symbolic = %AA.as_type.loc6_33.1 (constants.%AA.as_type)]
-// CHECK:STDOUT:     %X.ref.loc6_33: %A.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:     %impl.elem0.loc6_33: type = impl_witness_access constants.%A.lookup_impl_witness.9cf, element0 [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %.loc6_33.2: Core.Form = init_form %impl.elem0.loc6_33 [concrete = constants.%.262]
-// CHECK:STDOUT:     %.loc6_13.1: type = splice_block %.loc6_13.2 [concrete = constants.%A_where.type] {
-// CHECK:STDOUT:       %.Self.loc6_8: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
-// CHECK:STDOUT:       %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
-// CHECK:STDOUT:       %.Self.loc6_13: %A.type = symbolic_binding .Self [symbolic_self = constants.%.Self.dad]
-// CHECK:STDOUT:       %.Self.ref: %A.type = name_ref .Self, %.Self.loc6_13 [symbolic_self = constants.%.Self.dad]
-// CHECK:STDOUT:       %.Self.as_type: type = facet_access_type %.Self.ref [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc6_19: type = converted %.Self.ref, %.Self.as_type [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %X.ref.loc6_19: %A.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0]
-// CHECK:STDOUT:       %impl.elem0.loc6_19: type = impl_witness_access constants.%A.lookup_impl_witness.744, element0 [symbolic_self = constants.%impl.elem0]
-// CHECK:STDOUT:       %.loc6_25.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:       %.loc6_25.2: type = converted %.loc6_25.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:       %.loc6_13.2: type = where_expr [concrete = constants.%A_where.type] {
-// CHECK:STDOUT:         requirement_base_facet_type %A.ref
-// CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc6_19, %.loc6_25.2
-// CHECK:STDOUT:       }
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %AA.loc6_8.2: %A_where.type = symbolic_binding AA, 0 [symbolic = %AA.loc6_8.1 (constants.%AA)]
-// CHECK:STDOUT:     %return.param: ref %empty_tuple.type = out_param call_param0
-// CHECK:STDOUT:     %return: ref %empty_tuple.type = return_slot %return.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: interface @A {
-// CHECK:STDOUT:   %Self: %A.type = symbolic_binding Self, 0 [symbolic = constants.%Self]
-// CHECK:STDOUT:   %A.WithSelf.decl = interface_with_self_decl @A [concrete]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !with Self:
-// CHECK:STDOUT:   %X: type = assoc_const_decl @X [concrete] {
-// CHECK:STDOUT:     %assoc0: %A.assoc_type = assoc_entity element0, @A.WithSelf.%X [concrete = constants.%assoc0]
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:
-// CHECK:STDOUT: !members:
-// CHECK:STDOUT:   .Self = %Self
-// CHECK:STDOUT:   .X = @X.%assoc0
-// CHECK:STDOUT:   witness = (@A.WithSelf.%X)
-// CHECK:STDOUT:
-// CHECK:STDOUT: !requires:
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%AA.loc6_8.2: %A_where.type) {
-// CHECK:STDOUT:   %AA.patt.loc6_8.2: %pattern_type.634 = symbolic_binding_pattern AA, 0 [symbolic = %AA.patt.loc6_8.2 (constants.%AA.patt)]
-// CHECK:STDOUT:   %AA.loc6_8.1: %A_where.type = symbolic_binding AA, 0 [symbolic = %AA.loc6_8.1 (constants.%AA)]
-// CHECK:STDOUT:   %AA.as_type.loc6_33.1: type = facet_access_type %AA.loc6_8.1 [symbolic = %AA.as_type.loc6_33.1 (constants.%AA.as_type)]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:
-// CHECK:STDOUT:   fn() -> out %return.param: %empty_tuple.type {
-// CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %.loc7_11.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:     %.loc7_11.2: init %empty_tuple.type = tuple_init () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:     %.loc7_12: init %empty_tuple.type = converted %.loc7_11.1, %.loc7_11.2 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:     return %.loc7_12
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @A.WithSelf(constants.%Self) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @A.WithSelf(constants.%.Self.dad) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @A.WithSelf(constants.%AA) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @A.WithSelf(constants.%A.facet) {
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(constants.%AA) {
-// CHECK:STDOUT:   %AA.patt.loc6_8.2 => constants.%AA.patt
-// CHECK:STDOUT:   %AA.loc6_8.1 => constants.%AA
-// CHECK:STDOUT:   %AA.as_type.loc6_33.1 => constants.%AA.as_type
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: --- access_constant_in_self_facet_with_multiple_interfaces.carbon
-// CHECK:STDOUT:
-// CHECK:STDOUT: constants {
-// CHECK:STDOUT:   %A.type: type = facet_type <@A> [concrete]
-// CHECK:STDOUT:   %A.assoc_type: type = assoc_entity_type @A [concrete]
-// CHECK:STDOUT:   %assoc0.11e: %A.assoc_type = assoc_entity element0, @A.WithSelf.%X [concrete]
-// CHECK:STDOUT:   %B.type: type = facet_type <@B> [concrete]
-// CHECK:STDOUT:   %B.assoc_type: type = assoc_entity_type @B [concrete]
-// CHECK:STDOUT:   %assoc0.ee3: %B.assoc_type = assoc_entity element0, @B.WithSelf.%Y [concrete]
-// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
-// CHECK:STDOUT:   %.Self.c39: %type = symbolic_binding .Self [symbolic_self]
-// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
-// CHECK:STDOUT:   %BitAndWith.type.802: type = facet_type <@BitAndWith, @BitAndWith(type)> [concrete]
-// CHECK:STDOUT:   %BitAndWith.impl_witness: <witness> = impl_witness imports.%BitAndWith.impl_witness_table [concrete]
-// CHECK:STDOUT:   %BitAndWith.facet: %BitAndWith.type.802 = facet_value type, (%BitAndWith.impl_witness) [concrete]
-// CHECK:STDOUT:   %BitAndWith.WithSelf.Op.type.38f: type = fn_type @BitAndWith.WithSelf.Op, @BitAndWith.WithSelf(type, %BitAndWith.facet) [concrete]
-// CHECK:STDOUT:   %.d56: type = fn_type_with_self_type %BitAndWith.WithSelf.Op.type.38f, %BitAndWith.facet [concrete]
-// CHECK:STDOUT:   %type.as.BitAndWith.impl.Op.type: type = fn_type @type.as.BitAndWith.impl.Op [concrete]
-// CHECK:STDOUT:   %type.as.BitAndWith.impl.Op: %type.as.BitAndWith.impl.Op.type = struct_value () [concrete]
-// CHECK:STDOUT:   %type.as.BitAndWith.impl.Op.bound: <bound method> = bound_method %A.type, %type.as.BitAndWith.impl.Op [concrete]
-// CHECK:STDOUT:   %facet_type.678: type = facet_type <@A & @B> [concrete]
-// CHECK:STDOUT:   %.Self.8e5: %facet_type.678 = symbolic_binding .Self [symbolic_self]
-// CHECK:STDOUT:   %.Self.as_type: type = facet_access_type %.Self.8e5 [symbolic_self]
-// CHECK:STDOUT:   %A.lookup_impl_witness.b90: <witness> = lookup_impl_witness %.Self.8e5, @A [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0.bfe: type = impl_witness_access %A.lookup_impl_witness.b90, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
-// CHECK:STDOUT:   %B.lookup_impl_witness.3ef: <witness> = lookup_impl_witness %.Self.8e5, @B [symbolic_self]
-// CHECK:STDOUT:   %impl.elem0.3d7: type = impl_witness_access %B.lookup_impl_witness.3ef, element0 [symbolic_self]
-// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
-// CHECK:STDOUT:   %empty_struct: %empty_struct_type = struct_value () [concrete]
-// CHECK:STDOUT:   %facet_type.121: type = facet_type <@A & @B where %impl.elem0.bfe = %empty_tuple.type and %impl.elem0.3d7 = %empty_struct_type> [concrete]
-// CHECK:STDOUT:   %pattern_type.a40: type = pattern_type %facet_type.121 [concrete]
-// CHECK:STDOUT:   %AB.patt: %pattern_type.a40 = symbolic_binding_pattern AB, 0 [symbolic]
-// CHECK:STDOUT:   %AB: %facet_type.121 = symbolic_binding AB, 0 [symbolic]
-// CHECK:STDOUT:   %AB.as_type: type = facet_access_type %AB [symbolic]
-// CHECK:STDOUT:   %A.lookup_impl_witness.ed2: <witness> = lookup_impl_witness %AB, @A [symbolic]
-// CHECK:STDOUT:   %.262: Core.Form = init_form %empty_tuple.type [concrete]
-// CHECK:STDOUT:   %pattern_type.cb1: type = pattern_type %empty_tuple.type [concrete]
-// CHECK:STDOUT:   %return.param_patt.900: %pattern_type.cb1 = out_param_pattern [concrete]
-// CHECK:STDOUT:   %return.patt.427: %pattern_type.cb1 = return_slot_pattern %return.param_patt.900, %empty_tuple.type [concrete]
-// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
-// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
-// CHECK:STDOUT:   %B.lookup_impl_witness.77c: <witness> = lookup_impl_witness %AB, @B [symbolic]
-// CHECK:STDOUT:   %.469: Core.Form = init_form %empty_struct_type [concrete]
-// CHECK:STDOUT:   %pattern_type.a96: type = pattern_type %empty_struct_type [concrete]
-// CHECK:STDOUT:   %return.param_patt.296: %pattern_type.a96 = out_param_pattern [concrete]
-// CHECK:STDOUT:   %return.patt.c45: %pattern_type.a96 = return_slot_pattern %return.param_patt.296, %empty_struct_type [concrete]
-// CHECK:STDOUT:   %G.type: type = fn_type @G [concrete]
-// CHECK:STDOUT:   %G: %G.type = struct_value () [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: imports {
-// CHECK:STDOUT:   %Core.import_ref.9c3: %type.as.BitAndWith.impl.Op.type = import_ref Core//prelude/parts/as, loc{{\d+_\d+}}, loaded [concrete = constants.%type.as.BitAndWith.impl.Op]
-// CHECK:STDOUT:   %BitAndWith.impl_witness_table = impl_witness_table (%Core.import_ref.9c3), @type.as.BitAndWith.impl [concrete]
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: file {
-// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %AB.patt.loc14_8.1: %pattern_type.a40 = symbolic_binding_pattern AB, 0 [symbolic = %AB.patt.loc14_8.2 (constants.%AB.patt)]
-// CHECK:STDOUT:     %return.param_patt: %pattern_type.cb1 = out_param_pattern [concrete = constants.%return.param_patt.900]
-// CHECK:STDOUT:     %return.patt: %pattern_type.cb1 = return_slot_pattern %return.param_patt, %impl.elem0.loc14_49 [concrete = constants.%return.patt.427]
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %AB.ref: %facet_type.121 = name_ref AB, %AB.loc14_8.2 [symbolic = %AB.loc14_8.1 (constants.%AB)]
-// CHECK:STDOUT:     %AB.as_type.loc14_49.2: type = facet_access_type %AB.ref [symbolic = %AB.as_type.loc14_49.1 (constants.%AB.as_type)]
-// CHECK:STDOUT:     %.loc14_49.1: type = converted %AB.ref, %AB.as_type.loc14_49.2 [symbolic = %AB.as_type.loc14_49.1 (constants.%AB.as_type)]
-// CHECK:STDOUT:     %X.ref.loc14_49: %A.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0.11e]
-// CHECK:STDOUT:     %impl.elem0.loc14_49: type = impl_witness_access constants.%A.lookup_impl_witness.ed2, element0 [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:     %.loc14_49.2: Core.Form = init_form %impl.elem0.loc14_49 [concrete = constants.%.262]
-// CHECK:STDOUT:     %.loc14_17.1: type = splice_block %.loc14_17.2 [concrete = constants.%facet_type.121] {
-// CHECK:STDOUT:       %.Self.loc14_8: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
-// CHECK:STDOUT:       %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
-// CHECK:STDOUT:       %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B.type]
-// CHECK:STDOUT:       %impl.elem0.loc14_13: %.d56 = impl_witness_access constants.%BitAndWith.impl_witness, element0 [concrete = constants.%type.as.BitAndWith.impl.Op]
-// CHECK:STDOUT:       %bound_method: <bound method> = bound_method %A.ref, %impl.elem0.loc14_13 [concrete = constants.%type.as.BitAndWith.impl.Op.bound]
-// CHECK:STDOUT:       %type.as.BitAndWith.impl.Op.call: init type = call %bound_method(%A.ref, %B.ref) [concrete = constants.%facet_type.678]
-// CHECK:STDOUT:       %.loc14_13.1: type = value_of_initializer %type.as.BitAndWith.impl.Op.call [concrete = constants.%facet_type.678]
-// CHECK:STDOUT:       %.loc14_13.2: type = converted %type.as.BitAndWith.impl.Op.call, %.loc14_13.1 [concrete = constants.%facet_type.678]
-// CHECK:STDOUT:       %.Self.loc14_17: %facet_type.678 = symbolic_binding .Self [symbolic_self = constants.%.Self.8e5]
-// CHECK:STDOUT:       %.Self.ref.loc14_23: %facet_type.678 = name_ref .Self, %.Self.loc14_17 [symbolic_self = constants.%.Self.8e5]
-// CHECK:STDOUT:       %.Self.as_type.loc14_23: type = facet_access_type %.Self.ref.loc14_23 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc14_23: type = converted %.Self.ref.loc14_23, %.Self.as_type.loc14_23 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %X.ref.loc14_23: %A.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0.11e]
-// CHECK:STDOUT:       %impl.elem0.loc14_23: type = impl_witness_access constants.%A.lookup_impl_witness.b90, element0 [symbolic_self = constants.%impl.elem0.bfe]
-// CHECK:STDOUT:       %.loc14_29.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:       %.loc14_29.2: type = converted %.loc14_29.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:       %.Self.ref.loc14_35: %facet_type.678 = name_ref .Self, %.Self.loc14_17 [symbolic_self = constants.%.Self.8e5]
-// CHECK:STDOUT:       %.Self.as_type.loc14_35: type = facet_access_type %.Self.ref.loc14_35 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc14_35: type = converted %.Self.ref.loc14_35, %.Self.as_type.loc14_35 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %Y.ref: %B.assoc_type = name_ref Y, @Y.%assoc0 [concrete = constants.%assoc0.ee3]
-// CHECK:STDOUT:       %impl.elem0.loc14_35: type = impl_witness_access constants.%B.lookup_impl_witness.3ef, element0 [symbolic_self = constants.%impl.elem0.3d7]
-// CHECK:STDOUT:       %.loc14_41.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:       %.loc14_41.2: type = converted %.loc14_41.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:       %.loc14_17.2: type = where_expr [concrete = constants.%facet_type.121] {
-// CHECK:STDOUT:         requirement_base_facet_type %type.as.BitAndWith.impl.Op.call
-// CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc14_23, %.loc14_29.2
-// CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc14_35, %.loc14_41.2
-// CHECK:STDOUT:       }
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %AB.loc14_8.2: %facet_type.121 = symbolic_binding AB, 0 [symbolic = %AB.loc14_8.1 (constants.%AB)]
-// CHECK:STDOUT:     %return.param: ref %empty_tuple.type = out_param call_param0
-// CHECK:STDOUT:     %return: ref %empty_tuple.type = return_slot %return.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {
-// CHECK:STDOUT:     %AB.patt.loc18_8.1: %pattern_type.a40 = symbolic_binding_pattern AB, 0 [symbolic = %AB.patt.loc18_8.2 (constants.%AB.patt)]
-// CHECK:STDOUT:     %return.param_patt: %pattern_type.a96 = out_param_pattern [concrete = constants.%return.param_patt.296]
-// CHECK:STDOUT:     %return.patt: %pattern_type.a96 = return_slot_pattern %return.param_patt, %impl.elem0.loc18_49 [concrete = constants.%return.patt.c45]
-// CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %AB.ref: %facet_type.121 = name_ref AB, %AB.loc18_8.2 [symbolic = %AB.loc18_8.1 (constants.%AB)]
-// CHECK:STDOUT:     %AB.as_type.loc18_49.2: type = facet_access_type %AB.ref [symbolic = %AB.as_type.loc18_49.1 (constants.%AB.as_type)]
-// CHECK:STDOUT:     %.loc18_49.1: type = converted %AB.ref, %AB.as_type.loc18_49.2 [symbolic = %AB.as_type.loc18_49.1 (constants.%AB.as_type)]
-// CHECK:STDOUT:     %Y.ref.loc18_49: %B.assoc_type = name_ref Y, @Y.%assoc0 [concrete = constants.%assoc0.ee3]
-// CHECK:STDOUT:     %impl.elem0.loc18_49: type = impl_witness_access constants.%B.lookup_impl_witness.77c, element0 [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:     %.loc18_49.2: Core.Form = init_form %impl.elem0.loc18_49 [concrete = constants.%.469]
-// CHECK:STDOUT:     %.loc18_17.1: type = splice_block %.loc18_17.2 [concrete = constants.%facet_type.121] {
-// CHECK:STDOUT:       %.Self.loc18_8: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
-// CHECK:STDOUT:       %A.ref: type = name_ref A, file.%A.decl [concrete = constants.%A.type]
-// CHECK:STDOUT:       %B.ref: type = name_ref B, file.%B.decl [concrete = constants.%B.type]
-// CHECK:STDOUT:       %impl.elem0.loc18_13: %.d56 = impl_witness_access constants.%BitAndWith.impl_witness, element0 [concrete = constants.%type.as.BitAndWith.impl.Op]
-// CHECK:STDOUT:       %bound_method: <bound method> = bound_method %A.ref, %impl.elem0.loc18_13 [concrete = constants.%type.as.BitAndWith.impl.Op.bound]
-// CHECK:STDOUT:       %type.as.BitAndWith.impl.Op.call: init type = call %bound_method(%A.ref, %B.ref) [concrete = constants.%facet_type.678]
-// CHECK:STDOUT:       %.loc18_13.1: type = value_of_initializer %type.as.BitAndWith.impl.Op.call [concrete = constants.%facet_type.678]
-// CHECK:STDOUT:       %.loc18_13.2: type = converted %type.as.BitAndWith.impl.Op.call, %.loc18_13.1 [concrete = constants.%facet_type.678]
-// CHECK:STDOUT:       %.Self.loc18_17: %facet_type.678 = symbolic_binding .Self [symbolic_self = constants.%.Self.8e5]
-// CHECK:STDOUT:       %.Self.ref.loc18_23: %facet_type.678 = name_ref .Self, %.Self.loc18_17 [symbolic_self = constants.%.Self.8e5]
-// CHECK:STDOUT:       %.Self.as_type.loc18_23: type = facet_access_type %.Self.ref.loc18_23 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc18_23: type = converted %.Self.ref.loc18_23, %.Self.as_type.loc18_23 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %X.ref: %A.assoc_type = name_ref X, @X.%assoc0 [concrete = constants.%assoc0.11e]
-// CHECK:STDOUT:       %impl.elem0.loc18_23: type = impl_witness_access constants.%A.lookup_impl_witness.b90, element0 [symbolic_self = constants.%impl.elem0.bfe]
-// CHECK:STDOUT:       %.loc18_29.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:       %.loc18_29.2: type = converted %.loc18_29.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:       %.Self.ref.loc18_35: %facet_type.678 = name_ref .Self, %.Self.loc18_17 [symbolic_self = constants.%.Self.8e5]
-// CHECK:STDOUT:       %.Self.as_type.loc18_35: type = facet_access_type %.Self.ref.loc18_35 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %.loc18_35: type = converted %.Self.ref.loc18_35, %.Self.as_type.loc18_35 [symbolic_self = constants.%.Self.as_type]
-// CHECK:STDOUT:       %Y.ref.loc18_35: %B.assoc_type = name_ref Y, @Y.%assoc0 [concrete = constants.%assoc0.ee3]
-// CHECK:STDOUT:       %impl.elem0.loc18_35: type = impl_witness_access constants.%B.lookup_impl_witness.3ef, element0 [symbolic_self = constants.%impl.elem0.3d7]
-// CHECK:STDOUT:       %.loc18_41.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:       %.loc18_41.2: type = converted %.loc18_41.1, constants.%empty_struct_type [concrete = constants.%empty_struct_type]
-// CHECK:STDOUT:       %.loc18_17.2: type = where_expr [concrete = constants.%facet_type.121] {
-// CHECK:STDOUT:         requirement_base_facet_type %type.as.BitAndWith.impl.Op.call
-// CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc18_23, %.loc18_29.2
-// CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc18_35, %.loc18_41.2
-// CHECK:STDOUT:       }
-// CHECK:STDOUT:     }
-// CHECK:STDOUT:     %AB.loc18_8.2: %facet_type.121 = symbolic_binding AB, 0 [symbolic = %AB.loc18_8.1 (constants.%AB)]
-// CHECK:STDOUT:     %return.param: ref %empty_struct_type = out_param call_param0
-// CHECK:STDOUT:     %return: ref %empty_struct_type = return_slot %return.param
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%AB.loc14_8.2: %facet_type.121) {
-// CHECK:STDOUT:   %AB.patt.loc14_8.2: %pattern_type.a40 = symbolic_binding_pattern AB, 0 [symbolic = %AB.patt.loc14_8.2 (constants.%AB.patt)]
-// CHECK:STDOUT:   %AB.loc14_8.1: %facet_type.121 = symbolic_binding AB, 0 [symbolic = %AB.loc14_8.1 (constants.%AB)]
-// CHECK:STDOUT:   %AB.as_type.loc14_49.1: type = facet_access_type %AB.loc14_8.1 [symbolic = %AB.as_type.loc14_49.1 (constants.%AB.as_type)]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:
-// CHECK:STDOUT:   fn() -> out %return.param: %empty_tuple.type {
-// CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %.loc15_11.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:     %.loc15_11.2: init %empty_tuple.type = tuple_init () [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:     %.loc15_12: init %empty_tuple.type = converted %.loc15_11.1, %.loc15_11.2 [concrete = constants.%empty_tuple]
-// CHECK:STDOUT:     return %.loc15_12
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @G(%AB.loc18_8.2: %facet_type.121) {
-// CHECK:STDOUT:   %AB.patt.loc18_8.2: %pattern_type.a40 = symbolic_binding_pattern AB, 0 [symbolic = %AB.patt.loc18_8.2 (constants.%AB.patt)]
-// CHECK:STDOUT:   %AB.loc18_8.1: %facet_type.121 = symbolic_binding AB, 0 [symbolic = %AB.loc18_8.1 (constants.%AB)]
-// CHECK:STDOUT:   %AB.as_type.loc18_49.1: type = facet_access_type %AB.loc18_8.1 [symbolic = %AB.as_type.loc18_49.1 (constants.%AB.as_type)]
-// CHECK:STDOUT:
-// CHECK:STDOUT: !definition:
-// CHECK:STDOUT:
-// CHECK:STDOUT:   fn() -> out %return.param: %empty_struct_type {
-// CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %.loc19_11.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:     %.loc19_11.2: init %empty_struct_type = struct_init () [concrete = constants.%empty_struct]
-// CHECK:STDOUT:     %.loc19_12: init %empty_struct_type = converted %.loc19_11.1, %.loc19_11.2 [concrete = constants.%empty_struct]
-// CHECK:STDOUT:     return %.loc19_12
-// CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(constants.%AB) {
-// CHECK:STDOUT:   %AB.patt.loc14_8.2 => constants.%AB.patt
-// CHECK:STDOUT:   %AB.loc14_8.1 => constants.%AB
-// CHECK:STDOUT:   %AB.as_type.loc14_49.1 => constants.%AB.as_type
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: specific @G(constants.%AB) {
-// CHECK:STDOUT:   %AB.patt.loc18_8.2 => constants.%AB.patt
-// CHECK:STDOUT:   %AB.loc18_8.1 => constants.%AB
-// CHECK:STDOUT:   %AB.as_type.loc18_49.1 => constants.%AB.as_type
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/facet/access.carbon
+++ b/toolchain/check/testdata/facet/access.carbon
@@ -424,7 +424,7 @@ fn F(U:! W, V:! Z(.Self) where .Z0 impls (Y where .Y1 impls (X where .X1 = ()))
   V.(Z(V).Z1).(Y.Y1).(X.X1) as W;
 }
 
- // --- fail_todo_find_access_value_in_facet_from_specific_interface.carbon
+// --- fail_todo_find_access_value_in_facet_from_specific_interface.carbon
 library "[[@TEST_NAME]]";
 
 interface Z {}

--- a/toolchain/check/testdata/facet/validate_rewrite_constraints.carbon
+++ b/toolchain/check/testdata/facet/validate_rewrite_constraints.carbon
@@ -1434,3 +1434,64 @@ fn G(_:! Z where .Z2 = ()) {}
 fn F(T:! (Z where .Z1 impls (Y where .Y1 = ())) & (Z where .Z2 = .Z1.Y1)) {
   G(T);
 }
+
+// --- rewrite_in_impls_provided_by_facet_type.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+
+fn F(_:! type where .Self impls (Z where .Z1 = {})) {}
+
+fn G(T:! Z where .Z1 = {}) {
+  F(T);
+}
+
+// --- fail_todo_rewrite_in_impls_provided_by_extend_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+
+fn F(_:! type where .Self impls (Z where .Z1 = {})) {}
+
+constraint N {
+  extend require impls Z where .Z1 = {};
+}
+
+fn G(T:! N) {
+  // CHECK:STDERR: fail_todo_rewrite_in_impls_provided_by_extend_named_constraint.carbon:[[@LINE+7]]:3: error: cannot convert type `T` that implements `N` into type implementing `type where .Self impls Z and .(Z.Z1) = {}` [ConversionFailureFacetToFacet]
+  // CHECK:STDERR:   F(T);
+  // CHECK:STDERR:   ^~~~
+  // CHECK:STDERR: fail_todo_rewrite_in_impls_provided_by_extend_named_constraint.carbon:[[@LINE-10]]:6: note: initializing generic parameter `_` declared here [InitializingGenericParam]
+  // CHECK:STDERR: fn F(_:! type where .Self impls (Z where .Z1 = {})) {}
+  // CHECK:STDERR:      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  F(T);
+}
+
+// --- fail_todo_rewrite_in_impls_provided_by_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  let Z1:! type;
+}
+
+fn F(_:! type where .Self impls (Z where .Z1 = {})) {}
+
+constraint N {
+  require impls Z where .Z1 = {};
+}
+
+fn G(T:! N) {
+  // CHECK:STDERR: fail_todo_rewrite_in_impls_provided_by_named_constraint.carbon:[[@LINE+7]]:3: error: cannot convert type `T` that implements `N` into type implementing `type where .Self impls Z and .(Z.Z1) = {}` [ConversionFailureFacetToFacet]
+  // CHECK:STDERR:   F(T);
+  // CHECK:STDERR:   ^~~~
+  // CHECK:STDERR: fail_todo_rewrite_in_impls_provided_by_named_constraint.carbon:[[@LINE-10]]:6: note: initializing generic parameter `_` declared here [InitializingGenericParam]
+  // CHECK:STDERR: fn F(_:! type where .Self impls (Z where .Z1 = {})) {}
+  // CHECK:STDERR:      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  F(T);
+}


### PR DESCRIPTION
When a facet type contains a rewrite constraint like `.(J.J1).(I.I1)` the ImplWitnessAccess should only use its RHS value if it's trying to find `.(J.J1).(I.I1)`. It can't just look at the `.(I.I1)` part or it may grab the RHS for a similar `.(K.K2).(I.I1)` rewrite.

While it's not possible to write a nested access on the LHS of a rewrite constraint like `.(J.J1).(I.I1)`, it is possible to construct a facet type that ends up with that as its rewrite using nested facet types:
```carbon
T:! J where .J1 impls (I where .I1 = ())
```

The access `T.(J.J1).(I.I1)` should evaluate to `()`. The ImplWitnessAccess evaluation starts by looking for a rewrite of `.(I.I1)` in the type of the access self, which is `T.(J.J1)`. Then it looks for `.(I.I1)` in the type of that access self, which is `T`. At that point it finds the rewrite of `.(J.J1).(I.I1) = ()` and can use the `()`. However it can also find other rewrites that end in `.(I.I1)`.

To do this correctly, when moving through an ImplWitnessAccess to the next nested access self, we record the access (interface, element) pair that we are looking through. And then we require the rewrite constraint to be prefixed by all of the (interface, element) pairs that we have recorded.