### PR TITLE
Out-of-line cold YAML and debug-printing paths from widely-included headers

### DIFF
--- a/toolchain/base/shared_value_stores.cpp
+++ b/toolchain/base/shared_value_stores.cpp
@@ -17,4 +17,21 @@ template class ValueStore<IdentifierId, llvm::StringRef>;
 template class ValueStore<RealId, Real>;
 template class ValueStore<StringLiteralValueId, llvm::StringRef>;
 
+auto SharedValueStores::OutputYaml(
+    std::optional<llvm::StringRef> filename) const -> Yaml::OutputMapping {
+  return Yaml::OutputMapping([&, filename](Yaml::OutputMapping::Map map) {
+    if (filename) {
+      map.Add("filename", *filename);
+    }
+    map.Add("shared_values",
+            Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+              map.Add("ints", ints_.OutputYaml());
+              map.Add("reals", reals_.OutputYaml());
+              map.Add("floats", floats_.OutputYaml());
+              map.Add("identifiers", identifiers_.OutputYaml());
+              map.Add("strings", string_literals_.OutputYaml());
+            }));
+  });
+}
+
 }  // namespace Carbon

--- a/toolchain/base/shared_value_stores.h
+++ b/toolchain/base/shared_value_stores.h
@@ -50,21 +50,7 @@ class SharedValueStores : public Yaml::Printable<SharedValueStores> {
   }
 
   auto OutputYaml(std::optional<llvm::StringRef> filename = std::nullopt) const
-      -> Yaml::OutputMapping {
-    return Yaml::OutputMapping([&, filename](Yaml::OutputMapping::Map map) {
-      if (filename) {
-        map.Add("filename", *filename);
-      }
-      map.Add("shared_values",
-              Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                map.Add("ints", ints_.OutputYaml());
-                map.Add("reals", reals_.OutputYaml());
-                map.Add("floats", floats_.OutputYaml());
-                map.Add("identifiers", identifiers_.OutputYaml());
-                map.Add("strings", string_literals_.OutputYaml());
-              }));
-    });
-  }
+      -> Yaml::OutputMapping;
 
   // Collects memory usage for the various shared stores.
   auto CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label) const

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -85,6 +85,7 @@ cc_library(
     srcs = [
         "associated_constant.cpp",
         "builtin_function_kind.cpp",
+        "bundle.cpp",
         "class.cpp",
         "constant.cpp",
         "core_interface.cpp",

--- a/toolchain/sem_ir/bundle.cpp
+++ b/toolchain/sem_ir/bundle.cpp
@@ -1,0 +1,74 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/sem_ir/bundle.h"
+
+#include "toolchain/base/block_value_store_impl.h"
+#include "toolchain/base/value_store_impl.h"
+
+namespace Carbon::SemIR {
+
+auto BundleStore::OutputYaml() const -> Yaml::OutputMapping {
+  return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+    for (auto bundle_id : store_.ids()) {
+      AddYamlMapEntry(map, bundle_id);
+    }
+  });
+}
+
+auto BundleStore::OutputBundleYaml(RawBundleId bundle_id) const
+    -> Yaml::OutputMapping {
+  return Yaml::OutputMapping([this, bundle_id](Yaml::OutputMapping::Map map) {
+    AddYamlMapEntry(map, bundle_id);
+  });
+}
+
+auto BundleStore::CollectMemUsage(MemUsage& mem_usage,
+                                  llvm::StringRef label) const -> void {
+  store_.CollectMemUsage(mem_usage, label);
+  bundle_kind_cache_.CollectMemUsage(mem_usage, label);
+}
+
+auto BundleStore::BundleString(RawBundleId bundle_id) const -> std::string {
+  RawStringOstream out;
+  llvm::ListSeparator sep;
+  out << "{";
+  for (auto [i, raw_id] : llvm::enumerate(store_.Get(bundle_id))) {
+    PrintBundleField(out, sep, i, raw_id);
+  }
+  out << "}";
+  return out.TakeStr();
+}
+
+auto BundleStore::AddYamlMapEntry(Yaml::OutputMapping::Map& map,
+                                  RawBundleId bundle_id) const -> void {
+  auto kind_set = bundle_kind_cache_.GetWithDefault(bundle_id, IdKindSet{});
+  if (kind_set.empty()) {
+    map.Add(PrintToString(bundle_id),
+            Yaml::OutputScalar(BundleString(bundle_id)));
+  } else if (kind_set.size() == 1) {
+    IdAndKind typed_bundle_id(*kind_set.begin(), bundle_id.index);
+    auto bundle_string = typed_bundle_id.Dispatch<std::string>(
+        [this](auto id) { return BundleString(id); });
+    map.Add(PrintToString(bundle_id), Yaml::OutputScalar(bundle_string));
+  } else {
+    map.Add(PrintToString(bundle_id), YamlBundleMap(bundle_id, kind_set));
+  }
+}
+
+auto BundleStore::YamlBundleMap(RawBundleId bundle_id,
+                                const IdKindSet& kinds) const
+    -> Yaml::OutputMapping {
+  return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+    for (auto [i, id_kind] : llvm::enumerate(kinds)) {
+      IdAndKind typed_bundle_id(id_kind, bundle_id.index);
+      // TODO: make this a YAML sequence instead of a map.
+      map.Add(llvm::itostr(i),
+              typed_bundle_id.Dispatch<std::string>(
+                  [this](auto id) { return BundleString(id); }));
+    }
+  });
+}
+
+}  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/bundle.h
+++ b/toolchain/sem_ir/bundle.h
@@ -130,28 +130,15 @@ class BundleStore {
   // CacheDebugKind was previously called for that bundle; otherwise they will
   // be depicted as AnyRawIds, and may be conflated with other bundles that have
   // the same untyped ID (and hence the same numeric field values).
-  auto OutputYaml() const -> Yaml::OutputMapping {
-    return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-      for (auto bundle_id : store_.ids()) {
-        AddYamlMapEntry(map, bundle_id);
-      }
-    });
-  }
+  auto OutputYaml() const -> Yaml::OutputMapping;
 
   // Equivalent to OutputYaml, but the resulting mapping will contain only
   // the given bundle.
-  auto OutputBundleYaml(RawBundleId bundle_id) const -> Yaml::OutputMapping {
-    return Yaml::OutputMapping([this, bundle_id](Yaml::OutputMapping::Map map) {
-      AddYamlMapEntry(map, bundle_id);
-    });
-  }
+  auto OutputBundleYaml(RawBundleId bundle_id) const -> Yaml::OutputMapping;
 
   // Adds the store's memory usage to mem_usage.
   auto CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label) const
-      -> void {
-    store_.CollectMemUsage(mem_usage, label);
-    bundle_kind_cache_.CollectMemUsage(mem_usage, label);
-  }
+      -> void;
 
   // The number of stored bundles.
   auto size() const -> size_t { return store_.size(); }
@@ -234,16 +221,7 @@ class BundleStore {
     return out.TakeStr();
   }
 
-  auto BundleString(RawBundleId bundle_id) const -> std::string {
-    RawStringOstream out;
-    llvm::ListSeparator sep;
-    out << "{";
-    for (auto [i, raw_id] : llvm::enumerate(store_.Get(bundle_id))) {
-      PrintBundleField(out, sep, i, raw_id);
-    }
-    out << "}";
-    return out.TakeStr();
-  }
+  auto BundleString(RawBundleId bundle_id) const -> std::string;
 
   template <typename IdT>
     requires Internal::IsIdKindType<IdT>
@@ -253,37 +231,14 @@ class BundleStore {
 
   // Adds an entry for `bundle_id` to `map`.
   auto AddYamlMapEntry(Yaml::OutputMapping::Map& map,
-                       RawBundleId bundle_id) const -> void {
-    auto kind_set = bundle_kind_cache_.GetWithDefault(bundle_id, IdKindSet{});
-    if (kind_set.empty()) {
-      map.Add(PrintToString(bundle_id),
-              Yaml::OutputScalar(BundleString(bundle_id)));
-    } else if (kind_set.size() == 1) {
-      IdAndKind typed_bundle_id(*kind_set.begin(), bundle_id.index);
-      auto bundle_string = typed_bundle_id.Dispatch<std::string>(
-          [this](auto id) { return BundleString(id); });
-      map.Add(PrintToString(bundle_id), Yaml::OutputScalar(bundle_string));
-    } else {
-      map.Add(PrintToString(bundle_id), YamlBundleMap(bundle_id, kind_set));
-    }
-  }
+                       RawBundleId bundle_id) const -> void;
 
   // Returns a YAML mapping with an entry for each ID kind in `kinds`,
   // consisting of the string representation of the given bundle, interpreted as
   // a bundle of that kind. All entries in `kinds` must be specializations of
   // `BundleId`.
   auto YamlBundleMap(RawBundleId bundle_id, const IdKindSet& kinds) const
-      -> Yaml::OutputMapping {
-    return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-      for (auto [i, id_kind] : llvm::enumerate(kinds)) {
-        IdAndKind typed_bundle_id(id_kind, bundle_id.index);
-        // TODO: make this a YAML sequence instead of a map.
-        map.Add(llvm::itostr(i),
-                typed_bundle_id.Dispatch<std::string>(
-                    [this](auto id) { return BundleString(id); }));
-      }
-    });
-  }
+      -> Yaml::OutputMapping;
 
   // The bundles in the store, represented as blocks of `AnyRawId`s.
   //

--- a/toolchain/sem_ir/constant.cpp
+++ b/toolchain/sem_ir/constant.cpp
@@ -63,6 +63,24 @@ auto GetInstWithConstantValue(const File& file, ConstantId const_id) -> InstId {
   return file.inst_blocks().Get(block)[symbolic_const.index.index()];
 }
 
+auto ConstantValueStore::OutputYaml(bool include_singletons) const
+    -> Yaml::OutputMapping {
+  return Yaml::OutputMapping([&, include_singletons](
+                                 Yaml::OutputMapping::Map map) {
+    map.Add("values", Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+              for (auto [id, value] : values_.enumerate()) {
+                if (!include_singletons && IsSingletonInstId(id)) {
+                  continue;
+                }
+                if (!value.has_value() || value.is_constant()) {
+                  map.Add(PrintToString(id), Yaml::OutputScalar(value));
+                }
+              }
+            }));
+    map.Add("symbolic_constants", symbolic_constants_.OutputYaml());
+  });
+}
+
 }  // namespace Carbon::SemIR
 
 namespace Carbon {

--- a/toolchain/sem_ir/constant.h
+++ b/toolchain/sem_ir/constant.h
@@ -268,22 +268,7 @@ class ConstantValueStore {
   auto enumerate() const -> auto { return values_.enumerate(); }
 
   // Outputs assigned constant values, and all symbolic constants.
-  auto OutputYaml(bool include_singletons) const -> Yaml::OutputMapping {
-    return Yaml::OutputMapping([&, include_singletons](
-                                   Yaml::OutputMapping::Map map) {
-      map.Add("values", Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-                for (auto [id, value] : values_.enumerate()) {
-                  if (!include_singletons && IsSingletonInstId(id)) {
-                    continue;
-                  }
-                  if (!value.has_value() || value.is_constant()) {
-                    map.Add(PrintToString(id), Yaml::OutputScalar(value));
-                  }
-                }
-              }));
-      map.Add("symbolic_constants", symbolic_constants_.OutputYaml());
-    });
-  }
+  auto OutputYaml(bool include_singletons) const -> Yaml::OutputMapping;
 
   // The tag used in ConstantIds for concrete constants.
   using ConcreteIdTagType = IdTag<SemIR::ConstantId, Tag<SemIR::CheckIRId>>;

--- a/toolchain/sem_ir/name.cpp
+++ b/toolchain/sem_ir/name.cpp
@@ -67,4 +67,13 @@ auto NameStoreWrapper::GetIRBaseName(NameId name_id) const -> llvm::StringRef {
   return GetSpecialName(name_id, /*for_ir=*/true);
 }
 
+auto NameStoreWrapper::OutputYaml() const -> Yaml::OutputMapping {
+  return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+    for (auto [identifier_id, value] : identifiers_->enumerate()) {
+      map.Add(PrintToString(NameId{identifier_id.index}),
+              Yaml::OutputScalar(value));
+    }
+  });
+}
+
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/name.h
+++ b/toolchain/sem_ir/name.h
@@ -50,14 +50,7 @@ class NameStoreWrapper {
   // `name_id` is `None`.
   auto GetIRBaseName(NameId name_id) const -> llvm::StringRef;
 
-  auto OutputYaml() const -> Yaml::OutputMapping {
-    return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-      for (auto [identifier_id, value] : identifiers_->enumerate()) {
-        map.Add(PrintToString(NameId{identifier_id.index}),
-                Yaml::OutputScalar(value));
-      }
-    });
-  }
+  auto OutputYaml() const -> Yaml::OutputMapping;
 
  private:
   const SharedValueStores::IdentifierStore* identifiers_;

--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -201,4 +201,28 @@ auto ExtractScrutineeType(const File& sem_ir, TypeId type_id) -> TypeId {
   return type_id;
 }
 
+auto TypeStore::OutputYaml() const -> Yaml::OutputMapping {
+  return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
+    for (auto type_id : complete_types_) {
+      auto info = GetCompleteTypeInfo(type_id);
+      map.Add(
+          PrintToString(type_id),
+          Yaml::OutputMapping([&](Yaml::OutputMapping::Map map2) {
+            map2.Add("value_repr", Yaml::OutputScalar(info.value_repr));
+            map2.Add(
+                "object_layout",
+                Yaml::OutputMapping([&](Yaml::OutputMapping::Map map3) {
+                  map3.Add("size", Yaml::OutputScalar(info.object_layout.size));
+                  map3.Add("alignment",
+                           Yaml::OutputScalar(info.object_layout.alignment));
+                }));
+            if (info.abstract_class_id.has_value()) {
+              map2.Add("abstract_class_id",
+                       Yaml::OutputScalar(info.abstract_class_id));
+            }
+          }));
+    }
+  });
+}
+
 }  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -256,30 +256,7 @@ class TypeStore : public Yaml::Printable<TypeStore> {
     return complete_types_;
   }
 
-  auto OutputYaml() const -> Yaml::OutputMapping {
-    return Yaml::OutputMapping([&](Yaml::OutputMapping::Map map) {
-      for (auto type_id : complete_types_) {
-        auto info = GetCompleteTypeInfo(type_id);
-        map.Add(PrintToString(type_id),
-                Yaml::OutputMapping([&](Yaml::OutputMapping::Map map2) {
-                  map2.Add("value_repr", Yaml::OutputScalar(info.value_repr));
-                  map2.Add(
-                      "object_layout",
-                      Yaml::OutputMapping([&](Yaml::OutputMapping::Map map3) {
-                        map3.Add("size",
-                                 Yaml::OutputScalar(info.object_layout.size));
-                        map3.Add(
-                            "alignment",
-                            Yaml::OutputScalar(info.object_layout.alignment));
-                      }));
-                  if (info.abstract_class_id.has_value()) {
-                    map2.Add("abstract_class_id",
-                             Yaml::OutputScalar(info.abstract_class_id));
-                  }
-                }));
-      }
-    });
-  }
+  auto OutputYaml() const -> Yaml::OutputMapping;
 
   auto CollectMemUsage(MemUsage& mem_usage, llvm::StringRef label) const
       -> void {


### PR DESCRIPTION
These were defined inline in headers reached by most of the toolchain,
and as non-template functions their bodies -- including some very
expensive template instantiations -- are compiled in every including TU
even though they are only cold debug/dump paths:

- BundleStore's YAML output entry points instantiate IdAndKind::Dispatch
  over all ~50 ID kinds (two ~365ms instantiations per TU) plus
  Yaml::OutputScalar/std::function machinery; moved to a new bundle.cpp.
- TypeStore, ConstantValueStore, NameStoreWrapper, and SharedValueStores
  OutputYaml bodies wrap capturing lambdas in std::function via
  Yaml::OutputMapping; moved to their existing .cpp files.

This change appears to be worth another 10% compile time reduction.

Assisted-by: Claude