### PR TITLE
Highlight inline C++ as C++.

### DIFF
--- a/utils/textmate/Syntaxes/carbon.tmLanguage.json
+++ b/utils/textmate/Syntaxes/carbon.tmLanguage.json
@@ -10,6 +10,9 @@
       "include": "#comments"
     },
     {
+      "include": "#cpp-inline"
+    },
+    {
       "include": "#strings"
     },
     {
@@ -59,6 +62,94 @@
     }
   ],
   "repository": {
+    "cpp-inline": {
+      "patterns": [
+        {
+          "comment": "C++ inline import (triple-quoted)",
+          "begin": "\\b(import)\\b\\s+\\b(Cpp)\\b\\s+\\b(inline)\\b\\s*(''')([^\\s'#]*\\n)?",
+          "beginCaptures": {
+            "1": { "name": "storage.type.carbon" },
+            "2": { "name": "support.type.property-name.carbon" },
+            "3": { "name": "storage.type.carbon" },
+            "4": { "name": "string.quoted.triple.carbon" },
+            "5": { "name": "constant.character.escape.carbon" }
+          },
+          "end": "(''')\\s*(;)",
+          "endCaptures": {
+            "1": { "name": "string.quoted.triple.carbon" },
+            "2": { "name": "punctuation.terminator.carbon" }
+          },
+          "contentName": "meta.embedded.block.cpp",
+          "patterns": [
+            {
+              "include": "source.cpp"
+            }
+          ]
+        },
+        {
+          "comment": "C++ inline import (double-quoted)",
+          "begin": "\\b(import)\\b\\s+\\b(Cpp)\\b\\s+\\b(inline)\\b\\s*(\")",
+          "beginCaptures": {
+            "1": { "name": "storage.type.carbon" },
+            "2": { "name": "support.type.property-name.carbon" },
+            "3": { "name": "storage.type.carbon" },
+            "4": { "name": "string.quoted.double.carbon" }
+          },
+          "end": "(\")\\s*(;)",
+          "endCaptures": {
+            "1": { "name": "string.quoted.double.carbon" },
+            "2": { "name": "punctuation.terminator.carbon" }
+          },
+          "contentName": "meta.embedded.inline.cpp",
+          "patterns": [
+            {
+              "include": "source.cpp"
+            }
+          ]
+        },
+        {
+          "comment": "C++ inline block (triple-quoted)",
+          "begin": "\\b(inline)\\b\\s+\\b(Cpp)\\b\\s*(''')([^\\s'#]*\\n)?",
+          "beginCaptures": {
+            "1": { "name": "storage.type.carbon" },
+            "2": { "name": "support.type.property-name.carbon" },
+            "3": { "name": "string.quoted.triple.carbon" },
+            "4": { "name": "constant.character.escape.carbon" }
+          },
+          "end": "(''')\\s*(;)",
+          "endCaptures": {
+            "1": { "name": "string.quoted.triple.carbon" },
+            "2": { "name": "punctuation.terminator.carbon" }
+          },
+          "contentName": "meta.embedded.block.cpp",
+          "patterns": [
+            {
+              "include": "source.cpp"
+            }
+          ]
+        },
+        {
+          "comment": "C++ inline block (double-quoted)",
+          "begin": "\\b(inline)\\b\\s+\\b(Cpp)\\b\\s*(\")",
+          "beginCaptures": {
+            "1": { "name": "storage.type.carbon" },
+            "2": { "name": "support.type.property-name.carbon" },
+            "3": { "name": "string.quoted.double.carbon" }
+          },
+          "end": "(\")\\s*(;)",
+          "endCaptures": {
+            "1": { "name": "string.quoted.double.carbon" },
+            "2": { "name": "punctuation.terminator.carbon" }
+          },
+          "contentName": "meta.embedded.inline.cpp",
+          "patterns": [
+            {
+              "include": "source.cpp"
+            }
+          ]
+        }
+      ]
+    },
     "comments": {
       "patterns": [
         {
@@ -274,7 +365,7 @@
       "patterns": [
         {
           "name": "storage.type.carbon",
-          "match": "\\b(adapt|alias|choice|class|constraint|fn|import|interface|let|library|namespace|var)\\b"
+          "match": "\\b(adapt|alias|choice|class|constraint|fn|import|inline|interface|let|library|namespace|var)\\b"
         },
         {
           "name": "storage.type.carbon",

--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -96,8 +96,7 @@ function updateSplitLineNumbers(editor: TextEditor | undefined) {
 // Get an SVG image with a diagonal "C++" logo.
 const getCppSvgBase64 = (fillColor: string) => {
   const svg = [
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" ',
-    'preserveAspectRatio="none">',
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">',
     `<text x="50%" y="50%" font-size="10px" font-family="sans-serif" `,
     `fill="${fillColor}" text-anchor="middle" dominant-baseline="central" `,
     `transform="rotate(-45 10 10)">C++</text></svg>`,
@@ -116,7 +115,7 @@ const createCppDecorationType = (isWholeLine: boolean) => {
     /*border:*/ `none; ` +
     `background-image: url('data:image/svg+xml;base64,${base64}'); ` +
     `background-repeat: repeat; ` +
-    `background-size: 20px 100%;`;
+    `background-size: auto 100%;`;
   return window.createTextEditorDecorationType({
     light: { border: getBorder(lightSvgBase64) },
     dark: { border: getBorder(darkSvgBase64) },

--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -93,25 +93,39 @@ function updateSplitLineNumbers(editor: TextEditor | undefined) {
   editor.setDecorations(splitLineNumberDecorationType, decorations);
 }
 
-const cppBlockDecorationType = window.createTextEditorDecorationType({
-  light: {
-    backgroundColor: 'rgba(0, 0, 0, 0.03)',
-  },
-  dark: {
-    backgroundColor: 'rgba(255, 255, 255, 0.04)',
-  },
-  isWholeLine: true,
-});
+// Get an SVG image with a diagonal "C++" logo.
+const getCppSvgBase64 = (fillColor: string) => {
+  const svg = [
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" ',
+    'preserveAspectRatio="none">',
+    `<text x="50%" y="50%" font-size="10px" font-family="sans-serif" `,
+    `fill="${fillColor}" text-anchor="middle" dominant-baseline="central" `,
+    `transform="rotate(-45 10 10)">C++</text></svg>`,
+  ].join('');
+  return Buffer.from(svg).toString('base64');
+};
 
-const cppInlineDecorationType = window.createTextEditorDecorationType({
-  light: {
-    backgroundColor: 'rgba(0, 0, 0, 0.03)',
-  },
-  dark: {
-    backgroundColor: 'rgba(255, 255, 255, 0.04)',
-  },
-  isWholeLine: false,
-});
+const lightSvgBase64 = getCppSvgBase64('rgba(0,0,0,0.05)');
+const darkSvgBase64 = getCppSvgBase64('rgba(255,255,255,0.06)');
+
+// Create a decoration type for C++ code embedded in Carbon.
+const createCppDecorationType = (isWholeLine: boolean) => {
+  // We can't directly set a background image on a decoration, but we can set it
+  // via a CSS escape in the border property.
+  const getBorder = (base64: string) =>
+    /*border:*/ `none; ` +
+    `background-image: url('data:image/svg+xml;base64,${base64}'); ` +
+    `background-repeat: repeat; ` +
+    `background-size: 20px 100%;`;
+  return window.createTextEditorDecorationType({
+    light: { border: getBorder(lightSvgBase64) },
+    dark: { border: getBorder(darkSvgBase64) },
+    isWholeLine,
+  });
+};
+
+const cppBlockDecorationType = createCppDecorationType(true);
+const cppInlineDecorationType = createCppDecorationType(false);
 
 function updateCppInlineDecorations(editor: TextEditor | undefined) {
   if (!editor) {

--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -93,6 +93,85 @@ function updateSplitLineNumbers(editor: TextEditor | undefined) {
   editor.setDecorations(splitLineNumberDecorationType, decorations);
 }
 
+const cppBlockDecorationType = window.createTextEditorDecorationType({
+  light: {
+    backgroundColor: 'rgba(0, 0, 0, 0.03)',
+  },
+  dark: {
+    backgroundColor: 'rgba(255, 255, 255, 0.04)',
+  },
+  isWholeLine: true,
+});
+
+const cppInlineDecorationType = window.createTextEditorDecorationType({
+  light: {
+    backgroundColor: 'rgba(0, 0, 0, 0.03)',
+  },
+  dark: {
+    backgroundColor: 'rgba(255, 255, 255, 0.04)',
+  },
+  isWholeLine: false,
+});
+
+function updateCppInlineDecorations(editor: TextEditor | undefined) {
+  if (!editor) {
+    return;
+  }
+  const document = editor.document;
+  if (document.languageId !== 'carbon') {
+    return;
+  }
+
+  const text = document.getText();
+  const blockDecorations: DecorationOptions[] = [];
+  const inlineDecorations: DecorationOptions[] = [];
+
+  // 1. Triple-quoted blocks
+  const tripleRegex = /(?:import\s+Cpp\s+inline|inline\s+Cpp)\s*('''[^\s'#]*\n?([\s\S]*?)''')\s*;/g;
+  let match;
+  while ((match = tripleRegex.exec(text)) !== null) {
+    const content = match[2];
+    if (content) {
+      const startOffset = match.index + match[0].indexOf(content);
+      let endOffset = startOffset + content.length;
+
+      // If the content ends with a newline, exclude it from the range so that the
+      // line containing the closing quotes is not highlighted.
+      if (content.endsWith('\r\n')) {
+        endOffset -= 2;
+      } else if (content.endsWith('\n')) {
+        endOffset--;
+      }
+
+      blockDecorations.push({
+        range: new Range(
+          document.positionAt(startOffset),
+          document.positionAt(endOffset)
+        )
+      });
+    }
+  }
+
+  // 2. Double-quoted inline strings
+  const doubleRegex = /(?:import\s+Cpp\s+inline|inline\s+Cpp)\s*("((?:[^"\\]|\\.)*)")\s*;/g;
+  while ((match = doubleRegex.exec(text)) !== null) {
+    const content = match[2];
+    if (content) {
+      const startOffset = match.index + match[0].indexOf(content);
+      const endOffset = startOffset + content.length;
+      inlineDecorations.push({
+        range: new Range(
+          document.positionAt(startOffset),
+          document.positionAt(endOffset)
+        )
+      });
+    }
+  }
+
+  editor.setDecorations(cppBlockDecorationType, blockDecorations);
+  editor.setDecorations(cppInlineDecorationType, inlineDecorations);
+}
+
 /**
  * Splits a CLI-style quoted string.
  */
@@ -211,6 +290,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(
     window.onDidChangeActiveTextEditor((editor: TextEditor | undefined) => {
       updateSplitLineNumbers(editor);
+      updateCppInlineDecorations(editor);
     })
   );
 
@@ -219,6 +299,7 @@ export function activate(context: ExtensionContext) {
     workspace.onDidChangeTextDocument((event: TextDocumentChangeEvent) => {
       if (window.activeTextEditor && event.document === window.activeTextEditor.document) {
         updateSplitLineNumbers(window.activeTextEditor);
+        updateCppInlineDecorations(window.activeTextEditor);
       }
     })
   );
@@ -226,6 +307,7 @@ export function activate(context: ExtensionContext) {
   // Initial update
   if (window.activeTextEditor) {
     updateSplitLineNumbers(window.activeTextEditor);
+    updateCppInlineDecorations(window.activeTextEditor);
   }
 }
 


### PR DESCRIPTION
Switch into C++ syntax highlighting mode inside inline C++ fragments in Carbon code. Add a background to them to make their boundaries stand out a bit more.

Assisted-by: Gemini via Antigravity