### PR TITLE
Forbid nested `where` inside a `where` expression through eval

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -3087,8 +3087,7 @@ static auto AddRequirementRewrite(Context& context,
       {.lhs_id = rewrite.lhs_id, .rhs_id = rewrite.rhs_id});
 }
 
-static auto AddRequirementImpls(Context& context, SemIR::LocId loc_id,
-                                SemIR::RequirementImpls impls,
+static auto AddRequirementImpls(Context& context, SemIR::RequirementImpls impls,
                                 SemIR::FacetTypeInfo* info, Phase* phase)
     -> void {
   auto lhs_id = context.constant_values().GetConstantInstId(impls.lhs_id);
@@ -3107,22 +3106,23 @@ static auto AddRequirementImpls(Context& context, SemIR::LocId loc_id,
   auto facet_type = context.insts().GetAs<SemIR::FacetType>(rhs_id);
   const auto& rhs = context.facet_types().Get(facet_type.facet_type_id);
 
+  // We forbid `where` on the RHS of another `where`, so non-extend constraints
+  // can't be part of a facet type on the RHS of `where ... impls`.
+  CARBON_CHECK(rhs.self_impls_constraints.empty());
+  CARBON_CHECK(rhs.self_impls_named_constraints.empty());
+  CARBON_CHECK(rhs.type_impls_interfaces.empty());
+  CARBON_CHECK(rhs.type_impls_named_constraints.empty());
+  CARBON_CHECK(rhs.rewrite_constraints.empty());
+  CARBON_CHECK(!rhs.other_requirements);
+
   if (IsPeriodSelf(context, lhs_id)) {
     // A facet type with `.Self impls <RHS facet type>`. Whatever the RHS facet
     // type constrains for `.Self` gets forwarded to the output facet type to
     // also constrain `.Self`. Nothing on the RHS of `impls` can extend the
     // resulting facet type.
     llvm::append_range(info->self_impls_constraints, rhs.extend_constraints);
-    llvm::append_range(info->self_impls_constraints,
-                       rhs.self_impls_constraints);
     llvm::append_range(info->self_impls_named_constraints,
                        rhs.extend_named_constraints);
-    llvm::append_range(info->self_impls_named_constraints,
-                       rhs.self_impls_named_constraints);
-    llvm::append_range(info->type_impls_interfaces, rhs.type_impls_interfaces);
-    llvm::append_range(info->type_impls_named_constraints,
-                       rhs.type_impls_named_constraints);
-    llvm::append_range(info->rewrite_constraints, rhs.rewrite_constraints);
   } else {
     auto lhs_facet_or_type = GetCanonicalFacetOrTypeValue(context, lhs_id);
 
@@ -3143,90 +3143,22 @@ static auto AddRequirementImpls(Context& context, SemIR::LocId loc_id,
     llvm::append_range(
         info->type_impls_named_constraints,
         llvm::map_range(rhs.extend_named_constraints, extends_constraint));
-
-    // Impls constraints are written as `T impls X` where `T` is a facet and `X`
-    // is a facet type. The `T` can be `.Self`.
-    //
-    // A value for `.Self` is not known here, so we do not replace them
-    // generally. However in `T impls X where ...` the value of `.Self` on the
-    // RHS of the `where` refers to the `T`. Generally this would make the
-    // `.Self` be ambiguous, but any explicit use of an ambiguous `.Self` is
-    // diagnosed before we get here. So any explicit `.Self` left over are known
-    // to be non-ambiguous and refer to the top level value for `.Self`.
-    //
-    // However, implicit references to `.Self`, via designators, are bound to
-    // the innermost possible value, which makes them bound to the `T` on the
-    // RHS of the nested `where`. We need to replace those implicit `.Self`
-    // references here so that we are left with a facet type where all `.Self`
-    // references are to the same top-level value for `.Self` and can all be
-    // replaced together later.
-
-    auto period_self_replacement_id =
-        context.constant_values().Get(lhs_facet_or_type);
-
-    auto self_impls_interface = [&](SemIR::SpecificInterface si) {
-      return SubstPeriodSelf(context, loc_id, si, period_self_replacement_id,
-                             SubstPeriodSelfBehaviour::ImplicitOnly);
-    };
-    auto self_impls_constraint = [&](SemIR::SpecificNamedConstraint sc) {
-      return SubstPeriodSelf(context, loc_id, sc, period_self_replacement_id,
-                             SubstPeriodSelfBehaviour::ImplicitOnly);
-    };
-    auto type_impls_interface =
-        [&](SemIR::FacetTypeInfo::TypeImplsInterface impls)
-        -> SemIR::FacetTypeInfo::TypeImplsInterface {
-      auto self = SubstPeriodSelf(
-          context, loc_id, context.constant_values().Get(impls.self_type),
-          period_self_replacement_id, SubstPeriodSelfBehaviour::ImplicitOnly);
-      auto interface = SubstPeriodSelf(
-          context, loc_id, impls.specific_interface, period_self_replacement_id,
-          SubstPeriodSelfBehaviour::ImplicitOnly);
-      return {context.constant_values().GetInstId(self), interface};
-    };
-    auto type_impls_constraint =
-        [&](SemIR::FacetTypeInfo::TypeImplsNamedConstraint impls)
-        -> SemIR::FacetTypeInfo::TypeImplsNamedConstraint {
-      auto self = SubstPeriodSelf(
-          context, loc_id, context.constant_values().Get(impls.self_type),
-          period_self_replacement_id, SubstPeriodSelfBehaviour::ImplicitOnly);
-      auto constraint = SubstPeriodSelf(
-          context, loc_id, impls.specific_named_constraint,
-          period_self_replacement_id, SubstPeriodSelfBehaviour::ImplicitOnly);
-      return {context.constant_values().GetInstId(self), constraint};
-    };
-
-    llvm::append_range(
-        info->self_impls_constraints,
-        llvm::map_range(rhs.self_impls_constraints, self_impls_interface));
-    llvm::append_range(info->self_impls_named_constraints,
-                       llvm::map_range(rhs.self_impls_named_constraints,
-                                       self_impls_constraint));
-    llvm::append_range(
-        info->type_impls_interfaces,
-        llvm::map_range(rhs.type_impls_interfaces, type_impls_interface));
-    llvm::append_range(info->type_impls_named_constraints,
-                       llvm::map_range(rhs.type_impls_named_constraints,
-                                       type_impls_constraint));
-
-    auto rewrite_constraint =
-        [&](SemIR::FacetTypeInfo::RewriteConstraint rewrite)
-        -> SemIR::FacetTypeInfo::RewriteConstraint {
-      auto lhs_id = SubstPeriodSelf(
-          context, loc_id, context.constant_values().Get(rewrite.lhs_id),
-          period_self_replacement_id, SubstPeriodSelfBehaviour::ImplicitOnly);
-      auto rhs_id = SubstPeriodSelf(
-          context, loc_id, context.constant_values().Get(rewrite.rhs_id),
-          period_self_replacement_id, SubstPeriodSelfBehaviour::ImplicitOnly);
-      return {context.constant_values().GetInstId(lhs_id),
-              context.constant_values().GetInstId(rhs_id)};
-    };
-
-    llvm::append_range(
-        info->rewrite_constraints,
-        llvm::map_range(rhs.rewrite_constraints, rewrite_constraint));
   }
+}
 
-  info->other_requirements |= rhs.other_requirements;
+static auto AddRequirementEquivalent(Context& context,
+                                     SemIR::RequirementEquivalent equiv,
+                                     SemIR::FacetTypeInfo* info, Phase* phase)
+    -> void {
+  auto lhs_id = context.constant_values().GetConstantInstId(equiv.lhs_id);
+  auto rhs_id = context.constant_values().GetConstantInstId(equiv.rhs_id);
+  if (lhs_id == SemIR::ErrorInst::InstId ||
+      rhs_id == SemIR::ErrorInst::InstId) {
+    *phase = Phase::UnknownDueToError;
+    return;
+  }
+  // TODO: Handle equality requirements.
+  info->other_requirements = true;
 }
 
 // Add the constraints from the WhereExpr instruction into a FacetTypeInfo in
@@ -3268,13 +3200,11 @@ auto TryEvalTypedInst<SemIR::WhereExpr>(EvalContext& eval_context,
         break;
       }
       case CARBON_KIND(SemIR::RequirementImpls impls): {
-        AddRequirementImpls(eval_context.context(), SemIR::LocId(inst_id),
-                            impls, &info, &phase);
+        AddRequirementImpls(eval_context.context(), impls, &info, &phase);
         break;
       }
-      case CARBON_KIND(SemIR::RequirementEquivalent _): {
-        // TODO: Handle equality requirements.
-        info.other_requirements = true;
+      case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
+        AddRequirementEquivalent(eval_context.context(), equiv, &info, &phase);
         break;
       }
       default:

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -415,7 +415,7 @@ static auto FindWhere(Context& context, SemIR::ConstantId const_id) -> bool {
               context().insts().TryGetAs<SemIR::FacetType>(inst_id)) {
         const auto& info =
             context().facet_types().Get(facet_type->facet_type_id);
-        if (!SemIR::FacetTypeInfo::IsExtendedOnly(info)) {
+        if (!info.IsExtendedOnly()) {
           *found_ = true;
           return FullySubstituted;
         }

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -381,6 +381,77 @@ auto HandleParseNode(Context& /*context*/, Parse::RequirementAndId /*node_id*/)
   return true;
 }
 
+// Returns whether the constant value `const_id` contains a facet type
+// instruction with a `where` expression.
+//
+// This search ignores the type_id of insts, and just looks at the `const_id`
+// and its non-type operands recursively. Any use of a symbolic facet may have a
+// type with an arbitrary facet type (including a `where` expression). But we
+// are looking for a nested `where` that is part of the current `WhereExpr`
+// being checked.
+static auto FindWhere(Context& context, SemIR::ConstantId const_id) -> bool {
+  class FindWhereCallbacks : public SubstInstCallbacks {
+   public:
+    FindWhereCallbacks(Context* context, bool* found)
+        : SubstInstCallbacks(context), found_(found) {}
+
+    auto Subst(SemIR::InstId& inst_id) -> SubstResult override {
+      if (skip_type_next_) {
+        skip_type_next_ = false;
+        return FullySubstituted;
+      }
+      if (*found_ || inst_id == SemIR::TypeType::TypeInstId ||
+          inst_id == SemIR::ErrorInst::InstId) {
+        return FullySubstituted;
+      }
+
+      // Facet types can contain many references to the same value. Only search
+      // a given constant one time to avoid exponential costs.
+      if (!searched_.Insert(inst_id).is_inserted()) {
+        return FullySubstituted;
+      }
+
+      if (auto facet_type =
+              context().insts().TryGetAs<SemIR::FacetType>(inst_id)) {
+        const auto& info =
+            context().facet_types().Get(facet_type->facet_type_id);
+        if (!SemIR::FacetTypeInfo::IsExtendedOnly(info)) {
+          *found_ = true;
+          return FullySubstituted;
+        }
+      }
+
+      auto type_id = context().insts().Get(inst_id).type_id();
+      if (type_id.has_value() &&
+          context().types().Is<SemIR::FacetType>(type_id)) {
+        skip_type_next_ = true;
+      }
+
+      return SubstOperands;
+    }
+
+    auto Rebuild(SemIR::InstId orig_inst_id, SemIR::Inst /*new_inst*/)
+        -> SemIR::InstId override {
+      CARBON_FATAL("unexpected rebuild of inst {0}",
+                   context().insts().Get(orig_inst_id));
+    }
+
+   private:
+    bool* found_;
+    bool skip_type_next_ = false;
+    Set<SemIR::InstId> searched_;
+  };
+
+  if (!const_id.is_constant()) {
+    return false;
+  }
+
+  bool found = false;
+  FindWhereCallbacks callbacks(&context, &found);
+  SubstInst(context, context.constant_values().GetInstId(const_id), callbacks);
+  return found;
+}
+
 // There are two ways to nest `where` expressions, this diagnoses a `where`
 // expression inside the RHS of another `where` expression.
 //
@@ -399,6 +470,7 @@ static auto DiagnoseNestedWhere(Context& context, SemIR::LocId loc_id,
 }
 
 auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
+  auto where_loc = context.where_stack().back().loc_id;
   context.where_stack().pop_back();
   // Remove `PeriodSelf` from name lookup, undoing the `Push` done for the
   // `WhereOperand`.
@@ -411,8 +483,46 @@ auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
     type_id = SemIR::ErrorInst::TypeId;
   }
 
-  // TODO: Look at the constant value and diagnose NestedWhereInsideWhere if
-  // there are any non-extend constraints present.
+  for (auto inst_id : context.inst_blocks().Get(requirements_id)) {
+    auto inst = context.insts().Get(inst_id);
+    CARBON_KIND_SWITCH(inst) {
+      case CARBON_KIND(SemIR::RequirementBaseFacetType _): {
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementImpls impls): {
+        if (FindWhere(context, context.constant_values().Get(impls.lhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(impls.lhs_id), where_loc);
+          impls.lhs_id = SemIR::ErrorInst::InstId;
+        }
+        if (FindWhere(context, context.constant_values().Get(impls.rhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(impls.rhs_id), where_loc);
+          impls.rhs_id = SemIR::ErrorInst::InstId;
+        }
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementRewrite rewrite): {
+        if (FindWhere(context, context.constant_values().Get(rewrite.rhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(rewrite.rhs_id), where_loc);
+          rewrite.rhs_id = SemIR::ErrorInst::InstId;
+        }
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
+        if (FindWhere(context, context.constant_values().Get(equiv.lhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(equiv.lhs_id), where_loc);
+          equiv.lhs_id = SemIR::ErrorInst::InstId;
+        }
+        if (FindWhere(context, context.constant_values().Get(equiv.rhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(equiv.rhs_id), where_loc);
+          equiv.rhs_id = SemIR::ErrorInst::InstId;
+        }
+        break;
+      }
+      default:
+        CARBON_FATAL("unexpected `where` requirement inst {0}", inst);
+    }
+  }
+
   AddInstAndPush<SemIR::WhereExpr>(
       context, node_id,
       {.type_id = type_id, .requirements_id = requirements_id});

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -481,6 +481,30 @@ static auto CheckForNestedWhereInRequirementsAfterEval(
       context.inst_blocks().Get(requirements_id));
 
   for (auto& inst_id : checked_requirements) {
+    // Searches the `lhs_id` and `rhs_id` operands of the requirement inst. If a
+    // nested `where` is found and diagnosed, the requirement is rebuilt with an
+    // ErrorInst in its place and it replaces the `inst_id` in the requirements
+    // block.
+    auto find_and_diagnose_nested_where = [&](auto req_inst, bool check_lhs) {
+      bool found = false;
+      if (check_lhs &&
+          FindWhere(context, context.constant_values().Get(req_inst.lhs_id))) {
+        DiagnoseNestedWhere(context, SemIR::LocId(req_inst.lhs_id), where_loc);
+        req_inst.lhs_id = SemIR::ErrorInst::InstId;
+        found = diagnosed = true;
+      }
+      if (FindWhere(context, context.constant_values().Get(req_inst.rhs_id))) {
+        DiagnoseNestedWhere(context, SemIR::LocId(req_inst.rhs_id), where_loc);
+        req_inst.rhs_id = SemIR::ErrorInst::InstId;
+        found = diagnosed = true;
+      }
+      if (found) {
+        inst_id = AddInstInNoBlock(
+            context, SemIR::LocIdAndInst::RuntimeVerified(
+                         context.sem_ir(), SemIR::LocId(inst_id), req_inst));
+      }
+    };
+
     auto inst = context.insts().Get(inst_id);
     CARBON_KIND_SWITCH(inst) {
       case CARBON_KIND(SemIR::RequirementBaseFacetType _): {
@@ -488,52 +512,17 @@ static auto CheckForNestedWhereInRequirementsAfterEval(
         break;
       }
       case CARBON_KIND(SemIR::RequirementImpls impls): {
-        if (FindWhere(context, context.constant_values().Get(impls.lhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(impls.lhs_id), where_loc);
-          impls.lhs_id = SemIR::ErrorInst::InstId;
-          inst_id = AddInstInNoBlock(
-              context, SemIR::LocIdAndInst::RuntimeVerified(
-                           context.sem_ir(), SemIR::LocId(inst_id), impls));
-          diagnosed = true;
-        }
-        if (FindWhere(context, context.constant_values().Get(impls.rhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(impls.rhs_id), where_loc);
-          impls.rhs_id = SemIR::ErrorInst::InstId;
-          inst_id = AddInstInNoBlock(
-              context, SemIR::LocIdAndInst::RuntimeVerified(
-                           context.sem_ir(), SemIR::LocId(inst_id), impls));
-          diagnosed = true;
-        }
+        find_and_diagnose_nested_where(impls, true);
         break;
       }
       case CARBON_KIND(SemIR::RequirementRewrite rewrite): {
-        if (FindWhere(context, context.constant_values().Get(rewrite.rhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(rewrite.rhs_id), where_loc);
-          rewrite.rhs_id = SemIR::ErrorInst::InstId;
-          inst_id = AddInstInNoBlock(
-              context, SemIR::LocIdAndInst::RuntimeVerified(
-                           context.sem_ir(), SemIR::LocId(inst_id), rewrite));
-          diagnosed = true;
-        }
+        // The LHS of a rewrite can't have a `where` inside it, so we skip
+        // checking it.
+        find_and_diagnose_nested_where(rewrite, false);
         break;
       }
       case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
-        if (FindWhere(context, context.constant_values().Get(equiv.lhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(equiv.lhs_id), where_loc);
-          equiv.lhs_id = SemIR::ErrorInst::InstId;
-          inst_id = AddInstInNoBlock(
-              context, SemIR::LocIdAndInst::RuntimeVerified(
-                           context.sem_ir(), SemIR::LocId(inst_id), equiv));
-          diagnosed = true;
-        }
-        if (FindWhere(context, context.constant_values().Get(equiv.rhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(equiv.rhs_id), where_loc);
-          equiv.rhs_id = SemIR::ErrorInst::InstId;
-          inst_id = AddInstInNoBlock(
-              context, SemIR::LocIdAndInst::RuntimeVerified(
-                           context.sem_ir(), SemIR::LocId(inst_id), equiv));
-          diagnosed = true;
-        }
+        find_and_diagnose_nested_where(equiv, true);
         break;
       }
       default:

--- a/toolchain/check/handle_where.cpp
+++ b/toolchain/check/handle_where.cpp
@@ -469,6 +469,84 @@ static auto DiagnoseNestedWhere(Context& context, SemIR::LocId loc_id,
   builder.Emit();
 }
 
+// Look for nested `where` expressions on the RHS of the current `where` after
+// eval. If found, it is diagnosed and replaced with ErrorInst.
+static auto CheckForNestedWhereInRequirementsAfterEval(
+    Context& context, SemIR::LocId where_loc,
+    SemIR::InstBlockId requirements_id) -> SemIR::InstBlockId {
+  bool diagnosed = false;
+
+  // The requirements block, but we replace invalid operands with ErrorInst.
+  llvm::SmallVector<SemIR::InstId> checked_requirements(
+      context.inst_blocks().Get(requirements_id));
+
+  for (auto& inst_id : checked_requirements) {
+    auto inst = context.insts().Get(inst_id);
+    CARBON_KIND_SWITCH(inst) {
+      case CARBON_KIND(SemIR::RequirementBaseFacetType _): {
+        // Nested `where` is allowed on the LHS of a `where` expression.
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementImpls impls): {
+        if (FindWhere(context, context.constant_values().Get(impls.lhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(impls.lhs_id), where_loc);
+          impls.lhs_id = SemIR::ErrorInst::InstId;
+          inst_id = AddInstInNoBlock(
+              context, SemIR::LocIdAndInst::RuntimeVerified(
+                           context.sem_ir(), SemIR::LocId(inst_id), impls));
+          diagnosed = true;
+        }
+        if (FindWhere(context, context.constant_values().Get(impls.rhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(impls.rhs_id), where_loc);
+          impls.rhs_id = SemIR::ErrorInst::InstId;
+          inst_id = AddInstInNoBlock(
+              context, SemIR::LocIdAndInst::RuntimeVerified(
+                           context.sem_ir(), SemIR::LocId(inst_id), impls));
+          diagnosed = true;
+        }
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementRewrite rewrite): {
+        if (FindWhere(context, context.constant_values().Get(rewrite.rhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(rewrite.rhs_id), where_loc);
+          rewrite.rhs_id = SemIR::ErrorInst::InstId;
+          inst_id = AddInstInNoBlock(
+              context, SemIR::LocIdAndInst::RuntimeVerified(
+                           context.sem_ir(), SemIR::LocId(inst_id), rewrite));
+          diagnosed = true;
+        }
+        break;
+      }
+      case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
+        if (FindWhere(context, context.constant_values().Get(equiv.lhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(equiv.lhs_id), where_loc);
+          equiv.lhs_id = SemIR::ErrorInst::InstId;
+          inst_id = AddInstInNoBlock(
+              context, SemIR::LocIdAndInst::RuntimeVerified(
+                           context.sem_ir(), SemIR::LocId(inst_id), equiv));
+          diagnosed = true;
+        }
+        if (FindWhere(context, context.constant_values().Get(equiv.rhs_id))) {
+          DiagnoseNestedWhere(context, SemIR::LocId(equiv.rhs_id), where_loc);
+          equiv.rhs_id = SemIR::ErrorInst::InstId;
+          inst_id = AddInstInNoBlock(
+              context, SemIR::LocIdAndInst::RuntimeVerified(
+                           context.sem_ir(), SemIR::LocId(inst_id), equiv));
+          diagnosed = true;
+        }
+        break;
+      }
+      default:
+        CARBON_FATAL("unexpected `where` requirement inst {0}", inst);
+    }
+  }
+
+  if (!diagnosed) {
+    return requirements_id;
+  }
+  return context.inst_blocks().Add(checked_requirements);
+}
+
 auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
   auto where_loc = context.where_stack().back().loc_id;
   context.where_stack().pop_back();
@@ -479,49 +557,13 @@ auto HandleParseNode(Context& context, Parse::WhereExprId node_id) -> bool {
 
   auto type_id = SemIR::TypeType::TypeId;
   if (!context.where_stack().empty()) {
+    // This `where` expression is nested on the RHS of another `where`, which is
+    // an error.
     DiagnoseNestedWhere(context, node_id, context.where_stack().back().loc_id);
     type_id = SemIR::ErrorInst::TypeId;
   }
-
-  for (auto inst_id : context.inst_blocks().Get(requirements_id)) {
-    auto inst = context.insts().Get(inst_id);
-    CARBON_KIND_SWITCH(inst) {
-      case CARBON_KIND(SemIR::RequirementBaseFacetType _): {
-        break;
-      }
-      case CARBON_KIND(SemIR::RequirementImpls impls): {
-        if (FindWhere(context, context.constant_values().Get(impls.lhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(impls.lhs_id), where_loc);
-          impls.lhs_id = SemIR::ErrorInst::InstId;
-        }
-        if (FindWhere(context, context.constant_values().Get(impls.rhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(impls.rhs_id), where_loc);
-          impls.rhs_id = SemIR::ErrorInst::InstId;
-        }
-        break;
-      }
-      case CARBON_KIND(SemIR::RequirementRewrite rewrite): {
-        if (FindWhere(context, context.constant_values().Get(rewrite.rhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(rewrite.rhs_id), where_loc);
-          rewrite.rhs_id = SemIR::ErrorInst::InstId;
-        }
-        break;
-      }
-      case CARBON_KIND(SemIR::RequirementEquivalent equiv): {
-        if (FindWhere(context, context.constant_values().Get(equiv.lhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(equiv.lhs_id), where_loc);
-          equiv.lhs_id = SemIR::ErrorInst::InstId;
-        }
-        if (FindWhere(context, context.constant_values().Get(equiv.rhs_id))) {
-          DiagnoseNestedWhere(context, SemIR::LocId(equiv.rhs_id), where_loc);
-          equiv.rhs_id = SemIR::ErrorInst::InstId;
-        }
-        break;
-      }
-      default:
-        CARBON_FATAL("unexpected `where` requirement inst {0}", inst);
-    }
-  }
+  requirements_id = CheckForNestedWhereInRequirementsAfterEval(
+      context, where_loc, requirements_id);
 
   AddInstAndPush<SemIR::WhereExpr>(
       context, node_id,

--- a/toolchain/check/testdata/facet/nested_facet_types_from_eval.carbon
+++ b/toolchain/check/testdata/facet/nested_facet_types_from_eval.carbon
@@ -10,7 +10,27 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/facet/nested_facet_types_from_eval.carbon
 
-// --- todo_fail_where_nested_inside_where_through_alias.carbon
+// --- fail_where_nested_inside_where_through_alias_impls_lhs.carbon
+library "[[@TEST_NAME]]";
+
+interface I {}
+class C(T:! type);
+
+alias A = I where .Self == C;
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_lhs.carbon:[[@LINE+7]]:21: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where C(A) impls type) {}
+// CHECK:STDERR:                     ^~~~
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_lhs.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where C(A) impls type) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! type where C(A) impls type) {}
+
+// --- fail_where_nested_inside_where_through_alias_impls_rhs.carbon
 library "[[@TEST_NAME]]";
 
 interface I {}
@@ -21,10 +41,76 @@ alias A = I where .Self == C;
 // The use of `A` introduces a `where` expression inside the `where` written
 // here, which is an error.
 //
-// TODO This should fail.
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:                                 ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
 fn F(_:! type where .Self impls A) {}
 
-// --- todo_fail_where_nested_inside_where_through_fn_eval.carbon
+// --- fail_where_nested_inside_where_through_alias_rewrite_rhs.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let I1:! type; }
+class C;
+
+alias A = I where .Self == C;
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_rewrite_rhs.carbon:[[@LINE+7]]:24: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! I where .I1 = A) {}
+// CHECK:STDERR:                        ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_rewrite_rhs.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! I where .I1 = A) {}
+// CHECK:STDERR:          ^~~~~~~
+// CHECK:STDERR:
+fn F(_:! I where .I1 = A) {}
+
+// --- fail_where_nested_inside_where_through_alias_equiv_lhs.carbon
+library "[[@TEST_NAME]]";
+
+interface I {}
+class C;
+
+alias A = I where .Self == C;
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_equiv_lhs.carbon:[[@LINE+7]]:21: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where A == .Self) {}
+// CHECK:STDERR:                     ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_equiv_lhs.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where A == .Self) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! type where A == .Self) {}
+
+// --- fail_where_nested_inside_where_through_alias_equiv_rhs.carbon
+library "[[@TEST_NAME]]";
+
+interface I {}
+class C;
+
+alias A = I where .Self == C;
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_equiv_rhs.carbon:[[@LINE+7]]:30: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self == A) {}
+// CHECK:STDERR:                              ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_equiv_rhs.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self == A) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! type where .Self == A) {}
+
+// --- fail_where_nested_inside_where_through_fn_eval.carbon
 library "[[@TEST_NAME]]";
 
 interface I {}
@@ -37,10 +123,16 @@ eval fn E() -> type {
 // The use of `E()` introduces a `where` expression inside the `where`
 // written here, which is an error.
 //
-// TODO This should fail.
+// CHECK:STDERR: fail_where_nested_inside_where_through_fn_eval.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self impls E()) {}
+// CHECK:STDERR:                                 ^~~
+// CHECK:STDERR: fail_where_nested_inside_where_through_fn_eval.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self impls E()) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
 fn F(_:! type where .Self impls E()) {}
 
-// --- todo_fail_where_nested_inside_where_through_operator_eval.carbon
+// --- fail_where_nested_inside_where_through_operator_eval.carbon
 library "[[@TEST_NAME]]";
 
 interface I {}
@@ -58,5 +150,11 @@ alias X = {} as X1;
 // The use of `type * X` introduces a `where` expression inside the `where`
 // written here, which is an error.
 //
-// TODO This should fail.
+// CHECK:STDERR: fail_where_nested_inside_where_through_operator_eval.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self impls type * X) {}
+// CHECK:STDERR:                                 ^~~~~~~~
+// CHECK:STDERR: fail_where_nested_inside_where_through_operator_eval.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self impls type * X) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
 fn F(_:! type where .Self impls type * X) {}

--- a/toolchain/check/testdata/facet/nested_facet_types_from_eval.carbon
+++ b/toolchain/check/testdata/facet/nested_facet_types_from_eval.carbon
@@ -30,21 +30,118 @@ alias A = I where .Self == C;
 // CHECK:STDERR:
 fn F(_:! type where C(A) impls type) {}
 
-// --- fail_where_nested_inside_where_through_alias_impls_rhs.carbon
+// --- fail_where_nested_inside_where_through_alias_impls_rhs_with_self_impls_interface.carbon
 library "[[@TEST_NAME]]";
 
 interface I {}
-class C;
 
-alias A = I where .Self == C;
+alias A = type where .Self impls I;
 
 // The use of `A` introduces a `where` expression inside the `where` written
 // here, which is an error.
 //
-// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_self_impls_interface.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
 // CHECK:STDERR: fn F(_:! type where .Self impls A) {}
 // CHECK:STDERR:                                 ^
-// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_self_impls_interface.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! type where .Self impls A) {}
+
+// --- fail_where_nested_inside_where_through_alias_impls_rhs_with_self_impls_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+constraint N {}
+
+alias A = type where .Self impls N;
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_self_impls_named_constraint.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:                                 ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_self_impls_named_constraint.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! type where .Self impls A) {}
+
+// --- fail_where_nested_inside_where_through_alias_impls_rhs_with_type_impls_interface.carbon
+library "[[@TEST_NAME]]";
+
+interface I(T:! type) {}
+class C;
+
+alias A = type where C impls I(.Self);
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_type_impls_interface.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:                                 ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_type_impls_interface.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! type where .Self impls A) {}
+
+// --- fail_where_nested_inside_where_through_alias_impls_rhs_with_type_impls_named_constraint.carbon
+library "[[@TEST_NAME]]";
+
+constraint N(T:! type) {}
+class C;
+
+alias A = type where C impls N(.Self);
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_type_impls_named_constraint.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:                                 ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_type_impls_named_constraint.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! type where .Self impls A) {}
+
+// --- fail_where_nested_inside_where_through_alias_impls_rhs_with_rewrite.carbon
+library "[[@TEST_NAME]]";
+
+interface I { let I1:! type; }
+class C;
+
+alias A = I where .I1 = C;
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_rewrite.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:                                 ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_rewrite.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:          ^~~~~~~~~~
+// CHECK:STDERR:
+fn F(_:! type where .Self impls A) {}
+
+// --- fail_where_nested_inside_where_through_alias_impls_rhs_with_equiv.carbon
+library "[[@TEST_NAME]]";
+
+class C;
+
+alias A = type where .Self == C;
+
+// The use of `A` introduces a `where` expression inside the `where` written
+// here, which is an error.
+//
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_equiv.carbon:[[@LINE+7]]:33: error: found `where` expression nested on the right-hand side of `where` [NestedWhereInsideWhere]
+// CHECK:STDERR: fn F(_:! type where .Self impls A) {}
+// CHECK:STDERR:                                 ^
+// CHECK:STDERR: fail_where_nested_inside_where_through_alias_impls_rhs_with_equiv.carbon:[[@LINE+4]]:10: note: on right-hand side of `where` here [NestedWhereInsideWhereOuterNote]
 // CHECK:STDERR: fn F(_:! type where .Self impls A) {}
 // CHECK:STDERR:          ^~~~~~~~~~
 // CHECK:STDERR:

--- a/toolchain/sem_ir/facet_type_info.cpp
+++ b/toolchain/sem_ir/facet_type_info.cpp
@@ -173,6 +173,14 @@ auto FacetTypeInfo::ExtendedOnly(const FacetTypeInfo& info) -> FacetTypeInfo {
           .extend_named_constraints = info.extend_named_constraints};
 }
 
+auto FacetTypeInfo::IsExtendedOnly(const FacetTypeInfo& info) -> bool {
+  return info.self_impls_constraints.empty() &&
+         info.self_impls_named_constraints.empty() &&
+         info.type_impls_interfaces.empty() &&
+         info.type_impls_named_constraints.empty() &&
+         info.rewrite_constraints.empty() && !info.other_requirements;
+}
+
 auto FacetTypeInfo::Canonicalize() -> void {
   SortAndDeduplicate(extend_constraints, InterfaceLess);
   SortAndDeduplicate(self_impls_constraints, InterfaceLess);

--- a/toolchain/sem_ir/facet_type_info.cpp
+++ b/toolchain/sem_ir/facet_type_info.cpp
@@ -189,11 +189,7 @@ auto FacetTypeInfo::TryAsSingleExtend() const
 
 auto FacetTypeInfo::HasNoConstraints() const -> bool {
   return extend_constraints.empty() && extend_named_constraints.empty() &&
-         self_impls_constraints.empty() &&
-         self_impls_named_constraints.empty() &&
-         type_impls_interfaces.empty() &&
-         type_impls_named_constraints.empty() && rewrite_constraints.empty() &&
-         !other_requirements;
+         IsExtendedOnly();
 }
 
 auto FacetTypeInfo::IsExtendedOnly() const -> bool {

--- a/toolchain/sem_ir/facet_type_info.cpp
+++ b/toolchain/sem_ir/facet_type_info.cpp
@@ -173,12 +173,35 @@ auto FacetTypeInfo::ExtendedOnly(const FacetTypeInfo& info) -> FacetTypeInfo {
           .extend_named_constraints = info.extend_named_constraints};
 }
 
-auto FacetTypeInfo::IsExtendedOnly(const FacetTypeInfo& info) -> bool {
-  return info.self_impls_constraints.empty() &&
-         info.self_impls_named_constraints.empty() &&
-         info.type_impls_interfaces.empty() &&
-         info.type_impls_named_constraints.empty() &&
-         info.rewrite_constraints.empty() && !info.other_requirements;
+auto FacetTypeInfo::TryAsSingleExtend() const
+    -> std::optional<SingleExtendFacetType> {
+  if (!IsExtendedOnly()) {
+    return std::nullopt;
+  }
+  if (extend_constraints.size() == 1 && extend_named_constraints.empty()) {
+    return extend_constraints.front();
+  }
+  if (extend_constraints.empty() && extend_named_constraints.size() == 1) {
+    return extend_named_constraints.front();
+  }
+  return std::nullopt;
+}
+
+auto FacetTypeInfo::HasNoConstraints() const -> bool {
+  return extend_constraints.empty() && extend_named_constraints.empty() &&
+         self_impls_constraints.empty() &&
+         self_impls_named_constraints.empty() &&
+         type_impls_interfaces.empty() &&
+         type_impls_named_constraints.empty() && rewrite_constraints.empty() &&
+         !other_requirements;
+}
+
+auto FacetTypeInfo::IsExtendedOnly() const -> bool {
+  return self_impls_constraints.empty() &&
+         self_impls_named_constraints.empty() &&
+         type_impls_interfaces.empty() &&
+         type_impls_named_constraints.empty() && rewrite_constraints.empty() &&
+         !other_requirements;
 }
 
 auto FacetTypeInfo::Canonicalize() -> void {

--- a/toolchain/sem_ir/facet_type_info.h
+++ b/toolchain/sem_ir/facet_type_info.h
@@ -47,6 +47,10 @@ struct FacetTypeInfo : Printable<FacetTypeInfo> {
   // by the caller if desired.
   static auto ExtendedOnly(const FacetTypeInfo& info) -> FacetTypeInfo;
 
+  // Returns whether a FacetTypeInfo only contains constraints that are extended
+  // by the facet type. If true, `ExtendedOnly()` would be a no-op.
+  static auto IsExtendedOnly(const FacetTypeInfo& info) -> bool;
+
   // TODO: Need to switch to a processed, canonical form, that can support facet
   // type equality as defined by
   // https://github.com/carbon-language/carbon-lang/issues/2409.

--- a/toolchain/sem_ir/facet_type_info.h
+++ b/toolchain/sem_ir/facet_type_info.h
@@ -47,10 +47,6 @@ struct FacetTypeInfo : Printable<FacetTypeInfo> {
   // by the caller if desired.
   static auto ExtendedOnly(const FacetTypeInfo& info) -> FacetTypeInfo;
 
-  // Returns whether a FacetTypeInfo only contains constraints that are extended
-  // by the facet type. If true, `ExtendedOnly()` would be a no-op.
-  static auto IsExtendedOnly(const FacetTypeInfo& info) -> bool;
-
   // TODO: Need to switch to a processed, canonical form, that can support facet
   // type equality as defined by
   // https://github.com/carbon-language/carbon-lang/issues/2409.
@@ -124,33 +120,15 @@ struct FacetTypeInfo : Printable<FacetTypeInfo> {
   // interface with no other requirements. This returns the single interface or
   // named constraint that this facet type represents, or `std::nullopt` if it
   // has any other requirements.
-  auto TryAsSingleExtend() const -> std::optional<SingleExtendFacetType> {
-    if (!self_impls_constraints.empty() ||
-        !self_impls_named_constraints.empty() ||
-        !type_impls_interfaces.empty() ||
-        !type_impls_named_constraints.empty() || !rewrite_constraints.empty() ||
-        other_requirements) {
-      return std::nullopt;
-    }
-    if (extend_constraints.size() == 1 && extend_named_constraints.empty()) {
-      return extend_constraints.front();
-    }
-    if (extend_constraints.empty() && extend_named_constraints.size() == 1) {
-      return extend_named_constraints.front();
-    }
-    return std::nullopt;
-  }
+  auto TryAsSingleExtend() const -> std::optional<SingleExtendFacetType>;
 
   // Returns whether the facet type has no constraints, making it the facet type
   // version of `TypeType`.
-  auto HasNoConstraints() const -> bool {
-    return extend_constraints.empty() && extend_named_constraints.empty() &&
-           self_impls_constraints.empty() &&
-           self_impls_named_constraints.empty() &&
-           type_impls_interfaces.empty() &&
-           type_impls_named_constraints.empty() &&
-           rewrite_constraints.empty() && !other_requirements;
-  }
+  auto HasNoConstraints() const -> bool;
+
+  // Returns whether the facet type only contains constraints that are extended
+  // by the facet type. If true, `ExtendedOnly()` would be a no-op.
+  auto IsExtendedOnly() const -> bool;
 
   friend auto operator==(const FacetTypeInfo& lhs, const FacetTypeInfo& rhs)
       -> bool {


### PR DESCRIPTION
In #7378 we forbid writing `where` on the RHS of another `where` expression. However it's still possible to inject a `where` expression through eval, using an `alias` or an `eval fn`. We address this by looking in the constant value of constraints of a `WhereExpr` (which sees the outcome of eval) and searching for a nested `where` there. We can determine a facet type was written with a nested `where` by seeing that it has some non-extend constraint.