### PR TITLE
Propagate Carbon type alignments into LLVM IR.

### DIFF
--- a/toolchain/lower/aggregate.cpp
+++ b/toolchain/lower/aggregate.cpp
@@ -154,13 +154,14 @@ auto EmitAggregateValueRepr(FunctionContext& context,
     }
 
     case SemIR::ValueRepr::Pointer: {
-      auto* llvm_value_rep_type = context.GetType(GetPointeeType(value_type));
+      auto pointee_type = GetPointeeType(value_type);
 
       // Write the value representation to a local alloca so we can produce a
       // pointer to it as the value representation of the struct or tuple.
-      auto* alloca = context.builder().CreateAlloca(llvm_value_rep_type);
+      auto* alloca = context.CreateAlloca(pointee_type);
       for (auto [i, ref_id] :
            llvm::enumerate(context.sem_ir().inst_blocks().Get(refs_id))) {
+        auto* llvm_value_rep_type = context.GetType(pointee_type);
         context.StoreObject(
             context.GetValueRepr(context.GetTypeIdOfInst(ref_id)).type(),
             context.GetValue(ref_id),

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -103,6 +103,15 @@ class FileContext {
     return GetTypeAndDIType(type_id).llvm_ir_type;
   }
 
+  // Returns the alignment of the given type_id. This adds the alignment to the
+  // fingerprint.
+  auto GetAlignment(SemIR::TypeId type_id) -> llvm::Align {
+    return llvm::Align(sem_ir()
+                           .types()
+                           .GetCompleteTypeInfo(type_id)
+                           .object_layout.alignment.bytes());
+  }
+
   // Returns both the lowered llvm IR type and the lowered llvm IR debug info
   // type for the given type_id.
   auto GetTypeAndDIType(SemIR::TypeId type_id) const -> LoweredTypes {

--- a/toolchain/lower/function_context.cpp
+++ b/toolchain/lower/function_context.cpp
@@ -201,7 +201,7 @@ auto FunctionContext::MakeSyntheticBlock() -> llvm::BasicBlock* {
   return synthetic_block_;
 }
 
-auto FunctionContext::CreateAlloca(llvm::Type* type, const llvm::Twine& name)
+auto FunctionContext::CreateAlloca(TypeInFile type, const llvm::Twine& name)
     -> llvm::AllocaInst* {
   // Position the first alloca right before the start of the executable code in
   // the function.
@@ -221,9 +221,8 @@ auto FunctionContext::CreateAlloca(llvm::Type* type, const llvm::Twine& name)
     builder().SetCurrentDebugLocation(debug_loc);
 
     // Create an alloca for this variable in the entry block.
-    // TODO: Compute alignment of the type, which may be greater than the
-    // alignment computed by LLVM.
-    alloca = builder().CreateAlloca(type, /*ArraySize=*/nullptr, name);
+    alloca = builder().CreateAlloca(GetType(type), /*ArraySize=*/nullptr, name);
+    alloca->setAlignment(GetAlignment(type));
   }
 
   // Create a lifetime start intrinsic here to indicate where its scope really
@@ -345,9 +344,11 @@ auto FunctionContext::LoadObject(TypeInFile type, llvm::Value* addr,
   auto* llvm_type = GetType(type);
   auto* load_type = GetWidenedMemoryType(llvm_type);
 
-  // TODO: Include alias and alignment information.
-  llvm::Value* value = builder().CreateLoad(load_type, addr, name);
+  // TODO: Include alias information.
+  auto* load = builder().CreateLoad(load_type, addr, name);
+  load->setAlignment(GetAlignment(type));
 
+  llvm::Value* value = load;
   if (load_type != llvm_type) {
     value = builder().CreateTrunc(value, llvm_type);
   }
@@ -356,7 +357,6 @@ auto FunctionContext::LoadObject(TypeInFile type, llvm::Value* addr,
 
 auto FunctionContext::StoreObject(TypeInFile type, llvm::Value* value,
                                   llvm::Value* addr) -> void {
-  // TODO: Include alias and alignment information.
   auto* llvm_type = GetType(type);
   CARBON_CHECK(value->getType() == llvm_type);
 
@@ -367,7 +367,9 @@ auto FunctionContext::StoreObject(TypeInFile type, llvm::Value* value,
     value = builder().CreateZExt(value, store_type);
   }
 
-  builder().CreateStore(value, addr);
+  // TODO: Include alias information.
+  auto* store = builder().CreateStore(value, addr);
+  store->setAlignment(GetAlignment(type));
 }
 
 auto FunctionContext::CopyValue(TypeInFile type, SemIR::InstId source_id,
@@ -394,9 +396,7 @@ auto FunctionContext::CopyObject(TypeInFile type, SemIR::InstId source_id,
                                  SemIR::InstId dest_id) -> void {
   const auto& layout = llvm_module().getDataLayout();
   auto* llvm_type = GetType(type);
-  // TODO: Compute known alignment of the source and destination, which may
-  // be greater than the alignment computed by LLVM.
-  auto align = layout.getABITypeAlign(llvm_type);
+  auto align = GetAlignment(type);
 
   // TODO: Attach !tbaa.struct metadata indicating which portions of the
   // type we actually need to copy and which are padding.

--- a/toolchain/lower/function_context.h
+++ b/toolchain/lower/function_context.h
@@ -127,6 +127,14 @@ class FunctionContext {
     return llvm_type;
   }
 
+  // Returns the alignment of the given type_id. This adds the alignment to the
+  // fingerprint.
+  auto GetAlignment(TypeInFile type) -> llvm::Align {
+    auto align = GetFileContext(type.file).GetAlignment(type.type_id);
+    AddIntToCurrentFingerprint(align.value());
+    return align;
+  }
+
   // Returns the type of the given instruction in the current specific.
   auto GetTypeOfInst(SemIR::InstId inst_id) -> llvm::Type* {
     return GetType(GetTypeIdOfInst(inst_id));
@@ -166,7 +174,7 @@ class FunctionContext {
 
   // Creates an alloca instruction of the given type, adds it to the entry
   // block, and starts the lifetime of the corresponding storage.
-  auto CreateAlloca(llvm::Type* type, const llvm::Twine& name = llvm::Twine())
+  auto CreateAlloca(TypeInFile type, const llvm::Twine& name = llvm::Twine())
       -> llvm::AllocaInst*;
 
   // Returns the debug location to associate with the specified instruction.

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -393,7 +393,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
 auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
                 SemIR::VarStorage /* inst */) -> void {
   context.SetLocal(inst_id,
-                   context.CreateAlloca(context.GetTypeOfInst(inst_id)));
+                   context.CreateAlloca(context.GetTypeIdOfInst(inst_id)));
 }
 
 }  // namespace Carbon::Lower

--- a/toolchain/lower/handle_expr_category.cpp
+++ b/toolchain/lower/handle_expr_category.cpp
@@ -56,7 +56,7 @@ auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
 auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,
                 SemIR::TemporaryStorage /*inst*/) -> void {
   context.SetLocal(
-      inst_id, context.CreateAlloca(context.GetTypeOfInst(inst_id), "temp"));
+      inst_id, context.CreateAlloca(context.GetTypeIdOfInst(inst_id), "temp"));
 }
 
 auto HandleInst(FunctionContext& context, SemIR::InstId inst_id,

--- a/toolchain/lower/testdata/array/array_in_place.carbon
+++ b/toolchain/lower/testdata/array/array_in_place.carbon
@@ -24,7 +24,7 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [2 x { i32, i32, i32 }], align 8, !dbg !7
+// CHECK:STDOUT:   %_.var = alloca [2 x { i32, i32, i32 }], align 4, !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !7
 // CHECK:STDOUT:   %.loc16_47.6.array.index = getelementptr inbounds [2 x { i32, i32, i32 }], ptr %_.var, i32 0, i64 0, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_47.6.array.index), !dbg !9

--- a/toolchain/lower/testdata/array/assign_return_value.carbon
+++ b/toolchain/lower/testdata/array/assign_return_value.carbon
@@ -34,7 +34,7 @@ fn Run() {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !10 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %_.var = alloca [2 x i32], align 4, !dbg !14
-// CHECK:STDOUT:   %.loc16_28.1.temp = alloca { i32, i32 }, align 8, !dbg !15
+// CHECK:STDOUT:   %.loc16_28.1.temp = alloca { i32, i32 }, align 4, !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_28.1.temp), !dbg !15
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_28.1.temp), !dbg !15

--- a/toolchain/lower/testdata/array/base.carbon
+++ b/toolchain/lower/testdata/array/base.carbon
@@ -31,8 +31,8 @@ fn Run() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %_.var.loc14 = alloca [1 x i32], align 4, !dbg !8
 // CHECK:STDOUT:   %_.var.loc15 = alloca [2 x double], align 8, !dbg !9
-// CHECK:STDOUT:   %_.var.loc16 = alloca [5 x {}], align 8, !dbg !10
-// CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 8, !dbg !11
+// CHECK:STDOUT:   %_.var.loc16 = alloca [5 x {}], align 1, !dbg !10
+// CHECK:STDOUT:   %d.var = alloca { i32, i32, i32 }, align 4, !dbg !11
 // CHECK:STDOUT:   %_.var.loc18 = alloca [3 x i32], align 4, !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc14), !dbg !8
 // CHECK:STDOUT:   %.loc14_29.3.array.index = getelementptr inbounds [1 x i32], ptr %_.var.loc14, i32 0, i64 0, !dbg !13

--- a/toolchain/lower/testdata/array/iterate.carbon
+++ b/toolchain/lower/testdata/array/iterate.carbon
@@ -32,7 +32,7 @@ fn F() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc16_43.3.temp = alloca [6 x i32], align 4, !dbg !7
 // CHECK:STDOUT:   %var = alloca i32, align 4, !dbg !8
-// CHECK:STDOUT:   %.loc17_19.1.temp = alloca <{ i32, i1 }>, align 8, !dbg !8
+// CHECK:STDOUT:   %.loc17_19.1.temp = alloca <{ i32, i1 }>, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_43.3.temp), !dbg !7
 // CHECK:STDOUT:   %.loc16_43.4.array.index = getelementptr inbounds [6 x i32], ptr %.loc16_43.3.temp, i32 0, i64 0, !dbg !7
 // CHECK:STDOUT:   %.loc16_43.7.array.index = getelementptr inbounds [6 x i32], ptr %.loc16_43.3.temp, i32 0, i64 1, !dbg !7

--- a/toolchain/lower/testdata/array/layout.carbon
+++ b/toolchain/lower/testdata/array/layout.carbon
@@ -123,7 +123,7 @@ var c: array(Core.Int(257), 5) = (1, 2, 3, 4, 5);
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define internal void @_C__global_init.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 @_Cc.Main, ptr align 1 @array.loc3_1, i64 320, i1 false), !dbg !7
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 32 @_Cc.Main, ptr align 32 @array.loc3_1, i64 320, i1 false), !dbg !7
 // CHECK:STDOUT:   ret void, !dbg !8
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/cpp.carbon
+++ b/toolchain/lower/testdata/builtins/cpp.carbon
@@ -54,9 +54,9 @@ fn Test() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CTest.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc25_53.1.temp = alloca [16 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %.loc25_53.1.temp = alloca [16 x i8], align 8, !dbg !14
 // CHECK:STDOUT:   %.loc25_52.3.temp = alloca [4 x i32], align 4, !dbg !15
-// CHECK:STDOUT:   %.loc26_47.1.temp = alloca [16 x i8], align 1, !dbg !16
+// CHECK:STDOUT:   %.loc26_47.1.temp = alloca [16 x i8], align 8, !dbg !16
 // CHECK:STDOUT:   %.loc26_46.3.temp = alloca [4 x i32], align 4, !dbg !17
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc25_53.1.temp), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc25_52.3.temp), !dbg !15

--- a/toolchain/lower/testdata/builtins/no_op.carbon
+++ b/toolchain/lower/testdata/builtins/no_op.carbon
@@ -45,7 +45,7 @@ fn J() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !8 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   %a.var = alloca {}, align 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !9
 // CHECK:STDOUT:   ret void, !dbg !10
 // CHECK:STDOUT: }
@@ -61,7 +61,7 @@ fn J() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CJ.Main() #0 !dbg !13 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc33_11.1.temp = alloca {}, align 8, !dbg !14
+// CHECK:STDOUT:   %.loc33_11.1.temp = alloca {}, align 1, !dbg !14
 // CHECK:STDOUT:   call void @_CI.Main(), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc33_11.1.temp), !dbg !14
 // CHECK:STDOUT:   ret void, !dbg !15

--- a/toolchain/lower/testdata/class/adapt.carbon
+++ b/toolchain/lower/testdata/class/adapt.carbon
@@ -89,7 +89,7 @@ fn DoStuff(a: Int) -> Int {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CUse.Main() #0 !dbg !21 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %pa.var = alloca { i32, i32 }, align 8, !dbg !24
+// CHECK:STDOUT:   %pa.var = alloca { i32, i32 }, align 4, !dbg !24
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %pa.var), !dbg !24
 // CHECK:STDOUT:   call void @_CMake.PairAdapter.Main(ptr %pa.var), !dbg !25
 // CHECK:STDOUT:   %PairAdapter.GetB.call = call i32 @_CGetB.PairAdapter.Main(ptr %pa.var), !dbg !26

--- a/toolchain/lower/testdata/class/convert.carbon
+++ b/toolchain/lower/testdata/class/convert.carbon
@@ -47,7 +47,7 @@ fn DoIt() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CDoIt.Main() #0 !dbg !19 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %w.var = alloca { i32 }, align 8, !dbg !22
+// CHECK:STDOUT:   %w.var = alloca { i32 }, align 4, !dbg !22
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %w.var), !dbg !22
 // CHECK:STDOUT:   %.loc24_31.3.n = getelementptr inbounds nuw { i32 }, ptr %w.var, i32 0, i32 0, !dbg !23
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %w.var, ptr align 4 @IntWrapper.val.loc24_3, i64 4, i1 false), !dbg !22

--- a/toolchain/lower/testdata/class/field.carbon
+++ b/toolchain/lower/testdata/class/field.carbon
@@ -168,7 +168,7 @@ fn Run() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %o.var = alloca {}, align 8, !dbg !8
+// CHECK:STDOUT:   %o.var = alloca {}, align 1, !dbg !8
 // CHECK:STDOUT:   %_.var = alloca { ptr, {} }, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %o.var), !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
@@ -249,7 +249,7 @@ fn Run() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %o.var = alloca { i32 }, align 8, !dbg !8
+// CHECK:STDOUT:   %o.var = alloca { i32 }, align 4, !dbg !8
 // CHECK:STDOUT:   %_.var = alloca <{ ptr, { i32 } }>, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %o.var), !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9

--- a/toolchain/lower/testdata/class/generic.carbon
+++ b/toolchain/lower/testdata/class/generic.carbon
@@ -290,7 +290,7 @@ fn AccessTuple() -> (i32, i32, i32) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i1 @_CAccessBool.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca { i1, i32 }, align 8, !dbg !8
+// CHECK:STDOUT:   %c.var = alloca { i1, i32 }, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !8
 // CHECK:STDOUT:   %.loc16_37.2.v = getelementptr inbounds nuw { i1, i32 }, ptr %c.var, i32 0, i32 0, !dbg !9
 // CHECK:STDOUT:   %.loc16_37.5.w = getelementptr inbounds nuw { i1, i32 }, ptr %c.var, i32 0, i32 1, !dbg !9
@@ -321,7 +321,7 @@ fn AccessTuple() -> (i32, i32, i32) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CAccessInt.Main() #0 !dbg !29 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca { i1, i32 }, align 8, !dbg !32
+// CHECK:STDOUT:   %c.var = alloca { i1, i32 }, align 4, !dbg !32
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !32
 // CHECK:STDOUT:   %.loc21_37.2.v = getelementptr inbounds nuw { i1, i32 }, ptr %c.var, i32 0, i32 0, !dbg !33
 // CHECK:STDOUT:   %.loc21_37.5.w = getelementptr inbounds nuw { i1, i32 }, ptr %c.var, i32 0, i32 1, !dbg !33
@@ -334,7 +334,7 @@ fn AccessTuple() -> (i32, i32, i32) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CAccessEmpty.Main() #0 !dbg !36 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca { i1, {} }, align 8, !dbg !39
+// CHECK:STDOUT:   %c.var = alloca { i1, {} }, align 1, !dbg !39
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !39
 // CHECK:STDOUT:   %.loc26_37.2.v = getelementptr inbounds nuw { i1, {} }, ptr %c.var, i32 0, i32 0, !dbg !40
 // CHECK:STDOUT:   %.loc26_37.4.w = getelementptr inbounds nuw { i1, {} }, ptr %c.var, i32 0, i32 1, !dbg !40
@@ -359,7 +359,7 @@ fn AccessTuple() -> (i32, i32, i32) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CAccessTuple.Main(ptr sret({ i32, i32, i32 }) %return) #0 !dbg !51 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca { i1, { i32, i32, i32 } }, align 8, !dbg !52
+// CHECK:STDOUT:   %c.var = alloca { i1, { i32, i32, i32 } }, align 4, !dbg !52
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !52
 // CHECK:STDOUT:   %.loc31_57.2.v = getelementptr inbounds nuw { i1, { i32, i32, i32 } }, ptr %c.var, i32 0, i32 0, !dbg !53
 // CHECK:STDOUT:   %.loc31_57.4.w = getelementptr inbounds nuw { i1, { i32, i32, i32 } }, ptr %c.var, i32 0, i32 1, !dbg !53

--- a/toolchain/lower/testdata/class/value_access.carbon
+++ b/toolchain/lower/testdata/class/value_access.carbon
@@ -27,6 +27,7 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CF.Main(ptr %c) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %tuple = alloca { i32, i32, i32 }, align 4, !dbg !11
 // CHECK:STDOUT:   %.loc21_11.1.a = getelementptr inbounds nuw { { i32, i32, i32 } }, ptr %c, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %.loc21_11.1.a, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %.loc21_11.2 = load i32, ptr %tuple.elem0.tuple.elem, align 4, !dbg !11
@@ -34,7 +35,7 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   %.loc21_11.3 = load i32, ptr %tuple.elem1.loc21_11.tuple.elem, align 4, !dbg !11
 // CHECK:STDOUT:   %tuple.elem2.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %.loc21_11.1.a, i32 0, i32 2, !dbg !11
 // CHECK:STDOUT:   %.loc21_11.4 = load i32, ptr %tuple.elem2.tuple.elem, align 4, !dbg !11
-// CHECK:STDOUT:   %tuple = alloca { i32, i32, i32 }, align 8, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %tuple), !dbg !11
 // CHECK:STDOUT:   %tuple1 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   store i32 %.loc21_11.2, ptr %tuple1, align 4, !dbg !11
 // CHECK:STDOUT:   %tuple2 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple, i32 0, i32 1, !dbg !11
@@ -46,7 +47,11 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT:   ret i32 %tuple.elem1.loc21_13.tuple.elem.load, !dbg !12
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
+// CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!2}

--- a/toolchain/lower/testdata/class/virtual.carbon
+++ b/toolchain/lower/testdata/class/virtual.carbon
@@ -262,7 +262,7 @@ fn Use() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCreate.Create() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var.loc7 = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   %_.var.loc7 = alloca {}, align 1, !dbg !7
 // CHECK:STDOUT:   %_.var.loc8 = alloca { ptr, {} }, align 8, !dbg !8
 // CHECK:STDOUT:   %_.var.loc9 = alloca { { ptr, {} } }, align 8, !dbg !9
 // CHECK:STDOUT:   %_.var.loc12 = alloca { { ptr, {} } }, align 8, !dbg !10
@@ -528,7 +528,7 @@ fn Use() {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !16
 // CHECK:STDOUT:   %.loc13_24.2.vptr = getelementptr inbounds nuw <{ ptr, i32 }>, ptr %_.var, i32 0, i32 0, !dbg !20
 // CHECK:STDOUT:   %.loc13_24.5.m = getelementptr inbounds nuw <{ ptr, i32 }>, ptr %_.var, i32 0, i32 1, !dbg !20
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var, ptr align 1 @Base.val.loc13_3, i64 12, i1 false), !dbg !16
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %_.var, ptr align 8 @Base.val.loc13_3, i64 12, i1 false), !dbg !16
 // CHECK:STDOUT:   call void @"_COp.c06798f3d09e8cc8:core.Destroy.Core"(ptr %_.var), !dbg !16
 // CHECK:STDOUT:   call void @"_COp.c06798f3d09e8cc8:core.Destroy.Core"(ptr %v.var), !dbg !15
 // CHECK:STDOUT:   call void @"_COp.94e3ca86614aba5d:core.Destroy.Core"(ptr %i.var), !dbg !14
@@ -907,7 +907,7 @@ fn Use() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Base.Main.9ddc77f6d5c74933(ptr %self) #0 !dbg !39 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !42
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !42
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !42
 // CHECK:STDOUT:   call void @"_COp.07a02b3c29b03141:core.Destroy.Core"(ptr %_.var), !dbg !42
 // CHECK:STDOUT:   ret void, !dbg !43
@@ -916,7 +916,7 @@ fn Use() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Base.Main.dc3f1ae930f86538(ptr %self) #0 !dbg !44 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca { {} }, align 8, !dbg !47
+// CHECK:STDOUT:   %_.var = alloca { {} }, align 1, !dbg !47
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !47
 // CHECK:STDOUT:   call void @"_COp.64de2e862a836f25:core.Destroy.Core"(ptr %_.var), !dbg !47
 // CHECK:STDOUT:   ret void, !dbg !48
@@ -1095,8 +1095,8 @@ fn Use() {
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
 // CHECK:STDOUT: define void @"_CF:thunk:Base.Main:Derived.Main"(ptr sret({}) %return, ptr %self, ptr %n) #1 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc17_58.1.temp = alloca {}, align 8, !dbg !16
-// CHECK:STDOUT:   %.loc12_33.1.temp = alloca {}, align 8, !dbg !17
+// CHECK:STDOUT:   %.loc17_58.1.temp = alloca {}, align 1, !dbg !16
+// CHECK:STDOUT:   %.loc12_33.1.temp = alloca {}, align 1, !dbg !17
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_58.1.temp), !dbg !16
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc12_33.1.temp), !dbg !17
 // CHECK:STDOUT:   call void @"_CConvert.From.Main:ImplicitAs.9040cf91eef70a75.Core"(ptr %.loc12_33.1.temp, ptr %n), !dbg !17
@@ -1123,8 +1123,8 @@ fn Use() {
 // CHECK:STDOUT: define void @_CUse.Main() #0 !dbg !28 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %d.var = alloca { { ptr } }, align 8, !dbg !31
-// CHECK:STDOUT:   %.loc25_10.1.temp = alloca {}, align 8, !dbg !32
-// CHECK:STDOUT:   %.loc25_9.2.temp = alloca {}, align 8, !dbg !33
+// CHECK:STDOUT:   %.loc25_10.1.temp = alloca {}, align 1, !dbg !32
+// CHECK:STDOUT:   %.loc25_9.2.temp = alloca {}, align 1, !dbg !33
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %d.var), !dbg !31
 // CHECK:STDOUT:   %.loc23_31.2.base = getelementptr inbounds nuw { { ptr } }, ptr %d.var, i32 0, i32 0, !dbg !34
 // CHECK:STDOUT:   %.loc23_30.2.vptr = getelementptr inbounds nuw { ptr }, ptr %.loc23_31.2.base, i32 0, i32 0, !dbg !35

--- a/toolchain/lower/testdata/for/bindings.carbon
+++ b/toolchain/lower/testdata/for/bindings.carbon
@@ -41,11 +41,11 @@ fn For() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CFor.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %r.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %var = alloca {}, align 8, !dbg !8
-// CHECK:STDOUT:   %.loc29_33.1.temp = alloca <{ { i32, i32 }, i1 }>, align 8, !dbg !8
+// CHECK:STDOUT:   %r.var = alloca {}, align 1, !dbg !7
+// CHECK:STDOUT:   %var = alloca {}, align 1, !dbg !8
+// CHECK:STDOUT:   %.loc29_33.1.temp = alloca <{ { i32, i32 }, i1 }>, align 4, !dbg !8
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !9
-// CHECK:STDOUT:   %.loc29_33.8.temp = alloca { i32, i32 }, align 8, !dbg !8
+// CHECK:STDOUT:   %.loc29_33.8.temp = alloca { i32, i32 }, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %r.var), !dbg !7
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %r.var, ptr align 1 @EmptyRange.val.loc27_3, i64 0, i1 false), !dbg !7
 // CHECK:STDOUT:   call void @"_CNewCursor.EmptyRange.7920d9939e32908d.Main:Iterate.Core.9de724674fdcc2fc"(ptr %r.var), !dbg !8

--- a/toolchain/lower/testdata/for/break_continue.carbon
+++ b/toolchain/lower/testdata/for/break_continue.carbon
@@ -36,9 +36,9 @@ fn For() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CFor.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc20_32.1.temp = alloca { i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %.loc20_32.1.temp = alloca { i32, i32 }, align 4, !dbg !7
 // CHECK:STDOUT:   %var = alloca i32, align 4, !dbg !8
-// CHECK:STDOUT:   %.loc20_33.1.temp = alloca <{ i32, i1 }>, align 8, !dbg !8
+// CHECK:STDOUT:   %.loc20_33.1.temp = alloca <{ i32, i1 }>, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_32.1.temp), !dbg !7
 // CHECK:STDOUT:   call void @_CRange.Core(ptr %.loc20_32.1.temp, i32 100), !dbg !7
 // CHECK:STDOUT:   %IntRange.as.Iterate.impl.NewCursor.call = call i32 @"_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc20_32.1.temp), !dbg !8

--- a/toolchain/lower/testdata/for/for.carbon
+++ b/toolchain/lower/testdata/for/for.carbon
@@ -36,9 +36,9 @@ fn For() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CFor.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc21_32.1.temp = alloca { i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %.loc21_32.1.temp = alloca { i32, i32 }, align 4, !dbg !7
 // CHECK:STDOUT:   %var = alloca i32, align 4, !dbg !8
-// CHECK:STDOUT:   %.loc21_33.1.temp = alloca <{ i32, i1 }>, align 8, !dbg !8
+// CHECK:STDOUT:   %.loc21_33.1.temp = alloca <{ i32, i1 }>, align 4, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(), !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc21_32.1.temp), !dbg !7
 // CHECK:STDOUT:   call void @_CRange.Core(ptr %.loc21_32.1.temp, i32 100), !dbg !7

--- a/toolchain/lower/testdata/function/call/empty_struct.carbon
+++ b/toolchain/lower/testdata/function/call/empty_struct.carbon
@@ -30,7 +30,7 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !8 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   call void @_CEcho.Main(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11

--- a/toolchain/lower/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/lower/testdata/function/call/empty_tuple.carbon
@@ -30,7 +30,7 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !8 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   call void @_CEcho.Main(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11

--- a/toolchain/lower/testdata/function/call/implicit_empty_tuple_as_arg.carbon
+++ b/toolchain/lower/testdata/function/call/implicit_empty_tuple_as_arg.carbon
@@ -37,8 +37,8 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !10 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !11
-// CHECK:STDOUT:   %.loc19_23.1.temp = alloca {}, align 8, !dbg !12
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !11
+// CHECK:STDOUT:   %.loc19_23.1.temp = alloca {}, align 1, !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !11
 // CHECK:STDOUT:   call void @_CFoo.Main(), !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc19_23.1.temp), !dbg !12

--- a/toolchain/lower/testdata/function/call/return_implicit.carbon
+++ b/toolchain/lower/testdata/function/call/return_implicit.carbon
@@ -30,7 +30,7 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !8 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   call void @_CMakeImplicitEmptyTuple.Main(), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !11

--- a/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
@@ -43,7 +43,7 @@ fn Main() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMain.Main() #0 !dbg !16 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc18_21.1.temp = alloca { i32, i32, i32 }, align 8, !dbg !19
+// CHECK:STDOUT:   %.loc18_21.1.temp = alloca { i32, i32, i32 }, align 4, !dbg !19
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_21.1.temp), !dbg !19
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc18_21.1.temp, { i32 } { i32 1 }, ptr @tuple.c4c.loc18_20.6), !dbg !19
 // CHECK:STDOUT:   call void @"_COp.9eed32d146d768a4:core.Destroy.Core"(ptr %.loc18_21.1.temp), !dbg !19

--- a/toolchain/lower/testdata/function/definition/destroy.carbon
+++ b/toolchain/lower/testdata/function/definition/destroy.carbon
@@ -89,7 +89,7 @@ fn InitLet() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCallF.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc12_6.2.temp = alloca {}, align 8, !dbg !14
+// CHECK:STDOUT:   %.loc12_6.2.temp = alloca {}, align 1, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc12_6.2.temp), !dbg !14
 // CHECK:STDOUT:   call void @_CF.Main(ptr @C.val.loc12_6.6), !dbg !15
 // CHECK:STDOUT:   call void @_CG.Main(), !dbg !16
@@ -150,7 +150,7 @@ fn InitLet() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCallF.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !14
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var, ptr align 1 @C.val.loc6, i64 0, i1 false), !dbg !14
 // CHECK:STDOUT:   call void @_CF.Main(ptr %_.var), !dbg !15
@@ -223,7 +223,7 @@ fn InitLet() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CInitVar.Main() #0 !dbg !12 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !15
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !15
 // CHECK:STDOUT:   call void @_CF.Main(ptr %_.var), !dbg !16
 // CHECK:STDOUT:   call void @_CG.Main(), !dbg !17
@@ -240,7 +240,7 @@ fn InitLet() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CInitLet.Main() #0 !dbg !25 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc22_16.1.temp = alloca {}, align 8, !dbg !26
+// CHECK:STDOUT:   %.loc22_16.1.temp = alloca {}, align 1, !dbg !26
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_16.1.temp), !dbg !26
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc22_16.1.temp), !dbg !26
 // CHECK:STDOUT:   call void @_CG.Main(), !dbg !27

--- a/toolchain/lower/testdata/function/definition/var_param.carbon
+++ b/toolchain/lower/testdata/function/definition/var_param.carbon
@@ -68,12 +68,12 @@ fn Call() {
 // CHECK:STDOUT: define void @_CCall.Main() #0 !dbg !35 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %_.var.loc15 = alloca i32, align 4, !dbg !38
-// CHECK:STDOUT:   %_.var.loc16 = alloca {}, align 8, !dbg !39
+// CHECK:STDOUT:   %_.var.loc16 = alloca {}, align 1, !dbg !39
 // CHECK:STDOUT:   %_.var.loc18_12 = alloca i32, align 4, !dbg !40
-// CHECK:STDOUT:   %_.var.loc18_24 = alloca {}, align 8, !dbg !41
+// CHECK:STDOUT:   %_.var.loc18_24 = alloca {}, align 1, !dbg !41
 // CHECK:STDOUT:   %_.var.loc20 = alloca i32, align 4, !dbg !42
-// CHECK:STDOUT:   %.loc27_18.2.temp = alloca {}, align 8, !dbg !43
-// CHECK:STDOUT:   %_.var.loc21 = alloca {}, align 8, !dbg !44
+// CHECK:STDOUT:   %.loc27_18.2.temp = alloca {}, align 1, !dbg !43
+// CHECK:STDOUT:   %_.var.loc21 = alloca {}, align 1, !dbg !44
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc15), !dbg !38
 // CHECK:STDOUT:   store i32 1, ptr %_.var.loc15, align 4, !dbg !38
 // CHECK:STDOUT:   call void @_COneVar_i32.Main(ptr %_.var.loc15), !dbg !45

--- a/toolchain/lower/testdata/function/generic/call.carbon
+++ b/toolchain/lower/testdata/function/generic/call.carbon
@@ -40,8 +40,8 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !7
-// CHECK:STDOUT:   %d.var = alloca {}, align 8, !dbg !8
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !7
+// CHECK:STDOUT:   %d.var = alloca {}, align 1, !dbg !8
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !9
 // CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !7

--- a/toolchain/lower/testdata/function/generic/call_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic.carbon
@@ -131,8 +131,8 @@ fn M() {
 // CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !55
 // CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !56
 // CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !57
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !58
-// CHECK:STDOUT:   %.loc43_6.2.temp = alloca {}, align 8, !dbg !59
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !58
+// CHECK:STDOUT:   %.loc43_6.2.temp = alloca {}, align 1, !dbg !59
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc29_6.2.temp), !dbg !51
 // CHECK:STDOUT:   %H.call.loc29 = call i32 @_CH.Main.980bd46fd9fb5b99(i32 %x), !dbg !51
 // CHECK:STDOUT:   store i32 %H.call.loc29, ptr %.loc29_6.2.temp, align 4, !dbg !51
@@ -188,8 +188,8 @@ fn M() {
 // CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !81
 // CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !82
 // CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !83
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !84
-// CHECK:STDOUT:   %.loc43_6.2.temp = alloca {}, align 8, !dbg !85
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !84
+// CHECK:STDOUT:   %.loc43_6.2.temp = alloca {}, align 1, !dbg !85
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc29_6.2.temp), !dbg !77
 // CHECK:STDOUT:   %H.call.loc29 = call double @_CH.Main.3eb991d272a034fb(double %x), !dbg !77
 // CHECK:STDOUT:   store double %H.call.loc29, ptr %.loc29_6.2.temp, align 8, !dbg !77

--- a/toolchain/lower/testdata/function/generic/call_method.carbon
+++ b/toolchain/lower/testdata/function/generic/call_method.carbon
@@ -30,7 +30,7 @@ fn CallF() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CCallF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !8
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !8
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !8
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @C.val.loc20_3, i64 0, i1 false), !dbg !8

--- a/toolchain/lower/testdata/function/generic/call_recursive_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_basic.carbon
@@ -59,8 +59,8 @@ fn M() {
 // CHECK:STDOUT:   %m.var = alloca double, align 8, !dbg !15
 // CHECK:STDOUT:   %ptr_i32.var = alloca ptr, align 8, !dbg !16
 // CHECK:STDOUT:   %ptr_f64.var = alloca ptr, align 8, !dbg !17
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !18
-// CHECK:STDOUT:   %.loc40_9.2.temp = alloca {}, align 8, !dbg !19
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !18
+// CHECK:STDOUT:   %.loc40_9.2.temp = alloca {}, align 1, !dbg !19
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %n.var), !dbg !14
 // CHECK:STDOUT:   store i32 0, ptr %n.var, align 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %m.var), !dbg !15

--- a/toolchain/lower/testdata/function/generic/call_recursive_reorder_more.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_reorder_more.carbon
@@ -72,7 +72,7 @@ fn M() {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %val_i32.var), !dbg !8
 // CHECK:STDOUT:   store i32 poison, ptr %val_i32.var, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %val_i64.var), !dbg !9
-// CHECK:STDOUT:   store i64 poison, ptr %val_i64.var, align 4, !dbg !9
+// CHECK:STDOUT:   store i64 poison, ptr %val_i64.var, align 8, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %val_f64.var), !dbg !10
 // CHECK:STDOUT:   store double poison, ptr %val_f64.var, align 8, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %val_bool.var), !dbg !11
@@ -98,7 +98,7 @@ fn M() {
 // CHECK:STDOUT:   %.loc40_15 = load ptr, ptr %ptr_bool.var, align 8, !dbg !25
 // CHECK:STDOUT:   %.loc40_25 = load ptr, ptr %ptr_i16.var, align 8, !dbg !26
 // CHECK:STDOUT:   %F.call.loc40 = call i32 @_CF.Main.e1d834dc162d21b2(i1 %.loc40_51, ptr %.loc40_15, ptr %.loc40_25, i32 0), !dbg !27
-// CHECK:STDOUT:   %.loc41_5 = load i64, ptr %val_i64.var, align 4, !dbg !28
+// CHECK:STDOUT:   %.loc41_5 = load i64, ptr %val_i64.var, align 8, !dbg !28
 // CHECK:STDOUT:   %.loc41_14 = load i8, ptr %val_bool.var, align 1, !dbg !29
 // CHECK:STDOUT:   %.loc41_142 = trunc i8 %.loc41_14 to i1, !dbg !29
 // CHECK:STDOUT:   %.loc41_24 = load ptr, ptr %ptr_bool.var, align 8, !dbg !30

--- a/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
+++ b/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
@@ -63,7 +63,7 @@ fn M() {
 // CHECK:STDOUT:   %ptr_i8.var = alloca ptr, align 8, !dbg !16
 // CHECK:STDOUT:   %var_i32.var = alloca i32, align 4, !dbg !17
 // CHECK:STDOUT:   %var_f64.var = alloca double, align 8, !dbg !18
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !19
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !19
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %ptr_i32.var), !dbg !14
 // CHECK:STDOUT:   store ptr poison, ptr %ptr_i32.var, align 8, !dbg !14
 // CHECK:STDOUT:   %.loc34_5 = load ptr, ptr %ptr_i32.var, align 8, !dbg !20
@@ -138,7 +138,7 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr ptr @_CG.Main.3890ad819211e245(ptr %x) #0 !dbg !67 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !70
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !70
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !70
 // CHECK:STDOUT:   %C.Cfn.call = call ptr @_CCfn.C.Main.3890ad819211e245(ptr %c.var, ptr %x), !dbg !71
 // CHECK:STDOUT:   call void @"_COp.b8b1f433ad216ca6:core.Destroy.Core"(ptr %c.var), !dbg !70
@@ -148,7 +148,7 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr i32 @_CG.Main.980bd46fd9fb5b99(i32 %x) #0 !dbg !73 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !76
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !76
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !76
 // CHECK:STDOUT:   %C.Cfn.call = call i32 @_CCfn.C.Main.980bd46fd9fb5b99(ptr %c.var, i32 %x), !dbg !77
 // CHECK:STDOUT:   call void @"_COp.b8b1f433ad216ca6:core.Destroy.Core"(ptr %c.var), !dbg !76
@@ -158,7 +158,7 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr double @_CG.Main.3eb991d272a034fb(double %x) #0 !dbg !79 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !82
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !82
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !82
 // CHECK:STDOUT:   %C.Cfn.call = call double @_CCfn.C.Main.3eb991d272a034fb(ptr %c.var, double %x), !dbg !83
 // CHECK:STDOUT:   call void @"_COp.b8b1f433ad216ca6:core.Destroy.Core"(ptr %c.var), !dbg !82
@@ -168,7 +168,7 @@ fn M() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr %type @_CG.Main.22a6f624d7af1d76(%type %x) #0 !dbg !85 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !88
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !88
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !88
 // CHECK:STDOUT:   %C.Cfn.call = call %type @_CCfn.C.Main.22a6f624d7af1d76(ptr %c.var, %type %x), !dbg !89
 // CHECK:STDOUT:   call void @"_COp.b8b1f433ad216ca6:core.Destroy.Core"(ptr %c.var), !dbg !88

--- a/toolchain/lower/testdata/function/generic/type_representation.carbon
+++ b/toolchain/lower/testdata/function/generic/type_representation.carbon
@@ -211,7 +211,7 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Main.e4214cdf04e44ea0(ptr sret({ i32, i32 }) %return, ptr %a) #0 !dbg !91 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 8, !dbg !94
+// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 4, !dbg !94
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !94
 // CHECK:STDOUT:   call void @"_COp.X.Main:Copy.Main"(ptr %_.var, ptr %a), !dbg !95
 // CHECK:STDOUT:   call void @"_COp.X.Main:Copy.Main"(ptr %return, ptr %a), !dbg !96
@@ -222,7 +222,7 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Main.6942691454f579cd() #0 !dbg !98 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !99
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !99
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !99
 // CHECK:STDOUT:   call void @"_COp.61ea2aba74ab3bf1:Copy.Main"(), !dbg !100
 // CHECK:STDOUT:   call void @"_COp.61ea2aba74ab3bf1:Copy.Main"(), !dbg !101
@@ -232,7 +232,7 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Main.52eb52f0ffbd1db6(ptr sret({ i32, i32 }) %return, ptr %a) #0 !dbg !103 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 8, !dbg !106
+// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 4, !dbg !106
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !106
 // CHECK:STDOUT:   call void @"_COp.87cc08e781602b22:Copy.Main"(ptr %_.var, ptr %a), !dbg !107
 // CHECK:STDOUT:   call void @"_COp.87cc08e781602b22:Copy.Main"(ptr %return, ptr %a), !dbg !108
@@ -243,7 +243,7 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CF.Main.cbd425227ee9ed4b(ptr sret({ { i32, i32 }, { i32, i32 } }) %return, ptr %a) #0 !dbg !110 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca { { i32, i32 }, { i32, i32 } }, align 8, !dbg !113
+// CHECK:STDOUT:   %_.var = alloca { { i32, i32 }, { i32, i32 } }, align 4, !dbg !113
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !113
 // CHECK:STDOUT:   call void @"_COp.b1957bb3c5dab115:Copy.Main"(ptr %_.var, ptr %a), !dbg !114
 // CHECK:STDOUT:   call void @"_COp.b1957bb3c5dab115:Copy.Main"(ptr %return, ptr %a), !dbg !115

--- a/toolchain/lower/testdata/impl/impl.carbon
+++ b/toolchain/lower/testdata/impl/impl.carbon
@@ -147,8 +147,8 @@ impl C(B) as I {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF1.Main(ptr %x, ptr %y) #0 !dbg !15 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca {}, align 8, !dbg !21
-// CHECK:STDOUT:   %b.var = alloca {}, align 8, !dbg !22
+// CHECK:STDOUT:   %a.var = alloca {}, align 1, !dbg !21
+// CHECK:STDOUT:   %b.var = alloca {}, align 1, !dbg !22
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !21
 // CHECK:STDOUT:   call void @"_CF.C.Main:I.837256a62795a301.Main"(ptr %a.var, ptr %x), !dbg !23
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !22

--- a/toolchain/lower/testdata/impl/import_facet.carbon
+++ b/toolchain/lower/testdata/impl/import_facet.carbon
@@ -90,7 +90,7 @@ fn F(d: D(i32)) -> i32* {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define ptr @_CF.Main(ptr %d) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc5_21.1.temp = alloca {}, align 8, !dbg !10
+// CHECK:STDOUT:   %.loc5_21.1.temp = alloca {}, align 1, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc5_21.1.temp), !dbg !10
 // CHECK:STDOUT:   call void @"_CGetI.D.eb057aa32837c84e.Main:I.Main.c8fd090a2e741f70"(ptr %.loc5_21.1.temp, ptr %d), !dbg !10
 // CHECK:STDOUT:   %C.GetC.call = call ptr @_CGetC.C.Main.305e140e9c2d2c5b(ptr %.loc5_21.1.temp), !dbg !10

--- a/toolchain/lower/testdata/impl/import_thunk.carbon
+++ b/toolchain/lower/testdata/impl/import_thunk.carbon
@@ -102,8 +102,8 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
 // CHECK:STDOUT: define void @"_CF:thunk:I.01f5c37cad34e90b.Main:61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !25 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc20_19.1.temp = alloca { i32 }, align 8, !dbg !28
-// CHECK:STDOUT:   %.loc16_9.1.temp = alloca { i32 }, align 8, !dbg !29
+// CHECK:STDOUT:   %.loc20_19.1.temp = alloca { i32 }, align 4, !dbg !28
+// CHECK:STDOUT:   %.loc16_9.1.temp = alloca { i32 }, align 4, !dbg !29
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_19.1.temp), !dbg !28
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_9.1.temp), !dbg !29
 // CHECK:STDOUT:   call void @"_CConvert.A.Main:ImplicitAs.8b79c6c1932e58f6.Core"(ptr %.loc16_9.1.temp, ptr %a), !dbg !29
@@ -199,9 +199,9 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CTest.Main(ptr sret({ i32 }) %return, ptr %a) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc7_20.1.temp = alloca { i32 }, align 8, !dbg !10
-// CHECK:STDOUT:   %.loc7_20.2.temp = alloca { i32 }, align 8, !dbg !10
-// CHECK:STDOUT:   %.loc7_19.1.temp = alloca { i32 }, align 8, !dbg !11
+// CHECK:STDOUT:   %.loc7_20.1.temp = alloca { i32 }, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc7_20.2.temp = alloca { i32 }, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc7_19.1.temp = alloca { i32 }, align 4, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_20.1.temp), !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_20.2.temp), !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_19.1.temp), !dbg !11
@@ -298,8 +298,8 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
 // CHECK:STDOUT: define void @"_CF:thunk:I.5df87795ec73cda9.Main:X.Main:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !13 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc9_19.1.temp = alloca { i32 }, align 8, !dbg !16
-// CHECK:STDOUT:   %.2.temp = alloca { i32 }, align 8
+// CHECK:STDOUT:   %.loc9_19.1.temp = alloca { i32 }, align 4, !dbg !16
+// CHECK:STDOUT:   %.2.temp = alloca { i32 }, align 4
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_19.1.temp), !dbg !16
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.2.temp)
 // CHECK:STDOUT:   call void @"_CConvert.A.Main:ImplicitAs.0b3b8a3403fe0e1d.Core"(ptr %.2.temp, ptr %a), !dbg !17
@@ -387,9 +387,9 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CTest.Main(ptr sret({ i32 }) %return, ptr %a) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc8_19.1.temp = alloca { i32 }, align 8, !dbg !10
-// CHECK:STDOUT:   %.loc8_19.2.temp = alloca { i32 }, align 8, !dbg !10
-// CHECK:STDOUT:   %.loc8_18.1.temp = alloca { i32 }, align 8, !dbg !11
+// CHECK:STDOUT:   %.loc8_19.1.temp = alloca { i32 }, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc8_19.2.temp = alloca { i32 }, align 4, !dbg !10
+// CHECK:STDOUT:   %.loc8_18.1.temp = alloca { i32 }, align 4, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc8_19.1.temp), !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc8_19.2.temp), !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc8_18.1.temp), !dbg !11

--- a/toolchain/lower/testdata/impl/thunk.carbon
+++ b/toolchain/lower/testdata/impl/thunk.carbon
@@ -106,8 +106,8 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
 // CHECK:STDOUT: define void @"_CF:thunk:I.01f5c37cad34e90b.Main:61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !25 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc20_19.1.temp = alloca { i32 }, align 8, !dbg !28
-// CHECK:STDOUT:   %.loc16_9.1.temp = alloca { i32 }, align 8, !dbg !29
+// CHECK:STDOUT:   %.loc20_19.1.temp = alloca { i32 }, align 4, !dbg !28
+// CHECK:STDOUT:   %.loc16_9.1.temp = alloca { i32 }, align 4, !dbg !29
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc20_19.1.temp), !dbg !28
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_9.1.temp), !dbg !29
 // CHECK:STDOUT:   call void @"_CConvert.A.Main:ImplicitAs.8b79c6c1932e58f6.Core"(ptr %.loc16_9.1.temp, ptr %a), !dbg !29
@@ -139,9 +139,9 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CTest.Main(ptr sret({ i32 }) %return, ptr %a) #0 !dbg !47 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc24_20.1.temp = alloca { i32 }, align 8, !dbg !50
-// CHECK:STDOUT:   %.loc24_20.2.temp = alloca { i32 }, align 8, !dbg !50
-// CHECK:STDOUT:   %.loc24_19.1.temp = alloca { i32 }, align 8, !dbg !51
+// CHECK:STDOUT:   %.loc24_20.1.temp = alloca { i32 }, align 4, !dbg !50
+// CHECK:STDOUT:   %.loc24_20.2.temp = alloca { i32 }, align 4, !dbg !50
+// CHECK:STDOUT:   %.loc24_19.1.temp = alloca { i32 }, align 4, !dbg !51
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc24_20.1.temp), !dbg !50
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc24_20.2.temp), !dbg !50
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc24_19.1.temp), !dbg !51
@@ -248,9 +248,9 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCall.Main(ptr sret({}) %return, ptr %c, ptr %b) #0 !dbg !21 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc22_23.1.temp = alloca {}, align 8, !dbg !27
-// CHECK:STDOUT:   %.loc22_23.3.temp = alloca {}, align 8, !dbg !27
-// CHECK:STDOUT:   %.loc22_22.1.temp = alloca {}, align 8, !dbg !28
+// CHECK:STDOUT:   %.loc22_23.1.temp = alloca {}, align 1, !dbg !27
+// CHECK:STDOUT:   %.loc22_23.3.temp = alloca {}, align 1, !dbg !27
+// CHECK:STDOUT:   %.loc22_22.1.temp = alloca {}, align 1, !dbg !28
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_23.1.temp), !dbg !27
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_23.3.temp), !dbg !27
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_22.1.temp), !dbg !28
@@ -292,8 +292,8 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
 // CHECK:STDOUT: define linkonce_odr void @"_CF:thunk:I.a61d280f5ea4bfd8.Main:C.eb057aa32837c84e.Main:I.eb057aa32837c84e.Main.e43630e9a6c38c3f"(ptr sret({}) %return, ptr %self, ptr %x) #2 !dbg !47 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc18_38.2.temp = alloca {}, align 8, !dbg !51
-// CHECK:STDOUT:   %.loc12_21.1.temp = alloca {}, align 8, !dbg !52
+// CHECK:STDOUT:   %.loc18_38.2.temp = alloca {}, align 1, !dbg !51
+// CHECK:STDOUT:   %.loc12_21.1.temp = alloca {}, align 1, !dbg !52
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_38.2.temp), !dbg !51
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc12_21.1.temp), !dbg !52
 // CHECK:STDOUT:   call void @"_CConvert.B.Main:ImplicitAs.46f7e99dd8f31ccb.Core"(ptr %.loc12_21.1.temp, ptr %x), !dbg !52

--- a/toolchain/lower/testdata/index/array_element_access.carbon
+++ b/toolchain/lower/testdata/index/array_element_access.carbon
@@ -48,7 +48,7 @@ fn Run() {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca [2 x i32], align 4, !dbg !17
-// CHECK:STDOUT:   %.loc17_28.1.temp = alloca { i32, i32 }, align 8, !dbg !18
+// CHECK:STDOUT:   %.loc17_28.1.temp = alloca { i32, i32 }, align 4, !dbg !18
 // CHECK:STDOUT:   %b.var = alloca i32, align 4, !dbg !19
 // CHECK:STDOUT:   %_.var.loc19 = alloca i32, align 4, !dbg !20
 // CHECK:STDOUT:   %_.var.loc20 = alloca i32, align 4, !dbg !21

--- a/toolchain/lower/testdata/interop/cpp/class/import/alignment.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/alignment.carbon
@@ -1,0 +1,248 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/primitives.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/interop/cpp/class/import/alignment.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/interop/cpp/class/import/alignment.carbon
+
+// --- alignment.carbon
+
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+inline Cpp '''
+struct NaturallyAligned {
+  int n;
+};
+
+struct alignas(16) ExtraAlignment {
+  int n;
+};
+
+struct __attribute__((packed)) Packed {
+  int n;
+};
+
+template<typename T>
+void Take(T&);
+''';
+
+fn NaturallyAligned(n: i32) {
+  var a: Cpp.NaturallyAligned;
+  a.n = n;
+  Cpp.Take(ref a);
+}
+
+fn ExtraAlignment(n: i32) {
+  var a: Cpp.ExtraAlignment;
+  // TODO: We only specify a 4-byte alignment here, although we know that `a.n`
+  // has more alignment.
+  a.n = n;
+  Cpp.Take(ref a);
+}
+
+fn Packed(n: i32) {
+  var a: Cpp.Packed;
+  // TODO: We incorrectly specify a 4-byte alignment here. We may need to give
+  // underaligned fields a different type in order to prevent miscompiling code
+  // like this.
+  a.n = n;
+  Cpp.Take(ref a);
+}
+
+// CHECK:STDOUT: ; ModuleID = 'alignment.carbon'
+// CHECK:STDOUT: source_filename = "alignment.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CNaturallyAligned.Main(i32 %n) #0 !dbg !11 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %a.var = alloca [4 x i8], align 4, !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !17
+// CHECK:STDOUT:   call void @"_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.53704887462f6065"(ptr %a.var), !dbg !17
+// CHECK:STDOUT:   %.loc25.n = getelementptr inbounds nuw [4 x i8], ptr %a.var, i32 0, i32 0, !dbg !18
+// CHECK:STDOUT:   store i32 %n, ptr %.loc25.n, align 4, !dbg !18
+// CHECK:STDOUT:   call void @_Z4TakeI16NaturallyAlignedEvRT_(ptr %a.var), !dbg !19
+// CHECK:STDOUT:   ret void, !dbg !20
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN16NaturallyAlignedC1Ev.carbon_thunk.(ptr noundef %return) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8, !tbaa !21
+// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8, !tbaa !21
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
+// CHECK:STDOUT: define void @"_COp:thunk:Default.381601f5a2bd2e81.Core:NaturallyAligned.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !24 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN16NaturallyAlignedC1Ev.carbon_thunk.(ptr %return), !dbg !28
+// CHECK:STDOUT:   ret void, !dbg !28
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z4TakeI16NaturallyAlignedEvRT_(ptr noundef nonnull align 4 dereferenceable(4)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CExtraAlignment.Main(i32 %n) #0 !dbg !29 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %a.var = alloca [16 x i8], align 16, !dbg !32
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !32
+// CHECK:STDOUT:   call void @"_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.f529dae788690cbe"(ptr %a.var), !dbg !32
+// CHECK:STDOUT:   %.loc33.n = getelementptr inbounds nuw [16 x i8], ptr %a.var, i32 0, i32 0, !dbg !33
+// CHECK:STDOUT:   store i32 %n, ptr %.loc33.n, align 4, !dbg !33
+// CHECK:STDOUT:   call void @_Z4TakeI14ExtraAlignmentEvRT_(ptr %a.var), !dbg !34
+// CHECK:STDOUT:   ret void, !dbg !35
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN14ExtraAlignmentC1Ev.carbon_thunk.(ptr noundef %return) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8, !tbaa !36
+// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8, !tbaa !36
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
+// CHECK:STDOUT: define void @"_COp:thunk:Default.6ca50d719a15fa24.Core:ExtraAlignment.Cpp"(ptr sret([16 x i8]) %return) #2 !dbg !38 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN14ExtraAlignmentC1Ev.carbon_thunk.(ptr %return), !dbg !39
+// CHECK:STDOUT:   ret void, !dbg !39
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z4TakeI14ExtraAlignmentEvRT_(ptr noundef nonnull align 16 dereferenceable(16)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CPacked.Main(i32 %n) #0 !dbg !40 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %a.var = alloca [4 x i8], align 1, !dbg !43
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !43
+// CHECK:STDOUT:   call void @"_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.ee398c9a806dbb35"(ptr %a.var), !dbg !43
+// CHECK:STDOUT:   %.loc42.n = getelementptr inbounds nuw [4 x i8], ptr %a.var, i32 0, i32 0, !dbg !44
+// CHECK:STDOUT:   store i32 %n, ptr %.loc42.n, align 4, !dbg !44
+// CHECK:STDOUT:   call void @_Z4TakeI6PackedEvRT_(ptr %a.var), !dbg !45
+// CHECK:STDOUT:   ret void, !dbg !46
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN6PackedC1Ev.carbon_thunk.(ptr noundef %return) #1 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8, !tbaa !47
+// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8, !tbaa !47
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
+// CHECK:STDOUT: define void @"_COp:thunk:Default.ba085c8bae0456bc.Core:Packed.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !49 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN6PackedC1Ev.carbon_thunk.(ptr %return), !dbg !50
+// CHECK:STDOUT:   ret void, !dbg !50
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: declare void @_Z4TakeI6PackedEvRT_(ptr noundef nonnull align 1 dereferenceable(4)) #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #4
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @"_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.53704887462f6065"(ptr sret([4 x i8]) %return) #0 !dbg !51 {
+// CHECK:STDOUT:   call void @"_COp:thunk:Default.381601f5a2bd2e81.Core:NaturallyAligned.Cpp"(ptr %return), !dbg !53
+// CHECK:STDOUT:   ret void, !dbg !54
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @"_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.f529dae788690cbe"(ptr sret([16 x i8]) %return) #0 !dbg !55 {
+// CHECK:STDOUT:   call void @"_COp:thunk:Default.6ca50d719a15fa24.Core:ExtraAlignment.Cpp"(ptr %return), !dbg !56
+// CHECK:STDOUT:   ret void, !dbg !57
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @"_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.ee398c9a806dbb35"(ptr sret([4 x i8]) %return) #0 !dbg !58 {
+// CHECK:STDOUT:   call void @"_COp:thunk:Default.ba085c8bae0456bc.Core:Packed.Cpp"(ptr %return), !dbg !59
+// CHECK:STDOUT:   ret void, !dbg !60
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 2, 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #2 = { alwaysinline nounwind }
+// CHECK:STDOUT: attributes #3 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #4 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1, !2, !3, !4}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!5}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !6 = !DIFile(filename: "alignment.carbon", directory: "")
+// CHECK:STDOUT: !7 = !{!8, !8, i64 0}
+// CHECK:STDOUT: !8 = !{!"int", !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"omnipotent char", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "NaturallyAligned", linkageName: "_CNaturallyAligned.Main", scope: null, file: !6, line: 23, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !15)
+// CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
+// CHECK:STDOUT: !13 = !{null, !14}
+// CHECK:STDOUT: !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+// CHECK:STDOUT: !15 = !{!16}
+// CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !11, type: !14)
+// CHECK:STDOUT: !17 = !DILocation(line: 24, column: 3, scope: !11)
+// CHECK:STDOUT: !18 = !DILocation(line: 25, column: 3, scope: !11)
+// CHECK:STDOUT: !19 = !DILocation(line: 26, column: 3, scope: !11)
+// CHECK:STDOUT: !20 = !DILocation(line: 23, column: 1, scope: !11)
+// CHECK:STDOUT: !21 = !{!22, !22, i64 0}
+// CHECK:STDOUT: !22 = !{!"p1 _ZTS16NaturallyAligned", !23, i64 0}
+// CHECK:STDOUT: !23 = !{!"any pointer", !9, i64 0}
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:Default.381601f5a2bd2e81.Core:NaturallyAligned.Cpp", scope: null, file: !6, line: 7, type: !25, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !25 = !DISubroutineType(types: !26)
+// CHECK:STDOUT: !26 = !{!27}
+// CHECK:STDOUT: !27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !28 = !DILocation(line: 7, column: 8, scope: !24)
+// CHECK:STDOUT: !29 = distinct !DISubprogram(name: "ExtraAlignment", linkageName: "_CExtraAlignment.Main", scope: null, file: !6, line: 29, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !30)
+// CHECK:STDOUT: !30 = !{!31}
+// CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !14)
+// CHECK:STDOUT: !32 = !DILocation(line: 30, column: 3, scope: !29)
+// CHECK:STDOUT: !33 = !DILocation(line: 33, column: 3, scope: !29)
+// CHECK:STDOUT: !34 = !DILocation(line: 34, column: 3, scope: !29)
+// CHECK:STDOUT: !35 = !DILocation(line: 29, column: 1, scope: !29)
+// CHECK:STDOUT: !36 = !{!37, !37, i64 0}
+// CHECK:STDOUT: !37 = !{!"p1 _ZTS14ExtraAlignment", !23, i64 0}
+// CHECK:STDOUT: !38 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:Default.6ca50d719a15fa24.Core:ExtraAlignment.Cpp", scope: null, file: !6, line: 11, type: !25, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !39 = !DILocation(line: 11, column: 20, scope: !38)
+// CHECK:STDOUT: !40 = distinct !DISubprogram(name: "Packed", linkageName: "_CPacked.Main", scope: null, file: !6, line: 37, type: !12, spFlags: DISPFlagDefinition, unit: !5, retainedNodes: !41)
+// CHECK:STDOUT: !41 = !{!42}
+// CHECK:STDOUT: !42 = !DILocalVariable(arg: 1, scope: !40, type: !14)
+// CHECK:STDOUT: !43 = !DILocation(line: 38, column: 3, scope: !40)
+// CHECK:STDOUT: !44 = !DILocation(line: 42, column: 3, scope: !40)
+// CHECK:STDOUT: !45 = !DILocation(line: 43, column: 3, scope: !40)
+// CHECK:STDOUT: !46 = !DILocation(line: 37, column: 1, scope: !40)
+// CHECK:STDOUT: !47 = !{!48, !48, i64 0}
+// CHECK:STDOUT: !48 = !{!"p1 _ZTS6Packed", !23, i64 0}
+// CHECK:STDOUT: !49 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:Default.ba085c8bae0456bc.Core:Packed.Cpp", scope: null, file: !6, line: 15, type: !25, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !50 = !DILocation(line: 15, column: 32, scope: !49)
+// CHECK:STDOUT: !51 = distinct !DISubprogram(name: "Op", linkageName: "_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.53704887462f6065", scope: null, file: !52, line: 9, type: !25, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !52 = !DIFile(filename: "min_prelude/parts/default.carbon", directory: "")
+// CHECK:STDOUT: !53 = !DILocation(line: 9, column: 28, scope: !51)
+// CHECK:STDOUT: !54 = !DILocation(line: 9, column: 21, scope: !51)
+// CHECK:STDOUT: !55 = distinct !DISubprogram(name: "Op", linkageName: "_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.f529dae788690cbe", scope: null, file: !52, line: 9, type: !25, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !56 = !DILocation(line: 9, column: 28, scope: !55)
+// CHECK:STDOUT: !57 = !DILocation(line: 9, column: 21, scope: !55)
+// CHECK:STDOUT: !58 = distinct !DISubprogram(name: "Op", linkageName: "_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.ee398c9a806dbb35", scope: null, file: !52, line: 9, type: !25, spFlags: DISPFlagDefinition, unit: !5)
+// CHECK:STDOUT: !59 = !DILocation(line: 9, column: 28, scope: !58)
+// CHECK:STDOUT: !60 = !DILocation(line: 9, column: 21, scope: !58)

--- a/toolchain/lower/testdata/interop/cpp/constructor.carbon
+++ b/toolchain/lower/testdata/interop/cpp/constructor.carbon
@@ -179,7 +179,7 @@ fn Four() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc7_26.1.temp = alloca [8 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %.loc7_26.1.temp = alloca [8 x i8], align 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_26.1.temp), !dbg !14
 // CHECK:STDOUT:   call void @_ZN1CC1Ev.carbon_thunk.(ptr %.loc7_26.1.temp), !dbg !14
 // CHECK:STDOUT:   ret void, !dbg !15
@@ -198,7 +198,7 @@ fn Four() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !19 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc11_19.2.temp = alloca [8 x i8], align 1, !dbg !20
+// CHECK:STDOUT:   %.loc11_19.2.temp = alloca [8 x i8], align 4, !dbg !20
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc11_19.2.temp), !dbg !20
 // CHECK:STDOUT:   call void @_ZN1CC1Ev.carbon_thunk_tuple.(ptr %.loc11_19.2.temp), !dbg !20
 // CHECK:STDOUT:   ret void, !dbg !21
@@ -279,7 +279,7 @@ fn Four() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [8 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %_.var = alloca [8 x i8], align 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   call void @"_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.4fdc745d4b6d0e3c"(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   ret void, !dbg !15
@@ -381,10 +381,10 @@ fn Four() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc8_65.1.temp = alloca [4 x i8], align 1, !dbg !14
-// CHECK:STDOUT:   %_.var.loc9 = alloca [4 x i8], align 1, !dbg !15
-// CHECK:STDOUT:   %.loc12_65.1.temp = alloca [4 x i8], align 1, !dbg !16
-// CHECK:STDOUT:   %_.var.loc13 = alloca [4 x i8], align 1, !dbg !17
+// CHECK:STDOUT:   %.loc8_65.1.temp = alloca [4 x i8], align 4, !dbg !14
+// CHECK:STDOUT:   %_.var.loc9 = alloca [4 x i8], align 4, !dbg !15
+// CHECK:STDOUT:   %.loc12_65.1.temp = alloca [4 x i8], align 4, !dbg !16
+// CHECK:STDOUT:   %_.var.loc13 = alloca [4 x i8], align 4, !dbg !17
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc8_65.1.temp), !dbg !14
 // CHECK:STDOUT:   call void @_ZN26ImplicitlyDefaultedDefaultC1Ev.carbon_thunk.(ptr %.loc8_65.1.temp), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc9), !dbg !15
@@ -532,7 +532,7 @@ fn Four() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCopy.Main(ptr sret([4 x i8]) %return, ptr %c) #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc7_10.1.temp = alloca [4 x i8], align 1, !dbg !17
+// CHECK:STDOUT:   %.loc7_10.1.temp = alloca [4 x i8], align 4, !dbg !17
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_10.1.temp), !dbg !17
 // CHECK:STDOUT:   call void @_ZN4CopyC1ERKS_.carbon_thunk._(ptr %c, ptr %return), !dbg !17
 // CHECK:STDOUT:   ret void, !dbg !18
@@ -631,7 +631,7 @@ fn Four() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc7_44.1.temp = alloca [8 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %.loc7_44.1.temp = alloca [8 x i8], align 8, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc7_44.1.temp), !dbg !14
 // CHECK:STDOUT:   call void @_ZN7DerivedC1Ev.carbon_thunk.(ptr %.loc7_44.1.temp), !dbg !14
 // CHECK:STDOUT:   ret void, !dbg !15

--- a/toolchain/lower/testdata/interop/cpp/parameters.carbon
+++ b/toolchain/lower/testdata/interop/cpp/parameters.carbon
@@ -365,7 +365,7 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CTest.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca [12 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %x.var = alloca [12 x i8], align 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !14
 // CHECK:STDOUT:   call void @"_COp.cbe5dd53b28eb3d1:DefaultOrUnformed.Core.1cc04ab0b0144e39"(ptr %x.var), !dbg !14
 // CHECK:STDOUT:   %.loc8_4.a = getelementptr inbounds nuw [12 x i8], ptr %x.var, i32 0, i32 0, !dbg !15
@@ -484,7 +484,7 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CPassRefExpr.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %y.var = alloca [12 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %y.var = alloca [12 x i8], align 4, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %y.var), !dbg !14
 // CHECK:STDOUT:   %.loc8_4.a = getelementptr inbounds nuw [12 x i8], ptr %y.var, i32 0, i32 0, !dbg !15
 // CHECK:STDOUT:   store i32 1, ptr %.loc8_4.a, align 4, !dbg !15
@@ -513,7 +513,7 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CPassInitExpr.Main() #0 !dbg !23 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc17_24.1.temp = alloca [12 x i8], align 1, !dbg !24
+// CHECK:STDOUT:   %.loc17_24.1.temp = alloca [12 x i8], align 4, !dbg !24
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc17_24.1.temp), !dbg !24
 // CHECK:STDOUT:   call void @_CMake.Main(ptr %.loc17_24.1.temp), !dbg !24
 // CHECK:STDOUT:   call void @_Z11pass_struct1Y.carbon_thunk._(ptr %.loc17_24.1.temp), !dbg !25

--- a/toolchain/lower/testdata/interop/cpp/reference.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reference.carbon
@@ -138,8 +138,8 @@ fn GetRefs() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CPassRefs.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !14
-// CHECK:STDOUT:   %_.var.1 = alloca {}, align 8, !dbg !15
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !14
+// CHECK:STDOUT:   %_.var.1 = alloca {}, align 1, !dbg !15
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !16
 // CHECK:STDOUT:   %_.var.2 = alloca i32, align 4, !dbg !17
 // CHECK:STDOUT:   %.loc25_23.2.temp = alloca i32, align 4, !dbg !18
@@ -327,8 +327,8 @@ fn GetRefs() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CPassRefs.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !14
-// CHECK:STDOUT:   %.loc20_18.2.temp = alloca {}, align 8, !dbg !15
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !14
+// CHECK:STDOUT:   %.loc20_18.2.temp = alloca {}, align 1, !dbg !15
 // CHECK:STDOUT:   %n.var = alloca i32, align 4, !dbg !16
 // CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !17
 // CHECK:STDOUT:   %.loc26_23.2.temp = alloca i32, align 4, !dbg !18

--- a/toolchain/lower/testdata/interop/cpp/return.carbon
+++ b/toolchain/lower/testdata/interop/cpp/return.carbon
@@ -574,7 +574,7 @@ fn Call(x: Cpp.D) -> Cpp.C {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CLet.Main() #0 !dbg !20 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc9_27.1.temp = alloca [16 x i8], align 1, !dbg !23
+// CHECK:STDOUT:   %.loc9_27.1.temp = alloca [16 x i8], align 8, !dbg !23
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_27.1.temp), !dbg !23
 // CHECK:STDOUT:   call void @_Z4Makev.carbon_thunk.(ptr %.loc9_27.1.temp), !dbg !23
 // CHECK:STDOUT:   call void @_ZN1XD1Ev(ptr %.loc9_27.1.temp), !dbg !23
@@ -587,7 +587,7 @@ fn Call(x: Cpp.D) -> Cpp.C {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CVar.Main() #0 !dbg !25 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 1, !dbg !26
+// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 8, !dbg !26
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !26
 // CHECK:STDOUT:   call void @_Z4Makev.carbon_thunk.(ptr %_.var), !dbg !27
 // CHECK:STDOUT:   call void @_ZN1XD1Ev(ptr %_.var), !dbg !26

--- a/toolchain/lower/testdata/interop/cpp/reverse/class.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reverse/class.carbon
@@ -497,7 +497,7 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #2 !dbg !41 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca { i32, i32 }, align 8, !dbg !44
+// CHECK:STDOUT:   %c.var = alloca { i32, i32 }, align 4, !dbg !44
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !44
 // CHECK:STDOUT:   %.loc19_29.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %c.var, i32 0, i32 0, !dbg !45
 // CHECK:STDOUT:   %.loc19_29.6.b = getelementptr inbounds nuw { i32, i32 }, ptr %c.var, i32 0, i32 1, !dbg !45

--- a/toolchain/lower/testdata/interop/cpp/std_initializer_list.carbon
+++ b/toolchain/lower/testdata/interop/cpp/std_initializer_list.carbon
@@ -134,7 +134,7 @@ fn InitNontrivialDtor() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CInitDirectly.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 8, !dbg !14
 // CHECK:STDOUT:   %.loc13_50.3.temp = alloca [3 x i32], align 4, !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc13_50.3.temp), !dbg !15
@@ -166,7 +166,7 @@ fn InitNontrivialDtor() {
 // CHECK:STDOUT: define void @_CInitVectorLike.Main() #0 !dbg !32 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %_.var = alloca [1 x i8], align 1, !dbg !33
-// CHECK:STDOUT:   %.loc18_36.2.temp = alloca [16 x i8], align 1, !dbg !34
+// CHECK:STDOUT:   %.loc18_36.2.temp = alloca [16 x i8], align 8, !dbg !34
 // CHECK:STDOUT:   %.loc18_36.4.temp = alloca [3 x i32], align 4, !dbg !34
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !33
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_36.2.temp), !dbg !34
@@ -216,7 +216,7 @@ fn InitNontrivialDtor() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CInitNontrivialDtor.Main() #0 !dbg !45 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 1, !dbg !46
+// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 8, !dbg !46
 // CHECK:STDOUT:   %.loc23_69.17.temp = alloca [3 x [1 x i8]], align 1, !dbg !47
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !46
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc23_69.17.temp), !dbg !47
@@ -382,7 +382,7 @@ fn InitNontrivialDtor() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CInitDirectly.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 8, !dbg !14
 // CHECK:STDOUT:   %.loc13_50.3.temp = alloca [3 x i32], align 4, !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc13_50.3.temp), !dbg !15
@@ -414,7 +414,7 @@ fn InitNontrivialDtor() {
 // CHECK:STDOUT: define void @_CInitVectorLike.Main() #0 !dbg !32 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %_.var = alloca [1 x i8], align 1, !dbg !33
-// CHECK:STDOUT:   %.loc18_36.2.temp = alloca [16 x i8], align 1, !dbg !34
+// CHECK:STDOUT:   %.loc18_36.2.temp = alloca [16 x i8], align 8, !dbg !34
 // CHECK:STDOUT:   %.loc18_36.4.temp = alloca [3 x i32], align 4, !dbg !34
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !33
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_36.2.temp), !dbg !34
@@ -464,7 +464,7 @@ fn InitNontrivialDtor() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CInitNontrivialDtor.Main() #0 !dbg !47 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 1, !dbg !48
+// CHECK:STDOUT:   %_.var = alloca [16 x i8], align 8, !dbg !48
 // CHECK:STDOUT:   %.loc23_69.17.temp = alloca [3 x [1 x i8]], align 1, !dbg !49
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !48
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc23_69.17.temp), !dbg !49

--- a/toolchain/lower/testdata/interop/cpp/template.carbon
+++ b/toolchain/lower/testdata/interop/cpp/template.carbon
@@ -269,7 +269,7 @@ fn Call3() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCall1.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc12_12.2.temp = alloca {}, align 8, !dbg !14
+// CHECK:STDOUT:   %.loc12_12.2.temp = alloca {}, align 1, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc12_12.2.temp), !dbg !14
 // CHECK:STDOUT:   call void @_Z3fooIJEEv1XDpT_.carbon_thunk._(ptr @X.val.loc12_14.3), !dbg !15
 // CHECK:STDOUT:   ret void, !dbg !16
@@ -289,7 +289,7 @@ fn Call3() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCall2.Main() #0 !dbg !20 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc18_12.2.temp = alloca {}, align 8, !dbg !21
+// CHECK:STDOUT:   %.loc18_12.2.temp = alloca {}, align 1, !dbg !21
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_12.2.temp), !dbg !21
 // CHECK:STDOUT:   call void @_Z3fooIJiEEv1XDpT_.carbon_thunk.__(ptr @X.val.loc12_14.3, i32 2), !dbg !22
 // CHECK:STDOUT:   ret void, !dbg !23
@@ -312,7 +312,7 @@ fn Call3() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCall3.Main() #0 !dbg !24 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc24_12.2.temp = alloca {}, align 8, !dbg !25
+// CHECK:STDOUT:   %.loc24_12.2.temp = alloca {}, align 1, !dbg !25
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc24_12.2.temp), !dbg !25
 // CHECK:STDOUT:   call void @_Z3fooIJiiEEv1XDpT_.carbon_thunk.___(ptr @X.val.loc12_14.3, i32 2, i32 3), !dbg !26
 // CHECK:STDOUT:   ret void, !dbg !27

--- a/toolchain/lower/testdata/interop/cpp/virtual_base.carbon
+++ b/toolchain/lower/testdata/interop/cpp/virtual_base.carbon
@@ -111,7 +111,7 @@ fn AccessD(d: Cpp.D) -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CMake.Main() #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca [40 x i8], align 1, !dbg !14
+// CHECK:STDOUT:   %_.var = alloca [40 x i8], align 8, !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   call void @_ZN1DC1Ev.carbon_thunk.(ptr %_.var), !dbg !15
 // CHECK:STDOUT:   ret void, !dbg !16

--- a/toolchain/lower/testdata/let/copy_value_rep.carbon
+++ b/toolchain/lower/testdata/let/copy_value_rep.carbon
@@ -30,7 +30,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca { i32 }, align 8, !dbg !8
+// CHECK:STDOUT:   %x.var = alloca { i32 }, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   %.loc18_21.3.a = getelementptr inbounds nuw { i32 }, ptr %x.var, i32 0, i32 0, !dbg !9
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %x.var, ptr align 4 @X.val.loc18_3, i64 4, i1 false), !dbg !8

--- a/toolchain/lower/testdata/let/tuple.carbon
+++ b/toolchain/lower/testdata/let/tuple.carbon
@@ -26,44 +26,47 @@ fn F() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 4, !dbg !8
+// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 4, !dbg !9
+// CHECK:STDOUT:   %tuple.loc16_43 = alloca { i32, i32, i32 }, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_46 = alloca { i32, i32 }, align 4, !dbg !11
+// CHECK:STDOUT:   %tuple.loc16_47 = alloca { ptr, ptr }, align 8, !dbg !12
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !8
-// CHECK:STDOUT:   %tuple.elem0.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !10
-// CHECK:STDOUT:   %tuple.elem1.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !10
-// CHECK:STDOUT:   %tuple.elem2.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !10
+// CHECK:STDOUT:   %tuple.elem0.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !13
+// CHECK:STDOUT:   %tuple.elem1.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !13
+// CHECK:STDOUT:   %tuple.elem2.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !13
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @tuple.8d2.loc14_3, i64 12, i1 false), !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !9
-// CHECK:STDOUT:   %tuple.elem0.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !11
-// CHECK:STDOUT:   %tuple.elem1.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   %tuple.elem0.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !14
+// CHECK:STDOUT:   %tuple.elem1.loc15.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !14
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %b.var, ptr align 4 @tuple.57b.loc15_3, i64 8, i1 false), !dbg !9
-// CHECK:STDOUT:   %tuple.elem0.loc16_43.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !12
-// CHECK:STDOUT:   %.loc16_43.1 = load i32, ptr %tuple.elem0.loc16_43.tuple.elem, align 4, !dbg !12
-// CHECK:STDOUT:   %tuple.elem1.loc16_43.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !12
-// CHECK:STDOUT:   %.loc16_43.2 = load i32, ptr %tuple.elem1.loc16_43.tuple.elem, align 4, !dbg !12
-// CHECK:STDOUT:   %tuple.elem2.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !12
-// CHECK:STDOUT:   %.loc16_43.3 = load i32, ptr %tuple.elem2.loc16.tuple.elem, align 4, !dbg !12
-// CHECK:STDOUT:   %tuple.loc16_43 = alloca { i32, i32, i32 }, align 8, !dbg !12
-// CHECK:STDOUT:   %tuple.loc16_431 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_43, i32 0, i32 0, !dbg !12
-// CHECK:STDOUT:   store i32 %.loc16_43.1, ptr %tuple.loc16_431, align 4, !dbg !12
-// CHECK:STDOUT:   %tuple.loc16_432 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_43, i32 0, i32 1, !dbg !12
-// CHECK:STDOUT:   store i32 %.loc16_43.2, ptr %tuple.loc16_432, align 4, !dbg !12
-// CHECK:STDOUT:   %tuple.loc16_433 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_43, i32 0, i32 2, !dbg !12
-// CHECK:STDOUT:   store i32 %.loc16_43.3, ptr %tuple.loc16_433, align 4, !dbg !12
-// CHECK:STDOUT:   %tuple.elem0.loc16_46.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !13
-// CHECK:STDOUT:   %.loc16_46.1 = load i32, ptr %tuple.elem0.loc16_46.tuple.elem, align 4, !dbg !13
-// CHECK:STDOUT:   %tuple.elem1.loc16_46.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !13
-// CHECK:STDOUT:   %.loc16_46.2 = load i32, ptr %tuple.elem1.loc16_46.tuple.elem, align 4, !dbg !13
-// CHECK:STDOUT:   %tuple.loc16_46 = alloca { i32, i32 }, align 8, !dbg !13
-// CHECK:STDOUT:   %tuple.loc16_464 = getelementptr inbounds nuw { i32, i32 }, ptr %tuple.loc16_46, i32 0, i32 0, !dbg !13
-// CHECK:STDOUT:   store i32 %.loc16_46.1, ptr %tuple.loc16_464, align 4, !dbg !13
-// CHECK:STDOUT:   %tuple.loc16_465 = getelementptr inbounds nuw { i32, i32 }, ptr %tuple.loc16_46, i32 0, i32 1, !dbg !13
-// CHECK:STDOUT:   store i32 %.loc16_46.2, ptr %tuple.loc16_465, align 4, !dbg !13
-// CHECK:STDOUT:   %tuple.loc16_47 = alloca { ptr, ptr }, align 8, !dbg !14
-// CHECK:STDOUT:   %tuple.loc16_476 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_47, i32 0, i32 0, !dbg !14
-// CHECK:STDOUT:   store ptr %tuple.loc16_43, ptr %tuple.loc16_476, align 8, !dbg !14
-// CHECK:STDOUT:   %tuple.loc16_477 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_47, i32 0, i32 1, !dbg !14
-// CHECK:STDOUT:   store ptr %tuple.loc16_46, ptr %tuple.loc16_477, align 8, !dbg !14
+// CHECK:STDOUT:   %tuple.elem0.loc16_43.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   %.loc16_43.1 = load i32, ptr %tuple.elem0.loc16_43.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.elem1.loc16_43.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   %.loc16_43.2 = load i32, ptr %tuple.elem1.loc16_43.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.elem2.loc16.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !10
+// CHECK:STDOUT:   %.loc16_43.3 = load i32, ptr %tuple.elem2.loc16.tuple.elem, align 4, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %tuple.loc16_43), !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_431 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_43, i32 0, i32 0, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc16_43.1, ptr %tuple.loc16_431, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_432 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_43, i32 0, i32 1, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc16_43.2, ptr %tuple.loc16_432, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.loc16_433 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc16_43, i32 0, i32 2, !dbg !10
+// CHECK:STDOUT:   store i32 %.loc16_43.3, ptr %tuple.loc16_433, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.elem0.loc16_46.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   %.loc16_46.1 = load i32, ptr %tuple.elem0.loc16_46.tuple.elem, align 4, !dbg !11
+// CHECK:STDOUT:   %tuple.elem1.loc16_46.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   %.loc16_46.2 = load i32, ptr %tuple.elem1.loc16_46.tuple.elem, align 4, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %tuple.loc16_46), !dbg !11
+// CHECK:STDOUT:   %tuple.loc16_464 = getelementptr inbounds nuw { i32, i32 }, ptr %tuple.loc16_46, i32 0, i32 0, !dbg !11
+// CHECK:STDOUT:   store i32 %.loc16_46.1, ptr %tuple.loc16_464, align 4, !dbg !11
+// CHECK:STDOUT:   %tuple.loc16_465 = getelementptr inbounds nuw { i32, i32 }, ptr %tuple.loc16_46, i32 0, i32 1, !dbg !11
+// CHECK:STDOUT:   store i32 %.loc16_46.2, ptr %tuple.loc16_465, align 4, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %tuple.loc16_47), !dbg !12
+// CHECK:STDOUT:   %tuple.loc16_476 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_47, i32 0, i32 0, !dbg !12
+// CHECK:STDOUT:   store ptr %tuple.loc16_43, ptr %tuple.loc16_476, align 8, !dbg !12
+// CHECK:STDOUT:   %tuple.loc16_477 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_47, i32 0, i32 1, !dbg !12
+// CHECK:STDOUT:   store ptr %tuple.loc16_46, ptr %tuple.loc16_477, align 8, !dbg !12
 // CHECK:STDOUT:   %tuple.elem1.loc17_11.tuple.elem = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc16_47, i32 0, i32 1, !dbg !15
 // CHECK:STDOUT:   %tuple.elem1.loc17_11.tuple.elem.load = load ptr, ptr %tuple.elem1.loc17_11.tuple.elem, align 8, !dbg !15
 // CHECK:STDOUT:   %tuple.elem1.loc17_13.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %tuple.elem1.loc17_11.tuple.elem.load, i32 0, i32 1, !dbg !15
@@ -98,7 +101,7 @@ fn F() -> i32 {
 // CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
-// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 4, 3, 2, 1, 0 }
 // CHECK:STDOUT: uselistorder ptr @llvm.memcpy.p0.p0.i64, { 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
@@ -117,11 +120,11 @@ fn F() -> i32 {
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 14, column: 28, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 15, column: 23, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 16, column: 43, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 16, column: 46, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 16, column: 42, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 16, column: 43, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 16, column: 46, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 16, column: 42, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 14, column: 28, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 15, column: 23, scope: !4)
 // CHECK:STDOUT: !15 = !DILocation(line: 17, column: 10, scope: !4)
 // CHECK:STDOUT: !16 = !DILocation(line: 17, column: 3, scope: !4)
 // CHECK:STDOUT: !17 = distinct !DISubprogram(name: "Op", linkageName: "_COp.94e3ca86614aba5d:core.Destroy.Core", scope: null, file: !3, line: 15, type: !18, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !20)

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -48,7 +48,7 @@ fn G() -> (i32, i32) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main(ptr sret({ i32, i32 }) %return) #0 !dbg !18 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 8, !dbg !22
+// CHECK:STDOUT:   %b.var = alloca { i32, i32 }, align 4, !dbg !22
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !22
 // CHECK:STDOUT:   %tuple.elem0.loc21.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 0, !dbg !23
 // CHECK:STDOUT:   %tuple.elem1.loc21.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %b.var, i32 0, i32 1, !dbg !23

--- a/toolchain/lower/testdata/operators/overloaded.carbon
+++ b/toolchain/lower/testdata/operators/overloaded.carbon
@@ -94,7 +94,7 @@ fn Calculate(a: Number, b: Number) -> Number {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCalculate.Main(ptr sret({ i1 }) %return, ptr %a, ptr %b) #0 !dbg !29 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc30_10.1.temp = alloca { i1 }, align 8, !dbg !33
+// CHECK:STDOUT:   %.loc30_10.1.temp = alloca { i1 }, align 1, !dbg !33
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc30_10.1.temp), !dbg !33
 // CHECK:STDOUT:   call void @"_COp.Number.Main:Negate.Core"(ptr %.loc30_10.1.temp, ptr %a), !dbg !33
 // CHECK:STDOUT:   call void @"_COp.Number.Main:MulWith.3dbfed2bcb44ac1d.Core"(ptr %return, ptr %.loc30_10.1.temp, ptr %b), !dbg !33

--- a/toolchain/lower/testdata/packages/imported_type_completeness.carbon
+++ b/toolchain/lower/testdata/packages/imported_type_completeness.carbon
@@ -122,8 +122,8 @@ fn CallF() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define linkonce_odr void @_CG.Main.e43630e9a6c38c3f() #0 !dbg !17 {
-// CHECK:STDOUT:   %temp = alloca {}, align 8, !dbg !18
-// CHECK:STDOUT:   %temp1 = alloca {}, align 8, !dbg !19
+// CHECK:STDOUT:   %temp = alloca {}, align 1, !dbg !18
+// CHECK:STDOUT:   %temp1 = alloca {}, align 1, !dbg !19
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %temp), !dbg !18
 // CHECK:STDOUT:   %1 = call i123 @_CF.C.Main.e43630e9a6c38c3f(), !dbg !20
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %temp1), !dbg !19
@@ -267,7 +267,7 @@ fn CallF() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CCallF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc9_9.2.temp = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   %.loc9_9.2.temp = alloca {}, align 1, !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc9_9.2.temp), !dbg !7
 // CHECK:STDOUT:   call void @_CF.Main.48caacd0cd7b6e0f(ptr @C.val.a51.loc9_11.3), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.a2f46f9b7e36af17:core.Destroy.Core"(ptr @C.val.a51), !dbg !7

--- a/toolchain/lower/testdata/pointer/address_of_field.carbon
+++ b/toolchain/lower/testdata/pointer/address_of_field.carbon
@@ -27,7 +27,7 @@ fn F() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %s.var = alloca { i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %s.var = alloca { i32, i32 }, align 4, !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %s.var), !dbg !7
 // CHECK:STDOUT:   %.loc16_46.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %s.var, i32 0, i32 0, !dbg !8
 // CHECK:STDOUT:   %.loc16_46.6.b = getelementptr inbounds nuw { i32, i32 }, ptr %s.var, i32 0, i32 1, !dbg !8

--- a/toolchain/lower/testdata/primitives/optional.carbon
+++ b/toolchain/lower/testdata/primitives/optional.carbon
@@ -86,14 +86,14 @@ fn F(c: Core.Optional(C*)) -> Core.Optional(C*) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CAddOrRemoveConst.Main(i32 %a, i32 %b) #0 !dbg !24 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var.loc11 = alloca <{ i32, i1 }>, align 8, !dbg !30
-// CHECK:STDOUT:   %_.var.loc12 = alloca <{ i32, i1 }>, align 8, !dbg !31
-// CHECK:STDOUT:   %_.var.loc13 = alloca <{ i32, i1 }>, align 8, !dbg !32
-// CHECK:STDOUT:   %_.var.loc14 = alloca <{ i32, i1 }>, align 8, !dbg !33
-// CHECK:STDOUT:   %_.var.loc15 = alloca <{ i32, i1 }>, align 8, !dbg !34
-// CHECK:STDOUT:   %_.var.loc16 = alloca <{ i32, i1 }>, align 8, !dbg !35
-// CHECK:STDOUT:   %_.var.loc17 = alloca <{ i32, i1 }>, align 8, !dbg !36
-// CHECK:STDOUT:   %_.var.loc18 = alloca <{ i32, i1 }>, align 8, !dbg !37
+// CHECK:STDOUT:   %_.var.loc11 = alloca <{ i32, i1 }>, align 4, !dbg !30
+// CHECK:STDOUT:   %_.var.loc12 = alloca <{ i32, i1 }>, align 4, !dbg !31
+// CHECK:STDOUT:   %_.var.loc13 = alloca <{ i32, i1 }>, align 4, !dbg !32
+// CHECK:STDOUT:   %_.var.loc14 = alloca <{ i32, i1 }>, align 4, !dbg !33
+// CHECK:STDOUT:   %_.var.loc15 = alloca <{ i32, i1 }>, align 4, !dbg !34
+// CHECK:STDOUT:   %_.var.loc16 = alloca <{ i32, i1 }>, align 4, !dbg !35
+// CHECK:STDOUT:   %_.var.loc17 = alloca <{ i32, i1 }>, align 4, !dbg !36
+// CHECK:STDOUT:   %_.var.loc18 = alloca <{ i32, i1 }>, align 4, !dbg !37
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc11), !dbg !30
 // CHECK:STDOUT:   call void @"_CConvert.6391a65a70757668:ImplicitAs.116c0b3f4fb552e2.Core.d356e073ce1a5b35"(ptr %_.var.loc11, i32 %a), !dbg !30
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc12), !dbg !31

--- a/toolchain/lower/testdata/struct/empty.carbon
+++ b/toolchain/lower/testdata/struct/empty.carbon
@@ -22,8 +22,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !8
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   %x.var = alloca {}, align 1, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   ret i32 0, !dbg !10

--- a/toolchain/lower/testdata/struct/layout.carbon
+++ b/toolchain/lower/testdata/struct/layout.carbon
@@ -81,7 +81,7 @@ fn F() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %no_padding.var = alloca { i32, i32, i32 }, align 8, !dbg !7
+// CHECK:STDOUT:   %no_padding.var = alloca { i32, i32, i32 }, align 4, !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %no_padding.var), !dbg !7
 // CHECK:STDOUT:   %.loc8.x = getelementptr inbounds nuw { i32, i32, i32 }, ptr %no_padding.var, i32 0, i32 0, !dbg !8
 // CHECK:STDOUT:   call void @_CG.Main(ptr %.loc8.x), !dbg !9

--- a/toolchain/lower/testdata/struct/member_access.carbon
+++ b/toolchain/lower/testdata/struct/member_access.carbon
@@ -31,7 +31,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   %.loc14_48.3.a = getelementptr inbounds nuw <{ double, i32 }>, ptr %x.var, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   %.loc14_48.6.b = getelementptr inbounds nuw <{ double, i32 }>, ptr %x.var, i32 0, i32 1, !dbg !11
-// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %x.var, ptr align 1 @struct.084.loc14_3, i64 12, i1 false), !dbg !8
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %x.var, ptr align 8 @struct.084.loc14_3, i64 12, i1 false), !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %y.var), !dbg !9
 // CHECK:STDOUT:   %.loc15_17.1.b = getelementptr inbounds nuw <{ double, i32 }>, ptr %x.var, i32 0, i32 1, !dbg !12
 // CHECK:STDOUT:   %.loc15_17.2 = load i32, ptr %.loc15_17.1.b, align 4, !dbg !12

--- a/toolchain/lower/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/lower/testdata/struct/nested_struct_in_place.carbon
@@ -24,7 +24,7 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 8, !dbg !7
+// CHECK:STDOUT:   %_.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 4, !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !7
 // CHECK:STDOUT:   %.loc16_74.1.a = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %_.var, i32 0, i32 0, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_74.1.a), !dbg !9

--- a/toolchain/lower/testdata/struct/one_entry.carbon
+++ b/toolchain/lower/testdata/struct/one_entry.carbon
@@ -22,8 +22,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca { i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %_.var = alloca { i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %x.var = alloca { i32 }, align 4, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { i32 }, align 4, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   store { i32 } { i32 4 }, ptr %x.var, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9

--- a/toolchain/lower/testdata/struct/two_entries.carbon
+++ b/toolchain/lower/testdata/struct/two_entries.carbon
@@ -24,8 +24,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 4, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 4, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   %.loc14_46.3.a = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
 // CHECK:STDOUT:   %.loc14_46.6.b = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !10

--- a/toolchain/lower/testdata/tuple/access/element_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/element_access.carbon
@@ -25,7 +25,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8, !dbg !8
+// CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 4, !dbg !8
 // CHECK:STDOUT:   %_.var.loc15 = alloca i32, align 4, !dbg !9
 // CHECK:STDOUT:   %_.var.loc16 = alloca i32, align 4, !dbg !10
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !8

--- a/toolchain/lower/testdata/tuple/access/return_value_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/return_value_access.carbon
@@ -34,7 +34,7 @@ fn Run() {
 // CHECK:STDOUT: define i32 @main() #0 !dbg !10 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %_.var = alloca i32, align 4, !dbg !14
-// CHECK:STDOUT:   %.loc16_18.1.temp = alloca { i32, i32 }, align 8, !dbg !15
+// CHECK:STDOUT:   %.loc16_18.1.temp = alloca { i32, i32 }, align 4, !dbg !15
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !14
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc16_18.1.temp), !dbg !15
 // CHECK:STDOUT:   call void @_CF.Main(ptr %.loc16_18.1.temp), !dbg !15

--- a/toolchain/lower/testdata/tuple/empty.carbon
+++ b/toolchain/lower/testdata/tuple/empty.carbon
@@ -22,8 +22,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca {}, align 8, !dbg !8
-// CHECK:STDOUT:   %_.var = alloca {}, align 8, !dbg !9
+// CHECK:STDOUT:   %x.var = alloca {}, align 1, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca {}, align 1, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9
 // CHECK:STDOUT:   ret i32 0, !dbg !10

--- a/toolchain/lower/testdata/tuple/nested_tuple_in_place.carbon
+++ b/toolchain/lower/testdata/tuple/nested_tuple_in_place.carbon
@@ -24,7 +24,7 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %_.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 8, !dbg !7
+// CHECK:STDOUT:   %_.var = alloca { { i32, i32, i32 }, { i32, i32, i32 } }, align 4, !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !7
 // CHECK:STDOUT:   %tuple.elem0.tuple.elem = getelementptr inbounds nuw { { i32, i32, i32 }, { i32, i32, i32 } }, ptr %_.var, i32 0, i32 0, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %tuple.elem0.tuple.elem), !dbg !9

--- a/toolchain/lower/testdata/tuple/one_entry.carbon
+++ b/toolchain/lower/testdata/tuple/one_entry.carbon
@@ -22,8 +22,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca { i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %_.var = alloca { i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %x.var = alloca { i32 }, align 4, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { i32 }, align 4, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   store { i32 } { i32 1 }, ptr %x.var, align 4, !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var), !dbg !9

--- a/toolchain/lower/testdata/tuple/two_entries.carbon
+++ b/toolchain/lower/testdata/tuple/two_entries.carbon
@@ -24,8 +24,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 8, !dbg !8
-// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   %x.var = alloca { i32, i32 }, align 4, !dbg !8
+// CHECK:STDOUT:   %_.var = alloca { i32, i32 }, align 4, !dbg !9
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %x.var), !dbg !8
 // CHECK:STDOUT:   %tuple.elem0.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 0, !dbg !10
 // CHECK:STDOUT:   %tuple.elem1.loc14.tuple.elem = getelementptr inbounds nuw { i32, i32 }, ptr %x.var, i32 0, i32 1, !dbg !10

--- a/toolchain/lower/testdata/tuple/value_formation.carbon
+++ b/toolchain/lower/testdata/tuple/value_formation.carbon
@@ -26,8 +26,11 @@ fn F() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CF.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8, !dbg !7
-// CHECK:STDOUT:   %b.var = alloca { i32, i32, i32 }, align 8, !dbg !8
+// CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 4, !dbg !7
+// CHECK:STDOUT:   %b.var = alloca { i32, i32, i32 }, align 4, !dbg !8
+// CHECK:STDOUT:   %tuple.loc18_6 = alloca { i32, i32, i32 }, align 4, !dbg !9
+// CHECK:STDOUT:   %tuple.loc18_9 = alloca { i32, i32, i32 }, align 4, !dbg !10
+// CHECK:STDOUT:   %tuple.loc18_10 = alloca { ptr, ptr }, align 8, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %b.var), !dbg !8
 // CHECK:STDOUT:   %tuple.elem0.loc18_6.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !9
@@ -36,7 +39,7 @@ fn F() {
 // CHECK:STDOUT:   %.loc18_6.2 = load i32, ptr %tuple.elem1.loc18_6.tuple.elem, align 4, !dbg !9
 // CHECK:STDOUT:   %tuple.elem2.loc18_6.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 2, !dbg !9
 // CHECK:STDOUT:   %.loc18_6.3 = load i32, ptr %tuple.elem2.loc18_6.tuple.elem, align 4, !dbg !9
-// CHECK:STDOUT:   %tuple.loc18_6 = alloca { i32, i32, i32 }, align 8, !dbg !9
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %tuple.loc18_6), !dbg !9
 // CHECK:STDOUT:   %tuple.loc18_61 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc18_6, i32 0, i32 0, !dbg !9
 // CHECK:STDOUT:   store i32 %.loc18_6.1, ptr %tuple.loc18_61, align 4, !dbg !9
 // CHECK:STDOUT:   %tuple.loc18_62 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc18_6, i32 0, i32 1, !dbg !9
@@ -49,14 +52,14 @@ fn F() {
 // CHECK:STDOUT:   %.loc18_9.2 = load i32, ptr %tuple.elem1.loc18_9.tuple.elem, align 4, !dbg !10
 // CHECK:STDOUT:   %tuple.elem2.loc18_9.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %b.var, i32 0, i32 2, !dbg !10
 // CHECK:STDOUT:   %.loc18_9.3 = load i32, ptr %tuple.elem2.loc18_9.tuple.elem, align 4, !dbg !10
-// CHECK:STDOUT:   %tuple.loc18_9 = alloca { i32, i32, i32 }, align 8, !dbg !10
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %tuple.loc18_9), !dbg !10
 // CHECK:STDOUT:   %tuple.loc18_94 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc18_9, i32 0, i32 0, !dbg !10
 // CHECK:STDOUT:   store i32 %.loc18_9.1, ptr %tuple.loc18_94, align 4, !dbg !10
 // CHECK:STDOUT:   %tuple.loc18_95 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc18_9, i32 0, i32 1, !dbg !10
 // CHECK:STDOUT:   store i32 %.loc18_9.2, ptr %tuple.loc18_95, align 4, !dbg !10
 // CHECK:STDOUT:   %tuple.loc18_96 = getelementptr inbounds nuw { i32, i32, i32 }, ptr %tuple.loc18_9, i32 0, i32 2, !dbg !10
 // CHECK:STDOUT:   store i32 %.loc18_9.3, ptr %tuple.loc18_96, align 4, !dbg !10
-// CHECK:STDOUT:   %tuple.loc18_10 = alloca { ptr, ptr }, align 8, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %tuple.loc18_10), !dbg !11
 // CHECK:STDOUT:   %tuple.loc18_107 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc18_10, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   store ptr %tuple.loc18_6, ptr %tuple.loc18_107, align 8, !dbg !11
 // CHECK:STDOUT:   %tuple.loc18_108 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple.loc18_10, i32 0, i32 1, !dbg !11
@@ -84,7 +87,7 @@ fn F() {
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; uselistorder directives
 // CHECK:STDOUT: uselistorder ptr @"_COp.9eed32d146d768a4:core.Destroy.Core", { 1, 0 }
-// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 4, 3, 2, 1, 0 }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
 // CHECK:STDOUT: attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }

--- a/toolchain/lower/testdata/tuple/value_forwarding.carbon
+++ b/toolchain/lower/testdata/tuple/value_forwarding.carbon
@@ -25,6 +25,7 @@ fn F(a: (i32, i32, i32), b: (i32, i32, i32)) {
 // CHECK:STDOUT: define void @_CF.Main(ptr %a, ptr %b) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %tuple = alloca { ptr, ptr }, align 8, !dbg !11
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %tuple), !dbg !11
 // CHECK:STDOUT:   %tuple1 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple, i32 0, i32 0, !dbg !11
 // CHECK:STDOUT:   store ptr %a, ptr %tuple1, align 8, !dbg !11
 // CHECK:STDOUT:   %tuple2 = getelementptr inbounds nuw { ptr, ptr }, ptr %tuple, i32 0, i32 1, !dbg !11
@@ -33,7 +34,11 @@ fn F(a: (i32, i32, i32), b: (i32, i32, i32)) {
 // CHECK:STDOUT:   ret void, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #1
+// CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
 // CHECK:STDOUT: !llvm.dbg.cu = !{!2}

--- a/toolchain/lower/testdata/var/local.carbon
+++ b/toolchain/lower/testdata/var/local.carbon
@@ -94,7 +94,7 @@ fn G() -> (i32, i32, i32) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main(ptr sret({ i32, i32, i32 }) %return) #0 !dbg !10 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 8, !dbg !11
+// CHECK:STDOUT:   %a.var = alloca { i32, i32, i32 }, align 4, !dbg !11
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !11
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a.var, ptr align 4 @tuple.8d2.loc4_50, i64 12, i1 false), !dbg !11
 // CHECK:STDOUT:   %tuple.elem0.loc8_10.1.tuple.elem = getelementptr inbounds nuw { i32, i32, i32 }, ptr %a.var, i32 0, i32 0, !dbg !12

--- a/toolchain/lower/testdata/var/param.carbon
+++ b/toolchain/lower/testdata/var/param.carbon
@@ -58,7 +58,7 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !7
 // CHECK:STDOUT:   call void @_CMake.C.Main(ptr %c.var), !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(ptr %c.var), !dbg !9
@@ -111,7 +111,7 @@ fn G() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CG.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !7
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !7
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %c.var), !dbg !7
 // CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %c.var, ptr align 1 @C.val.loc11, i64 0, i1 false), !dbg !7
 // CHECK:STDOUT:   call void @_CF.Main(ptr %c.var), !dbg !8

--- a/toolchain/lower/testdata/var/uninitialized.carbon
+++ b/toolchain/lower/testdata/var/uninitialized.carbon
@@ -27,8 +27,8 @@ fn Run() {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %a.var = alloca i32, align 4, !dbg !8
 // CHECK:STDOUT:   %b.var = alloca double, align 8, !dbg !9
-// CHECK:STDOUT:   %c.var = alloca {}, align 8, !dbg !10
-// CHECK:STDOUT:   %d.var = alloca {}, align 8, !dbg !11
+// CHECK:STDOUT:   %c.var = alloca {}, align 1, !dbg !10
+// CHECK:STDOUT:   %d.var = alloca {}, align 1, !dbg !11
 // CHECK:STDOUT:   %e.var = alloca i1, align 1, !dbg !12
 // CHECK:STDOUT:   %f.var = alloca ptr, align 8, !dbg !13
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !8


### PR DESCRIPTION
Use the Carbon-computed alignment for allocas, loads, stores, and memcpys. Previously we used whatever LLVM felt like giving us, which would result in ABI mismatches and runtime crashes due to misalignment when creating objects of imported C++ class types, as well as resulting in some surprising choices like `(i32, i32)` and `()` having 8-byte alignment instead of 4 and 1, respectively.