### PR TITLE
Give `splice_inst` a concrete category where possible.

### DIFF
--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -3453,8 +3453,8 @@ template <typename InstT>
 static auto TryExecTypedInst(FunctionExecContext& eval_context,
                              SemIR::InstId inst_id, SemIR::Inst inst)
     -> SemIR::ConstantId {
-  if constexpr (InstT::Kind.expr_category().TryAsFixedCategory() ==
-                SemIR::ExprCategory::NotExpr) {
+  if constexpr (InstT::Kind.expr_category() ==
+                SemIR::InstExprCategory(SemIR::ExprCategory::NotExpr)) {
     // Instructions in this category are assumed to not have a runtime effect.
     // This includes some kinds of declaration.
     return SemIR::ConstantId::None;

--- a/toolchain/check/testdata/basics/raw_sem_ir/bundle.carbon
+++ b/toolchain/check/testdata/basics/raw_sem_ir/bundle.carbon
@@ -213,15 +213,15 @@ fn F(Form:! Core.Form) ->? Form;
 // CHECK:STDOUT:       0:               inst7000002E
 // CHECK:STDOUT:     inst_block70000009:
 // CHECK:STDOUT:       0:               inst70000019
-// CHECK:STDOUT:       1:               inst70000029
+// CHECK:STDOUT:       1:               inst70000025
+// CHECK:STDOUT:       2:               inst70000029
 // CHECK:STDOUT:     inst_block7000000A:
 // CHECK:STDOUT:       0:               inst7000001F
 // CHECK:STDOUT:       1:               inst70000020
-// CHECK:STDOUT:       2:               inst70000025
-// CHECK:STDOUT:       3:               inst7000002C
-// CHECK:STDOUT:       4:               inst7000001C
-// CHECK:STDOUT:       5:               inst7000002E
-// CHECK:STDOUT:       6:               inst7000002F
+// CHECK:STDOUT:       2:               inst7000002C
+// CHECK:STDOUT:       3:               inst7000001C
+// CHECK:STDOUT:       4:               inst7000002E
+// CHECK:STDOUT:       5:               inst7000002F
 // CHECK:STDOUT:     inst_block7000000B:
 // CHECK:STDOUT:       0:               inst7000001C
 // CHECK:STDOUT:     inst_block7000000C:

--- a/toolchain/check/testdata/function/call/form.carbon
+++ b/toolchain/check/testdata/function/call/form.carbon
@@ -657,9 +657,9 @@ fn G() {
 // CHECK:STDOUT:   %Fm: Core.Form = symbolic_binding Fm, 0 [symbolic]
 // CHECK:STDOUT:   %.42f: type = type_component_of %Fm [symbolic]
 // CHECK:STDOUT:   %pattern_type.177: type = pattern_type %.42f [symbolic]
-// CHECK:STDOUT:   %.f15: %pattern_type.177 = splice_inst @F.%.loc4_23.2 [template]
+// CHECK:STDOUT:   %.f15: %pattern_type.177 = splice_inst @F.%.loc4_23.3 [template]
 // CHECK:STDOUT:   %v.patt.0b3: %pattern_type.177 = at_binding_pattern v, %.f15 [template]
-// CHECK:STDOUT:   %.677: %pattern_type.177 = splice_inst @F.%.loc4_30.2 [template]
+// CHECK:STDOUT:   %.677: %pattern_type.177 = splice_inst @F.%.loc4_30.3 [template]
 // CHECK:STDOUT:   %return.patt.113: %pattern_type.177 = return_slot_pattern %.677, %.42f [template]
 // CHECK:STDOUT:   %.cfa: <instruction> = form_param_pattern_action %Fm, v [template]
 // CHECK:STDOUT:   %.26b: %pattern_type.177 = splice_inst %.cfa [template]
@@ -801,26 +801,26 @@ fn G() {
 // CHECK:STDOUT:   %Core.import = import Core
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %Fm.patt.loc4_8.1: %pattern_type.13f = symbolic_binding_pattern Fm, 0 [symbolic = %Fm.patt.loc4_8.2 (constants.%Fm.patt)]
-// CHECK:STDOUT:     %v.patt.loc4_23.1: @F.%pattern_type (%pattern_type.177) = at_binding_pattern v, %.loc4_23.5 [template = %v.patt.loc4_23.2 (constants.%v.patt.0b3)]
-// CHECK:STDOUT:     %return.patt.loc4_30.1: @F.%pattern_type (%pattern_type.177) = return_slot_pattern %.loc4_30.5, %.loc4_34 [template = %return.patt.loc4_30.2 (constants.%return.patt.113)]
+// CHECK:STDOUT:     %.loc4_23.2: @F.%pattern_type (%pattern_type.177) = splice_inst %.loc4_23.3 [template = %.loc4_23.4 (constants.%.f15)]
+// CHECK:STDOUT:     %v.patt.loc4_23.1: @F.%pattern_type (%pattern_type.177) = at_binding_pattern v, %.loc4_23.2 [template = %v.patt.loc4_23.2 (constants.%v.patt.0b3)]
+// CHECK:STDOUT:     %.loc4_30.2: @F.%pattern_type (%pattern_type.177) = splice_inst %.loc4_30.3 [template = %.loc4_30.4 (constants.%.677)]
+// CHECK:STDOUT:     %return.patt.loc4_30.1: @F.%pattern_type (%pattern_type.177) = return_slot_pattern %.loc4_30.2, %.loc4_34 [template = %return.patt.loc4_30.2 (constants.%return.patt.113)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc4_23.5: @F.%pattern_type (%pattern_type.177) = splice_inst %.loc4_23.2 [template = %.loc4_23.3 (constants.%.f15)]
 // CHECK:STDOUT:     %Fm.ref.loc4_34: Core.Form = name_ref Fm, %Fm.loc4_8.2 [symbolic = %Fm.loc4_8.1 (constants.%Fm)]
 // CHECK:STDOUT:     %.loc4_34: type = type_component_of %Fm.ref.loc4_34 [symbolic = %.loc4_26.1 (constants.%.42f)]
-// CHECK:STDOUT:     %.loc4_30.5: @F.%pattern_type (%pattern_type.177) = splice_inst %.loc4_30.2 [template = %.loc4_30.3 (constants.%.677)]
 // CHECK:STDOUT:     %.loc4_15: type = splice_block %Form.ref [concrete = Core.Form] {
 // CHECK:STDOUT:       %.Self: %type = symbolic_binding .Self [symbolic_self = constants.%.Self]
 // CHECK:STDOUT:       %Core.ref: <namespace> = name_ref Core, imports.%Core [concrete = imports.%Core]
 // CHECK:STDOUT:       %Form.ref: type = name_ref Form, imports.%Core.Form [concrete = Core.Form]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %Fm.loc4_8.2: Core.Form = symbolic_binding Fm, 0 [symbolic = %Fm.loc4_8.1 (constants.%Fm)]
-// CHECK:STDOUT:     %.loc4_23.1: @F.%.loc4_26.1 (%.42f) = splice_inst %.loc4_23.4
+// CHECK:STDOUT:     %.loc4_23.1: @F.%.loc4_26.1 (%.42f) = splice_inst %.loc4_23.5
 // CHECK:STDOUT:     %.loc4_26.2: Core.Form = splice_block %Fm.ref.loc4_26 [symbolic = %Fm.loc4_8.1 (constants.%Fm)] {
 // CHECK:STDOUT:       %Fm.ref.loc4_26: Core.Form = name_ref Fm, %Fm.loc4_8.2 [symbolic = %Fm.loc4_8.1 (constants.%Fm)]
 // CHECK:STDOUT:       %.loc4_26.3: type = type_component_of %Fm.ref.loc4_26 [symbolic = %.loc4_26.1 (constants.%.42f)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %v: @F.%.loc4_26.1 (%.42f) = wrapper_binding v, %.loc4_23.1
-// CHECK:STDOUT:     %.loc4_30.1: @F.%.loc4_26.1 (%.42f) = splice_inst %.loc4_30.4
+// CHECK:STDOUT:     %.loc4_30.1: @F.%.loc4_26.1 (%.42f) = splice_inst %.loc4_30.5
 // CHECK:STDOUT:     %return: @F.%.loc4_26.1 (%.42f) = return_slot %.loc4_30.1
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {} {}
@@ -830,15 +830,15 @@ fn G() {
 // CHECK:STDOUT:   %Fm.patt.loc4_8.2: %pattern_type.13f = symbolic_binding_pattern Fm, 0 [symbolic = %Fm.patt.loc4_8.2 (constants.%Fm.patt)]
 // CHECK:STDOUT:   %Fm.loc4_8.1: Core.Form = symbolic_binding Fm, 0 [symbolic = %Fm.loc4_8.1 (constants.%Fm)]
 // CHECK:STDOUT:   %.loc4_26.1: type = type_component_of %Fm.loc4_8.1 [symbolic = %.loc4_26.1 (constants.%.42f)]
-// CHECK:STDOUT:   %.loc4_23.2: <instruction> = form_param_pattern_action %Fm.ref.loc4_26, v [template]
+// CHECK:STDOUT:   %.loc4_23.3: <instruction> = form_param_pattern_action %Fm.ref.loc4_26, v [template]
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %.loc4_26.1 [symbolic = %pattern_type (constants.%pattern_type.177)]
-// CHECK:STDOUT:   %.loc4_23.3: @F.%pattern_type (%pattern_type.177) = splice_inst %.loc4_23.2 [template = %.loc4_23.3 (constants.%.f15)]
-// CHECK:STDOUT:   %v.patt.loc4_23.2: @F.%pattern_type (%pattern_type.177) = at_binding_pattern v, %.loc4_23.3 [template = %v.patt.loc4_23.2 (constants.%v.patt.0b3)]
-// CHECK:STDOUT:   %.loc4_30.2: <instruction> = out_form_param_pattern_action %Fm.ref.loc4_34 [template]
-// CHECK:STDOUT:   %.loc4_30.3: @F.%pattern_type (%pattern_type.177) = splice_inst %.loc4_30.2 [template = %.loc4_30.3 (constants.%.677)]
-// CHECK:STDOUT:   %return.patt.loc4_30.2: @F.%pattern_type (%pattern_type.177) = return_slot_pattern %.loc4_30.3, %.loc4_26.1 [template = %return.patt.loc4_30.2 (constants.%return.patt.113)]
-// CHECK:STDOUT:   %.loc4_23.4: <instruction> = callee_pattern_match_action constants.%.f15, call_param0 [template]
-// CHECK:STDOUT:   %.loc4_30.4: <instruction> = callee_pattern_match_action constants.%.677, call_param1 [template]
+// CHECK:STDOUT:   %.loc4_23.4: @F.%pattern_type (%pattern_type.177) = splice_inst %.loc4_23.3 [template = %.loc4_23.4 (constants.%.f15)]
+// CHECK:STDOUT:   %v.patt.loc4_23.2: @F.%pattern_type (%pattern_type.177) = at_binding_pattern v, %.loc4_23.4 [template = %v.patt.loc4_23.2 (constants.%v.patt.0b3)]
+// CHECK:STDOUT:   %.loc4_30.3: <instruction> = out_form_param_pattern_action %Fm.ref.loc4_34 [template]
+// CHECK:STDOUT:   %.loc4_30.4: @F.%pattern_type (%pattern_type.177) = splice_inst %.loc4_30.3 [template = %.loc4_30.4 (constants.%.677)]
+// CHECK:STDOUT:   %return.patt.loc4_30.2: @F.%pattern_type (%pattern_type.177) = return_slot_pattern %.loc4_30.4, %.loc4_26.1 [template = %return.patt.loc4_30.2 (constants.%return.patt.113)]
+// CHECK:STDOUT:   %.loc4_23.5: <instruction> = callee_pattern_match_action constants.%.f15, call_param0 [template]
+// CHECK:STDOUT:   %.loc4_30.5: <instruction> = callee_pattern_match_action constants.%.677, call_param1 [template]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %.loc4_26.1 [symbolic = %require_complete (constants.%require_complete.c9b)]
@@ -935,30 +935,30 @@ fn G() {
 // CHECK:STDOUT:   %Fm.patt.loc4_8.2 => constants.%Fm.patt
 // CHECK:STDOUT:   %Fm.loc4_8.1 => constants.%Fm
 // CHECK:STDOUT:   %.loc4_26.1 => constants.%.42f
-// CHECK:STDOUT:   %.loc4_23.2 => constants.%.cfa
+// CHECK:STDOUT:   %.loc4_23.3 => constants.%.cfa
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.177
-// CHECK:STDOUT:   %.loc4_23.3 => constants.%.26b
+// CHECK:STDOUT:   %.loc4_23.4 => constants.%.26b
 // CHECK:STDOUT:   %v.patt.loc4_23.2 => constants.%v.patt.cda
-// CHECK:STDOUT:   %.loc4_30.2 => constants.%.94f
-// CHECK:STDOUT:   %.loc4_30.3 => constants.%.1ac
+// CHECK:STDOUT:   %.loc4_30.3 => constants.%.94f
+// CHECK:STDOUT:   %.loc4_30.4 => constants.%.1ac
 // CHECK:STDOUT:   %return.patt.loc4_30.2 => constants.%return.patt.333
-// CHECK:STDOUT:   %.loc4_23.4 => constants.%.095
-// CHECK:STDOUT:   %.loc4_30.4 => constants.%.efc
+// CHECK:STDOUT:   %.loc4_23.5 => constants.%.095
+// CHECK:STDOUT:   %.loc4_30.5 => constants.%.efc
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%.795) {
 // CHECK:STDOUT:   %Fm.patt.loc4_8.2 => constants.%Fm.patt
 // CHECK:STDOUT:   %Fm.loc4_8.1 => constants.%.795
 // CHECK:STDOUT:   %.loc4_26.1 => constants.%i32
-// CHECK:STDOUT:   %.loc4_23.2 => constants.%inst.splice_block
+// CHECK:STDOUT:   %.loc4_23.3 => constants.%inst.splice_block
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.6b6
-// CHECK:STDOUT:   %.loc4_23.3 => constants.%v.var_patt.13561f.1
+// CHECK:STDOUT:   %.loc4_23.4 => constants.%v.var_patt.13561f.1
 // CHECK:STDOUT:   %v.patt.loc4_23.2 => constants.%v.patt.b2b
-// CHECK:STDOUT:   %.loc4_30.2 => constants.%inst.out_param_pattern
-// CHECK:STDOUT:   %.loc4_30.3 => constants.%return.param_patt.a9a4c7.1
+// CHECK:STDOUT:   %.loc4_30.3 => constants.%inst.out_param_pattern
+// CHECK:STDOUT:   %.loc4_30.4 => constants.%return.param_patt.a9a4c7.1
 // CHECK:STDOUT:   %return.patt.loc4_30.2 => constants.%return.patt.e1b
-// CHECK:STDOUT:   %.loc4_23.4 => constants.%.095
-// CHECK:STDOUT:   %.loc4_30.4 => constants.%.efc
+// CHECK:STDOUT:   %.loc4_23.5 => constants.%.095
+// CHECK:STDOUT:   %.loc4_30.5 => constants.%.efc
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
@@ -968,15 +968,15 @@ fn G() {
 // CHECK:STDOUT:   %Fm.patt.loc4_8.2 => constants.%Fm.patt
 // CHECK:STDOUT:   %Fm.loc4_8.1 => constants.%.512
 // CHECK:STDOUT:   %.loc4_26.1 => constants.%i32
-// CHECK:STDOUT:   %.loc4_23.2 => constants.%inst.ref_param_pattern
+// CHECK:STDOUT:   %.loc4_23.3 => constants.%inst.ref_param_pattern
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.6b6
-// CHECK:STDOUT:   %.loc4_23.3 => constants.%v.param_patt.e9ad17.1
+// CHECK:STDOUT:   %.loc4_23.4 => constants.%v.param_patt.e9ad17.1
 // CHECK:STDOUT:   %v.patt.loc4_23.2 => constants.%v.patt.5c0
-// CHECK:STDOUT:   %.loc4_30.2 => constants.%inst.ref_return_pattern
-// CHECK:STDOUT:   %.loc4_30.3 => constants.%.ae0167.1
+// CHECK:STDOUT:   %.loc4_30.3 => constants.%inst.ref_return_pattern
+// CHECK:STDOUT:   %.loc4_30.4 => constants.%.ae0167.1
 // CHECK:STDOUT:   %return.patt.loc4_30.2 => constants.%return.patt.c62
-// CHECK:STDOUT:   %.loc4_23.4 => constants.%.095
-// CHECK:STDOUT:   %.loc4_30.4 => constants.%.efc
+// CHECK:STDOUT:   %.loc4_23.5 => constants.%.095
+// CHECK:STDOUT:   %.loc4_30.5 => constants.%.efc
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a
@@ -986,15 +986,15 @@ fn G() {
 // CHECK:STDOUT:   %Fm.patt.loc4_8.2 => constants.%Fm.patt
 // CHECK:STDOUT:   %Fm.loc4_8.1 => constants.%.c2a
 // CHECK:STDOUT:   %.loc4_26.1 => constants.%i32
-// CHECK:STDOUT:   %.loc4_23.2 => constants.%inst.value_param_pattern
+// CHECK:STDOUT:   %.loc4_23.3 => constants.%inst.value_param_pattern
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.6b6
-// CHECK:STDOUT:   %.loc4_23.3 => constants.%v.param_patt.733534.1
+// CHECK:STDOUT:   %.loc4_23.4 => constants.%v.param_patt.733534.1
 // CHECK:STDOUT:   %v.patt.loc4_23.2 => constants.%v.patt.971
-// CHECK:STDOUT:   %.loc4_30.2 => constants.%inst.value_return_pattern
-// CHECK:STDOUT:   %.loc4_30.3 => constants.%.1a588f.1
+// CHECK:STDOUT:   %.loc4_30.3 => constants.%inst.value_return_pattern
+// CHECK:STDOUT:   %.loc4_30.4 => constants.%.1a588f.1
 // CHECK:STDOUT:   %return.patt.loc4_30.2 => constants.%return.patt.45a
-// CHECK:STDOUT:   %.loc4_23.4 => constants.%.095
-// CHECK:STDOUT:   %.loc4_30.4 => constants.%.efc
+// CHECK:STDOUT:   %.loc4_23.5 => constants.%.095
+// CHECK:STDOUT:   %.loc4_30.5 => constants.%.efc
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type.f8a

--- a/toolchain/sem_ir/expr_info.cpp
+++ b/toolchain/sem_ir/expr_info.cpp
@@ -39,14 +39,6 @@ static auto GetExprCategoryImpl(const File* ir, InstId inst_id)
     auto untyped_inst = ir->insts().Get(inst_id);
     auto category_from_kind = untyped_inst.kind().expr_category();
 
-    // If this instruction kind has a fixed category, return it.
-    if (auto fixed_category = category_from_kind.TryAsFixedCategory()) {
-      return {.category = *fixed_category == ExprCategory::Value
-                              ? value_category
-                              : *fixed_category,
-              .inner_inst_id = inst_id};
-    }
-
     // Handle any special cases that use
     // ComputedExprCategory::DependsOnOperands.
     auto handle_special_case =
@@ -102,38 +94,60 @@ static auto GetExprCategoryImpl(const File* ir, InstId inst_id)
             return ExprCategory::ReprInitializing;
           }
         }
+      } else if constexpr (std::same_as<TypedInstT, SpliceInst>) {
+        auto action = ir->insts().Get(inst.inst_id);
+        if (auto* action_category = std::get_if<ActionExprCategory>(
+                &action.kind().expr_category())) {
+          if (action_category->category == ExprCategory::Value) {
+            return value_category;
+          } else {
+            return action_category->category;
+          }
+        } else {
+          CARBON_FATAL("Inst doesn't have action category: {0}", action);
+        }
       } else {
         static_assert(
-            TypedInstT::Kind.expr_category().TryAsComputedCategory() !=
-                ComputedExprCategory::DependsOnOperands,
+            TypedInstT::Kind.expr_category() !=
+                InstExprCategory(ComputedExprCategory::DependsOnOperands),
             "Missing expression category computation for type");
       }
       CARBON_FATAL("Unreachable");
     };
 
-    // If the category depends on the operands of the instruction, determine it.
-    // Usually this means the category is the same as the category of an
-    // operand.
-    switch (*category_from_kind.TryAsComputedCategory()) {
-      case ComputedExprCategory::ValueIfHasType: {
-        return {.category = untyped_inst.kind().has_type()
+    CARBON_KIND_SWITCH(category_from_kind) {
+      case CARBON_KIND(ExprCategory fixed_category): {
+        // If this instruction kind has a fixed category, return it.
+        return {.category = fixed_category == ExprCategory::Value
                                 ? value_category
-                                : ExprCategory::NotExpr,
+                                : fixed_category,
                 .inner_inst_id = inst_id};
       }
-
-      case ComputedExprCategory::SameAsFirstOperand: {
-        inst_id = AsAnyInstId(untyped_inst.arg0_and_kind());
-        break;
+      case CARBON_KIND(ActionExprCategory _): {
+        // Actions are always value expressions.
+        return {.category = value_category, .inner_inst_id = inst_id};
       }
-
-      case ComputedExprCategory::SameAsSecondOperand: {
-        inst_id = AsAnyInstId(untyped_inst.arg1_and_kind());
-        break;
-      }
-
-      case ComputedExprCategory::DependsOnOperands: {
-        switch (untyped_inst.kind()) {
+      case CARBON_KIND(ComputedExprCategory computed_category): {
+        // If the category depends on the operands of the instruction, determine
+        // it. Usually this means the category is the same as the category of an
+        // operand.
+        switch (computed_category) {
+          case ComputedExprCategory::ValueIfHasType: {
+            return {.category = untyped_inst.kind().has_type()
+                                    ? value_category
+                                    : ExprCategory::NotExpr,
+                    .inner_inst_id = inst_id};
+          }
+          case ComputedExprCategory::SameAsFirstOperand: {
+            inst_id = AsAnyInstId(untyped_inst.arg0_and_kind());
+            break;
+          }
+          case ComputedExprCategory::SameAsSecondOperand: {
+            inst_id = AsAnyInstId(untyped_inst.arg1_and_kind());
+            break;
+          }
+          case ComputedExprCategory::DependsOnOperands: {
+            switch (untyped_inst.kind()) {
 #define CARBON_SEM_IR_INST_KIND(TypedInstT)                             \
   case TypedInstT::Kind: {                                              \
     auto category = handle_special_case(untyped_inst.As<TypedInstT>()); \
@@ -143,6 +157,8 @@ static auto GetExprCategoryImpl(const File* ir, InstId inst_id)
     break;                                                              \
   }
 #include "toolchain/sem_ir/inst_kind.def"
+            }
+          }
         }
       }
     }

--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -119,37 +119,24 @@ enum ComputedExprCategory : int8_t {
   DependsOnOperands = -4,
 };
 
+// A tag type that specifies the category of the inst that will be produced by
+// a given kind of action. This also implicitly specifies the category of the
+// action itself, because all actions have category `Value`.
+struct ActionExprCategory {
+  // The category of insts produced by this kind of action. This should be
+  // `Dependent` if the action can produce insts with different categories.
+  ExprCategory category;
+
+  friend constexpr auto operator==(const ActionExprCategory& lhs,
+                                   const ActionExprCategory& rhs)
+      -> bool = default;
+};
+
 // What kind of expression category an instruction kind produces. The expression
 // category in general may depend on the operands of the instruction, but we can
 // handle most cases based on the instruction kind alone.
-class InstExprCategory {
- public:
-  constexpr explicit(false) InstExprCategory(ExprCategory cat)
-      : kind_(static_cast<int8_t>(cat)) {}
-  constexpr explicit(false) InstExprCategory(ComputedExprCategory kind)
-      : kind_(static_cast<int8_t>(kind)) {}
-
-  // If this instruction always has the same category, returns that category.
-  // Otherwise returns nullopt.
-  constexpr auto TryAsFixedCategory() const -> std::optional<ExprCategory> {
-    return kind_ >= 0 ? std::optional(static_cast<ExprCategory>(kind_))
-                      : std::nullopt;
-  }
-
-  // If the category of this instruction depends on its operands, returns the
-  // kind of computation to use to determine the category. Otherwise returns
-  // nullopt.
-  constexpr auto TryAsComputedCategory() const
-      -> std::optional<ComputedExprCategory> {
-    return kind_ < 0 ? std::optional(static_cast<ComputedExprCategory>(kind_))
-                     : std::nullopt;
-  }
-
- private:
-  // A value from either the `ExprCategory` or `ComputedExprCategory`
-  // enumerations.
-  int8_t kind_;
-};
+using InstExprCategory =
+    std::variant<ExprCategory, ComputedExprCategory, ActionExprCategory>;
 
 // Whether an instruction defines a type.
 enum class InstIsType : int8_t {
@@ -324,7 +311,7 @@ class InstKind : public CARBON_ENUM_BASE(InstKind) {
   }
 
   // Returns the category of expression represented by this instruction kind.
-  auto expr_category() const -> InstExprCategory {
+  auto expr_category() const -> const InstExprCategory& {
     return definition_info(*this).expr_category;
   }
 

--- a/toolchain/sem_ir/typed_insts.h
+++ b/toolchain/sem_ir/typed_insts.h
@@ -80,6 +80,7 @@ struct AccessMemberAction {
   static constexpr auto Kind =
       InstKind::AccessMemberAction.Define<Parse::NodeId>(
           {.ir_name = "access_member_action",
+           .expr_category = ActionExprCategory(ExprCategory::Dependent),
            .constant_kind = InstConstantKind::InstAction,
            .is_lowered = false});
 
@@ -94,6 +95,7 @@ struct AccessOptionalMemberAction {
   static constexpr auto Kind =
       InstKind::AccessOptionalMemberAction.Define<Parse::NodeId>(
           {.ir_name = "access_optional_member_action",
+           .expr_category = ActionExprCategory(ExprCategory::Dependent),
            .constant_kind = InstConstantKind::InstAction,
            .is_lowered = false});
 
@@ -394,7 +396,7 @@ struct CalleePatternMatchAction {
   static constexpr auto Kind =
       InstKind::CalleePatternMatchAction.Define<Parse::NodeId>(
           {.ir_name = "callee_pattern_match_action",
-           .expr_category = ExprCategory::Dependent,
+           .expr_category = ActionExprCategory(ExprCategory::Dependent),
            .constant_kind = InstConstantKind::InstAction,
            .is_lowered = false});
 
@@ -418,7 +420,7 @@ struct CallerPatternMatchAction {
   static constexpr auto Kind =
       InstKind::CallerPatternMatchAction.Define<Parse::NodeId>(
           {.ir_name = "caller_pattern_match_action",
-           .expr_category = ExprCategory::Dependent,
+           .expr_category = ActionExprCategory(ExprCategory::Dependent),
            .constant_kind = InstConstantKind::InstAction,
            .is_lowered = false});
 
@@ -561,6 +563,7 @@ struct ConvertToValueAction {
   static constexpr auto Kind =
       InstKind::ConvertToValueAction.Define<Parse::NodeId>(
           {.ir_name = "convert_to_value_action",
+           .expr_category = ActionExprCategory(ExprCategory::Value),
            .constant_kind = InstConstantKind::InstAction,
            .is_lowered = false});
 
@@ -825,7 +828,7 @@ struct FormParamPatternAction {
   static constexpr auto Kind =
       InstKind::FormParamPatternAction.Define<Parse::FormBindingPatternId>(
           {.ir_name = "form_param_pattern_action",
-           .expr_category = ExprCategory::Value,
+           .expr_category = ActionExprCategory(ExprCategory::Pattern),
            .constant_kind = InstConstantKind::ConstantInstAction,
            .is_lowered = false});
 
@@ -1387,7 +1390,7 @@ struct OutFormParamPatternAction {
       InstKind::OutFormParamPatternAction
           .Define<Parse::NodeIdOneOf<Parse::ReturnFormId, Parse::ReturnTypeId>>(
               {.ir_name = "out_form_param_pattern_action",
-               .expr_category = ExprCategory::Value,
+               .expr_category = ActionExprCategory(ExprCategory::Pattern),
                .constant_kind = InstConstantKind::ConstantInstAction,
                .is_lowered = false});
 
@@ -1482,6 +1485,7 @@ struct RefBinding {
 struct RefineTypeAction {
   static constexpr auto Kind = InstKind::RefineTypeAction.Define<Parse::NodeId>(
       {.ir_name = "refine_type_action",
+       .expr_category = ActionExprCategory(ExprCategory::Dependent),
        .constant_kind = InstConstantKind::InstAction,
        .is_lowered = false});
 
@@ -1873,7 +1877,7 @@ struct SpliceBlock {
 struct SpliceInst {
   static constexpr auto Kind = InstKind::SpliceInst.Define<Parse::NodeId>(
       {.ir_name = "splice_inst",
-       .expr_category = ExprCategory::Dependent,
+       .expr_category = ComputedExprCategory::DependsOnOperands,
        .constant_kind = InstConstantKind::Indirect});
 
   TypeId type_id;


### PR DESCRIPTION
This ensures that splices are put in the pattern block when they produce patterns, and also fixes some latent bugs in how actions were categorized.