### PR TITLE
Add `utils/vscode/BUILD`

### DIFF
--- a/utils/vscode/BUILD
+++ b/utils/vscode/BUILD
@@ -1,0 +1,15 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+exports_files(
+    [
+        "package.json",
+        "carbon.tmLanguage.json",
+        "semir.tmLanguage.json",
+        "carbon-check-test.tmLanguage.json",
+        "language-configuration.json",
+        "images/icon.png",
+        "LICENSE",
+    ],
+)


### PR DESCRIPTION
This helps with some VSCode derivatives' extension management.