### PR TITLE
Support dumping ImportIRInstId from its printed id

### DIFF
--- a/scripts/lldbinit.py
+++ b/scripts/lldbinit.py
@@ -89,6 +89,7 @@ Example usage:
         "inst_block": "SemIR::MakeInstBlockId",
         "inst": "SemIR::MakeInstId",
         "interface": "SemIR::MakeInterfaceId",
+        "import_ir_inst": "SemIR::MakeImportIRInstId",
         "name": "SemIR::MakeNameId",
         "name_scope": "SemIR::MakeNameScopeId",
         "identified_facet_type": "SemIR::MakeIdentifiedFacetTypeId",

--- a/toolchain/sem_ir/dump.cpp
+++ b/toolchain/sem_ir/dump.cpp
@@ -640,6 +640,9 @@ LLVM_DUMP_METHOD static auto MakeIdentifiedFacetTypeId(int id)
     -> IdentifiedFacetTypeId {
   return IdentifiedFacetTypeId(id);
 }
+LLVM_DUMP_METHOD static auto MakeImportIRInstId(int id) -> ImportIRInstId {
+  return ImportIRInstId(id);
+}
 LLVM_DUMP_METHOD static auto MakeNamedConstraintId(int id)
     -> NamedConstraintId {
   return NamedConstraintId(id);


### PR DESCRIPTION
Add support to the dump command to `dump context import_ir_inst123`

Support for dumping the ids was previously added, but missed support for parsing and creating a C++ id from its printed id.