### PR TITLE
Sync utils/textmate directory to carbon.tmbundle repository.

### DIFF
--- a/scripts/sync_repos.sh
+++ b/scripts/sync_repos.sh
@@ -23,6 +23,7 @@ git config --global user.name "$GIT_USERNAME"
 
 declare -A MIRRORS
 MIRRORS["utils/vim"]="vim-carbon-lang"
+MIRRORS["utils/textmate"]="carbon.tmbundle"
 
 for dir in "${!MIRRORS[@]}"; do
   SRC_DIR="$dir"


### PR DESCRIPTION
Provide a cut-down repository containing just our textmate bundle, both for easy installation in general and so that github's linguist in particular can pick it up and use it for highlighting Carbon files.

The sync_repos script is automatically run by our github workflow whenever utils/ changes.