### PR TITLE
Switch a few stragglers to `uv` and update python to 3.12

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -112,7 +112,7 @@ bazel_dep(name = "rules_python", version = "1.9.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
-    python_version = "3.11",
+    python_version = "3.12",
 )
 use_repo(python, "python_versions")
 

--- a/bazel/check_deps/update_roots.py
+++ b/bazel/check_deps/update_roots.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.12"
+# ///
+
 
 """Update the roots of the Carbon build used for dependency checking.
 

--- a/bazel/version/gen_tmpl.py
+++ b/bazel/version/gen_tmpl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 # NOTE: The `uv` shebang and inline metadata above are only used for direct

--- a/examples/bazel/update_module_to_nightly.py
+++ b/examples/bazel/update_module_to_nightly.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.12"
+# ///
+
 
 """Updates example module file to use the nightly toolchain release.
 

--- a/github_tools/MODULE.bazel
+++ b/github_tools/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "rules_python", version = "0.27.1")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
-    python_version = "3.11",
+    python_version = "3.12",
 )
 use_repo(python, "python_versions")
 
@@ -24,7 +24,7 @@ use_repo(python, "python_versions")
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "py_deps",
-    python_version = "3.11",
+    python_version = "3.12",
     requirements_lock = "//:requirements.txt",
 )
 use_repo(pip, "py_deps")

--- a/github_tools/check_dependent_pr.py
+++ b/github_tools/check_dependent_pr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.12"
 # dependencies = [
 #   "gql==2.0.0",
 #   "requests",

--- a/github_tools/pr_comments.py
+++ b/github_tools/pr_comments.py
@@ -1,4 +1,13 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "gql==2.0.0",
+#   "requests",
+# ]
+# ///
+
 
 """Figure out comments on a GitHub PR."""
 
@@ -14,7 +23,7 @@ import hashlib
 import importlib.util
 import os
 import textwrap
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, override
 
 # Do some extra work to support direct runs.
 try:
@@ -178,6 +187,7 @@ class _PRComment(_Comment):
     def __lt__(self, other: "_PRComment") -> bool:
         return self.timestamp < other.timestamp
 
+    @override
     def format(self, long: bool) -> str:
         return "%s\n%s" % (self.url, super().format(long))
 

--- a/proposals/p000555-operator-precedence/figures.py
+++ b/proposals/p000555-operator-precedence/figures.py
@@ -1,4 +1,9 @@
-#! /usr/bin/env python
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.12"
+# ///
+
 
 __copyright__ = """
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM

--- a/proposals/scripts/check_proposal_names.py
+++ b/proposals/scripts/check_proposal_names.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.12"
+# ///
+
 
 """Renames proposal files to match convention."""
 

--- a/proposals/scripts/new_proposal.py
+++ b/proposals/scripts/new_proposal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 """Prepares a new proposal file and PR."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 [project]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 
 [tool.ruff]
 line-length = 80
-target-version = "py310"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "ANN"]

--- a/scripts/bazel_mod_deps.py
+++ b/scripts/bazel_mod_deps.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/bench_runner.py
+++ b/scripts/bench_runner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.12"
 # dependencies = [
 #     "numpy",
 #     "rich",
@@ -73,7 +73,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Optional, override
 
 import numpy as np  # type: ignore
 import scipy as sp  # type: ignore
@@ -288,6 +288,7 @@ class DeltaKind(Enum):
     REGRESSION = "[slower]👎[/slower]"
     NOISE = ""
 
+    @override
     def __str__(self) -> str:
         return self.value
 

--- a/scripts/calculate_release_shas.py
+++ b/scripts/calculate_release_shas.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/check_build_graph.py
+++ b/scripts/check_build_graph.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/check_header_guards.py
+++ b/scripts/check_header_guards.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 """Checks for missing or incorrect header guards."""

--- a/scripts/check_sha_filenames.py
+++ b/scripts/check_sha_filenames.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/fix_cc_deps.py
+++ b/scripts/fix_cc_deps.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/forbid_llvm_googletest.py
+++ b/scripts/forbid_llvm_googletest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/query_module_versions.py
+++ b/scripts/query_module_versions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/run_bazel.py
+++ b/scripts/run_bazel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/run_bazelisk.py
+++ b/scripts/run_bazelisk.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/run_buildifier.py
+++ b/scripts/run_buildifier.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/run_buildozer.py
+++ b/scripts/run_buildozer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/source_stats.py
+++ b/scripts/source_stats.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/target_determinator.py
+++ b/scripts/target_determinator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 

--- a/scripts/workspace_status.py
+++ b/scripts/workspace_status.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 # NOTE: The `uv` shebang and inline metadata above are only used for direct

--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 """Autoupdates testdata in toolchain."""

--- a/toolchain/diagnostics/check_diagnostics.py
+++ b/toolchain/diagnostics/check_diagnostics.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.12"
+# ///
+
 
 """Checks diagnostic use.
 
@@ -19,7 +24,7 @@ import re
 import sys
 from concurrent import futures
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Set
+from typing import Dict, List, NamedTuple, Set, override
 
 # Example or test diagnostics, ignored because they're expected to not pass.
 IGNORED = set(
@@ -36,6 +41,7 @@ IGNORED = set(
 class Loc(NamedTuple):
     """A location for a diagnostic."""
 
+    @override
     def __str__(self) -> str:
         return f"{str(self.path)}:{self.line}"
 

--- a/website/prebuild.py
+++ b/website/prebuild.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # ///
 
 """Updates files in preparation for a jekyll build.


### PR DESCRIPTION
Not sure how these got missed when moving other things to `uv`, but this should clean them up.

The bump to Python 3.12 is so that we can use `@override` with the simple import from `typing`. This is needed by the newest versions of `ty` to do type checking. Added the relevant `@override` annotations.

Assisted-by: Antigravity with Gemini