### PR TITLE
Fix handling of backticks in proposal names.

### DIFF
--- a/proposals/scripts/new_proposal.py
+++ b/proposals/scripts/new_proposal.py
@@ -93,8 +93,7 @@ def _calculate_branch(parsed_args: argparse.Namespace) -> str:
     if parsed_args.branch:
         assert isinstance(parsed_args.branch, str)
         return parsed_args.branch
-    # Only use the first 20 chars of the title for branch names.
-    return "proposal-%s" % (parsed_args.title.lower().replace(" ", "-")[0:20])
+    return "proposal-%s" % slugify(parsed_args.title)
 
 
 def _find_tool(tool: str) -> str:

--- a/proposals/scripts/new_proposal_test.py
+++ b/proposals/scripts/new_proposal_test.py
@@ -27,7 +27,16 @@ class TestNewProposal(unittest.TestCase):
         )
         self.assertEqual(
             new_proposal._calculate_branch(parsed_args),
-            "proposal-a-really-long-long-l",
+            "proposal-a-really-long-long-long-title",
+        )
+
+    def test_calculate_branch_special(self):
+        parsed_args = new_proposal._parse_args(
+            ["A title with #*%$ special `char`s"]
+        )
+        self.assertEqual(
+            new_proposal._calculate_branch(parsed_args),
+            "proposal-a-title-with-special-char-s",
         )
 
     def test_calculate_branch_flag(self):


### PR DESCRIPTION
Use slugify, as it properly handles all proposal names. This also makes our branch name consistent with the file name of the proposal.