### PR TITLE
Canonicalize the path to clang resource directory

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -307,7 +307,7 @@
   "moduleExtensions": {
     "//bazel/cc_toolchains:clang_configuration.bzl%clang_toolchain_extension": {
       "general": {
-        "bzlTransitiveDigest": "H3RsK0MbgutDMSlPWTwZq4Vk1U5sjDtgJ5MXQxg7GLU=",
+        "bzlTransitiveDigest": "zlzuUB95ZT/0gx6Xy5Ercb4YiRyDEn9PzsoEcN6q2gk=",
         "usagesDigest": "lTxkeAFhR0iBEa3dg5hWvtd2HFCr5zCJx/fl27A+IKA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -83,7 +83,11 @@ def _compute_clang_resource_dir(repository_ctx, clang):
     ).stdout
 
     # The only line printed is this path.
-    return output.splitlines()[0]
+    dir_path = repository_ctx.path(output.splitlines()[0])
+
+    # Canonicalize the path to help ensure string matching succeeds
+    # even with clang installs returning a non-canonical path.
+    return str(dir_path.realpath)
 
 def _compute_mac_os_sysroot(repository_ctx):
     """Runs `xcrun` to extract the correct sysroot."""


### PR DESCRIPTION
When building Carbon on Fedora, clang reports the
resource directory as `/usr/bin/../lib/clang/22`.
This fails to string match against `/usr/lib/clang/22`
and so bazel reports an error.

This PR canonicalizes the path returned by clang
so that it will string match successfully.
