### PR TITLE
Use LLVM RTTI to make Lower::Context::Finalize less brittle

### DIFF
--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -347,6 +347,13 @@ class CarbonExternalASTSource : public SemIR::ReadOnlyASTSource {
       llvm::DenseMap<const clang::CXXRecordDecl*, clang::CharUnits>&
           vbase_offsets) -> bool override;
 
+  auto isA(const void* class_id) const -> bool override {
+    return class_id == &id || ReadOnlyASTSource::isA(class_id);
+  }
+  static auto classof(const ExternalASTSource* s) -> bool {
+    return s->isA(&id);
+  }
+
  private:
   // Builds the top-level C++ namespace `Carbon` and adds it to the translation
   // unit.
@@ -382,8 +389,13 @@ class CarbonExternalASTSource : public SemIR::ReadOnlyASTSource {
         SemIR::ImportIRInst(clang_source_loc_id));
   }
 
+  // For LLVM RTTI.
+  static char id;
+
   Check::Context* context_;
 };
+
+char CarbonExternalASTSource::id;
 
 }  // namespace
 

--- a/toolchain/lower/context.cpp
+++ b/toolchain/lower/context.cpp
@@ -10,6 +10,7 @@
 #include "common/growing_range.h"
 #include "common/raw_string_ostream.h"
 #include "common/vlog.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include "toolchain/lower/file_context.h"
 #include "toolchain/sem_ir/inst_namer.h"
@@ -74,16 +75,18 @@ auto Context::Finalize() && -> std::unique_ptr<llvm::Module> {
     if (file_context) {
       if (file_context->cpp_file()) {
         // Remove the `CarbonExternalASTSource` installed during check
-        // (always the last child of the multiplex source) and replace
-        // it with a `ReadOnlyASTSource`. This is necessary because the
-        // original source has a now-invalid pointer to a
+        // and replace it with a `ReadOnlyASTSource`. This is necessary
+        // because the original source has a now-invalid pointer to a
         // `Check::Context`.
         auto& ast = const_cast<clang::ASTContext&>(
             file_context->cpp_file()->ast_context());
         auto* multiplex_source =
             cast<clang::MultiplexExternalSemaSource>(ast.getExternalSource());
         auto& child_sources = multiplex_source->GetSources();
-        child_sources.pop_back();
+        llvm::erase_if(child_sources, [](const auto& src) {
+          // `CarbonExternalASTSource` inherits from `ReadOnlyASTSource`.
+          return llvm::isa<SemIR::ReadOnlyASTSource>(src.get());
+        });
         multiplex_source->AddSource(
             llvm::makeIntrusiveRefCnt<SemIR::ReadOnlyASTSource>(
                 file_context->sem_ir()));

--- a/toolchain/sem_ir/read_only_ast_source.cpp
+++ b/toolchain/sem_ir/read_only_ast_source.cpp
@@ -6,6 +6,8 @@
 
 namespace Carbon::SemIR {
 
+char ReadOnlyASTSource::id;
+
 // Get the field offset for each field in a class.
 //
 // Returns true on success, false if any error occurs.

--- a/toolchain/sem_ir/read_only_ast_source.h
+++ b/toolchain/sem_ir/read_only_ast_source.h
@@ -22,7 +22,17 @@ class ReadOnlyASTSource : public clang::ExternalSemaSource {
       llvm::DenseMap<const clang::CXXRecordDecl*, clang::CharUnits>&
           vbase_offsets) -> bool override;
 
+  auto isA(const void* class_id) const -> bool override {
+    return class_id == &id || ExternalSemaSource::isA(class_id);
+  }
+  static auto classof(const ExternalASTSource* s) -> bool {
+    return s->isA(&id);
+  }
+
  private:
+  // For LLVM RTTI.
+  static char id;
+
   const File& sem_ir_;
 };
 


### PR DESCRIPTION
Add LLVM RTTI to ReadOnlyASTSource (and CarbonExternalASTSource). Change Finalize to erase any multiplex child sources that match ReadOnlyASTSource; this includes CarbonExternalASTSource since it's a subclass.

As suggested here: https://github.com/carbon-language/carbon-lang/pull/7335#pullrequestreview-4488057948