### PR TITLE
Don't crash when converting a tuple to `type` if it contains an ErrorInst

### DIFF
--- a/toolchain/check/convert.cpp
+++ b/toolchain/check/convert.cpp
@@ -428,6 +428,9 @@ static auto ConvertTupleToType(Context& context, SemIR::LocId loc_id,
                                SemIR::TypeId value_type_id,
                                ConversionTarget target) -> SemIR::TypeInstId {
   auto value_const_id = context.constant_values().Get(value_id);
+  if (value_const_id == SemIR::ErrorInst::ConstantId) {
+    return SemIR::ErrorInst::TypeInstId;
+  }
   if (!value_const_id.is_constant()) {
     // Types are constants. The input value must have a constant value to
     // convert.


### PR DESCRIPTION
The conversion will just produce an ErrorInst output.

Right now I am not sure how to get an ErrorInst into that position, but with https://github.com/carbon-language/carbon-lang/pull/7364 rejecting `.Self` we end up with this, and it crashes otherwise.