### PR TITLE
Remove licence declaration from BUILD file

### DIFF
--- a/utils/vscode/BUILD
+++ b/utils/vscode/BUILD
@@ -1,9 +1,3 @@
-# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
-# Exceptions. See /LICENSE for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-licenses(["notice"])
-
 exports_files(
     [
         "package.json",


### PR DESCRIPTION
These were mistakenly added due to misunderstanding a CI failure.
