### PR TITLE
Fix crash lowering reference return.

### DIFF
--- a/toolchain/check/return.cpp
+++ b/toolchain/check/return.cpp
@@ -231,11 +231,10 @@ auto BuildReturnVar(Context& context, Parse::ReturnStatementId node_id)
   }
 
   auto return_param_id = GetReturnedVarParam(context, function);
-  if (!return_param_id.has_value()) {
-    // If we don't have a return slot, we're returning by value. Convert to a
-    // value expression.
-    returned_var_id = ConvertToValueExpr(context, returned_var_id);
-  }
+
+  // Convert to a value expression in case the return logic needs a value, and
+  // to indicate that this was a `return var`, not a reference return.
+  returned_var_id = ConvertToValueExpr(context, returned_var_id);
 
   AddReturnCleanupBlockWithExpr(
       context, node_id,

--- a/toolchain/check/testdata/class/local.carbon
+++ b/toolchain/check/testdata/class/local.carbon
@@ -195,7 +195,8 @@ class A {
 // CHECK:STDOUT:   assign %return.param, %.loc19_18
 // CHECK:STDOUT:   %Self.ref.loc19: type = name_ref Self, constants.%B [concrete = constants.%B]
 // CHECK:STDOUT:   %b: ref %B = ref_binding b, %return.param
-// CHECK:STDOUT:   return %b to %return.param
+// CHECK:STDOUT:   %.loc19_23: %B = acquire_value %b
+// CHECK:STDOUT:   return %.loc19_23 to %return.param
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @Destroy.Op.loc26_19.1(%self.param: ref %i32.builtin) = "no_op";

--- a/toolchain/check/testdata/class/self/self_type.carbon
+++ b/toolchain/check/testdata/class/self/self_type.carbon
@@ -186,6 +186,7 @@ fn Class.F[self: Self]() -> i32 {
 // CHECK:STDOUT:   %.loc19_17.4: init %Class to %s.ref.loc19_5 = class_init (%.loc19_17.3)
 // CHECK:STDOUT:   %.loc19_7: init %Class = converted %.loc19_17.1, %.loc19_17.4
 // CHECK:STDOUT:   assign %s.ref.loc19_5, %.loc19_7
-// CHECK:STDOUT:   return %s to %return.param
+// CHECK:STDOUT:   %.loc18_19: %Class = acquire_value %s
+// CHECK:STDOUT:   return %.loc18_19 to %return.param
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/return/returned_var.carbon
+++ b/toolchain/check/testdata/return/returned_var.carbon
@@ -167,7 +167,8 @@ fn G() -> i32 {
 // CHECK:STDOUT:   assign %return.param, %.loc21_12
 // CHECK:STDOUT:   %C.ref.loc21: type = name_ref C, file.%C.decl [concrete = constants.%C]
 // CHECK:STDOUT:   %result: ref %C = ref_binding result, %return.param
-// CHECK:STDOUT:   return %result to %return.param
+// CHECK:STDOUT:   %.loc21_22: %C = acquire_value %result
+// CHECK:STDOUT:   return %.loc21_22 to %return.param
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @G() -> out %return.param: %i32 {

--- a/toolchain/lower/handle.cpp
+++ b/toolchain/lower/handle.cpp
@@ -276,6 +276,30 @@ auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,
 
 auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,
                 SemIR::ReturnExpr inst) -> void {
+  auto expr_cat = SemIR::GetExprCategory(context.sem_ir(), inst.expr_id);
+  switch (expr_cat) {
+    case SemIR::ExprCategory::EphemeralRef:
+    case SemIR::ExprCategory::DurableRef:
+      // Reference return.
+      context.builder().CreateRet(context.GetValue(inst.expr_id));
+      return;
+
+    case SemIR::ExprCategory::Value:
+      // Return of a `returned var`.
+    case SemIR::ExprCategory::ReprInitializing:
+    case SemIR::ExprCategory::InPlaceInitializing:
+      // Initializing return.
+      break;
+
+    case SemIR::ExprCategory::Mixed:
+    case SemIR::ExprCategory::RefTagged:
+    case SemIR::ExprCategory::NotExpr:
+    case SemIR::ExprCategory::Error:
+    case SemIR::ExprCategory::Pattern:
+    case SemIR::ExprCategory::Dependent:
+      CARBON_FATAL("Unexpected category for `return` expression");
+  }
+
   auto result_type = context.GetTypeIdOfInst(inst.expr_id);
   switch (context.GetInitRepr(result_type).kind) {
     case SemIR::InitRepr::None:
@@ -293,23 +317,9 @@ auto HandleInst(FunctionContext& context, SemIR::InstId /*inst_id*/,
       return;
     case SemIR::InitRepr::ByCopy: {
       auto* value = context.GetValue(inst.expr_id);
-      switch (SemIR::GetExprCategory(context.sem_ir(), inst.expr_id)) {
-        case SemIR::ExprCategory::Value:
-        case SemIR::ExprCategory::ReprInitializing:
-        case SemIR::ExprCategory::EphemeralRef:
-        case SemIR::ExprCategory::DurableRef:
-          break;
-        case SemIR::ExprCategory::InPlaceInitializing:
-          value =
-              context.builder().CreateLoad(context.GetType(result_type), value);
-          break;
-        case SemIR::ExprCategory::Mixed:
-        case SemIR::ExprCategory::RefTagged:
-        case SemIR::ExprCategory::NotExpr:
-        case SemIR::ExprCategory::Error:
-        case SemIR::ExprCategory::Pattern:
-        case SemIR::ExprCategory::Dependent:
-          CARBON_FATAL("Unexpected category for `return` expression");
+      if (expr_cat == SemIR::ExprCategory::InPlaceInitializing) {
+        value =
+            context.builder().CreateLoad(context.GetType(result_type), value);
       }
       context.builder().CreateRet(value);
       return;

--- a/toolchain/lower/testdata/array/global.carbon
+++ b/toolchain/lower/testdata/array/global.carbon
@@ -1,0 +1,64 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/array/global.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/array/global.carbon
+
+// --- global_array_reference.carbon
+library "[[@TEST_NAME]]";
+
+var a: array(i32, 4) = (0, 1, 2, 3);
+
+fn Get() -> ref array(i32, 4) {
+  return a;
+}
+
+// CHECK:STDOUT: ; ModuleID = 'global_array_reference.carbon'
+// CHECK:STDOUT: source_filename = "global_array_reference.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @_Ca.Main = global [4 x i32] zeroinitializer
+// CHECK:STDOUT: @array.loc3_1 = internal constant [4 x i32] [i32 0, i32 1, i32 2, i32 3]
+// CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @_C__global_init.Main, ptr null }]
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define ptr @_CGet.Main() #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret ptr @_Ca.Main, !dbg !8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define internal void @_C__global_init.Main() #0 !dbg !9 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 4 @_Ca.Main, ptr align 4 @array.loc3_1, i64 16, i1 false), !dbg !12
+// CHECK:STDOUT:   ret void, !dbg !13
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "global_array_reference.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "Get", linkageName: "_CGet.Main", scope: null, file: !3, line: 5, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{!7}
+// CHECK:STDOUT: !7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !8 = !DILocation(line: 6, column: 3, scope: !4)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !3, type: !10, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = !DISubroutineType(types: !11)
+// CHECK:STDOUT: !11 = !{null}
+// CHECK:STDOUT: !12 = !DILocation(line: 3, column: 1, scope: !9)
+// CHECK:STDOUT: !13 = !DILocation(line: 0, scope: !9)

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -1706,6 +1706,14 @@ struct Return {
 //
 // If `expr_id` is an initializer, this consumes it. If `dest_id` is not `None`
 // and `expr_id` has a storage argument, the storage argument must be `dest_id`.
+//
+// The interpretation of the `ReturnExpr` depends on the category of `expr_id`:
+//
+// * If it is an initializing expression, we're performing a normal
+//   by-initialization return.
+// * If it is a reference, we're performing a `ref` return.
+// * If it is a value expression, we're performing a `return var;`, and it's the
+//   value of the returned variable.
 struct ReturnExpr {
   static constexpr auto Kind = InstKind::ReturnExpr.Define<Parse::NodeId>(
       {.ir_name = "return",


### PR DESCRIPTION
Fix a lowering crash when lowering a return by reference of a type with an in-place initializing representation. We previously misinterpreted this as an in-place initializing return.

This is addressed by changing lowering to interpret a `ReturnExpr` of a reference expression as a reference return. However, that exposes another issue: `return var;` produces a `ReturnExpr` of a reference expression in the case where it returns in place! To fix that, we switch `return var;` to producing a `ReturnExpr` of a value expression regardless of whether the function has a return slot. This makes the representation of `return var;` more uniform:

* If the expression is a reference, we're performing a `ref` return.
* If the expression is an initializing expression, we're performing a normal by-initialization return.
* If the expression is a value expression, we're performing a `return var;`.