### PR TITLE
Require all constraints in `where` to have a designator

### DIFF
--- a/docs/design/generics/details.md
+++ b/docs/design/generics/details.md
@@ -3520,8 +3520,8 @@ fn Contains_SameType_Equivalent
 
 ### Constraints must use a designator
 
-We don't allow a `where` constraint unless it applies a restriction to the
-current type. This means referring to some
+We don't allow a constraint in a `where` clause unless it applies a restriction
+to the current type. This means referring to some
 [designator](#kinds-of-where-constraints), like `.MemberName`, or
 [`.Self`](#recursive-constraints). Examples:
 
@@ -3558,6 +3558,37 @@ impl forall [T:! B] T as A {}
 This clarifies the meaning of the `where` clause and reduces the number of
 redundant ways to express a restriction, following the
 [one-way principle](/docs/project/principles/one_way.md).
+
+Note that multiple constraints can be combined in a single `where` expression,
+but this does not change their meaning. Likewise, each constraint in a `where`
+clause must contain a designator.
+
+```carbon
+// ✅ Allowed
+fn F(T:! type where C(.Self) impls (A & B));
+// Which is the same as:
+fn F(T:! (type where C(.Self) impls A) and (type where C(.Self) impls B));
+
+// ✅ Allowed
+fn F(T:! type where C impls (A(.Self) & B(.Self)));
+// Which is the same as:
+fn F(T:! (type where C impls A(.Self)) and (type where C impls B(.Self)));
+
+// ❌ Error: `where C impls A` does not use `.Self` or a designator
+fn F(T:! type where C impls (A & B(.Self)));
+// Which is the same as:
+fn F(T:! (type where C impls A) & (type where C impls B(.Self)));
+
+// ✅ Allowed
+fn F(T:! type where C impls A(.Self) and X == .Self);
+// Which is the same as:
+fn F(T:! (type where C impls A(.Self)) & (type where X == .Self));
+
+// ❌ Error: `where X == Y` does not use `.Self` or a designator
+fn F(T:! type where C impls A(.Self) and X == Y);
+// Which is the same as:
+fn F(T:! (type where C impls A(.Self)) & (type where X == Y));
+```
 
 **Alternative considered:** This rule was added in proposal
 [#2376](https://github.com/carbon-language/carbon-lang/pull/2376), which

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -120,10 +120,76 @@ auto HandleParseNode(Context& context, Parse::WhereOperandId node_id) -> bool {
   return true;
 }
 
+// Returns whether a designator (`.Self` or `.MemberName`) is present in
+// `inst_id`.
+static auto FindDesignator(Context& context, SemIR::ConstantId const_id)
+    -> bool {
+  class SubstFindDesignator : public SubstInstCallbacks {
+   public:
+    explicit SubstFindDesignator(Context* context, bool* found)
+        : SubstInstCallbacks(context), found_(found) {}
+
+    auto Subst(SemIR::InstId& inst_id) -> SubstResult override {
+      if (*found_) {
+        return FullySubstituted;
+      }
+
+      // An error was diagnosed for the where clause already.
+      if (inst_id == SemIR::ErrorInst::InstId) {
+        *found_ = true;
+        return FullySubstituted;
+      }
+
+      // TypeType has type TypeType, avoid recursing on its type.
+      if (context().insts().Is<SemIR::TypeType>(inst_id)) {
+        return FullySubstituted;
+      }
+
+      // `.MemberName` is represented as an ImplWitnessAccess through `.Self` so
+      // we only need to look for `.Self` here.
+      if (IsPeriodSelf(context(), inst_id)) {
+        *found_ = true;
+        return FullySubstituted;
+      }
+
+      return SubstOperands;
+    }
+
+    auto Rebuild(SemIR::InstId /*orig_inst_id*/, SemIR::Inst /*new_inst*/)
+        -> SemIR::InstId override {
+      CARBON_FATAL("unexpected rebuild, no insts should change");
+    }
+
+    bool* found_;
+  };
+
+  // A facet type may contain designators but they do not constrain this where
+  // clause's type.
+  if (context.constant_values().InstIs<SemIR::FacetType>(const_id)) {
+    return false;
+  }
+
+  bool found = false;
+  SubstFindDesignator callbacks(&context, &found);
+  SubstInst(context, context.constant_values().GetInstId(const_id), callbacks);
+  return found;
+}
+
+static auto DiagnoseMissingDesignator(Context& context, SemIR::LocId loc_id)
+    -> void {
+  CARBON_DIAGNOSTIC(WhereWithoutDesignator, Error,
+                    "constraint in `where` clause without a designator; "
+                    "expected `.Self` or a member access like `.M`");
+  context.emitter().Emit(loc_id, WhereWithoutDesignator);
+}
+
 auto HandleParseNode(Context& context, Parse::RequirementEqualId node_id)
     -> bool {
   auto [rhs_node, rhs_id] = context.node_stack().PopExprWithNodeId();
   auto lhs_id = context.node_stack().PopExpr();
+
+  // Rewrites always contain a designator since the LHS must be one. This is
+  // checked elsewhere.
 
   // Convert rhs to type of lhs.
   auto lhs_type_id = context.insts().Get(lhs_id).type_id();
@@ -164,7 +230,17 @@ auto HandleParseNode(Context& context, Parse::RequirementEqualEqualId node_id)
   auto rhs = context.node_stack().PopExpr();
   auto lhs = context.node_stack().PopExpr();
   // TODO: Type check lhs and rhs are comparable.
-  // TODO: Require that at least one side uses a designator.
+
+  auto const_lhs = context.constant_values().Get(lhs);
+  auto const_rhs = context.constant_values().Get(rhs);
+  if (!FindDesignator(context, const_lhs) &&
+      !FindDesignator(context, const_rhs)) {
+    if (const_lhs != SemIR::ErrorInst::ConstantId &&
+        const_rhs != SemIR::ErrorInst::ConstantId) {
+      DiagnoseMissingDesignator(context, node_id);
+    }
+    lhs = rhs = SemIR::ErrorInst::InstId;
+  }
 
   // Build up the list of arguments for the `WhereExpr` inst.
   context.args_type_info_stack().AddInstId(
@@ -203,6 +279,50 @@ auto HandleParseNode(Context& context, Parse::RequirementImplsId node_id)
     -> bool {
   auto [rhs_node, rhs_id] = context.node_stack().PopExprWithNodeId();
   auto [lhs_node, lhs_id] = context.node_stack().PopExprWithNodeId();
+
+  auto const_lhs = context.constant_values().Get(lhs_id);
+  auto const_rhs = context.constant_values().Get(rhs_id);
+  if (!FindDesignator(context, const_lhs)) {
+    // The RHS of an `impls` may be another `where`. We require a designator to
+    // be present in each constraint created from the LHS of that `where`, which
+    // equates to requiring a designator in each extend constraint of the facet
+    // type.
+    //
+    // If a designator is part of the LHS of the `impls` or the LHS of the inner
+    // `where`, then that implies all constraints nested within the `where`
+    // clause will constrain the top level type in some way.
+    if (auto facet_type =
+            context.constant_values().TryGetInstAs<SemIR::FacetType>(
+                const_rhs)) {
+      const auto& info = context.facet_types().Get(facet_type->facet_type_id);
+      for (auto extend : llvm::concat<SemIR::SpecificId>(
+               llvm::map_range(
+                   info.extend_constraints,
+                   [](SemIR::SpecificInterface i) { return i.specific_id; }),
+               llvm::map_range(info.extend_named_constraints,
+                               [](SemIR::SpecificNamedConstraint c) {
+                                 return c.specific_id;
+                               }))) {
+        bool found_designator = false;
+        for (auto inst_id : context.inst_blocks().Get(
+                 context.specifics().GetArgsOrEmpty(extend))) {
+          if (FindDesignator(context, context.constant_values().Get(inst_id))) {
+            found_designator = true;
+            break;
+          }
+        }
+        if (!found_designator) {
+          if (const_lhs != SemIR::ErrorInst::ConstantId &&
+              const_rhs != SemIR::ErrorInst::ConstantId) {
+            DiagnoseMissingDesignator(context, node_id);
+          }
+          lhs_id = rhs_id = SemIR::ErrorInst::InstId;
+          const_lhs = const_rhs = SemIR::ErrorInst::ConstantId;
+          break;
+        }
+      }
+    }
+  }
 
   // Check lhs is a facet and rhs is a facet type.
   auto lhs_as_type = ExprAsType(context, lhs_node, lhs_id);
@@ -268,149 +388,6 @@ auto HandleParseNode(Context& /*context*/, Parse::RequirementAndId /*node_id*/)
   return true;
 }
 
-// Returns whether a designator (`.Self` or `.MemberName`) is present in the
-// where clause.
-static auto FindDesignator(Context& context,
-                           SemIR::InstBlockId requirements_block_id) -> bool {
-  llvm::SmallVector<SemIR::InstId> requirements;
-
-  struct WorkItem {
-    SemIR::InstBlockId requirements_block_id;
-    bool search_rhs;
-  };
-  llvm::SmallVector<WorkItem> work = {{requirements_block_id, true}};
-
-  while (!work.empty()) {
-    auto item = work.pop_back_val();
-    auto block = context.inst_blocks().GetOrEmpty(item.requirements_block_id);
-    if (item.search_rhs) {
-      requirements.reserve(block.size() * 2);
-    }
-
-    for (auto inst_id : block) {
-      auto inst = context.insts().Get(inst_id);
-      CARBON_KIND_SWITCH(inst) {
-        case CARBON_KIND(SemIR::RequirementBaseFacetType base): {
-          requirements.push_back(base.base_type_inst_id);
-          break;
-        }
-        case CARBON_KIND(SemIR::RequirementRewrite rewrite): {
-          if (item.search_rhs) {
-            requirements.push_back(rewrite.lhs_id);
-            // The LHS of a rewrite currently always constrains the current
-            // type, so looking in the RHS is redundant.
-            //
-            // Regardless, if the RHS is a facet type, designators inside it
-            // don't constrain the current type, so we don't recurse into it.
-            auto const_rhs_id =
-                context.constant_values().GetConstantInstId(rewrite.rhs_id);
-            if (const_rhs_id.has_value() &&
-                !context.insts().Is<SemIR::FacetType>(const_rhs_id)) {
-              requirements.push_back(rewrite.rhs_id);
-            }
-          }
-          break;
-        }
-        case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
-          if (item.search_rhs) {
-            // If the instruction is a facet type, designators inside it don't
-            // constrain the current type, so we don't recurse into it.
-            auto const_lhs_id =
-                context.constant_values().GetConstantInstId(equiv.rhs_id);
-            if (const_lhs_id.has_value() &&
-                !context.insts().Is<SemIR::FacetType>(const_lhs_id)) {
-              requirements.push_back(equiv.lhs_id);
-            }
-            // If the instruction is a facet type, designators inside it don't
-            // constrain the current type, so we don't recurse into it.
-            auto const_rhs_id =
-                context.constant_values().GetConstantInstId(equiv.rhs_id);
-            if (const_rhs_id.has_value() &&
-                !context.insts().Is<SemIR::FacetType>(const_rhs_id)) {
-              requirements.push_back(equiv.rhs_id);
-            }
-          }
-          break;
-        }
-        case CARBON_KIND(SemIR::RequirementImpls impls): {
-          if (item.search_rhs) {
-            requirements.push_back(impls.lhs_id);
-
-            CARBON_KIND_SWITCH(context.insts().Get(impls.rhs_id)) {
-                // If the RHS of the `impls` contains a `where`, then it will be
-                // a WhereExpr instruction. We require a designator to be part
-                // of the constraint on the LHS of the nested `where`, so we
-                // won't search the RHS of a nested `where`.
-              case CARBON_KIND(SemIR::WhereExpr rhs_where_expr): {
-                work.push_back({rhs_where_expr.requirements_id, false});
-                break;
-              }
-                // Otherwise, it's a facet type without a `where`, so we will
-                // search that for a designator.
-              default:
-                requirements.push_back(impls.rhs_id);
-                break;
-            }
-          }
-          break;
-        }
-        default:
-          CARBON_CHECK(inst_id == SemIR::ErrorInst::InstId,
-                       "unexpected inst {0} in requirements", inst);
-      }
-    }
-  }
-
-  class SubstFindDesignator : public SubstInstCallbacks {
-   public:
-    explicit SubstFindDesignator(Context* context, bool* found)
-        : SubstInstCallbacks(context), found_(found) {}
-
-    auto Subst(SemIR::InstId& inst_id) -> SubstResult override {
-      if (*found_) {
-        return FullySubstituted;
-      }
-
-      // An error was diagnosed for the where clause already.
-      if (inst_id == SemIR::ErrorInst::InstId) {
-        *found_ = true;
-        return FullySubstituted;
-      }
-
-      // TypeType has type TypeType, avoid recursing on its type.
-      if (context().insts().Is<SemIR::TypeType>(inst_id)) {
-        return FullySubstituted;
-      }
-
-      // `.MemberName` is represented as an ImplWitnessAccess through `.Self` so
-      // we only need to look for `.Self` here.
-      if (IsPeriodSelf(context(), inst_id)) {
-        *found_ = true;
-        return FullySubstituted;
-      }
-
-      return SubstOperands;
-    }
-
-    auto Rebuild(SemIR::InstId /*orig_inst_id*/, SemIR::Inst /*new_inst*/)
-        -> SemIR::InstId override {
-      CARBON_FATAL("unexpected rebuild, no insts should change");
-    }
-
-    bool* found_;
-  };
-
-  for (auto inst_id : requirements) {
-    bool found = false;
-    SubstFindDesignator callbacks(&context, &found);
-    SubstInst(context, inst_id, callbacks);
-    if (found) {
-      return true;
-    }
-  }
-  return false;
-}
-
 auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
   context.where_stack().pop_back();
   // Remove `PeriodSelf` from name lookup, undoing the `Push` done for the
@@ -418,20 +395,9 @@ auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
   context.scope_stack().Pop(/*check_unused=*/true);
   SemIR::InstBlockId requirements_id = context.args_type_info_stack().Pop();
 
-  auto type_id = SemIR::TypeType::TypeId;
-  if (!FindDesignator(context, requirements_id)) {
-    CARBON_DIAGNOSTIC(
-        WhereWithoutDesignator, Error,
-        "`where` clause without a designator that constrains the current type; "
-        "did not find `.Self` or a member access like `.M` that refers to the "
-        "current type");
-    context.emitter().Emit(node_id, WhereWithoutDesignator);
-    type_id = SemIR::ErrorInst::TypeId;
-  }
-
   AddInstAndPush<SemIR::WhereExpr>(
       context, node_id,
-      {.type_id = type_id, .requirements_id = requirements_id});
+      {.type_id = SemIR::TypeType::TypeId, .requirements_id = requirements_id});
   return true;
 }
 

--- a/toolchain/check/testdata/eval/unexpected_runtime.carbon
+++ b/toolchain/check/testdata/eval/unexpected_runtime.carbon
@@ -70,14 +70,14 @@ library "[[@TEST_NAME]]";
 
 var x: type;
 
-interface Z {}
+interface Z(T:! type) {}
 
 class D {
   // CHECK:STDERR: fail_unexpected_runtime_impls_lhs.carbon:[[@LINE+4]]:29: error: cannot evaluate type expression [TypeExprEvaluationFailure]
-  // CHECK:STDERR:   extend impl as type where x impls Z {}
+  // CHECK:STDERR:   extend impl as type where x impls Z(.Self) {}
   // CHECK:STDERR:                             ^
   // CHECK:STDERR:
-  extend impl as type where x impls Z {}
+  extend impl as type where x impls Z(.Self) {}
 }
 
 // --- fail_unexpected_runtime_impls_rhs.carbon

--- a/toolchain/check/testdata/facet/validate_impl_constraints.carbon
+++ b/toolchain/check/testdata/facet/validate_impl_constraints.carbon
@@ -396,13 +396,8 @@ constraint W(T:! type) {
 }
 
 fn F(B:! W(E), C:! type where E impls V(.Self)) {
-  // These find a witness for `E as X(E)` from the facet `B`.
+  // Find a witness for `E as X(E)` from the facet `B`.
   E as (V(C) where B impls X(.Self));
-  // CHECK:STDERR: find_witness_from_facet_in_lookup_target_facet_type.carbon:[[@LINE+4]]:20: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
-  // CHECK:STDERR:   E as (V(C) where B impls X(E));
-  // CHECK:STDERR:                    ^~~~~~~~~~~~
-  // CHECK:STDERR:
-  E as (V(C) where B impls X(E));
 }
 
 // --- find_witness_from_facet_in_specific_in_lookup_target_facet_type.carbon
@@ -418,13 +413,8 @@ constraint W(T:! type) {
 }
 
 fn F(B:! W(E), C:! type where E impls V(.Self)) {
-  // These find a witness for `E as X(E)` from the facet `B`.
+  // Find a witness for `E as X(E)` from the facet `B`.
   E as (V(C) where D(B) impls X(.Self));
-  // CHECK:STDERR: find_witness_from_facet_in_specific_in_lookup_target_facet_type.carbon:[[@LINE+4]]:20: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
-  // CHECK:STDERR:   E as (V(C) where D(B) impls X(E));
-  // CHECK:STDERR:                    ^~~~~~~~~~~~~~~
-  // CHECK:STDERR:
-  E as (V(C) where D(B) impls X(E));
 }
 
 // --- facet_has_witness_for_impl_witness_access.carbon

--- a/toolchain/check/testdata/facet/validate_impl_constraints.carbon
+++ b/toolchain/check/testdata/facet/validate_impl_constraints.carbon
@@ -398,6 +398,10 @@ constraint W(T:! type) {
 fn F(B:! W(E), C:! type where E impls V(.Self)) {
   // These find a witness for `E as X(E)` from the facet `B`.
   E as (V(C) where B impls X(.Self));
+  // CHECK:STDERR: find_witness_from_facet_in_lookup_target_facet_type.carbon:[[@LINE+4]]:20: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+  // CHECK:STDERR:   E as (V(C) where B impls X(E));
+  // CHECK:STDERR:                    ^~~~~~~~~~~~
+  // CHECK:STDERR:
   E as (V(C) where B impls X(E));
 }
 
@@ -416,6 +420,10 @@ constraint W(T:! type) {
 fn F(B:! W(E), C:! type where E impls V(.Self)) {
   // These find a witness for `E as X(E)` from the facet `B`.
   E as (V(C) where D(B) impls X(.Self));
+  // CHECK:STDERR: find_witness_from_facet_in_specific_in_lookup_target_facet_type.carbon:[[@LINE+4]]:20: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+  // CHECK:STDERR:   E as (V(C) where D(B) impls X(E));
+  // CHECK:STDERR:                    ^~~~~~~~~~~~~~~
+  // CHECK:STDERR:
   E as (V(C) where D(B) impls X(E));
 }
 

--- a/toolchain/check/testdata/impl/lookup/access.carbon
+++ b/toolchain/check/testdata/impl/lookup/access.carbon
@@ -53,31 +53,3 @@ fn H(U:! type, V:! Z where .Z1 impls (Y where .Y1 = U)) {
   // query's.
   V as X(U);
 }
-
-// --- fail_concrete_impl_witness_access_in_type_structure.carbon
-library "[[@TEST_NAME]]";
-
-interface Z(T:! type) {
-  let Z1:! type;
-}
-interface Y {}
-
-class C;
-
-// Converting to this facet type requires a lookup for `C.(Z(C).Z1) as Y`. That
-// has a type structure that contains a fully concrete ImplWitnessAccess. But if
-// the lookup fails because there is no impl for `C as Z(C)`, then the access
-// remains in the type structure as is. This test ensures the type structure can
-// handle this edge case.
-fn F(unused T:! Z(.Self) where C impls (Z(C) where .Z1 impls Y)) {}
-
-fn G(T:! Z(.Self)) {
-  // CHECK:STDERR: fail_concrete_impl_witness_access_in_type_structure.carbon:[[@LINE+7]]:3: error: cannot convert type `T` that implements `Z(.Self)` into type implementing `Z(.Self) where C impls Z(C) and C.(Z(C).Z1) impls Y` [ConversionFailureFacetToFacet]
-  // CHECK:STDERR:   F(T);
-  // CHECK:STDERR:   ^~~~
-  // CHECK:STDERR: fail_concrete_impl_witness_access_in_type_structure.carbon:[[@LINE-6]]:1: note: while deducing parameters of generic declared here [DeductionGenericHere]
-  // CHECK:STDERR: fn F(unused T:! Z(.Self) where C impls (Z(C) where .Z1 impls Y)) {}
-  // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
-  F(T);
-}

--- a/toolchain/check/testdata/where_expr/designator.carbon
+++ b/toolchain/check/testdata/where_expr/designator.carbon
@@ -96,9 +96,9 @@ library "[[@TEST_NAME]]";
 
 interface I {}
 
-// CHECK:STDERR: fail_impls_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:27: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_impls_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:38: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(U:! type, unused T:! type where U impls I) {}
-// CHECK:STDERR:                           ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:                                      ^~~~~~~~~
 // CHECK:STDERR:
 fn F(U:! type, unused T:! type where U impls I) {}
 
@@ -109,9 +109,9 @@ interface I {
   let X:! type;
 }
 
-// CHECK:STDERR: fail_equality_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:24: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_equality_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:35: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(U:! I, unused T:! type where U.X == ()) {}
-// CHECK:STDERR:                        ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:                                   ^~~~~~~~~
 // CHECK:STDERR:
 fn F(U:! I, unused T:! type where U.X == ()) {}
 
@@ -122,9 +122,13 @@ interface I {
   let X:! type;
 }
 
-// CHECK:STDERR: fail_combined_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:24: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_combined_constraint_does_not_constrain_self.carbon:[[@LINE+8]]:35: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(U:! I, unused T:! type where U impls I and U.X == ()) {}
-// CHECK:STDERR:                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:                                   ^~~~~~~~~
+// CHECK:STDERR:
+// CHECK:STDERR: fail_combined_constraint_does_not_constrain_self.carbon:[[@LINE+4]]:49: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(U:! I, unused T:! type where U impls I and U.X == ()) {}
+// CHECK:STDERR:                                                 ^~~~~~~~~
 // CHECK:STDERR:
 fn F(U:! I, unused T:! type where U impls I and U.X == ()) {}
 
@@ -152,9 +156,9 @@ class C;
 // facet type `type where...`. We should not consider the designator in the
 // nested where expression as making the `C impls ...` constraint valid.
 
-// CHECK:STDERR: fail_impls_with_nested_facet_type_with_rewrite_does_not_constrain_self.carbon:[[@LINE+4]]:18: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_impls_with_nested_facet_type_with_rewrite_does_not_constrain_self.carbon:[[@LINE+4]]:29: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F1(unused T:! type where C impls (I where .I1 = C)) {}
-// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:                             ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F1(unused T:! type where C impls (I where .I1 = C)) {}
 
@@ -171,9 +175,9 @@ class C;
 // facet type `type where...`. We should not consider the designator in the
 // nested where expression as making the `C impls ...` constraint valid.
 
-// CHECK:STDERR: fail_impls_with_nested_facet_type_with_equiv_does_not_constrain_self.carbon:[[@LINE+4]]:18: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_impls_with_nested_facet_type_with_equiv_does_not_constrain_self.carbon:[[@LINE+4]]:29: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F2(unused T:! type where C impls (I where .I1 == C)) {}
-// CHECK:STDERR:                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:                             ^~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F2(unused T:! type where C impls (I where .I1 == C)) {}
 
@@ -191,9 +195,9 @@ class C;
 // facet type `type where...`. We should not consider the designator in the
 // nested where expression as making the `C impls ...` constraint valid.
 
-// CHECK:STDERR: fail_impls_with_nested_facet_type_with_impls_does_not_constrain_self.carbon:[[@LINE+4]]:56: error: `.Self` is ambiguous after nested `where` in `<type> impls ...` clause. [AmbiguousPeriodSelf]
+// CHECK:STDERR: fail_impls_with_nested_facet_type_with_impls_does_not_constrain_self.carbon:[[@LINE+4]]:29: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F3(unused T:! type where C impls (I where .I1 impls J(.Self))) {}
-// CHECK:STDERR:                                                        ^~~~~~~~
+// CHECK:STDERR:                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F3(unused T:! type where C impls (I where .I1 impls J(.Self))) {}
 
@@ -210,9 +214,9 @@ class C;
 // facet type `I where...`. We should not consider the designator in the nested
 // where expression as making the `C impls ...` constraint valid.
 
-// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_rewrite_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_rewrite_does_not_constrain_self.carbon:[[@LINE+4]]:28: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 = C)) {}
-// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:                            ^~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F(unused T:! type where C == (I where .I1 = C)) {}
 
@@ -229,9 +233,9 @@ class C;
 // facet type `I where...`. We should not consider the designator in the nested
 // where expression as making the `C impls ...` constraint valid.
 
-// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_equiv_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_equiv_does_not_constrain_self.carbon:[[@LINE+4]]:28: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 == C)) {}
-// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:                            ^~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F(unused T:! type where C == (I where .I1 == C)) {}
 
@@ -249,11 +253,102 @@ class C;
 // facet type `I where...`. We should not consider the designator in the nested
 // where expression as making the `C impls ...` constraint valid.
 
-// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_impls_does_not_constrain_self.carbon:[[@LINE+4]]:17: error: `where` clause without a designator that constrains the current type; did not find `.Self` or a member access like `.M` that refers to the current type [WhereWithoutDesignator]
+// CHECK:STDERR: fail_equiv_with_nested_facet_type_with_impls_does_not_constrain_self.carbon:[[@LINE+4]]:28: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
 // CHECK:STDERR: fn F(unused T:! type where C == (I where .I1 impls J(.Self))) {}
-// CHECK:STDERR:                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 fn F(unused T:! type where C == (I where .I1 impls J(.Self))) {}
+
+// --- fail_impls_with_nested_facet_type_does_not_constrain_self.carbon
+library "[[@TEST_NAME]]";
+
+interface I {
+  let I1:! type;
+}
+interface J(T:! type) {}
+class C;
+
+// The `.I1` satisfies constraining the "current type" of the inner nested facet
+// type `I where ...`. But it does not constrain the current type of the outer
+// facet type `I where...`. We should not consider the designator in the nested
+// where expression as making the `(I where ...) impls ...` constraint valid.
+
+// CHECK:STDERR: fail_impls_with_nested_facet_type_does_not_constrain_self.carbon:[[@LINE+4]]:28: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where (I where .I1 impls J(.Self)) impls I) {}
+// CHECK:STDERR:                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where (I where .I1 impls J(.Self)) impls I) {}
+
+// --- fail_where_without_designator_in_one_equiv_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface I {}
+interface J(T:! type) {}
+class A(T:! type);
+class B;
+class C;
+
+// CHECK:STDERR: fail_where_without_designator_in_one_equiv_constraint.carbon:[[@LINE+4]]:46: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where A(.Self) == B and A(B) == B) {}
+// CHECK:STDERR:                                              ^~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where A(.Self) == B and A(B) == B) {}
+
+interface Z {
+  let Z0:! type;
+}
+
+// CHECK:STDERR: fail_where_without_designator_in_one_equiv_constraint.carbon:[[@LINE+4]]:41: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+// CHECK:STDERR: fn G(unused T:! Z where A(.Z0) == B and A(B) == B) {}
+// CHECK:STDERR:                                         ^~~~~~~~~
+// CHECK:STDERR:
+fn G(unused T:! Z where A(.Z0) == B and A(B) == B) {}
+
+// --- fail_where_without_designator_in_one_impls_interface.carbon
+library "[[@TEST_NAME]]";
+
+interface I {}
+interface J(T:! type) {}
+class C;
+
+// CHECK:STDERR: fail_where_without_designator_in_one_impls_interface.carbon:[[@LINE+4]]:28: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where C impls (I & J(.Self))) {}
+// CHECK:STDERR:                            ^~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where C impls (I & J(.Self))) {}
+
+interface Z {
+  let Z0:! type;
+}
+
+// CHECK:STDERR: fail_where_without_designator_in_one_impls_interface.carbon:[[@LINE+4]]:25: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+// CHECK:STDERR: fn G(unused T:! Z where C impls (I & J(.Z0))) {}
+// CHECK:STDERR:                         ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn G(unused T:! Z where C impls (I & J(.Z0))) {}
+
+// --- fail_where_without_designator_in_one_impls_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+constraint I {}
+constraint J(T:! type) {}
+class C;
+
+// CHECK:STDERR: fail_where_without_designator_in_one_impls_named_constraint.carbon:[[@LINE+4]]:28: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+// CHECK:STDERR: fn F(unused T:! type where C impls (I & J(.Self))) {}
+// CHECK:STDERR:                            ^~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn F(unused T:! type where C impls (I & J(.Self))) {}
+
+interface Z {
+  let Z0:! type;
+}
+
+// CHECK:STDERR: fail_where_without_designator_in_one_impls_named_constraint.carbon:[[@LINE+4]]:25: error: constraint in `where` clause without a designator; expected `.Self` or a member access like `.M` [WhereWithoutDesignator]
+// CHECK:STDERR: fn G(unused T:! Z where C impls (I & J(.Z0))) {}
+// CHECK:STDERR:                         ^~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+fn G(unused T:! Z where C impls (I & J(.Z0))) {}
 
 // CHECK:STDOUT: --- success.carbon
 // CHECK:STDOUT:


### PR DESCRIPTION
Instead of requiring just one to have a designator, require each one. You can't write `(type where A == B) & (type where C == .Self)` because `A == B` has no designator. If the two facet types are combined into a single `where` syntactically, their meaning does not change, and what we allow should not change either. That is, `type where A == B and C == .Self` should be rejected since `A == B` does not contain a designator.

The design is also updated to make this clear.