### PR TITLE
Test and mitigate infinite cycles in impl lookup

### DIFF
--- a/toolchain/check/context.h
+++ b/toolchain/check/context.h
@@ -242,6 +242,10 @@ class Context {
   using ImplLookupCacheMap = Map<ImplLookupCacheKey, SemIR::ConstantId>;
   auto impl_lookup_cache() -> ImplLookupCacheMap& { return impl_lookup_cache_; }
 
+  auto impl_lookup_no_symbolic_final_lookups() -> int& {
+    return impl_lookup_no_symbolic_final_lookups_;
+  }
+
   // An impl lookup query that resulted in a concrete witness from finding an
   // `impl` declaration (not though a facet value), and its result. Used to look
   // for conflicting `impl` declarations.
@@ -545,6 +549,12 @@ class Context {
   // Tracks a mapping from (self, interface) to witness, for queries that had
   // final results.
   ImplLookupCacheMap impl_lookup_cache_;
+
+  // While non-zero, symbolic lookups for final impls are prevented in order to
+  // prevent cycles. This is incremented while replacing `.Self` in a facet type
+  // from an impl lookup query that we are searching for a witness for the
+  // query.
+  int impl_lookup_no_symbolic_final_lookups_ = 0;
 
   // Tracks impl lookup queries that lead to concrete witness results, along
   // with those results. Used to verify that the same queries produce the same

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -371,9 +371,31 @@ static auto CollectFacetWitnessSources(
     auto type_id = context.insts().Get(facet).type_id();
     if (type_id != SemIR::TypeType::TypeId) {
       auto facet_type = context.types().GetAs<SemIR::FacetType>(type_id);
+
+      // When we identify the facet type within a facet in the query, we also
+      // replace `.Self` with the `facet_const_id`, which has the same type as
+      // the facet type we're identifying. If that `.Self` replacement is in a
+      // `LookupImplWitness` instruction, it will evaluate and look for a final
+      // impl. When we find a generic `final impl` and try to deduce its
+      // parameters, we may end up trying to convert the `facet_const_id` which
+      // does an impl lookup and comes back here. If we replace `.Self` again,
+      // we just cycle indefinitely identifying and substituting
+      // `facet_const_id` into its type. We break that cycle here by preventing
+      // `final impl` lookups while replacing `.Self`.
+      //
+      // TODO: This prevents some legitimate code from working, as we can't find
+      // some witnesses that involve concrete associated constants from a
+      // symbolic facet. We could consider another approach: When we identify
+      // and replace `.Self` with `facet_const_id` in each constraint in its
+      // facet type, remove that constraint from the type of `facet_const_id`.
+      // Then each cycle back through to `facet_const_id` will have a smaller
+      // type until it runs out of constraints.
+      context.impl_lookup_no_symbolic_final_lookups()++;
       auto identified_id =
           TryToIdentifyFacetType(context, loc_id, facet_const_id, facet_type,
                                  allow_partially_identified);
+      context.impl_lookup_no_symbolic_final_lookups()--;
+
       if (identified_id.has_value()) {
         witnesses.push_back({.facet_const_id = facet_const_id,
                              .identified_facet_type_id = identified_id});
@@ -1194,6 +1216,9 @@ auto EvalLookupSingleFinalWitness(Context& context, SemIR::LocId loc_id,
 
   bool query_is_concrete =
       QueryIsConcrete(context, query_self_const_id, query_specific_interface);
+  if (!query_is_concrete && context.impl_lookup_no_symbolic_final_lookups()) {
+    return SemIR::ConstantId::None;
+  }
 
   auto query_type_structure = BuildTypeStructure(
       context, context.constant_values().GetInstId(query_self_const_id),

--- a/toolchain/check/testdata/facet/period_self.carbon
+++ b/toolchain/check/testdata/facet/period_self.carbon
@@ -293,6 +293,241 @@ fn F() {
   C as (Z where .Z1 impls Y);
 }
 
+// --- fail_infinite_cycle_identifying_associated_constant_as_impls_type_missing_impls_m.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = {} {}
+
+interface Z {}
+
+// This is missing `.Self impls M` so the `final impl` is not used, through
+// deduction is attempted.
+//
+// CHECK:STDERR: fail_infinite_cycle_identifying_associated_constant_as_impls_type_missing_impls_m.carbon:[[@LINE+7]]:46: error: cannot implicitly convert expression of type `T.(L.W)` to `{}` [ConversionFailure]
+// CHECK:STDERR: fn F(T:! L where .W impls Z, a: T.W) -> {} { return a; }
+// CHECK:STDERR:                                              ^~~~~~~~~
+// CHECK:STDERR: fail_infinite_cycle_identifying_associated_constant_as_impls_type_missing_impls_m.carbon:[[@LINE+4]]:46: note: type `T.(L.W)` does not implement interface `Core.ImplicitAs({})` [MissingImplInMemberAccessInContext]
+// CHECK:STDERR: fn F(T:! L where .W impls Z, a: T.W) -> {} { return a; }
+// CHECK:STDERR:                                              ^~~~~~~~~
+// CHECK:STDERR:
+fn F(T:! L where .W impls Z, a: T.W) -> {} { return a; }
+
+// --- infinite_cycle_identifying_associated_constant_as_impls_type.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = {} {}
+
+interface Z {}
+
+// This can make an infinite cycle in the toolchain:
+// 0. `T.W` looks for a witness for `L` in the facet type of `T`
+// 1. We identify the facet type of `T` and replace `.Self` with `T` throughout.
+// 2. The `.W` becomes `T.W` which is evaluated and does an impl lookup `T as L`.
+// 3. We find the final impl for `T:! M` and try to convert `T as M`.
+// 4. We look for a witness for `M` in the facet type of `T`.
+// 5. Go to step 1.
+//
+// Because the `.W` is part of an `impls` constraint, it is substituted as part
+// of identifying.
+fn F(T:! L where .W impls Z and .Self impls M, a: T.W) -> {} { return a; }
+
+// --- fail_infinite_cycle_identifying_associated_constant_in_impls_interface_as_type_missing_m.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+interface Z(T:! type) {}
+
+// This is missing `.Self impls M` so the `final impl` is not used, through
+// deduction is attempted.
+//
+// CHECK:STDERR: fail_infinite_cycle_identifying_associated_constant_in_impls_interface_as_type_missing_m.carbon:[[@LINE+7]]:53: error: cannot implicitly convert expression of type `T.(L.W)` to `()` [ConversionFailure]
+// CHECK:STDERR: fn F(T:! L where .Self impls Z(.W), a: T.W) -> () { return a; }
+// CHECK:STDERR:                                                     ^~~~~~~~~
+// CHECK:STDERR: fail_infinite_cycle_identifying_associated_constant_in_impls_interface_as_type_missing_m.carbon:[[@LINE+4]]:53: note: type `T.(L.W)` does not implement interface `Core.ImplicitAs(())` [MissingImplInMemberAccessInContext]
+// CHECK:STDERR: fn F(T:! L where .Self impls Z(.W), a: T.W) -> () { return a; }
+// CHECK:STDERR:                                                     ^~~~~~~~~
+// CHECK:STDERR:
+fn F(T:! L where .Self impls Z(.W), a: T.W) -> () { return a; }
+
+// --- infinite_cycle_identifying_associated_constant_in_impls_interface_as_type.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+interface Z(T:! type) {}
+
+// This can make an infinite cycle in the toolchain:
+// 0. `T.W` looks for a witness for `L` in the facet type of `T`
+// 1. We identify the facet type of `T` and replace `.Self` with `T` throughout.
+// 2. The `.W` becomes `T.W` which is evaluated and does an impl lookup `T as L`.
+// 3. We find the final impl for `T:! M` and try to convert `T as M`.
+// 4. We look for a witness for `M` in the facet type of `T`.
+// 5. Go to step 1.
+//
+// Because the `.W` is part of an `impls` constraint, it is substituted as part
+// of identifying. In this case it is inside a FacetAccessType instruction.
+fn F(T:! L where .Self impls Z(.W) and .Self impls M, a: T.W) -> () { return a; }
+
+// --- fail_infinite_cycle_identifying_associated_constant_in_impls_interface_as_facet_type_missing_m.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+interface Y {}
+interface Z(T:! Y) {}
+
+// This is missing `.Self impls M` so the `final impl` is not used, through
+// deduction is attempted.
+//
+// CHECK:STDERR: fail_infinite_cycle_identifying_associated_constant_in_impls_interface_as_facet_type_missing_m.carbon:[[@LINE+7]]:68: error: cannot implicitly convert expression of type `T.(L.W)` to `()` [ConversionFailure]
+// CHECK:STDERR: fn F(T:! L where .W impls Y and .Self impls Z(.W), a: T.W) -> () { return a; }
+// CHECK:STDERR:                                                                    ^~~~~~~~~
+// CHECK:STDERR: fail_infinite_cycle_identifying_associated_constant_in_impls_interface_as_facet_type_missing_m.carbon:[[@LINE+4]]:68: note: type `T.(L.W)` does not implement interface `Core.ImplicitAs(())` [MissingImplInMemberAccessInContext]
+// CHECK:STDERR: fn F(T:! L where .W impls Y and .Self impls Z(.W), a: T.W) -> () { return a; }
+// CHECK:STDERR:                                                                    ^~~~~~~~~
+// CHECK:STDERR:
+fn F(T:! L where .W impls Y and .Self impls Z(.W), a: T.W) -> () { return a; }
+
+// --- infinite_cycle_identifying_associated_constant_in_impls_interface_as_facet_type.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+interface Y {}
+interface Z(T:! Y) {}
+
+// This can make an infinite cycle in the toolchain:
+// 0. `T.W` looks for a witness for `L` in the facet type of `T`
+// 1. We identify the facet type of `T` and replace `.Self` with `T` throughout.
+// 2. The `.W` becomes `T.W` which is evaluated and does an impl lookup `T as L`.
+// 3. We find the final impl for `T:! M` and try to convert `T as M`.
+// 4. We look for a witness for `M` in the facet type of `T`.
+// 5. Go to step 1.
+//
+// Because the `.W` is part of an `impls` constraint, it is substituted as part
+// of identifying. In this case it is inside a FacetValue instruction, which is
+// converting it to `Y`.
+fn F(T:! L where .W impls Y and .Self impls Z(.W) and .Self impls M, a: T.W) -> () { return a; }
+
+// --- concrete_access_witness_m_in_extend_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+interface Z(Z1:! type) {}
+
+class C(C1:! type);
+
+// Should pass. `.W` can resolve to `()` immediately through the type of `.Self`
+// (since the type of `.Self` contains `M`) and the `final impl`. So we can get
+// a witness for `C(())` from `T`.
+fn I(T:! (L & M) where C(.W) impls Z(.Self)) {
+  C(()) as Z(T);
+}
+
+// --- fail_todo_concrete_access_witness_m_in_impls_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+interface Z(Z1:! type) {}
+
+class C(C1:! type);
+
+// Should pass. `.W` can resolve to `()` immediately through the type of `.Self`
+// (since the type of `.Self` contains `M`) and the `final impl`. So we can get
+// a witness for `C(())` from `T`.
+//
+// TODO: How come we don't get `.W` evaluating to `()` when `M` comes from a
+// non-extend constraint?
+fn H(T:! (L where .Self impls M) where C(.W) impls Z(.Self)) {
+  // CHECK:STDERR: fail_todo_concrete_access_witness_m_in_impls_constraint.carbon:[[@LINE+4]]:3: error: cannot convert type `C(())` into type implementing `Z(T)` [ConversionFailureTypeToFacet]
+  // CHECK:STDERR:   C(()) as Z(T);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~
+  // CHECK:STDERR:
+  C(()) as Z(T);
+}
+
+// --- fail_todo_concrete_access_witness_m_in_earlier_constraint.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+interface Z(Z1:! type) {}
+
+class C(C1:! type);
+
+
+// Should pass. `.W` can resolve to `()` immediately through the type of `.Self`
+// (since the type of `.Self` contains `M`) and the `final impl`. So we can get
+// a witness for `C(())` from `T`.
+//
+// TODO: How come we don't get `.W` evaluating to `()` when `M` comes from an
+// earlier constraint? Is the `where_stack` not working with `.Self`?
+fn G(T:! L where .Self impls M and C(.W) impls Z(.Self)) {
+  // CHECK:STDERR: fail_todo_concrete_access_witness_m_in_earlier_constraint.carbon:[[@LINE+4]]:3: error: cannot convert type `C(())` into type implementing `Z(T)` [ConversionFailureTypeToFacet]
+  // CHECK:STDERR:   C(()) as Z(T);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~
+  // CHECK:STDERR:
+  C(()) as Z(T);
+}
+
+// --- fail_todo_concrete_access_witness.carbon
+library "[[@TEST_NAME]]";
+
+interface L { let W:! type; }
+
+interface M {}
+final impl forall [T:! M] T as L where .W = () {}
+
+interface Z(Z1:! type) {}
+
+class C(C1:! type);
+
+// This does not pass because `.W` can't resolve to `()` where it is written.
+// The fact that `T impls M` comes later in the facet type. And we don't allow
+// `.W` to evaluate to `()` later when identifying the type of `T` to look for a
+// witness for `C(()) as Z(T)` in order to avoid cycles.
+//
+// TODO: We would like this to pass though, without introducing an infinite
+// cycle that identifies `T`, which deduces `T:! M` for the `impl`, which
+// identifies `T`. See TODO in CollectFacetWitnessSources for ideas.
+fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
+  // CHECK:STDERR: fail_todo_concrete_access_witness.carbon:[[@LINE+4]]:3: error: cannot convert type `C(())` into type implementing `Z(T)` [ConversionFailureTypeToFacet]
+  // CHECK:STDERR:   C(()) as Z(T);
+  // CHECK:STDERR:   ^~~~~~~~~~~~~
+  // CHECK:STDERR:
+  C(()) as Z(T);
+}
+
 // CHECK:STDOUT: --- period_self_param.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {


### PR DESCRIPTION
Impl lookup identifies the types of facets in the query, replacing `.Self` in each type with the facet. This allows references using the facet from outside the facet type to match similar structures inside the facet type.

However replacing `.Self` with the facet can re-evaluate symbolic impl lookups inside the facet type. These can perform deduction in generic `final impl`s, which can attempt to convert the facet. Convert does an impl lookup with that facet in the query, which causes us to form an infinite recursion cycle.

Add tests that caused such a cycle, to demonstrate we no longer crash. Some of these tests fail impl lookups using concrete values in the query that match values from a `final impl`, with TODOs to address them.