### PR TITLE
vscode: don't use carbon LSP for testdata files

### DIFF
--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -291,7 +291,6 @@ export function activate(context: ExtensionContext) {
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
       { language: 'carbon' },
-      { language: 'carbon-testdata' },
     ],
   };
 


### PR DESCRIPTION
These files aren't exactly written in Carbon, but rather in some meta-language with file splits and semantically meaningful comments, and in any case getting red squiggles for expected errors is distracting and largely unhelpful.

(We *could* teach the LSP to run the test and produce errors if the test doesn't match its expectations, but it's not clear that that would be helpful in practice either.)