### PR TITLE
Update design docs to reflect #6177: C++ Interop: Mapping `std::string_view` to `Core.Str`

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -3627,12 +3627,14 @@ Further, C++ reference types like `T&` will be translated to `T*` in Carbon,
 which is Carbon's non-null pointer type.
 
 Carbon will work to have idiomatic vocabulary _view_ types for common data
-structures, like `std::string_view` and `std::span`, map transparently between
-C++ and the Carbon equivalents. This will include data layout so that even
-pointers to these types translate seamlessly, contingent on a suitable C++ ABI
-for those types, potentially by re-compiling the C++ code with a customized ABI.
-We will also explore how to expand coverage to similar view types in other
-libraries.
+structures map transparently between C++ and the Carbon equivalents. For
+instance, C++'s `std::string_view` maps directly to Carbon's `Core.Str` (see
+[here](interoperability/README.md#stdstring_view-and-str)). Other view types,
+like `std::span`, are intended to map similarly. This includes matching the data
+layout so that even pointers to these types translate seamlessly, contingent on
+a compatible standard library ABI (potentially by re-compiling the C++ code with
+a customized ABI). We will also explore how to expand coverage to similar view
+types in other libraries.
 
 However, Carbon's containers will be distinct from the C++ standard library
 containers in order to maximize our ability to improve performance and leverage
@@ -3646,6 +3648,11 @@ containers without performance loss or constraining the Carbon container
 implementations. In the other direction, Carbon containers will satisfy C++
 container requirements, so templated C++ code can operate directly on Carbon
 containers as well.
+
+> References:
+>
+> -   Proposal
+>     [#6177: C++ Interop: Mapping `std::string_view` to `Core.Str`](https://github.com/carbon-language/carbon-lang/pull/6177)
 
 ### Inheritance
 

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -253,23 +253,16 @@ have corresponding types in Carbon.
 
 C++'s `std::string_view` maps directly to Carbon's `str` (which is an alias for
 `Core.Str`) when importing C++ headers. The Carbon compiler treats
-`std::string_view` as a type alias for `str` at the ABI level.
+`std::string_view` as a type alias for `str` at the ABI level, with identical
+memory representation.
 
-To support this mapping:
-
--   **Identical Representation:** The memory layout (sequence of fields, size,
-    and alignment) of `std::string_view` and `str` must be identical for the
-    target platform and C++ standard library.
--   **Target Restrictions:** This direct mapping is initially enabled only on
-    64-bit targets (since `str` has a 64-bit size field, whereas C++
-    `std::string_view` uses `size_t`, which is 32-bit on 32-bit platforms) and
-    where the standard library representation matches the
-    pointer-first-then-size layout of `str` (such as `libc++` used by Clang and
-    MSVC STL). For platforms with other layout conventions (like `libstdc++`'s
-    size-first-then-pointer layout), this mapping is disabled by default until
-    layout compatibility is established.
--   **Semantic Alignment:** Both `str` and `std::string_view` are views of a
-    `char` sequence, see [character types](#character-types).
+This direct mapping is initially enabled only on 64-bit targets (since `str` has
+a 64-bit size field, whereas C++ `std::string_view` uses `size_t`, which is
+32-bit on 32-bit platforms) and where the standard library representation
+matches the pointer-first-then-size layout of `str` (such as `libc++` used by
+Clang and MSVC STL). For platforms with other layout conventions (like
+`libstdc++`'s size-first-then-pointer layout), this mapping is disabled by
+default until layout compatibility is established.
 
 > References:
 >

--- a/docs/design/interoperability/README.md
+++ b/docs/design/interoperability/README.md
@@ -32,9 +32,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [TODO: Integers](#todo-integers)
     -   [Literals](#literals)
     -   [Character types](#character-types)
-        -   [References](#references)
 -   [TODO: Advanced type mapping: pointers, references, and `const`](#todo-advanced-type-mapping-pointers-references-and-const)
--   [TODO: Bi-directional type mapping: standard library types](#todo-bi-directional-type-mapping-standard-library-types)
+-   [Bi-directional type mapping: standard library types](#bi-directional-type-mapping-standard-library-types)
+    -   [`std::string_view` and `str`](#stdstring_view-and-str)
 -   [TODO: The operator interoperability model](#todo-the-operator-interoperability-model)
 
 <!-- tocstop -->
@@ -237,13 +237,43 @@ is treated as `unsigned` by default (`-funsigned-char`). When interoperating
 with a signed C++ `char` type (`-fno-unsigned-char`), Carbon will maintain
 interoperability, though bits will be interpreted differently in each language.
 
-#### References
-
--   Proposal
-    [#6710: `char` redesign](https://github.com/carbon-language/carbon-lang/pull/6710)
+> References:
+>
+> -   Proposal
+>     [#6710: `char` redesign](https://github.com/carbon-language/carbon-lang/pull/6710)
 
 ## TODO: Advanced type mapping: pointers, references, and `const`
 
-## TODO: Bi-directional type mapping: standard library types
+## Bi-directional type mapping: standard library types
+
+TODO: C++ view types such as `std::span` and other standard library types will
+have corresponding types in Carbon.
+
+### `std::string_view` and `str`
+
+C++'s `std::string_view` maps directly to Carbon's `str` (which is an alias for
+`Core.Str`) when importing C++ headers. The Carbon compiler treats
+`std::string_view` as a type alias for `str` at the ABI level.
+
+To support this mapping:
+
+-   **Identical Representation:** The memory layout (sequence of fields, size,
+    and alignment) of `std::string_view` and `str` must be identical for the
+    target platform and C++ standard library.
+-   **Target Restrictions:** This direct mapping is initially enabled only on
+    64-bit targets (since `str` has a 64-bit size field, whereas C++
+    `std::string_view` uses `size_t`, which is 32-bit on 32-bit platforms) and
+    where the standard library representation matches the
+    pointer-first-then-size layout of `str` (such as `libc++` used by Clang and
+    MSVC STL). For platforms with other layout conventions (like `libstdc++`'s
+    size-first-then-pointer layout), this mapping is disabled by default until
+    layout compatibility is established.
+-   **Semantic Alignment:** Both `str` and `std::string_view` are views of a
+    `char` sequence, see [character types](#character-types).
+
+> References:
+>
+> -   Proposal
+>     [#6177: C++ Interop: Mapping `std::string_view` to `Core.Str`](https://github.com/carbon-language/carbon-lang/pull/6177)
 
 ## TODO: The operator interoperability model


### PR DESCRIPTION
Assisted-by: Gemini via Antigravity