### PR TITLE
Textmate grammar: avoid variable-width lookbehind.

### DIFF
--- a/utils/textmate/Syntaxes/carbon.tmLanguage.json
+++ b/utils/textmate/Syntaxes/carbon.tmLanguage.json
@@ -400,7 +400,11 @@
       "patterns": [
         {
           "name": "support.class.carbon",
-          "match": "(?<=\\b(package|Core)\\s)\\w+"
+          "match": "(?<=\\bpackage\\s)\\w+"
+        },
+        {
+          "name": "support.class.carbon",
+          "match": "(?<=\\bCore\\s)\\w+"
         },
         {
           "name": "support.type.property-name.carbon",


### PR DESCRIPTION
This is not supported by the textmate parser in github's linguist.

Assisted-by: Gemini via Antigravity