### PR TITLE
Update to newer LLVM.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -83,8 +83,8 @@ git_override(
     build_file_content = "# empty",
     # We pin to specific upstream commits and try to track top-of-tree
     # reasonably closely rather than pinning to a specific release.
-    # HEAD as of 2026-06-23.
-    commit = "bab165ecb0d64686849dfa14d1798589eee7b66e",
+    # HEAD as of 2026-06-28.
+    commit = "f3a69752ac184360afeb921d157ae08b89c2c091",
     patch_cmds = ["echo \"module(name='llvm-raw')\" > MODULE.bazel"],
     patch_strip = 1,
     patches = [

--- a/toolchain/base/mem_usage.h
+++ b/toolchain/base/mem_usage.h
@@ -50,8 +50,11 @@ class MemUsage {
   // Adds memory usage for a `llvm::BumpPtrAllocator`.
   auto Collect(std::string label, const llvm::BumpPtrAllocator& allocator)
       -> void {
-    Add(std::move(label), allocator.getBytesAllocated(),
-        allocator.getTotalMemory());
+    // LLVM's BumpPtrAllocator no longer tracks the exact number of bytes
+    // allocated to avoid overhead on the hot path. We use the total memory
+    // (the capacity of the slabs) for both.
+    auto total_memory = allocator.getTotalMemory();
+    Add(std::move(label), total_memory, total_memory);
   }
 
   // Adds memory usage for a `Map`.


### PR DESCRIPTION
One API fix: BumpPtrAllocator no longer tracks the amount of memory it's handed out separately from the amount of memory it has allocated from the system.

Assisted-by: Gemini via Antigravity