### PR TITLE
Refactor and extend tool usage skills

### DIFF
--- a/.agents/skills/agent_tools/SKILL.md
+++ b/.agents/skills/agent_tools/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: Tool usage
+name: Agent tools
 description:
-    Instructions for AI assistants on what tools to use in the carbon-lang
-    project.
+    Guidelines and restrictions on shell commands and file manipulation tools
+    for AI assistants.
 ---
 
-# Tool usage
+# Agent tools
 
 <!--
 Part of the Carbon Language project, under the Apache License v2.0 with LLVM
@@ -13,30 +13,11 @@ Exceptions. See /LICENSE for license information.
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
-## Bazelisk and Bazel
-
-We use `bazelisk` for build and test.
-
-**IMPORTANT**: AI assistants use `bazelisk` instead of `bazel`.
-
-## Prek
-
-Running `prek` is mandatory. To run it on all files:
-
-```bash
-prek run -a
-```
-
-To validate a specific list of files:
-
-```bash
-prek run --files <files>
-```
+AI assistants working on the Carbon repository **MUST NOT** use legacy or
+generic UNIX shell search/edit commands when specialized environment tools
+exist.
 
 ## Command line tools restrictions
-
-AI assistants **MUST NOT** use legacy or generic UNIX shell search/edit commands
-when specialized environment tools exist.
 
 -   **DO NOT USE**: `cat`, `less`, `grep`, `sed`, or other shell utilities for
     viewing, searching, or modifying files.
@@ -44,11 +25,11 @@ when specialized environment tools exist.
 -   **DO NOT USE**: Writing custom scripts in other languages to circumvent this
     limitation.
 -   **DO USE**: High-fidelity semantic API tools:
-    -   Viewing: Use `view_file` instead of `cat` / `less`.
-    -   Searching: Use `grep_search` / `find_by_name` instead of `grep` /
+    -   **Viewing**: Use `view_file` instead of `cat` / `less`.
+    -   **Searching**: Use `grep_search` / `find_by_name` instead of `grep` /
         `find`.
-    -   Modifying: Use `replace_file_content`, `multi_replace_file_content`, or
-        `write_to_file` instead of `sed` / `patch` / `python` edits.
+    -   **Modifying**: Use `replace_file_content`, `multi_replace_file_content`,
+        or `write_to_file` instead of `sed` / `patch` / `python` edits.
 
 You may only write and run temporary programs to modify source code if no
 semantic tool is applicable or when performing complex, systematic transforms

--- a/.agents/skills/bazel/SKILL.md
+++ b/.agents/skills/bazel/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: Bazel usage
 description:
-    Instructions for using Bazel or Bazelisk to build, test, and debug in the
-    Carbon repository.
+    Instructions that **MUST** be followed when using Bazel or Bazelisk to
+    build, test, and debug in the Carbon repository.
 ---
 
 # Bazel usage

--- a/.agents/skills/jj/SKILL.md
+++ b/.agents/skills/jj/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: Jujutsu (jj) usage
+description:
+    Instructions for using Jujutsu (jj) for version control in the Carbon
+    repository.
+---
+
+# Jujutsu (jj) usage
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+[Jujutsu](https://github.com/jj-vcs/jj) is a Git-compatible version control
+system that may be used in Carbon checkouts.
+
+> [!IMPORTANT] You can detect if Jujutsu is in use by checking for a `.jj`
+> directory in the repository root. If present, you **must** use `jj` and **must
+> not** use `git`.
+
+## General usage
+
+Always use the `--no-pager` flag when invoking `jj` to prevent the command from
+blocking or waiting for terminal paging.
+
+## Common commands
+
+### Syncing with remote
+
+-   **Fetch from remote**: `jj --no-pager git fetch`
+-   **Create a new change on top of trunk**: `jj --no-pager new trunk`
+-   **Show repository status and log**: `jj --no-pager` (or `jj --no-pager log`)
+
+### Managing changes
+
+-   **View diff of current changes**: `jj --no-pager diff`
+-   **Commit changes**: `jj --no-pager commit`
+    -   _Note_: Prefer using `jj commit` over the combination of `jj describe`
+        and `jj new`.
+-   **Abandon/discard current changes**: `jj --no-pager abandon`
+-   **Rebase current change onto trunk**: `jj --no-pager rebase -d trunk`

--- a/.agents/skills/jj/SKILL.md
+++ b/.agents/skills/jj/SKILL.md
@@ -18,7 +18,7 @@ system that may be used in Carbon checkouts.
 
 > [!IMPORTANT] You can detect if Jujutsu is in use by checking for a `.jj`
 > directory in the repository root. If present, you **must** use `jj` and **must
-> not** use `git`.
+> not** use `git`. If absent, you **must not** use `jj`.
 
 ## General usage
 
@@ -31,7 +31,8 @@ blocking or waiting for terminal paging.
 
 -   **Fetch from remote**: `jj --no-pager git fetch`
 -   **Create a new change on top of trunk**: `jj --no-pager new trunk`
--   **Show repository status and log**: `jj --no-pager` (or `jj --no-pager log`)
+-   **Show repository status**: `jj --no-pager status`
+-   **Show commit history**: `jj --no-pager log`
 
 ### Managing changes
 
@@ -40,4 +41,4 @@ blocking or waiting for terminal paging.
     -   _Note_: Prefer using `jj commit` over the combination of `jj describe`
         and `jj new`.
 -   **Abandon/discard current changes**: `jj --no-pager abandon`
--   **Rebase current change onto trunk**: `jj --no-pager rebase -d trunk`
+-   **Rebase current change onto trunk**: `jj --no-pager rebase -o trunk`

--- a/.agents/skills/prek/SKILL.md
+++ b/.agents/skills/prek/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: Prek
+description:
+    Instructions for running prek, the Carbon pre-submit/style/lint checker.
+---
+
+# Prek
+
+<!--
+Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+Exceptions. See /LICENSE for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+`prek` is the Carbon pre-submit, style, and lint checker. Running it is
+mandatory before submitting any changes.
+
+## Running prek
+
+To run `prek` on all files:
+
+```bash
+prek run -a
+```
+
+To validate a specific list of files:
+
+```bash
+prek run --files <files>
+```
+
+## Running prek in a Jujutsu (jj) workspace
+
+If you are working in a Jujutsu workspace, running `prek` directly will fail
+because it expects a standard Git repository structure. Instead, use the helper
+script:
+
+```bash
+./scripts/jj_prek.sh
+```
+
+This script runs `prek` on all files that have changed between `trunk` and your
+current Jujutsu `@` change.
+
+## Prek dependency errors
+
+> [!TIP] If `prek` fails with an error about resolving dependencies or security
+> policy, you may be running in a restricted environment where the
+> special-purpose `gpkg` tool is required. Prefix the command with `gpkg`, for
+> example: `gpkg prek run -a` or `gpkg ./scripts/jj_prek.sh`.

--- a/.agents/skills/prek/SKILL.md
+++ b/.agents/skills/prek/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Prek
 description:
-    Instructions for running prek, the Carbon pre-submit/style/lint checker.
+    Instructions for running prek, the Carbon pre-submit/style/lint checker, that *MUST* be run before submitting an change.
 ---
 
 # Prek

--- a/.agents/skills/prek/SKILL.md
+++ b/.agents/skills/prek/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: Prek
 description:
-    Instructions for running prek, the Carbon pre-submit/style/lint checker, that *MUST* be run before submitting an change.
+    Instructions for running prek, the Carbon pre-submit/style/lint checker,
+    that *MUST* be run before submitting an change.
 ---
 
 # Prek

--- a/scripts/jj_prek.sh
+++ b/scripts/jj_prek.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Runs prek within a jj repository that is backed by a git repository, including
+# the case where the repository is a non-colocated jj workspace.
+
+set -eu
+
+# Find the .git directory, and map `@` to a git commit.
+export GIT_DIR="$(jj git root --ignore-working-copy)"
+HEAD="$(jj show --no-patch --ignore-working-copy -r @ --template 'commit_id')"
+
+# Create a git index file describing `@`.
+export GIT_INDEX_FILE="$(mktemp)"
+trap 'rm -f "$GIT_INDEX_FILE"' EXIT
+git read-tree "$HEAD"
+
+# Run prek with the `.git` directory and index we built earlier.
+prek run --from-ref trunk --to-ref "$HEAD"


### PR DESCRIPTION
Split out the `prek` tool usage instructions into a separate skill. This should make the agent more likely to realize the skill is relevant to a particular task and consult it. Extend the skill to include instructions for using `prek` in a jj workspace, and add a helper script for that situation.

Add a `jj` skill, with the main purpose being to instruct the agent to use `jj` not `git`, and to use `--no-pager` when running it.

Extend the `bazel` tool description slightly to more strongly encourage agents to read and follow it.

Assisted-by: Gemini via Antigravity