### PR TITLE
Option to run all of `file_test` under LLDB

### DIFF
--- a/.vscode/lldb_launch.json
+++ b/.vscode/lldb_launch.json
@@ -22,6 +22,24 @@
     {
       "type": "lldb-dap",
       "request": "launch",
+      "name": "file_test (all files) (lldb)",
+      "program": "bazel-bin/toolchain/testing/file_test",
+      "args": [],
+      "debuggerRoot": "${workspaceFolder}",
+      "initCommands": [
+        "command script import external/+llvm_project+llvm-project/llvm/utils/lldbDataFormatters.py",
+        "command script import scripts/lldbinit.py",
+        "settings append target.source-map \".\" \"${workspaceFolder}\"",
+        "settings append target.source-map \"/proc/self/cwd\" \"${workspaceFolder}\"",
+        "settings set escape-non-printables false",
+        "settings set target.max-string-summary-length 10000",
+        "env TEST_TARGET=//toolchain/testing:file_test",
+        "env TEST_TMPDIR=/tmp"
+      ]
+    },
+    {
+      "type": "lldb-dap",
+      "request": "launch",
       "name": "carbon compile (lldb)",
       "program": "bazel-bin/toolchain/carbon",
       "args": [


### PR DESCRIPTION
This is handy when `file_test`'s stack trace fails to report which file caused the crash.
