### PR TITLE
Use clang_decls as the source of truth for function interop mapping

### DIFF
--- a/toolchain/check/cpp/constant.cpp
+++ b/toolchain/check/cpp/constant.cpp
@@ -303,11 +303,12 @@ auto MaybeModifyCppThunkCallForConstEval(Context& context, SemIR::Call* call)
             .GetAs<SemIR::FunctionDecl>(thunk_callee_inst_id)
             .function_id);
 
-    function_decl =
-        cast<clang::FunctionDecl>(context.clang_decls()
-                                      .Get(thunk_callee_function.clang_decl_id)
-                                      .GetAsKey()
-                                      .decl);
+    function_decl = cast<clang::FunctionDecl>(
+        context.clang_decls()
+            .Get(context.clang_decls().Lookup(
+                thunk_callee_function.first_decl_id()))
+            .GetAsKey()
+            .decl);
 
     if (!(function_decl->isConstexpr() || function_decl->isConsteval())) {
       return;

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -448,9 +448,10 @@ auto CarbonExternalASTSource::GetOrExportFunctionToCpp(
     SemIR::InstId target_inst_id, SemIR::FunctionId function_id)
     -> clang::FunctionDecl* {
   const SemIR::Function& function = context_->functions().Get(function_id);
-  if (function.clang_decl_id.has_value()) {
+  auto clang_decl_id = context_->clang_decls().Lookup(function.first_decl_id());
+  if (clang_decl_id.has_value()) {
     return cast<clang::FunctionDecl>(
-        context_->clang_decls().Get(function.clang_decl_id).key.decl);
+        context_->clang_decls().Get(clang_decl_id).key.decl);
   }
 
   return ExportFunctionToCpp(*context_, SemIR::LocId(target_inst_id),

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -149,7 +149,8 @@ auto ImportCpp(Context& context,
         context.clang_decls().Add(
             {.key = SemIR::ClangDeclKey(
                  context.ast_context().getTranslationUnitDecl()),
-             .inst_id = name_scope.inst_id()}),
+             .inst_id = name_scope.inst_id(),
+             .is_imported = true}),
         /*is_cpp_scope=*/true);
   } else {
     name_scope.set_has_error();
@@ -524,7 +525,8 @@ static auto ImportNamespaceDecl(Context& context,
   context.name_scopes()
       .Get(result.name_scope_id)
       .set_clang_decl_context_id(
-          context.clang_decls().Add({.key = key, .inst_id = result.inst_id}),
+          context.clang_decls().Add(
+              {.key = key, .inst_id = result.inst_id, .is_imported = true}),
           /*is_cpp_scope=*/true);
   return result.inst_id;
 }
@@ -587,8 +589,8 @@ static auto ImportTagDecl(Context& context, clang::TagDecl* clang_decl)
 
   // TODO: The caller does the same lookup. Avoid doing it twice.
   auto key = SemIR::ClangDeclKey(clang_decl);
-  auto clang_decl_id =
-      context.clang_decls().Add({.key = key, .inst_id = class_inst_id});
+  auto clang_decl_id = context.clang_decls().Add(
+      {.key = key, .inst_id = class_inst_id, .is_imported = true});
 
   // Name lookup into the Carbon class looks in the C++ class definition.
   auto& class_info = context.classes().Get(class_id);
@@ -814,7 +816,8 @@ static auto ImportClassObjectRepr(Context& context, SemIR::ClassId class_id,
     // The imported SemIR::FieldDecl represents the original declaration `decl`,
     // which is either the field or the indirect field declaration.
     auto key = SemIR::ClangDeclKey::ForNonFunctionDecl(decl);
-    context.clang_decls().Add({.key = key, .inst_id = field_decl_id});
+    context.clang_decls().Add(
+        {.key = key, .inst_id = field_decl_id, .is_imported = true});
 
     // Compute the offset to the field that appears directly in the class.
     uint64_t offset = clang_layout.getFieldOffset(
@@ -1063,13 +1066,15 @@ static auto ImportEnumConstantDecl(Context& context,
                    context.sem_ir(), import_ir_inst_id,
                    SemIR::IntValue{.type_id = type_id, .int_id = int_id}));
   context.imports().push_back(inst_id);
-  context.clang_decls().Add({.key = key, .inst_id = inst_id});
+  context.clang_decls().Add(
+      {.key = key, .inst_id = inst_id, .is_imported = true});
   return inst_id;
 }
 
 // Mark the given `key` as failed in `clang_decls`.
 static auto MarkFailedDecl(Context& context, SemIR::ClangDeclKey key) {
-  context.clang_decls().Add({.key = key, .inst_id = SemIR::ErrorInst::InstId});
+  context.clang_decls().Add(
+      {.key = key, .inst_id = SemIR::ErrorInst::InstId, .is_imported = true});
 }
 
 // Creates an integer type of the given size.
@@ -1215,7 +1220,8 @@ static auto MapTagType(Context& context, const clang::TagType& type)
     if (auto* record_decl = dyn_cast<clang::CXXRecordDecl>(tag_decl)) {
       auto custom_type = LookupCustomRecordType(context, record_decl);
       if (custom_type.inst_id.has_value()) {
-        context.clang_decls().Add({.key = key, .inst_id = custom_type.inst_id});
+        context.clang_decls().Add(
+            {.key = key, .inst_id = custom_type.inst_id, .is_imported = true});
         return custom_type;
       }
     }
@@ -1891,7 +1897,7 @@ static auto ImportFunction(Context& context, SemIR::LocId loc_id,
   context.clang_decls().Add(
       {.key = SemIR::ClangDeclKey::ForFunctionDecl(clang_decl, signature_id),
        .inst_id = decl_id,
-       .is_external = true});
+       .is_imported = true});
 
   return function_id;
 }
@@ -2128,8 +2134,10 @@ static auto ImportVarDecl(Context& context, SemIR::LocId loc_id,
 
   // Register the variable so we don't create it again, and track the
   // corresponding declaration to use for mangling.
-  auto clang_decl_id = context.clang_decls().Add(
-      {.key = SemIR::ClangDeclKey(var_decl), .inst_id = var_storage_inst_id});
+  auto clang_decl_id =
+      context.clang_decls().Add({.key = SemIR::ClangDeclKey(var_decl),
+                                 .inst_id = var_storage_inst_id,
+                                 .is_imported = true});
   context.cpp_global_names().Add({.key = {.entity_name_id = entity_name_id},
                                   .clang_decl_id = clang_decl_id});
 
@@ -2165,7 +2173,8 @@ static auto ImportTemplateDecl(Context& context,
   auto name_id = context.entity_names().Add(
       {.name_id = AddIdentifierName(context, template_decl->getName()),
        .parent_scope_id = GetParentNameScopeId(context, template_decl)});
-  auto decl_id = context.clang_decls().Add({.key = key, .inst_id = inst_id});
+  auto decl_id = context.clang_decls().Add(
+      {.key = key, .inst_id = inst_id, .is_imported = true});
   value.type_id = GetCppTemplateNameType(context, name_id, decl_id);
 
   // Update the value with its type.
@@ -2196,7 +2205,8 @@ static auto ImportDeclAfterDependencies(Context& context, SemIR::LocId loc_id,
                                  type.getAsString()));
       return SemIR::ErrorInst::InstId;
     }
-    context.clang_decls().Add({.key = key, .inst_id = type_inst_id});
+    context.clang_decls().Add(
+        {.key = key, .inst_id = type_inst_id, .is_imported = true});
     return type_inst_id;
   }
   if (isa<clang::FieldDecl, clang::IndirectFieldDecl>(clang_decl)) {

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -1888,10 +1888,10 @@ static auto ImportFunction(Context& context, SemIR::LocId loc_id,
           }});
   context.imports().push_back(decl_id);
 
-  context.functions().Get(function_id).clang_decl_id =
-      context.clang_decls().Add({.key = SemIR::ClangDeclKey::ForFunctionDecl(
-                                     clang_decl, signature_id),
-                                 .inst_id = decl_id});
+  context.clang_decls().Add(
+      {.key = SemIR::ClangDeclKey::ForFunctionDecl(clang_decl, signature_id),
+       .inst_id = decl_id,
+       .is_external = true});
 
   return function_id;
 }

--- a/toolchain/check/cpp/operators.cpp
+++ b/toolchain/check/cpp/operators.cpp
@@ -732,8 +732,8 @@ static auto GetAsCppFunctionDecl(Context& context, SemIR::InstId inst_id)
   if (!function_type) {
     return nullptr;
   }
-  SemIR::ClangDeclId clang_decl_id =
-      context.functions().Get(function_type->function_id).clang_decl_id;
+  SemIR::ClangDeclId clang_decl_id = context.clang_decls().Lookup(
+      context.functions().Get(function_type->function_id).first_decl_id());
   return clang_decl_id.has_value()
              ? dyn_cast<clang::FunctionDecl>(
                    context.clang_decls().Get(clang_decl_id).key.decl)

--- a/toolchain/check/cpp/thunk.cpp
+++ b/toolchain/check/cpp/thunk.cpp
@@ -245,11 +245,17 @@ struct CalleeFunctionInfo {
 
 auto IsCppThunkRequired(Context& context, const SemIR::Function& function)
     -> bool {
-  if (!function.clang_decl_id.has_value()) {
+  auto clang_decl_id = context.clang_decls().Lookup(function.first_decl_id());
+  if (!clang_decl_id.has_value()) {
     return false;
   }
 
-  const auto& decl_info = context.clang_decls().Get(function.clang_decl_id);
+  const auto& decl_info = context.clang_decls().Get(clang_decl_id);
+
+  if (!decl_info.is_external) {
+    return false;
+  }
+
   const auto& signature =
       context.clang_decl_signatures().Get(decl_info.key.signature_id);
   auto* decl = cast<clang::FunctionDecl>(decl_info.key.decl);
@@ -646,7 +652,9 @@ static auto BuildThunkBody(CppContext& cpp_context, clang::Sema& sema,
 auto BuildCppThunk(Context& context, const SemIR::Function& callee_function)
     -> clang::FunctionDecl* {
   auto clang_decl_key =
-      context.clang_decls().Get(callee_function.clang_decl_id).key;
+      context.clang_decls()
+          .Get(context.clang_decls().Lookup(callee_function.first_decl_id()))
+          .key;
   clang::FunctionDecl* callee_function_decl =
       clang_decl_key.decl->getAsFunction();
   CARBON_CHECK(callee_function_decl);

--- a/toolchain/check/cpp/thunk.cpp
+++ b/toolchain/check/cpp/thunk.cpp
@@ -252,7 +252,7 @@ auto IsCppThunkRequired(Context& context, const SemIR::Function& function)
 
   const auto& decl_info = context.clang_decls().Get(clang_decl_id);
 
-  if (!decl_info.is_external) {
+  if (!decl_info.is_imported) {
     return false;
   }
 

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -3452,9 +3452,14 @@ static auto TryEvalCall(EvalContext& outer_eval_context, SemIR::LocId loc_id,
                         const SemIR::Function& function,
                         SemIR::SpecificId specific_id,
                         SemIR::InstBlockId args_id) -> SemIR::ConstantId {
-  if (function.clang_decl_id != SemIR::ClangDeclId::None) {
-    return EvalCppCall(outer_eval_context.context(), loc_id,
-                       function.clang_decl_id, args_id);
+  auto clang_decl_id = outer_eval_context.sem_ir().clang_decls().Lookup(
+      function.first_decl_id());
+  if (clang_decl_id.has_value() && outer_eval_context.sem_ir()
+                                       .clang_decls()
+                                       .Get(clang_decl_id)
+                                       .is_external) {
+    return EvalCppCall(outer_eval_context.context(), loc_id, clang_decl_id,
+                       args_id);
   } else if (function.body_block_ids.empty()) {
     // TODO: Diagnose this.
     return SemIR::ConstantId::NotConstant;

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -3457,7 +3457,7 @@ static auto TryEvalCall(EvalContext& outer_eval_context, SemIR::LocId loc_id,
   if (clang_decl_id.has_value() && outer_eval_context.sem_ir()
                                        .clang_decls()
                                        .Get(clang_decl_id)
-                                       .is_external) {
+                                       .is_imported) {
     return EvalCppCall(outer_eval_context.context(), loc_id, clang_decl_id,
                        args_id);
   } else if (function.body_block_ids.empty()) {

--- a/toolchain/check/import_ref.cpp
+++ b/toolchain/check/import_ref.cpp
@@ -3744,7 +3744,7 @@ static auto TryResolveTypedInst(ImportRefResolver& resolver,
             resolver.local_context(), SemIR::LocId(inst_id),
             resolver.import_ir(), name_scope.clang_decl_context_id())) {
       auto clang_decl_id = resolver.local_context().clang_decls().Add(
-          {.key = *key, .inst_id = inst_id});
+          {.key = *key, .inst_id = inst_id, .is_imported = true});
       local_scope.set_clang_decl_context_id(clang_decl_id, true);
     }
   }

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -139,12 +139,45 @@ auto FileContext::LowerDefinitions() -> void {
   // variables.
   if (auto global_ctor_id = sem_ir().global_ctor_id();
       global_ctor_id.has_value()) {
-    auto llvm_function = BuildFunctionDecl(global_ctor_id);
-    functions_.Set(global_ctor_id, llvm_function);
+    // This is basically an inlined and specialized version of
+    // `BuildFunctionDecl` because global_ctor is a bit special (it has no
+    // declarations, for one thing).
+    // TODO: Consider making the global ctor not a function at all, but a
+    // special block.
+    auto function_type_info = BuildFunctionTypeInfo(
+        {{this, global_ctor_id, SemIR::SpecificId::None}});
+    std::string mangled_name = "_C__global_init.";
+    auto package_id = sem_ir().package_id();
+    if (auto ident_id = package_id.AsIdentifierId(); ident_id.has_value()) {
+      mangled_name += sem_ir().identifiers().Get(ident_id);
+    } else {
+      mangled_name += package_id.AsSpecialName();
+    }
+
+    auto* llvm_function = llvm_module().getFunction(mangled_name);
+
+    if (!llvm_function) {
+      llvm_function = llvm::Function::Create(function_type_info.type,
+                                             llvm::Function::InternalLinkage,
+                                             mangled_name, llvm_module());
+      CARBON_CHECK(llvm_function->getName() == mangled_name,
+                   "Mangled name collision: {0}", mangled_name);
+    }
+    FunctionInfo function_info = {
+        .type = function_type_info.type,
+        .di_type = function_type_info.di_type,
+        .lowered_param_indices =
+            std::move(function_type_info.lowered_param_indices),
+        .unused_param_indices =
+            std::move(function_type_info.unused_param_indices),
+        .llvm_function = llvm_function,
+        .inexact = function_type_info.inexact};
+    functions_.Set(global_ctor_id, function_info);
+
     const auto& global_ctor = sem_ir().functions().Get(global_ctor_id);
     BuildFunctionBody(global_ctor_id, SemIR::SpecificId::None, global_ctor,
                       *this, global_ctor);
-    llvm::appendToGlobalCtors(llvm_module(), llvm_function->llvm_function,
+    llvm::appendToGlobalCtors(llvm_module(), llvm_function,
                               /*Priority=*/0);
   }
 }

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -347,12 +347,21 @@ auto FileContext::GetOrCreateLLVMFunction(
     const FunctionTypeInfo& function_type_info, SemIR::FunctionId function_id,
     SemIR::SpecificId specific_id) -> llvm::Function* {
   // If this is a C++ function, tell Clang that we referenced it.
-  if (auto clang_decl_id = sem_ir().functions().Get(function_id).clang_decl_id;
-      clang_decl_id.has_value()) {
-    CARBON_CHECK(!specific_id.has_value(),
-                 "Specific functions cannot have C++ definitions");
-    return HandleReferencedCppFunction(
-        sem_ir().clang_decls().Get(clang_decl_id).key.decl->getAsFunction());
+  // The global_ctor function can't be a C++ function (but doesn't have any
+  // decl_id so it doesn't fall out naturally from the handling below)
+  if (function_id != sem_ir().global_ctor_id()) {
+    const auto& function = sem_ir().functions().Get(function_id);
+    auto clang_decl_id =
+        sem_ir().clang_decls().Lookup(function.first_decl_id());
+    if (clang_decl_id.has_value()) {
+      const auto& clang_decl = sem_ir().clang_decls().Get(clang_decl_id);
+      if (clang_decl.is_external) {
+        CARBON_CHECK(!specific_id.has_value(),
+                     "Specific functions cannot have C++ definitions");
+        return HandleReferencedCppFunction(
+            clang_decl.key.decl->getAsFunction());
+      }
+    }
   }
 
   SemIR::Mangler m(sem_ir(), context().total_ir_count(),

--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -355,7 +355,7 @@ auto FileContext::GetOrCreateLLVMFunction(
         sem_ir().clang_decls().Lookup(function.first_decl_id());
     if (clang_decl_id.has_value()) {
       const auto& clang_decl = sem_ir().clang_decls().Get(clang_decl_id);
-      if (clang_decl.is_external) {
+      if (clang_decl.is_imported) {
         CARBON_CHECK(!specific_id.has_value(),
                      "Specific functions cannot have C++ definitions");
         return HandleReferencedCppFunction(

--- a/toolchain/lower/handle_call.cpp
+++ b/toolchain/lower/handle_call.cpp
@@ -637,7 +637,10 @@ static auto HandleVirtualCall(FunctionContext& context,
   auto* pointer_type =
       llvm::PointerType::get(context.llvm_context(), /* address space */ 0);
   llvm::Value* virtual_fn;
-  if (function.clang_decl_id.has_value()) {
+  auto clang_decl_id =
+      context.sem_ir().clang_decls().Lookup(function.first_decl_id());
+  if (clang_decl_id.has_value() &&
+      context.sem_ir().clang_decls().Get(clang_decl_id).is_external) {
     // Use absolute vtables for clang interop - the itanium vtable contains
     // function pointers.
     auto* virtual_function_pointer_address = context.builder().CreateGEP(

--- a/toolchain/lower/handle_call.cpp
+++ b/toolchain/lower/handle_call.cpp
@@ -640,7 +640,7 @@ static auto HandleVirtualCall(FunctionContext& context,
   auto clang_decl_id =
       context.sem_ir().clang_decls().Lookup(function.first_decl_id());
   if (clang_decl_id.has_value() &&
-      context.sem_ir().clang_decls().Get(clang_decl_id).is_external) {
+      context.sem_ir().clang_decls().Get(clang_decl_id).is_imported) {
     // Use absolute vtables for clang interop - the itanium vtable contains
     // function pointers.
     auto* virtual_function_pointer_address = context.builder().CreateGEP(

--- a/toolchain/lower/testdata/var/global.carbon
+++ b/toolchain/lower/testdata/var/global.carbon
@@ -44,6 +44,12 @@ library "[[@TEST_NAME]]";
 var (_: i32, x: i32) = (1, 2);
 var (_: i32, _: i32) = (3, 4);
 
+// --- not_main_package.carbon
+
+package Other;
+
+var a: i32 = 1;
+
 // CHECK:STDOUT: ; ModuleID = 'simple.carbon'
 // CHECK:STDOUT: source_filename = "simple.carbon"
 // CHECK:STDOUT:
@@ -224,3 +230,30 @@ var (_: i32, _: i32) = (3, 4);
 // CHECK:STDOUT: !7 = !DILocation(line: 4, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 5, column: 1, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT: ; ModuleID = 'not_main_package.carbon'
+// CHECK:STDOUT: source_filename = "not_main_package.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: @_Ca.Other = global i32 0
+// CHECK:STDOUT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @_C__global_init.Other, ptr null }]
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define internal void @_C__global_init.Other() #0 !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   store i32 1, ptr @_Ca.Other, align 4, !dbg !7
+// CHECK:STDOUT:   ret void, !dbg !8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "not_main_package.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Other", scope: null, file: !3, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{null}
+// CHECK:STDOUT: !7 = !DILocation(line: 4, column: 1, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)

--- a/toolchain/sem_ir/clang_decl.h
+++ b/toolchain/sem_ir/clang_decl.h
@@ -180,6 +180,10 @@ struct ClangDecl : public Printable<ClangDecl> {
   // The instruction the Clang declaration is mapped to.
   InstId inst_id;
 
+  // True if this declaration originated from C++. False if this declaration was
+  // created by exporting some Carbon declaration to C++.
+  bool is_external = false;
+
   auto GetAsKey() const -> ClangDeclKey { return key; }
 };
 

--- a/toolchain/sem_ir/clang_decl.h
+++ b/toolchain/sem_ir/clang_decl.h
@@ -182,7 +182,7 @@ struct ClangDecl : public Printable<ClangDecl> {
 
   // True if this declaration originated from C++. False if this declaration was
   // created by exporting some Carbon declaration to C++.
-  bool is_external = false;
+  bool is_imported = false;
 
   auto GetAsKey() const -> ClangDeclKey { return key; }
 };

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -157,12 +157,6 @@ struct FunctionFields {
   // function, in lexical order. The first block is the entry block. This will
   // be empty for declarations that don't have a visible definition.
   llvm::SmallVector<InstBlockId> body_block_ids = {};
-
-  // If the function is imported from C++, the Clang function declaration. Used
-  // for mangling and inline function definition code generation. The AST is
-  // owned by `CompileSubcommand` so we expect it to be live from `Function`
-  // creation to mangling.
-  ClangDeclId clang_decl_id = ClangDeclId::None;
 };
 
 inline constexpr FunctionFields::CallParamIndexRanges

--- a/toolchain/sem_ir/mangler.cpp
+++ b/toolchain/sem_ir/mangler.cpp
@@ -192,8 +192,13 @@ auto Mangler::Mangle(SemIR::FunctionId function_id,
   }
 
   // Clang should emit C++ function declarations for us.
-  CARBON_CHECK(!function.clang_decl_id.has_value(),
-               "Shouldn't mangle C++ function");
+  if (function_id != sem_ir().global_ctor_id()) {
+    auto clang_decl_id =
+        sem_ir().clang_decls().Lookup(function.first_decl_id());
+    CARBON_CHECK(!clang_decl_id.has_value() ||
+                     !sem_ir().clang_decls().Get(clang_decl_id).is_external,
+                 "Shouldn't mangle C++ function");
+  }
 
   RawStringOstream os;
   os << "_C";

--- a/toolchain/sem_ir/mangler.cpp
+++ b/toolchain/sem_ir/mangler.cpp
@@ -196,7 +196,7 @@ auto Mangler::Mangle(SemIR::FunctionId function_id,
     auto clang_decl_id =
         sem_ir().clang_decls().Lookup(function.first_decl_id());
     CARBON_CHECK(!clang_decl_id.has_value() ||
-                     !sem_ir().clang_decls().Get(clang_decl_id).is_external,
+                     !sem_ir().clang_decls().Get(clang_decl_id).is_imported,
                  "Shouldn't mangle C++ function");
   }
 


### PR DESCRIPTION
Removing the clang_decl_id on SemIR::Function - using only the
clang_decls map to create the association between SemIR::Function and
clang::FunctionDecls.

This adds an `is_external` flag to ClangDecl to indicate whether the
entity originated from Carbon or was imported from another language.
(I'm open to names - I guess for now we mostly use "is this from C++" to
be more specific than "is this external" - eg: NameScope::is_cpp_scope)
