### PR TITLE
Subst the whole facet type to replace `.Self` in identify

### DIFF
--- a/toolchain/check/handle_require.cpp
+++ b/toolchain/check/handle_require.cpp
@@ -180,7 +180,7 @@ struct ValidateRequireResult {
 // not valid.
 static auto ValidateRequire(Context& context, SemIR::LocId full_require_loc_id,
                             SemIR::LocId constraint_loc_id,
-                            SemIR::InstId self_inst_id,
+                            SemIR::TypeInstId self_inst_id,
                             SemIR::InstId constraint_inst_id,
                             SemIR::InstId scope_inst_id)
     -> std::optional<ValidateRequireResult> {
@@ -244,7 +244,7 @@ static auto ValidateRequire(Context& context, SemIR::LocId full_require_loc_id,
 
   auto identified_facet_type_id = RequireIdentifiedFacetType(
       context, constraint_loc_id, self_type_id.AsConstantId(),
-      *constraint_facet_type, [&](auto& builder) {
+      context.types().GetTypeInstId(constraint_type_id), [&](auto& builder) {
         CARBON_DIAGNOSTIC(
             RequireImplsUnidentifiedFacetType, Context,
             "facet type {0} cannot be identified in `require` declaration",

--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -79,8 +79,8 @@ auto CheckAssociatedFunctionImplementation(
 
   return BuildThunk(context, interface_function_type.function_id,
                     interface_function_specific_id,
-                    /*signature_self_type_override_id=*/SemIR::TypeId::None,
-                    impl_decl_id, defer_thunk_definition);
+                    /*override_self_type_id=*/SemIR::TypeId::None, impl_decl_id,
+                    defer_thunk_definition);
 }
 
 static auto GetScopeInstId(Context& context, SemIR::InstId scope_inst_id)
@@ -874,15 +874,14 @@ auto CheckConstraintIsInterface(Context& context, SemIR::LocId loc_id,
                                 SemIR::TypeInstId constraint_id)
     -> SemIR::SpecificInterface {
   auto canon_constraint_id =
-      context.constant_values().GetConstantInstId(constraint_id);
+      context.constant_values().GetConstantTypeInstId(constraint_id);
   if (canon_constraint_id == SemIR::ErrorInst::TypeInstId) {
     return SemIR::SpecificInterface::None;
   }
-  auto facet_type =
-      context.insts().GetAs<SemIR::FacetType>(canon_constraint_id);
   auto identified_id = RequireIdentifiedFacetType(
       context, SemIR::LocId(constraint_id),
-      context.constant_values().Get(self_id), facet_type, [&](auto& builder) {
+      context.constant_values().Get(self_id), canon_constraint_id,
+      [&](auto& builder) {
         CARBON_DIAGNOSTIC(ImplOfUnidentifiedFacetType, Context,
                           "facet type {0} cannot be identified in `impl as`",
                           InstIdAsType);

--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -216,14 +216,14 @@ static auto GetRequiredImplsFromConstraint(
     SemIR::ConstantId query_facet_type_const_id, bool diagnose)
     -> std::optional<RequiredImplsFromConstraint> {
   auto facet_type_inst_id =
-      context.constant_values().GetInstId(query_facet_type_const_id);
+      context.types().GetTypeInstIdForTypeConstantId(query_facet_type_const_id);
   auto facet_type_inst =
       context.insts().GetAs<SemIR::FacetType>(facet_type_inst_id);
   const auto& facet_type_info =
       context.facet_types().Get(facet_type_inst.facet_type_id);
 
   auto identified_id = RequireIdentifiedFacetType(
-      context, loc_id, query_self_const_id, facet_type_inst,
+      context, loc_id, query_self_const_id, facet_type_inst_id,
       [&](auto& builder) {
         CARBON_DIAGNOSTIC(ImplLookupInUnidentifiedFacetType, Context,
                           "facet type {0} can not be identified", InstIdAsType);
@@ -370,8 +370,6 @@ static auto CollectFacetWitnessSources(
 
     auto type_id = context.insts().Get(facet).type_id();
     if (type_id != SemIR::TypeType::TypeId) {
-      auto facet_type = context.types().GetAs<SemIR::FacetType>(type_id);
-
       // Identifying the facet type of `facet_const_id` causes `.Self` to be
       // replaced with `facet_const_id`. The resulting `LookupImplWitness`
       // evaluation searches for a `final impl`. The toolchain needs to deduce
@@ -391,8 +389,9 @@ static auto CollectFacetWitnessSources(
           context.impl_lookup_no_symbolic_final_lookups();
       ++no_symbolic_final_lookups;
       auto identified_id = TryToIdentifyFacetType(
-          context, loc_id, facet_const_id, facet_type,
-          allow_partially_identified, /*subst_period_self=*/true);
+          context, loc_id, facet_const_id,
+          context.types().GetTypeInstId(type_id), allow_partially_identified,
+          /*subst_period_self=*/true);
       --no_symbolic_final_lookups;
 
       if (identified_id.has_value()) {
@@ -468,12 +467,11 @@ static auto CollectFacetWitnessSources(
     for (auto [self_const_id, facet_type_const_id] : impls) {
       auto canon_self_const_id =
           GetCanonicalFacetOrTypeValue(context, self_const_id);
-      // TypeType is never stored in the impls stack, so we always have a
-      // FacetType.
-      auto facet_type = context.constant_values().GetInstAs<SemIR::FacetType>(
-          facet_type_const_id);
+      // TypeType (and ErrorInst) is never stored in the impls stack, so we
+      // always have a FacetType in `facet_type_const_id`.
       auto identified_id = TryToIdentifyFacetType(
-          context, loc_id, canon_self_const_id, facet_type,
+          context, loc_id, canon_self_const_id,
+          context.types().GetTypeInstIdForTypeConstantId(facet_type_const_id),
           /*allow_partially_identified=*/true,
           /*subst_period_self=*/false);
       if (identified_id.has_value()) {

--- a/toolchain/check/period_self.cpp
+++ b/toolchain/check/period_self.cpp
@@ -219,12 +219,11 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
                .facet_value_inst_id = replacement_self_inst_id}));
     }
 
-    auto period_self_facet_type =
-        context().types().GetAs<SemIR::FacetType>(period_self_type_id);
     auto identified_period_self_type_id = RequireIdentifiedFacetType(
         context(), loc_id_,
         context().constant_values().Get(replacement_self_inst_id),
-        period_self_facet_type, [&](auto& /*builder*/) {
+        context().types().GetTypeInstId(period_self_type_id),
+        [&](auto& /*builder*/) {
           // Given `I where .Self == ()`, the type of `.Self` is `I` and we're
           // replacing `.Self` with some `T` that must also implement `I`.
           // However `I` can be a generic with arbitrary complexity and the
@@ -373,7 +372,7 @@ auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
 }
 
 auto SubstPeriodSelfInFacetType(Context& context, SemIR::LocId loc_id,
-                                SemIR::TypeInstId self_type_inst_id,
+                                SemIR::InstId self_inst_id,
                                 SemIR::TypeInstId facet_type_inst_id)
     -> SemIR::TypeInstId {
   auto canon_facet_type_inst_id =
@@ -382,8 +381,7 @@ auto SubstPeriodSelfInFacetType(Context& context, SemIR::LocId loc_id,
     return SemIR::ErrorInst::TypeInstId;
   }
 
-  auto period_self_replacement_id =
-      context.constant_values().Get(self_type_inst_id);
+  auto period_self_replacement_id = context.constant_values().Get(self_inst_id);
 
   auto orig_facet_type =
       context.insts().GetAs<SemIR::FacetType>(canon_facet_type_inst_id);

--- a/toolchain/check/period_self.h
+++ b/toolchain/check/period_self.h
@@ -74,7 +74,7 @@ auto SubstPeriodSelf(
 // instruction is added for the output FacetType if anything does get replaced,
 // and the original instruction id is preserved otherwise.
 auto SubstPeriodSelfInFacetType(Context& context, SemIR::LocId loc_id,
-                                SemIR::TypeInstId self_type_inst_id,
+                                SemIR::InstId self_inst_id,
                                 SemIR::TypeInstId facet_type_inst_id)
     -> SemIR::TypeInstId;
 

--- a/toolchain/check/testdata/facet/period_self.carbon
+++ b/toolchain/check/testdata/facet/period_self.carbon
@@ -553,12 +553,14 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:   %I.lookup_impl_witness.67f: <witness> = lookup_impl_witness %.Self.0f0, @I, @I(%.Self.as_type.246) [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %I.lookup_impl_witness.67f, element0 [symbolic_self]
 // CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
-// CHECK:STDOUT:   %I_where.type: type = facet_type <@I, @I(%.Self.as_type.246) where %impl.elem0 = %empty_tuple.type> [symbolic_self]
-// CHECK:STDOUT:   %pattern_type.021: type = pattern_type %I_where.type [symbolic_self]
+// CHECK:STDOUT:   %I_where.type.4b7: type = facet_type <@I, @I(%.Self.as_type.246) where %impl.elem0 = %empty_tuple.type> [symbolic_self]
+// CHECK:STDOUT:   %pattern_type.021: type = pattern_type %I_where.type.4b7 [symbolic_self]
 // CHECK:STDOUT:   %T.patt.e6f: %pattern_type.021 = symbolic_binding_pattern T, 0 [symbolic]
-// CHECK:STDOUT:   %T.8c8: %I_where.type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %T.8c8: %I_where.type.4b7 = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %T.as_type: type = facet_access_type %T.8c8 [symbolic]
 // CHECK:STDOUT:   %facet_value: %type = facet_value %T.as_type, () [symbolic]
+// CHECK:STDOUT:   %I.type.a52: type = facet_type <@I, @I(%T.as_type)> [symbolic]
+// CHECK:STDOUT:   %I_where.type.e53: type = facet_type <@I, @I(%T.as_type) where %impl.elem0 = %empty_tuple.type> [symbolic]
 // CHECK:STDOUT:   %I.lookup_impl_witness.506: <witness> = lookup_impl_witness %T.8c8, @I, @I(%T.as_type) [symbolic]
 // CHECK:STDOUT:   %I.facet: %I.type.f3d = facet_value %T.as_type, (%I.lookup_impl_witness.506) [symbolic]
 // CHECK:STDOUT:   %.262: Core.Form = init_form %empty_tuple.type [concrete]
@@ -586,28 +588,30 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.cb1 = out_param_pattern [concrete = constants.%return.param_patt]
 // CHECK:STDOUT:     %return.patt: %pattern_type.cb1 = return_slot_pattern %return.param_patt, %impl.elem0.loc8_39 [concrete = constants.%return.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref: %I_where.type = name_ref T, %T.loc8_7.2 [symbolic = %T.loc8_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:     %T.ref: %I_where.type.4b7 = name_ref T, %T.loc8_7.2 [symbolic = %T.loc8_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:     %T.as_type.loc8_39.2: type = facet_access_type %T.ref [symbolic = %T.as_type.loc8_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %.loc8_39.1: type = converted %T.ref, %T.as_type.loc8_39.2 [symbolic = %T.as_type.loc8_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %.loc8_39.2: %I.assoc_type.ea7 = specific_constant @I1.%assoc0, @I.WithSelf(constants.%.Self.as_type.246, constants.%T.8c8) [symbolic_self = constants.%assoc0.c72]
 // CHECK:STDOUT:     %I1.ref.loc8_39: %I.assoc_type.ea7 = name_ref I1, %.loc8_39.2 [symbolic_self = constants.%assoc0.c72]
 // CHECK:STDOUT:     %facet_value.loc8_39.2: %type = facet_value constants.%T.as_type, () [symbolic = %facet_value.loc8_39.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %.loc8_39.3: %type = converted constants.%T.as_type, %facet_value.loc8_39.2 [symbolic = %facet_value.loc8_39.1 (constants.%facet_value)]
+// CHECK:STDOUT:     %I.type.loc8_39.2: type = facet_type <@I, @I(constants.%T.as_type)> [symbolic = %I.type.loc8_39.1 (constants.%I.type.a52)]
 // CHECK:STDOUT:     %T.as_type.loc8_39.3: type = facet_access_type constants.%T.8c8 [symbolic = %T.as_type.loc8_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %facet_value.loc8_39.3: %type = facet_value %T.as_type.loc8_39.3, () [symbolic = %facet_value.loc8_39.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %.loc8_39.4: %type = converted constants.%T.8c8, %facet_value.loc8_39.3 [symbolic = %facet_value.loc8_39.1 (constants.%facet_value)]
+// CHECK:STDOUT:     %I_where.type.loc8_39.2: type = facet_type <@I, @I(constants.%T.as_type) where constants.%impl.elem0 = constants.%empty_tuple.type> [symbolic = %I_where.type.loc8_39.1 (constants.%I_where.type.e53)]
 // CHECK:STDOUT:     %T.as_type.loc8_39.4: type = facet_access_type constants.%T.8c8 [symbolic = %T.as_type.loc8_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %facet_value.loc8_39.4: %type = facet_value %T.as_type.loc8_39.4, () [symbolic = %facet_value.loc8_39.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %.loc8_39.5: %type = converted constants.%T.8c8, %facet_value.loc8_39.4 [symbolic = %facet_value.loc8_39.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %impl.elem0.loc8_39: type = impl_witness_access constants.%I.lookup_impl_witness.506, element0 [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:     %.loc8_39.6: Core.Form = init_form %impl.elem0.loc8_39 [concrete = constants.%.262]
-// CHECK:STDOUT:     %.loc8_19.1: type = splice_block %.loc8_19.2 [symbolic_self = constants.%I_where.type] {
+// CHECK:STDOUT:     %.loc8_19.1: type = splice_block %.loc8_19.2 [symbolic_self = constants.%I_where.type.4b7] {
 // CHECK:STDOUT:       %.Self.loc8_7: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
 // CHECK:STDOUT:       %I.ref: %I.type.335 = name_ref I, file.%I.decl [concrete = constants.%I.generic]
 // CHECK:STDOUT:       %.Self.ref.loc8_12: %type = name_ref .Self, %.Self.loc8_7 [symbolic_self = constants.%.Self.c39]
 // CHECK:STDOUT:       %.Self.as_type.loc8_17: type = facet_access_type %.Self.ref.loc8_12 [symbolic_self = constants.%.Self.as_type.246]
 // CHECK:STDOUT:       %.loc8_17: type = converted %.Self.ref.loc8_12, %.Self.as_type.loc8_17 [symbolic_self = constants.%.Self.as_type.246]
-// CHECK:STDOUT:       %I.type: type = facet_type <@I, @I(constants.%.Self.as_type.246)> [symbolic_self = constants.%I.type.f3d]
+// CHECK:STDOUT:       %I.type.loc8_17: type = facet_type <@I, @I(constants.%.Self.as_type.246)> [symbolic_self = constants.%I.type.f3d]
 // CHECK:STDOUT:       %.Self.loc8_19: %I.type.f3d = symbolic_binding .Self [symbolic_self = constants.%.Self.0f0]
 // CHECK:STDOUT:       %.Self.ref.loc8_25: %I.type.f3d = name_ref .Self, %.Self.loc8_19 [symbolic_self = constants.%.Self.0f0]
 // CHECK:STDOUT:       %.Self.as_type.loc8_25: type = facet_access_type %.Self.ref.loc8_25 [symbolic_self = constants.%.Self.as_type.a1c]
@@ -617,12 +621,12 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:       %impl.elem0.loc8_25: type = impl_witness_access constants.%I.lookup_impl_witness.67f, element0 [symbolic_self = constants.%impl.elem0]
 // CHECK:STDOUT:       %.loc8_32.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
 // CHECK:STDOUT:       %.loc8_32.2: type = converted %.loc8_32.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:       %.loc8_19.2: type = where_expr [symbolic_self = constants.%I_where.type] {
-// CHECK:STDOUT:         requirement_base_facet_type %I.type
+// CHECK:STDOUT:       %.loc8_19.2: type = where_expr [symbolic_self = constants.%I_where.type.4b7] {
+// CHECK:STDOUT:         requirement_base_facet_type %I.type.loc8_17
 // CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc8_25, %.loc8_32.2
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc8_7.2: %I_where.type = symbolic_binding T, 0 [symbolic = %T.loc8_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:     %T.loc8_7.2: %I_where.type.4b7 = symbolic_binding T, 0 [symbolic = %T.loc8_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:     %return.param: ref %empty_tuple.type = out_param call_param0
 // CHECK:STDOUT:     %return: ref %empty_tuple.type = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -631,7 +635,7 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.cb1 = out_param_pattern [concrete = constants.%return.param_patt]
 // CHECK:STDOUT:     %return.patt: %pattern_type.cb1 = return_slot_pattern %return.param_patt, %impl.elem0.loc12_47 [concrete = constants.%return.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref: %I_where.type = name_ref T, %T.loc12_7.2 [symbolic = %T.loc12_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:     %T.ref: %I_where.type.4b7 = name_ref T, %T.loc12_7.2 [symbolic = %T.loc12_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:     %T.as_type.loc12_47.2: type = facet_access_type %T.ref [symbolic = %T.as_type.loc12_47.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %.loc12_47.1: type = converted %T.ref, %T.as_type.loc12_47.2 [symbolic = %T.as_type.loc12_47.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %.loc12_47.2: %I.assoc_type.ea7 = specific_constant @I1.%assoc0, @I.WithSelf(constants.%.Self.as_type.246, constants.%T.8c8) [symbolic_self = constants.%assoc0.c72]
@@ -641,7 +645,7 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:     %.loc12_47.3: %type = converted constants.%T.8c8, %facet_value.loc12_47.2 [symbolic = %facet_value.loc12_47.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %impl.elem0.loc12_47: type = impl_witness_access constants.%I.lookup_impl_witness.506, element0 [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:     %.loc12_47.4: Core.Form = init_form %impl.elem0.loc12_47 [concrete = constants.%.262]
-// CHECK:STDOUT:     %.loc12_27.1: type = splice_block %.loc12_27.2 [symbolic_self = constants.%I_where.type] {
+// CHECK:STDOUT:     %.loc12_27.1: type = splice_block %.loc12_27.2 [symbolic_self = constants.%I_where.type.4b7] {
 // CHECK:STDOUT:       %.Self.loc12_7: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
 // CHECK:STDOUT:       %I.ref: %I.type.335 = name_ref I, file.%I.decl [concrete = constants.%I.generic]
 // CHECK:STDOUT:       %.Self.ref.loc12_12: %type = name_ref .Self, %.Self.loc12_7 [symbolic_self = constants.%.Self.c39]
@@ -658,12 +662,12 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:       %impl.elem0.loc12_33: type = impl_witness_access constants.%I.lookup_impl_witness.67f, element0 [symbolic_self = constants.%impl.elem0]
 // CHECK:STDOUT:       %.loc12_40.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
 // CHECK:STDOUT:       %.loc12_40.2: type = converted %.loc12_40.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:       %.loc12_27.2: type = where_expr [symbolic_self = constants.%I_where.type] {
+// CHECK:STDOUT:       %.loc12_27.2: type = where_expr [symbolic_self = constants.%I_where.type.4b7] {
 // CHECK:STDOUT:         requirement_base_facet_type %I.type
 // CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc12_33, %.loc12_40.2
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc12_7.2: %I_where.type = symbolic_binding T, 0 [symbolic = %T.loc12_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:     %T.loc12_7.2: %I_where.type.4b7 = symbolic_binding T, 0 [symbolic = %T.loc12_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:     %return.param: ref %empty_tuple.type = out_param call_param0
 // CHECK:STDOUT:     %return: ref %empty_tuple.type = return_slot %return.param
 // CHECK:STDOUT:   }
@@ -695,11 +699,13 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%T.loc8_7.2: %I_where.type) {
+// CHECK:STDOUT: generic fn @F(%T.loc8_7.2: %I_where.type.4b7) {
 // CHECK:STDOUT:   %T.patt.loc8_7.2: %pattern_type.021 = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_7.2 (constants.%T.patt.e6f)]
-// CHECK:STDOUT:   %T.loc8_7.1: %I_where.type = symbolic_binding T, 0 [symbolic = %T.loc8_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:   %T.loc8_7.1: %I_where.type.4b7 = symbolic_binding T, 0 [symbolic = %T.loc8_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:   %T.as_type.loc8_39.1: type = facet_access_type %T.loc8_7.1 [symbolic = %T.as_type.loc8_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:   %facet_value.loc8_39.1: %type = facet_value %T.as_type.loc8_39.1, () [symbolic = %facet_value.loc8_39.1 (constants.%facet_value)]
+// CHECK:STDOUT:   %I.type.loc8_39.1: type = facet_type <@I, @I(%T.as_type.loc8_39.1)> [symbolic = %I.type.loc8_39.1 (constants.%I.type.a52)]
+// CHECK:STDOUT:   %I_where.type.loc8_39.1: type = facet_type <@I, @I(%T.as_type.loc8_39.1) where constants.%impl.elem0 = constants.%empty_tuple.type> [symbolic = %I_where.type.loc8_39.1 (constants.%I_where.type.e53)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -712,9 +718,9 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @G(%T.loc12_7.2: %I_where.type) {
+// CHECK:STDOUT: generic fn @G(%T.loc12_7.2: %I_where.type.4b7) {
 // CHECK:STDOUT:   %T.patt.loc12_7.2: %pattern_type.021 = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc12_7.2 (constants.%T.patt.e6f)]
-// CHECK:STDOUT:   %T.loc12_7.1: %I_where.type = symbolic_binding T, 0 [symbolic = %T.loc12_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:   %T.loc12_7.1: %I_where.type.4b7 = symbolic_binding T, 0 [symbolic = %T.loc12_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:   %T.as_type.loc12_47.1: type = facet_access_type %T.loc12_7.1 [symbolic = %T.as_type.loc12_47.1 (constants.%T.as_type)]
 // CHECK:STDOUT:   %facet_value.loc12_47.1: %type = facet_value %T.as_type.loc12_47.1, () [symbolic = %facet_value.loc12_47.1 (constants.%facet_value)]
 // CHECK:STDOUT:
@@ -783,6 +789,8 @@ fn F(T:! L where C(.W) impls Z(.Self) and .Self impls M) {
 // CHECK:STDOUT:   %T.loc8_7.1 => constants.%T.8c8
 // CHECK:STDOUT:   %T.as_type.loc8_39.1 => constants.%T.as_type
 // CHECK:STDOUT:   %facet_value.loc8_39.1 => constants.%facet_value
+// CHECK:STDOUT:   %I.type.loc8_39.1 => constants.%I.type.a52
+// CHECK:STDOUT:   %I_where.type.loc8_39.1 => constants.%I_where.type.e53
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @G(constants.%T.8c8) {

--- a/toolchain/check/testdata/facet/self_in_interface_param.carbon
+++ b/toolchain/check/testdata/facet/self_in_interface_param.carbon
@@ -39,12 +39,14 @@ fn G(_:! I(.Self) where .I1 = ()) {}
 // CHECK:STDOUT:   %I.lookup_impl_witness.67f: <witness> = lookup_impl_witness %.Self.0f0, @I, @I(%.Self.as_type.246) [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0: type = impl_witness_access %I.lookup_impl_witness.67f, element0 [symbolic_self]
 // CHECK:STDOUT:   %empty_tuple: %empty_tuple.type = tuple_value () [concrete]
-// CHECK:STDOUT:   %I_where.type: type = facet_type <@I, @I(%.Self.as_type.246) where %impl.elem0 = %empty_tuple.type> [symbolic_self]
-// CHECK:STDOUT:   %pattern_type.021: type = pattern_type %I_where.type [symbolic_self]
+// CHECK:STDOUT:   %I_where.type.4b7: type = facet_type <@I, @I(%.Self.as_type.246) where %impl.elem0 = %empty_tuple.type> [symbolic_self]
+// CHECK:STDOUT:   %pattern_type.021: type = pattern_type %I_where.type.4b7 [symbolic_self]
 // CHECK:STDOUT:   %T.patt.e6f: %pattern_type.021 = symbolic_binding_pattern T, 0 [symbolic]
-// CHECK:STDOUT:   %T.8c8: %I_where.type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %T.8c8: %I_where.type.4b7 = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %T.as_type: type = facet_access_type %T.8c8 [symbolic]
 // CHECK:STDOUT:   %facet_value: %type = facet_value %T.as_type, () [symbolic]
+// CHECK:STDOUT:   %I.type.a52: type = facet_type <@I, @I(%T.as_type)> [symbolic]
+// CHECK:STDOUT:   %I_where.type.e53: type = facet_type <@I, @I(%T.as_type) where %impl.elem0 = %empty_tuple.type> [symbolic]
 // CHECK:STDOUT:   %I.lookup_impl_witness.506: <witness> = lookup_impl_witness %T.8c8, @I, @I(%T.as_type) [symbolic]
 // CHECK:STDOUT:   %.262: Core.Form = init_form %empty_tuple.type [concrete]
 // CHECK:STDOUT:   %pattern_type.cb1: type = pattern_type %empty_tuple.type [concrete]
@@ -60,28 +62,30 @@ fn G(_:! I(.Self) where .I1 = ()) {}
 // CHECK:STDOUT:     %return.param_patt: %pattern_type.cb1 = out_param_pattern [concrete = constants.%return.param_patt]
 // CHECK:STDOUT:     %return.patt: %pattern_type.cb1 = return_slot_pattern %return.param_patt, %impl.elem0.loc18_39 [concrete = constants.%return.patt]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %T.ref: %I_where.type = name_ref T, %T.loc18_7.2 [symbolic = %T.loc18_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:     %T.ref: %I_where.type.4b7 = name_ref T, %T.loc18_7.2 [symbolic = %T.loc18_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:     %T.as_type.loc18_39.2: type = facet_access_type %T.ref [symbolic = %T.as_type.loc18_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %.loc18_39.1: type = converted %T.ref, %T.as_type.loc18_39.2 [symbolic = %T.as_type.loc18_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %.loc18_39.2: %I.assoc_type.ea7 = specific_constant @I1.%assoc0, @I.WithSelf(constants.%.Self.as_type.246, constants.%T.8c8) [symbolic_self = constants.%assoc0.c72]
 // CHECK:STDOUT:     %I1.ref.loc18_39: %I.assoc_type.ea7 = name_ref I1, %.loc18_39.2 [symbolic_self = constants.%assoc0.c72]
 // CHECK:STDOUT:     %facet_value.loc18_39.2: %type = facet_value constants.%T.as_type, () [symbolic = %facet_value.loc18_39.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %.loc18_39.3: %type = converted constants.%T.as_type, %facet_value.loc18_39.2 [symbolic = %facet_value.loc18_39.1 (constants.%facet_value)]
+// CHECK:STDOUT:     %I.type.loc18_39.2: type = facet_type <@I, @I(constants.%T.as_type)> [symbolic = %I.type.loc18_39.1 (constants.%I.type.a52)]
 // CHECK:STDOUT:     %T.as_type.loc18_39.3: type = facet_access_type constants.%T.8c8 [symbolic = %T.as_type.loc18_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %facet_value.loc18_39.3: %type = facet_value %T.as_type.loc18_39.3, () [symbolic = %facet_value.loc18_39.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %.loc18_39.4: %type = converted constants.%T.8c8, %facet_value.loc18_39.3 [symbolic = %facet_value.loc18_39.1 (constants.%facet_value)]
+// CHECK:STDOUT:     %I_where.type.loc18_39.2: type = facet_type <@I, @I(constants.%T.as_type) where constants.%impl.elem0 = constants.%empty_tuple.type> [symbolic = %I_where.type.loc18_39.1 (constants.%I_where.type.e53)]
 // CHECK:STDOUT:     %T.as_type.loc18_39.4: type = facet_access_type constants.%T.8c8 [symbolic = %T.as_type.loc18_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     %facet_value.loc18_39.4: %type = facet_value %T.as_type.loc18_39.4, () [symbolic = %facet_value.loc18_39.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %.loc18_39.5: %type = converted constants.%T.8c8, %facet_value.loc18_39.4 [symbolic = %facet_value.loc18_39.1 (constants.%facet_value)]
 // CHECK:STDOUT:     %impl.elem0.loc18_39: type = impl_witness_access constants.%I.lookup_impl_witness.506, element0 [concrete = constants.%empty_tuple.type]
 // CHECK:STDOUT:     %.loc18_39.6: Core.Form = init_form %impl.elem0.loc18_39 [concrete = constants.%.262]
-// CHECK:STDOUT:     %.loc18_19.1: type = splice_block %.loc18_19.2 [symbolic_self = constants.%I_where.type] {
+// CHECK:STDOUT:     %.loc18_19.1: type = splice_block %.loc18_19.2 [symbolic_self = constants.%I_where.type.4b7] {
 // CHECK:STDOUT:       %.Self.loc18_7: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
 // CHECK:STDOUT:       %I.ref: %I.type.335 = name_ref I, file.%I.decl [concrete = constants.%I.generic]
 // CHECK:STDOUT:       %.Self.ref.loc18_12: %type = name_ref .Self, %.Self.loc18_7 [symbolic_self = constants.%.Self.c39]
 // CHECK:STDOUT:       %.Self.as_type.loc18_17: type = facet_access_type %.Self.ref.loc18_12 [symbolic_self = constants.%.Self.as_type.246]
 // CHECK:STDOUT:       %.loc18_17: type = converted %.Self.ref.loc18_12, %.Self.as_type.loc18_17 [symbolic_self = constants.%.Self.as_type.246]
-// CHECK:STDOUT:       %I.type: type = facet_type <@I, @I(constants.%.Self.as_type.246)> [symbolic_self = constants.%I.type.f3d]
+// CHECK:STDOUT:       %I.type.loc18_17: type = facet_type <@I, @I(constants.%.Self.as_type.246)> [symbolic_self = constants.%I.type.f3d]
 // CHECK:STDOUT:       %.Self.loc18_19: %I.type.f3d = symbolic_binding .Self [symbolic_self = constants.%.Self.0f0]
 // CHECK:STDOUT:       %.Self.ref.loc18_25: %I.type.f3d = name_ref .Self, %.Self.loc18_19 [symbolic_self = constants.%.Self.0f0]
 // CHECK:STDOUT:       %.Self.as_type.loc18_25: type = facet_access_type %.Self.ref.loc18_25 [symbolic_self = constants.%.Self.as_type.a1c]
@@ -91,22 +95,24 @@ fn G(_:! I(.Self) where .I1 = ()) {}
 // CHECK:STDOUT:       %impl.elem0.loc18_25: type = impl_witness_access constants.%I.lookup_impl_witness.67f, element0 [symbolic_self = constants.%impl.elem0]
 // CHECK:STDOUT:       %.loc18_32.1: %empty_tuple.type = tuple_literal () [concrete = constants.%empty_tuple]
 // CHECK:STDOUT:       %.loc18_32.2: type = converted %.loc18_32.1, constants.%empty_tuple.type [concrete = constants.%empty_tuple.type]
-// CHECK:STDOUT:       %.loc18_19.2: type = where_expr [symbolic_self = constants.%I_where.type] {
-// CHECK:STDOUT:         requirement_base_facet_type %I.type
+// CHECK:STDOUT:       %.loc18_19.2: type = where_expr [symbolic_self = constants.%I_where.type.4b7] {
+// CHECK:STDOUT:         requirement_base_facet_type %I.type.loc18_17
 // CHECK:STDOUT:         requirement_rewrite %impl.elem0.loc18_25, %.loc18_32.2
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc18_7.2: %I_where.type = symbolic_binding T, 0 [symbolic = %T.loc18_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:     %T.loc18_7.2: %I_where.type.4b7 = symbolic_binding T, 0 [symbolic = %T.loc18_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:     %return.param: ref %empty_tuple.type = out_param call_param0
 // CHECK:STDOUT:     %return: ref %empty_tuple.type = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%T.loc18_7.2: %I_where.type) {
+// CHECK:STDOUT: generic fn @F(%T.loc18_7.2: %I_where.type.4b7) {
 // CHECK:STDOUT:   %T.patt.loc18_7.2: %pattern_type.021 = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc18_7.2 (constants.%T.patt.e6f)]
-// CHECK:STDOUT:   %T.loc18_7.1: %I_where.type = symbolic_binding T, 0 [symbolic = %T.loc18_7.1 (constants.%T.8c8)]
+// CHECK:STDOUT:   %T.loc18_7.1: %I_where.type.4b7 = symbolic_binding T, 0 [symbolic = %T.loc18_7.1 (constants.%T.8c8)]
 // CHECK:STDOUT:   %T.as_type.loc18_39.1: type = facet_access_type %T.loc18_7.1 [symbolic = %T.as_type.loc18_39.1 (constants.%T.as_type)]
 // CHECK:STDOUT:   %facet_value.loc18_39.1: %type = facet_value %T.as_type.loc18_39.1, () [symbolic = %facet_value.loc18_39.1 (constants.%facet_value)]
+// CHECK:STDOUT:   %I.type.loc18_39.1: type = facet_type <@I, @I(%T.as_type.loc18_39.1)> [symbolic = %I.type.loc18_39.1 (constants.%I.type.a52)]
+// CHECK:STDOUT:   %I_where.type.loc18_39.1: type = facet_type <@I, @I(%T.as_type.loc18_39.1) where constants.%impl.elem0 = constants.%empty_tuple.type> [symbolic = %I_where.type.loc18_39.1 (constants.%I_where.type.e53)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:
@@ -124,5 +130,7 @@ fn G(_:! I(.Self) where .I1 = ()) {}
 // CHECK:STDOUT:   %T.loc18_7.1 => constants.%T.8c8
 // CHECK:STDOUT:   %T.as_type.loc18_39.1 => constants.%T.as_type
 // CHECK:STDOUT:   %facet_value.loc18_39.1 => constants.%facet_value
+// CHECK:STDOUT:   %I.type.loc18_39.1 => constants.%I.type.a52
+// CHECK:STDOUT:   %I_where.type.loc18_39.1 => constants.%I_where.type.e53
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/impl/assoc_const_self.carbon
+++ b/toolchain/check/testdata/impl/assoc_const_self.carbon
@@ -754,14 +754,15 @@ fn CallF() {
 // CHECK:STDOUT:   %ImplicitAs.type.313: type = facet_type <@ImplicitAs, @ImplicitAs(%.Self.as_type)> [symbolic_self]
 // CHECK:STDOUT:   %I.lookup_impl_witness.a48: <witness> = lookup_impl_witness %.Self.9e9, @I [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0: %.Self.as_type = impl_witness_access %I.lookup_impl_witness.a48, element0 [symbolic_self]
-// CHECK:STDOUT:   %I_where.type: type = facet_type <@I where %empty_struct_type impls @ImplicitAs, @ImplicitAs(%.Self.as_type) and %impl.elem0 = %empty_struct> [concrete]
-// CHECK:STDOUT:   %pattern_type.be2: type = pattern_type %I_where.type [concrete]
+// CHECK:STDOUT:   %I_where.type.366d4a.1: type = facet_type <@I where %empty_struct_type impls @ImplicitAs, @ImplicitAs(%.Self.as_type) and %impl.elem0 = %empty_struct> [concrete]
+// CHECK:STDOUT:   %pattern_type.be2: type = pattern_type %I_where.type.366d4a.1 [concrete]
 // CHECK:STDOUT:   %T.patt: %pattern_type.be2 = symbolic_binding_pattern T, 0 [symbolic]
-// CHECK:STDOUT:   %T: %I_where.type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %T: %I_where.type.366d4a.1 = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %CallF.type: type = fn_type @CallF [concrete]
 // CHECK:STDOUT:   %CallF: %CallF.type = struct_value () [concrete]
+// CHECK:STDOUT:   %I_where.type.366d4a.2: type = facet_type <@I where %empty_struct_type impls @ImplicitAs, @ImplicitAs(%empty_struct_type) and %impl.elem0 = %empty_struct> [concrete]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: imports {
@@ -785,7 +786,7 @@ fn CallF() {
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
 // CHECK:STDOUT:     %T.patt.loc8_7.1: %pattern_type.be2 = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_7.2 (constants.%T.patt)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc8_12.1: type = splice_block %.loc8_12.2 [concrete = constants.%I_where.type] {
+// CHECK:STDOUT:     %.loc8_12.1: type = splice_block %.loc8_12.2 [concrete = constants.%I_where.type.366d4a.1] {
 // CHECK:STDOUT:       %.Self.loc8_7: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.c39]
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:       %.Self.loc8_12: %I.type = symbolic_binding .Self [symbolic_self = constants.%.Self.9e9]
@@ -805,13 +806,13 @@ fn CallF() {
 // CHECK:STDOUT:       %.loc8_60.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
 // CHECK:STDOUT:       %empty_struct: %empty_struct_type = struct_value () [concrete = constants.%empty_struct]
 // CHECK:STDOUT:       %.loc8_60.2: %empty_struct_type = converted %.loc8_60.1, %empty_struct [concrete = constants.%empty_struct]
-// CHECK:STDOUT:       %.loc8_12.2: type = where_expr [concrete = constants.%I_where.type] {
+// CHECK:STDOUT:       %.loc8_12.2: type = where_expr [concrete = constants.%I_where.type.366d4a.1] {
 // CHECK:STDOUT:         requirement_base_facet_type %I.ref
 // CHECK:STDOUT:         requirement_impls %.loc8_19.2, %ImplicitAs.type
 // CHECK:STDOUT:         requirement_rewrite %impl.elem0, %.loc8_60.2
 // CHECK:STDOUT:       }
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc8_7.2: %I_where.type = symbolic_binding T, 0 [symbolic = %T.loc8_7.1 (constants.%T)]
+// CHECK:STDOUT:     %T.loc8_7.2: %I_where.type.366d4a.1 = symbolic_binding T, 0 [symbolic = %T.loc8_7.1 (constants.%T)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %CallF.decl: %CallF.type = fn_decl @CallF [concrete = constants.%CallF] {} {}
 // CHECK:STDOUT: }
@@ -833,9 +834,9 @@ fn CallF() {
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%T.loc8_7.2: %I_where.type) {
+// CHECK:STDOUT: generic fn @F(%T.loc8_7.2: %I_where.type.366d4a.1) {
 // CHECK:STDOUT:   %T.patt.loc8_7.2: %pattern_type.be2 = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc8_7.2 (constants.%T.patt)]
-// CHECK:STDOUT:   %T.loc8_7.1: %I_where.type = symbolic_binding T, 0 [symbolic = %T.loc8_7.1 (constants.%T)]
+// CHECK:STDOUT:   %T.loc8_7.1: %I_where.type.366d4a.1 = symbolic_binding T, 0 [symbolic = %T.loc8_7.1 (constants.%T)]
 // CHECK:STDOUT:
 // CHECK:STDOUT:   fn();
 // CHECK:STDOUT: }
@@ -844,6 +845,7 @@ fn CallF() {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
 // CHECK:STDOUT:   %.loc19: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:   %I_where.type: type = facet_type <@I where constants.%empty_struct_type impls @ImplicitAs, @ImplicitAs(constants.%empty_struct_type) and constants.%impl.elem0 = constants.%empty_struct> [concrete = constants.%I_where.type.366d4a.2]
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/range_for.carbon
+++ b/toolchain/check/testdata/interop/cpp/range_for.carbon
@@ -772,8 +772,8 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %CppUnsafeDeref.lookup_impl_witness.712: <witness> = lookup_impl_witness %impl.elem0.109, @CppUnsafeDeref [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0.56a: type = impl_witness_access %CppUnsafeDeref.lookup_impl_witness.712, element0 [symbolic_self]
 // CHECK:STDOUT:   %impl.elem1.222: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.143, element1 [symbolic_self]
-// CHECK:STDOUT:   %CppRangeForIterate_where.type: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
-// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type = symbolic_binding R, 0 [symbolic]
+// CHECK:STDOUT:   %CppRangeForIterate_where.type.1c721f.1: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
+// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type.1c721f.1 = symbolic_binding R, 0 [symbolic]
 // CHECK:STDOUT:   %CppRangeForIterate.lookup_impl_witness.7e2712.2: <witness> = lookup_impl_witness %R.39b, @CppRangeForIterate [symbolic]
 // CHECK:STDOUT:   %impl.elem1.7a0bff.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element1 [symbolic]
 // CHECK:STDOUT:   %impl.elem0.73eb7f.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element0 [symbolic]
@@ -877,7 +877,7 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %Iterator.Op.type.0aed5d.4: type = fn_type @Iterator.Op.4 [concrete]
 // CHECK:STDOUT:   %Iterator.Op.a2a866.4: %Iterator.Op.type.0aed5d.4 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.444: <witness> = custom_witness (%Iterator.Op.a2a866.4), @Inc [concrete]
-// CHECK:STDOUT:   %facet_value.cd6: %CppRangeForIterate_where.type = facet_value %MutableRange, (%custom_witness.df9cc1.2, %Copy.impl_witness.0e0, %custom_witness.ed3, %custom_witness.955, %custom_witness.1f5, %custom_witness.ef8, %custom_witness.981, %custom_witness.444) [concrete]
+// CHECK:STDOUT:   %facet_value.cd6: %CppRangeForIterate_where.type.1c721f.1 = facet_value %MutableRange, (%custom_witness.df9cc1.2, %Copy.impl_witness.0e0, %custom_witness.ed3, %custom_witness.955, %custom_witness.1f5, %custom_witness.ef8, %custom_witness.981, %custom_witness.444) [concrete]
 // CHECK:STDOUT:   %tuple.type.508: type = tuple_type (%Iterator.3ee, %Iterator.3ee) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.1d8f74.10: type = fn_type @Destroy.Op.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.10: %Destroy.Op.type.1d8f74.10 = struct_value () [concrete]
@@ -915,7 +915,7 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %Iterator.Op.type.0f34b8.4: type = fn_type @Iterator.Op.8 [concrete]
 // CHECK:STDOUT:   %Iterator.Op.1c3e4a.4: %Iterator.Op.type.0f34b8.4 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.746: <witness> = custom_witness (%Iterator.Op.1c3e4a.4), @Inc [concrete]
-// CHECK:STDOUT:   %facet_value.e88: %CppRangeForIterate_where.type = facet_value %ConstRange, (%custom_witness.df9cc1.2, %Copy.impl_witness.0e0, %custom_witness.23e, %custom_witness.6e8, %custom_witness.150, %custom_witness.adb, %custom_witness.941, %custom_witness.746) [concrete]
+// CHECK:STDOUT:   %facet_value.e88: %CppRangeForIterate_where.type.1c721f.1 = facet_value %ConstRange, (%custom_witness.df9cc1.2, %Copy.impl_witness.0e0, %custom_witness.23e, %custom_witness.6e8, %custom_witness.150, %custom_witness.adb, %custom_witness.941, %custom_witness.746) [concrete]
 // CHECK:STDOUT:   %tuple.type.69f: type = tuple_type (%Iterator.260, %Iterator.260) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.1d8f74.11: type = fn_type @Destroy.Op.3 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.11: %Destroy.Op.type.1d8f74.11 = struct_value () [concrete]
@@ -1124,10 +1124,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %m.ref: ref %MutableRange = name_ref m, %m
 // CHECK:STDOUT:   %impl.elem2.loc49: %.d6a = impl_witness_access constants.%Iterate.impl_witness.cea, element2 [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.8d2]
 // CHECK:STDOUT:   %bound_method.loc49_19.1: <bound method> = bound_method %m.ref, %impl.elem2.loc49
-// CHECK:STDOUT:   %facet_value.loc49_19.1: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.ed3, constants.%custom_witness.955, constants.%custom_witness.1f5, constants.%custom_witness.ef8, constants.%custom_witness.981, constants.%custom_witness.444) [concrete = constants.%facet_value.cd6]
-// CHECK:STDOUT:   %.loc49_19.1: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc49_19.1 [concrete = constants.%facet_value.cd6]
-// CHECK:STDOUT:   %facet_value.loc49_19.2: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.ed3, constants.%custom_witness.955, constants.%custom_witness.1f5, constants.%custom_witness.ef8, constants.%custom_witness.981, constants.%custom_witness.444) [concrete = constants.%facet_value.cd6]
-// CHECK:STDOUT:   %.loc49_19.2: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc49_19.2 [concrete = constants.%facet_value.cd6]
+// CHECK:STDOUT:   %facet_value.loc49_19.1: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.ed3, constants.%custom_witness.955, constants.%custom_witness.1f5, constants.%custom_witness.ef8, constants.%custom_witness.981, constants.%custom_witness.444) [concrete = constants.%facet_value.cd6]
+// CHECK:STDOUT:   %.loc49_19.1: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc49_19.1 [concrete = constants.%facet_value.cd6]
+// CHECK:STDOUT:   %facet_value.loc49_19.2: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.ed3, constants.%custom_witness.955, constants.%custom_witness.1f5, constants.%custom_witness.ef8, constants.%custom_witness.981, constants.%custom_witness.444) [concrete = constants.%facet_value.cd6]
+// CHECK:STDOUT:   %.loc49_19.2: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc49_19.2 [concrete = constants.%facet_value.cd6]
 // CHECK:STDOUT:   %specific_fn.loc49_19.1: <specific function> = specific_function %impl.elem2.loc49, @R.as_type.as.Iterate.impl.NewCursor(constants.%facet_value.cd6) [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.specific_fn.bf1]
 // CHECK:STDOUT:   %bound_method.loc49_19.2: <bound method> = bound_method %m.ref, %specific_fn.loc49_19.1
 // CHECK:STDOUT:   %var.loc49: ref %tuple.type.508 = var_storage invalid
@@ -1140,10 +1140,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %addr.loc49: %ptr.45c = addr_of %var.loc49
 // CHECK:STDOUT:   %impl.elem3.loc49: %.d23 = impl_witness_access constants.%Iterate.impl_witness.cea, element3 [concrete = constants.%R.as_type.as.Iterate.impl.Next.34d]
 // CHECK:STDOUT:   %bound_method.loc49_19.3: <bound method> = bound_method %m.ref, %impl.elem3.loc49
-// CHECK:STDOUT:   %facet_value.loc49_19.3: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.ed3, constants.%custom_witness.955, constants.%custom_witness.1f5, constants.%custom_witness.ef8, constants.%custom_witness.981, constants.%custom_witness.444) [concrete = constants.%facet_value.cd6]
-// CHECK:STDOUT:   %.loc49_19.3: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc49_19.3 [concrete = constants.%facet_value.cd6]
-// CHECK:STDOUT:   %facet_value.loc49_19.4: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.ed3, constants.%custom_witness.955, constants.%custom_witness.1f5, constants.%custom_witness.ef8, constants.%custom_witness.981, constants.%custom_witness.444) [concrete = constants.%facet_value.cd6]
-// CHECK:STDOUT:   %.loc49_19.4: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc49_19.4 [concrete = constants.%facet_value.cd6]
+// CHECK:STDOUT:   %facet_value.loc49_19.3: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.ed3, constants.%custom_witness.955, constants.%custom_witness.1f5, constants.%custom_witness.ef8, constants.%custom_witness.981, constants.%custom_witness.444) [concrete = constants.%facet_value.cd6]
+// CHECK:STDOUT:   %.loc49_19.3: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc49_19.3 [concrete = constants.%facet_value.cd6]
+// CHECK:STDOUT:   %facet_value.loc49_19.4: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.ed3, constants.%custom_witness.955, constants.%custom_witness.1f5, constants.%custom_witness.ef8, constants.%custom_witness.981, constants.%custom_witness.444) [concrete = constants.%facet_value.cd6]
+// CHECK:STDOUT:   %.loc49_19.4: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc49_19.4 [concrete = constants.%facet_value.cd6]
 // CHECK:STDOUT:   %specific_fn.loc49_19.2: <specific function> = specific_function %impl.elem3.loc49, @R.as_type.as.Iterate.impl.Next(constants.%facet_value.cd6) [concrete = constants.%R.as_type.as.Iterate.impl.Next.specific_fn.dd5]
 // CHECK:STDOUT:   %bound_method.loc49_19.4: <bound method> = bound_method %m.ref, %specific_fn.loc49_19.2
 // CHECK:STDOUT:   %.loc49_19.5: ref %Optional.e28 = temporary_storage
@@ -1194,10 +1194,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %c.ref: %ConstRange = name_ref c, %c
 // CHECK:STDOUT:   %impl.elem2.loc55: %.744 = impl_witness_access constants.%Iterate.impl_witness.12a, element2 [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.2f6]
 // CHECK:STDOUT:   %bound_method.loc55_19.1: <bound method> = bound_method %c.ref, %impl.elem2.loc55
-// CHECK:STDOUT:   %facet_value.loc55_19.1: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.23e, constants.%custom_witness.6e8, constants.%custom_witness.150, constants.%custom_witness.adb, constants.%custom_witness.941, constants.%custom_witness.746) [concrete = constants.%facet_value.e88]
-// CHECK:STDOUT:   %.loc55_19.1: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc55_19.1 [concrete = constants.%facet_value.e88]
-// CHECK:STDOUT:   %facet_value.loc55_19.2: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.23e, constants.%custom_witness.6e8, constants.%custom_witness.150, constants.%custom_witness.adb, constants.%custom_witness.941, constants.%custom_witness.746) [concrete = constants.%facet_value.e88]
-// CHECK:STDOUT:   %.loc55_19.2: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc55_19.2 [concrete = constants.%facet_value.e88]
+// CHECK:STDOUT:   %facet_value.loc55_19.1: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.23e, constants.%custom_witness.6e8, constants.%custom_witness.150, constants.%custom_witness.adb, constants.%custom_witness.941, constants.%custom_witness.746) [concrete = constants.%facet_value.e88]
+// CHECK:STDOUT:   %.loc55_19.1: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc55_19.1 [concrete = constants.%facet_value.e88]
+// CHECK:STDOUT:   %facet_value.loc55_19.2: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.23e, constants.%custom_witness.6e8, constants.%custom_witness.150, constants.%custom_witness.adb, constants.%custom_witness.941, constants.%custom_witness.746) [concrete = constants.%facet_value.e88]
+// CHECK:STDOUT:   %.loc55_19.2: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc55_19.2 [concrete = constants.%facet_value.e88]
 // CHECK:STDOUT:   %specific_fn.loc55_19.1: <specific function> = specific_function %impl.elem2.loc55, @R.as_type.as.Iterate.impl.NewCursor(constants.%facet_value.e88) [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.specific_fn.a05]
 // CHECK:STDOUT:   %bound_method.loc55_19.2: <bound method> = bound_method %c.ref, %specific_fn.loc55_19.1
 // CHECK:STDOUT:   %var.loc55: ref %tuple.type.69f = var_storage invalid
@@ -1209,10 +1209,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %addr.loc55: %ptr.c5c = addr_of %var.loc55
 // CHECK:STDOUT:   %impl.elem3.loc55: %.03b = impl_witness_access constants.%Iterate.impl_witness.12a, element3 [concrete = constants.%R.as_type.as.Iterate.impl.Next.393]
 // CHECK:STDOUT:   %bound_method.loc55_19.3: <bound method> = bound_method %c.ref, %impl.elem3.loc55
-// CHECK:STDOUT:   %facet_value.loc55_19.3: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.23e, constants.%custom_witness.6e8, constants.%custom_witness.150, constants.%custom_witness.adb, constants.%custom_witness.941, constants.%custom_witness.746) [concrete = constants.%facet_value.e88]
-// CHECK:STDOUT:   %.loc55_19.3: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc55_19.3 [concrete = constants.%facet_value.e88]
-// CHECK:STDOUT:   %facet_value.loc55_19.4: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.23e, constants.%custom_witness.6e8, constants.%custom_witness.150, constants.%custom_witness.adb, constants.%custom_witness.941, constants.%custom_witness.746) [concrete = constants.%facet_value.e88]
-// CHECK:STDOUT:   %.loc55_19.4: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc55_19.4 [concrete = constants.%facet_value.e88]
+// CHECK:STDOUT:   %facet_value.loc55_19.3: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.23e, constants.%custom_witness.6e8, constants.%custom_witness.150, constants.%custom_witness.adb, constants.%custom_witness.941, constants.%custom_witness.746) [concrete = constants.%facet_value.e88]
+// CHECK:STDOUT:   %.loc55_19.3: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc55_19.3 [concrete = constants.%facet_value.e88]
+// CHECK:STDOUT:   %facet_value.loc55_19.4: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.0e0, constants.%custom_witness.23e, constants.%custom_witness.6e8, constants.%custom_witness.150, constants.%custom_witness.adb, constants.%custom_witness.941, constants.%custom_witness.746) [concrete = constants.%facet_value.e88]
+// CHECK:STDOUT:   %.loc55_19.4: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc55_19.4 [concrete = constants.%facet_value.e88]
 // CHECK:STDOUT:   %specific_fn.loc55_19.2: <specific function> = specific_function %impl.elem3.loc55, @R.as_type.as.Iterate.impl.Next(constants.%facet_value.e88) [concrete = constants.%R.as_type.as.Iterate.impl.Next.specific_fn.4cc]
 // CHECK:STDOUT:   %bound_method.loc55_19.4: <bound method> = bound_method %c.ref, %specific_fn.loc55_19.2
 // CHECK:STDOUT:   %.loc55_19.5: ref %Optional.e28 = temporary_storage
@@ -1396,8 +1396,8 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %CppUnsafeDeref.lookup_impl_witness.712: <witness> = lookup_impl_witness %impl.elem0.109, @CppUnsafeDeref [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0.56a: type = impl_witness_access %CppUnsafeDeref.lookup_impl_witness.712, element0 [symbolic_self]
 // CHECK:STDOUT:   %impl.elem1.222: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.143, element1 [symbolic_self]
-// CHECK:STDOUT:   %CppRangeForIterate_where.type: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
-// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type = symbolic_binding R, 0 [symbolic]
+// CHECK:STDOUT:   %CppRangeForIterate_where.type.1c721f.1: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
+// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type.1c721f.1 = symbolic_binding R, 0 [symbolic]
 // CHECK:STDOUT:   %CppRangeForIterate.lookup_impl_witness.7e2712.2: <witness> = lookup_impl_witness %R.39b, @CppRangeForIterate [symbolic]
 // CHECK:STDOUT:   %impl.elem1.7a0bff.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element1 [symbolic]
 // CHECK:STDOUT:   %impl.elem0.73eb7f.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element0 [symbolic]
@@ -1483,7 +1483,7 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %Sentinel.Op.type.0aed5d.2: type = fn_type @Sentinel.Op.2 [concrete]
 // CHECK:STDOUT:   %Sentinel.Op.a2a866.2: %Sentinel.Op.type.0aed5d.2 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.1f52e9.2: <witness> = custom_witness (%Sentinel.Op.a2a866.2), @Copy [concrete]
-// CHECK:STDOUT:   %facet_value.55a: %CppRangeForIterate_where.type = facet_value %MutableRange, (%custom_witness.e7a31c.1, %custom_witness.d0da43.1, %custom_witness.6b6, %custom_witness.95581e.1, %custom_witness.1f52e9.1, %custom_witness.90a, %custom_witness.3e8, %custom_witness.444, %custom_witness.95581e.2, %custom_witness.1f52e9.2) [concrete]
+// CHECK:STDOUT:   %facet_value.55a: %CppRangeForIterate_where.type.1c721f.1 = facet_value %MutableRange, (%custom_witness.e7a31c.1, %custom_witness.d0da43.1, %custom_witness.6b6, %custom_witness.95581e.1, %custom_witness.1f52e9.1, %custom_witness.90a, %custom_witness.3e8, %custom_witness.444, %custom_witness.95581e.2, %custom_witness.1f52e9.2) [concrete]
 // CHECK:STDOUT:   %tuple.type.829: type = tuple_type (%Iterator.3ee, %Sentinel.9b2) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.1d8f74.8: type = fn_type @Destroy.Op.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.8: %Destroy.Op.type.1d8f74.8 = struct_value () [concrete]
@@ -1528,7 +1528,7 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %Sentinel.Op.type.0f34b8.2: type = fn_type @Sentinel.Op.4 [concrete]
 // CHECK:STDOUT:   %Sentinel.Op.1c3e4a.2: %Sentinel.Op.type.0f34b8.2 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.15091a.2: <witness> = custom_witness (%Sentinel.Op.1c3e4a.2), @Copy [concrete]
-// CHECK:STDOUT:   %facet_value.445: %CppRangeForIterate_where.type = facet_value %ConstRange, (%custom_witness.e7a31c.1, %custom_witness.d0da43.1, %custom_witness.a03, %custom_witness.6e8a2e.1, %custom_witness.15091a.1, %custom_witness.78b, %custom_witness.c55, %custom_witness.746, %custom_witness.6e8a2e.2, %custom_witness.15091a.2) [concrete]
+// CHECK:STDOUT:   %facet_value.445: %CppRangeForIterate_where.type.1c721f.1 = facet_value %ConstRange, (%custom_witness.e7a31c.1, %custom_witness.d0da43.1, %custom_witness.a03, %custom_witness.6e8a2e.1, %custom_witness.15091a.1, %custom_witness.78b, %custom_witness.c55, %custom_witness.746, %custom_witness.6e8a2e.2, %custom_witness.15091a.2) [concrete]
 // CHECK:STDOUT:   %tuple.type.99f: type = tuple_type (%Iterator.260, %Sentinel.4c4) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.1d8f74.9: type = fn_type @Destroy.Op.3 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.9: %Destroy.Op.type.1d8f74.9 = struct_value () [concrete]
@@ -1751,10 +1751,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %m.ref: ref %MutableRange = name_ref m, %m
 // CHECK:STDOUT:   %impl.elem2.loc59: %.47d = impl_witness_access constants.%Iterate.impl_witness.096, element2 [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.498]
 // CHECK:STDOUT:   %bound_method.loc59_29.1: <bound method> = bound_method %m.ref, %impl.elem2.loc59
-// CHECK:STDOUT:   %facet_value.loc59_29.1: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.6b6, constants.%custom_witness.95581e.1, constants.%custom_witness.1f52e9.1, constants.%custom_witness.90a, constants.%custom_witness.3e8, constants.%custom_witness.444, constants.%custom_witness.95581e.2, constants.%custom_witness.1f52e9.2) [concrete = constants.%facet_value.55a]
-// CHECK:STDOUT:   %.loc59_29.1: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc59_29.1 [concrete = constants.%facet_value.55a]
-// CHECK:STDOUT:   %facet_value.loc59_29.2: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.6b6, constants.%custom_witness.95581e.1, constants.%custom_witness.1f52e9.1, constants.%custom_witness.90a, constants.%custom_witness.3e8, constants.%custom_witness.444, constants.%custom_witness.95581e.2, constants.%custom_witness.1f52e9.2) [concrete = constants.%facet_value.55a]
-// CHECK:STDOUT:   %.loc59_29.2: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc59_29.2 [concrete = constants.%facet_value.55a]
+// CHECK:STDOUT:   %facet_value.loc59_29.1: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.6b6, constants.%custom_witness.95581e.1, constants.%custom_witness.1f52e9.1, constants.%custom_witness.90a, constants.%custom_witness.3e8, constants.%custom_witness.444, constants.%custom_witness.95581e.2, constants.%custom_witness.1f52e9.2) [concrete = constants.%facet_value.55a]
+// CHECK:STDOUT:   %.loc59_29.1: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc59_29.1 [concrete = constants.%facet_value.55a]
+// CHECK:STDOUT:   %facet_value.loc59_29.2: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.6b6, constants.%custom_witness.95581e.1, constants.%custom_witness.1f52e9.1, constants.%custom_witness.90a, constants.%custom_witness.3e8, constants.%custom_witness.444, constants.%custom_witness.95581e.2, constants.%custom_witness.1f52e9.2) [concrete = constants.%facet_value.55a]
+// CHECK:STDOUT:   %.loc59_29.2: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc59_29.2 [concrete = constants.%facet_value.55a]
 // CHECK:STDOUT:   %specific_fn.loc59_29.1: <specific function> = specific_function %impl.elem2.loc59, @R.as_type.as.Iterate.impl.NewCursor(constants.%facet_value.55a) [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.specific_fn.532]
 // CHECK:STDOUT:   %bound_method.loc59_29.2: <bound method> = bound_method %m.ref, %specific_fn.loc59_29.1
 // CHECK:STDOUT:   %var.loc59: ref %tuple.type.829 = var_storage invalid
@@ -1767,10 +1767,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %addr.loc59: %ptr.d6b = addr_of %var.loc59
 // CHECK:STDOUT:   %impl.elem3.loc59: %.fd2 = impl_witness_access constants.%Iterate.impl_witness.096, element3 [concrete = constants.%R.as_type.as.Iterate.impl.Next.055]
 // CHECK:STDOUT:   %bound_method.loc59_29.3: <bound method> = bound_method %m.ref, %impl.elem3.loc59
-// CHECK:STDOUT:   %facet_value.loc59_29.3: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.6b6, constants.%custom_witness.95581e.1, constants.%custom_witness.1f52e9.1, constants.%custom_witness.90a, constants.%custom_witness.3e8, constants.%custom_witness.444, constants.%custom_witness.95581e.2, constants.%custom_witness.1f52e9.2) [concrete = constants.%facet_value.55a]
-// CHECK:STDOUT:   %.loc59_29.3: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc59_29.3 [concrete = constants.%facet_value.55a]
-// CHECK:STDOUT:   %facet_value.loc59_29.4: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.6b6, constants.%custom_witness.95581e.1, constants.%custom_witness.1f52e9.1, constants.%custom_witness.90a, constants.%custom_witness.3e8, constants.%custom_witness.444, constants.%custom_witness.95581e.2, constants.%custom_witness.1f52e9.2) [concrete = constants.%facet_value.55a]
-// CHECK:STDOUT:   %.loc59_29.4: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc59_29.4 [concrete = constants.%facet_value.55a]
+// CHECK:STDOUT:   %facet_value.loc59_29.3: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.6b6, constants.%custom_witness.95581e.1, constants.%custom_witness.1f52e9.1, constants.%custom_witness.90a, constants.%custom_witness.3e8, constants.%custom_witness.444, constants.%custom_witness.95581e.2, constants.%custom_witness.1f52e9.2) [concrete = constants.%facet_value.55a]
+// CHECK:STDOUT:   %.loc59_29.3: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc59_29.3 [concrete = constants.%facet_value.55a]
+// CHECK:STDOUT:   %facet_value.loc59_29.4: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.6b6, constants.%custom_witness.95581e.1, constants.%custom_witness.1f52e9.1, constants.%custom_witness.90a, constants.%custom_witness.3e8, constants.%custom_witness.444, constants.%custom_witness.95581e.2, constants.%custom_witness.1f52e9.2) [concrete = constants.%facet_value.55a]
+// CHECK:STDOUT:   %.loc59_29.4: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc59_29.4 [concrete = constants.%facet_value.55a]
 // CHECK:STDOUT:   %specific_fn.loc59_29.2: <specific function> = specific_function %impl.elem3.loc59, @R.as_type.as.Iterate.impl.Next(constants.%facet_value.55a) [concrete = constants.%R.as_type.as.Iterate.impl.Next.specific_fn.5cb]
 // CHECK:STDOUT:   %bound_method.loc59_29.4: <bound method> = bound_method %m.ref, %specific_fn.loc59_29.2
 // CHECK:STDOUT:   %.loc59_29.5: ref %Optional.95f = temporary_storage
@@ -1820,10 +1820,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %c.ref: %ConstRange = name_ref c, %c
 // CHECK:STDOUT:   %impl.elem2.loc63: %.763 = impl_witness_access constants.%Iterate.impl_witness.40c, element2 [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.bd2]
 // CHECK:STDOUT:   %bound_method.loc63_29.1: <bound method> = bound_method %c.ref, %impl.elem2.loc63
-// CHECK:STDOUT:   %facet_value.loc63_29.1: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.a03, constants.%custom_witness.6e8a2e.1, constants.%custom_witness.15091a.1, constants.%custom_witness.78b, constants.%custom_witness.c55, constants.%custom_witness.746, constants.%custom_witness.6e8a2e.2, constants.%custom_witness.15091a.2) [concrete = constants.%facet_value.445]
-// CHECK:STDOUT:   %.loc63_29.1: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc63_29.1 [concrete = constants.%facet_value.445]
-// CHECK:STDOUT:   %facet_value.loc63_29.2: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.a03, constants.%custom_witness.6e8a2e.1, constants.%custom_witness.15091a.1, constants.%custom_witness.78b, constants.%custom_witness.c55, constants.%custom_witness.746, constants.%custom_witness.6e8a2e.2, constants.%custom_witness.15091a.2) [concrete = constants.%facet_value.445]
-// CHECK:STDOUT:   %.loc63_29.2: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc63_29.2 [concrete = constants.%facet_value.445]
+// CHECK:STDOUT:   %facet_value.loc63_29.1: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.a03, constants.%custom_witness.6e8a2e.1, constants.%custom_witness.15091a.1, constants.%custom_witness.78b, constants.%custom_witness.c55, constants.%custom_witness.746, constants.%custom_witness.6e8a2e.2, constants.%custom_witness.15091a.2) [concrete = constants.%facet_value.445]
+// CHECK:STDOUT:   %.loc63_29.1: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc63_29.1 [concrete = constants.%facet_value.445]
+// CHECK:STDOUT:   %facet_value.loc63_29.2: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.a03, constants.%custom_witness.6e8a2e.1, constants.%custom_witness.15091a.1, constants.%custom_witness.78b, constants.%custom_witness.c55, constants.%custom_witness.746, constants.%custom_witness.6e8a2e.2, constants.%custom_witness.15091a.2) [concrete = constants.%facet_value.445]
+// CHECK:STDOUT:   %.loc63_29.2: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc63_29.2 [concrete = constants.%facet_value.445]
 // CHECK:STDOUT:   %specific_fn.loc63_29.1: <specific function> = specific_function %impl.elem2.loc63, @R.as_type.as.Iterate.impl.NewCursor(constants.%facet_value.445) [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.specific_fn.7c7]
 // CHECK:STDOUT:   %bound_method.loc63_29.2: <bound method> = bound_method %c.ref, %specific_fn.loc63_29.1
 // CHECK:STDOUT:   %var.loc63: ref %tuple.type.99f = var_storage invalid
@@ -1835,10 +1835,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %addr.loc63: %ptr.2f7 = addr_of %var.loc63
 // CHECK:STDOUT:   %impl.elem3.loc63: %.bca = impl_witness_access constants.%Iterate.impl_witness.40c, element3 [concrete = constants.%R.as_type.as.Iterate.impl.Next.c50]
 // CHECK:STDOUT:   %bound_method.loc63_29.3: <bound method> = bound_method %c.ref, %impl.elem3.loc63
-// CHECK:STDOUT:   %facet_value.loc63_29.3: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.a03, constants.%custom_witness.6e8a2e.1, constants.%custom_witness.15091a.1, constants.%custom_witness.78b, constants.%custom_witness.c55, constants.%custom_witness.746, constants.%custom_witness.6e8a2e.2, constants.%custom_witness.15091a.2) [concrete = constants.%facet_value.445]
-// CHECK:STDOUT:   %.loc63_29.3: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc63_29.3 [concrete = constants.%facet_value.445]
-// CHECK:STDOUT:   %facet_value.loc63_29.4: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.a03, constants.%custom_witness.6e8a2e.1, constants.%custom_witness.15091a.1, constants.%custom_witness.78b, constants.%custom_witness.c55, constants.%custom_witness.746, constants.%custom_witness.6e8a2e.2, constants.%custom_witness.15091a.2) [concrete = constants.%facet_value.445]
-// CHECK:STDOUT:   %.loc63_29.4: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc63_29.4 [concrete = constants.%facet_value.445]
+// CHECK:STDOUT:   %facet_value.loc63_29.3: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.a03, constants.%custom_witness.6e8a2e.1, constants.%custom_witness.15091a.1, constants.%custom_witness.78b, constants.%custom_witness.c55, constants.%custom_witness.746, constants.%custom_witness.6e8a2e.2, constants.%custom_witness.15091a.2) [concrete = constants.%facet_value.445]
+// CHECK:STDOUT:   %.loc63_29.3: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc63_29.3 [concrete = constants.%facet_value.445]
+// CHECK:STDOUT:   %facet_value.loc63_29.4: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.e7a31c.1, constants.%custom_witness.d0da43.1, constants.%custom_witness.a03, constants.%custom_witness.6e8a2e.1, constants.%custom_witness.15091a.1, constants.%custom_witness.78b, constants.%custom_witness.c55, constants.%custom_witness.746, constants.%custom_witness.6e8a2e.2, constants.%custom_witness.15091a.2) [concrete = constants.%facet_value.445]
+// CHECK:STDOUT:   %.loc63_29.4: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc63_29.4 [concrete = constants.%facet_value.445]
 // CHECK:STDOUT:   %specific_fn.loc63_29.2: <specific function> = specific_function %impl.elem3.loc63, @R.as_type.as.Iterate.impl.Next(constants.%facet_value.445) [concrete = constants.%R.as_type.as.Iterate.impl.Next.specific_fn.a9a]
 // CHECK:STDOUT:   %bound_method.loc63_29.4: <bound method> = bound_method %c.ref, %specific_fn.loc63_29.2
 // CHECK:STDOUT:   %.loc63_29.5: ref %Optional.95f = temporary_storage
@@ -2024,8 +2024,8 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %CppUnsafeDeref.lookup_impl_witness.712: <witness> = lookup_impl_witness %impl.elem0.109, @CppUnsafeDeref [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0.56a: type = impl_witness_access %CppUnsafeDeref.lookup_impl_witness.712, element0 [symbolic_self]
 // CHECK:STDOUT:   %impl.elem1.222: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.143, element1 [symbolic_self]
-// CHECK:STDOUT:   %CppRangeForIterate_where.type: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
-// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type = symbolic_binding R, 0 [symbolic]
+// CHECK:STDOUT:   %CppRangeForIterate_where.type.1c721f.1: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
+// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type.1c721f.1 = symbolic_binding R, 0 [symbolic]
 // CHECK:STDOUT:   %CppRangeForIterate.lookup_impl_witness.7e2712.2: <witness> = lookup_impl_witness %R.39b, @CppRangeForIterate [symbolic]
 // CHECK:STDOUT:   %impl.elem1.7a0bff.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element1 [symbolic]
 // CHECK:STDOUT:   %impl.elem0.73eb7f.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element0 [symbolic]
@@ -2112,7 +2112,7 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %Iterator.Op.type.ac7e09.4: type = fn_type @Iterator.Op.4 [concrete]
 // CHECK:STDOUT:   %Iterator.Op.583fda.4: %Iterator.Op.type.ac7e09.4 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.393: <witness> = custom_witness (%Iterator.Op.583fda.4), @Inc [concrete]
-// CHECK:STDOUT:   %facet_value.c05: %CppRangeForIterate_where.type = facet_value %ConstRange, (%custom_witness.df9cc1.2, %Copy.impl_witness.873, %custom_witness.5d5, %custom_witness.213, %custom_witness.a31, %custom_witness.994, %custom_witness.821, %custom_witness.393) [concrete]
+// CHECK:STDOUT:   %facet_value.c05: %CppRangeForIterate_where.type.1c721f.1 = facet_value %ConstRange, (%custom_witness.df9cc1.2, %Copy.impl_witness.873, %custom_witness.5d5, %custom_witness.213, %custom_witness.a31, %custom_witness.994, %custom_witness.821, %custom_witness.393) [concrete]
 // CHECK:STDOUT:   %tuple.type.005: type = tuple_type (%Iterator, %Iterator) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.1d8f74.10: type = fn_type @Destroy.Op.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.10: %Destroy.Op.type.1d8f74.10 = struct_value () [concrete]
@@ -2300,10 +2300,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %c.ref: %ConstRange = name_ref c, %c
 // CHECK:STDOUT:   %impl.elem2: %.e0f = impl_witness_access constants.%Iterate.impl_witness.1f0, element2 [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.d2e]
 // CHECK:STDOUT:   %bound_method.loc38_19.1: <bound method> = bound_method %c.ref, %impl.elem2
-// CHECK:STDOUT:   %facet_value.loc38_19.1: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.5d5, constants.%custom_witness.213, constants.%custom_witness.a31, constants.%custom_witness.994, constants.%custom_witness.821, constants.%custom_witness.393) [concrete = constants.%facet_value.c05]
-// CHECK:STDOUT:   %.loc38_19.1: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc38_19.1 [concrete = constants.%facet_value.c05]
-// CHECK:STDOUT:   %facet_value.loc38_19.2: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.5d5, constants.%custom_witness.213, constants.%custom_witness.a31, constants.%custom_witness.994, constants.%custom_witness.821, constants.%custom_witness.393) [concrete = constants.%facet_value.c05]
-// CHECK:STDOUT:   %.loc38_19.2: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc38_19.2 [concrete = constants.%facet_value.c05]
+// CHECK:STDOUT:   %facet_value.loc38_19.1: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.5d5, constants.%custom_witness.213, constants.%custom_witness.a31, constants.%custom_witness.994, constants.%custom_witness.821, constants.%custom_witness.393) [concrete = constants.%facet_value.c05]
+// CHECK:STDOUT:   %.loc38_19.1: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc38_19.1 [concrete = constants.%facet_value.c05]
+// CHECK:STDOUT:   %facet_value.loc38_19.2: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.5d5, constants.%custom_witness.213, constants.%custom_witness.a31, constants.%custom_witness.994, constants.%custom_witness.821, constants.%custom_witness.393) [concrete = constants.%facet_value.c05]
+// CHECK:STDOUT:   %.loc38_19.2: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc38_19.2 [concrete = constants.%facet_value.c05]
 // CHECK:STDOUT:   %specific_fn.loc38_19.1: <specific function> = specific_function %impl.elem2, @R.as_type.as.Iterate.impl.NewCursor(constants.%facet_value.c05) [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc38_19.2: <bound method> = bound_method %c.ref, %specific_fn.loc38_19.1
 // CHECK:STDOUT:   %var: ref %tuple.type.005 = var_storage invalid
@@ -2315,10 +2315,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %addr: %ptr.d1a = addr_of %var
 // CHECK:STDOUT:   %impl.elem3: %.50c = impl_witness_access constants.%Iterate.impl_witness.1f0, element3 [concrete = constants.%R.as_type.as.Iterate.impl.Next.0b7]
 // CHECK:STDOUT:   %bound_method.loc38_19.3: <bound method> = bound_method %c.ref, %impl.elem3
-// CHECK:STDOUT:   %facet_value.loc38_19.3: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.5d5, constants.%custom_witness.213, constants.%custom_witness.a31, constants.%custom_witness.994, constants.%custom_witness.821, constants.%custom_witness.393) [concrete = constants.%facet_value.c05]
-// CHECK:STDOUT:   %.loc38_19.3: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc38_19.3 [concrete = constants.%facet_value.c05]
-// CHECK:STDOUT:   %facet_value.loc38_19.4: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.5d5, constants.%custom_witness.213, constants.%custom_witness.a31, constants.%custom_witness.994, constants.%custom_witness.821, constants.%custom_witness.393) [concrete = constants.%facet_value.c05]
-// CHECK:STDOUT:   %.loc38_19.4: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc38_19.4 [concrete = constants.%facet_value.c05]
+// CHECK:STDOUT:   %facet_value.loc38_19.3: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.5d5, constants.%custom_witness.213, constants.%custom_witness.a31, constants.%custom_witness.994, constants.%custom_witness.821, constants.%custom_witness.393) [concrete = constants.%facet_value.c05]
+// CHECK:STDOUT:   %.loc38_19.3: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc38_19.3 [concrete = constants.%facet_value.c05]
+// CHECK:STDOUT:   %facet_value.loc38_19.4: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.5d5, constants.%custom_witness.213, constants.%custom_witness.a31, constants.%custom_witness.994, constants.%custom_witness.821, constants.%custom_witness.393) [concrete = constants.%facet_value.c05]
+// CHECK:STDOUT:   %.loc38_19.4: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc38_19.4 [concrete = constants.%facet_value.c05]
 // CHECK:STDOUT:   %specific_fn.loc38_19.2: <specific function> = specific_function %impl.elem3, @R.as_type.as.Iterate.impl.Next(constants.%facet_value.c05) [concrete = constants.%R.as_type.as.Iterate.impl.Next.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc38_19.4: <bound method> = bound_method %c.ref, %specific_fn.loc38_19.2
 // CHECK:STDOUT:   %.loc38_19.5: ref %Optional.f48 = temporary_storage
@@ -2457,8 +2457,8 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %CppUnsafeDeref.lookup_impl_witness.712: <witness> = lookup_impl_witness %impl.elem0.109, @CppUnsafeDeref [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0.56a: type = impl_witness_access %CppUnsafeDeref.lookup_impl_witness.712, element0 [symbolic_self]
 // CHECK:STDOUT:   %impl.elem1.222: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.143, element1 [symbolic_self]
-// CHECK:STDOUT:   %CppRangeForIterate_where.type: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
-// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type = symbolic_binding R, 0 [symbolic]
+// CHECK:STDOUT:   %CppRangeForIterate_where.type.1c721f.1: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
+// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type.1c721f.1 = symbolic_binding R, 0 [symbolic]
 // CHECK:STDOUT:   %CppRangeForIterate.lookup_impl_witness.7e2712.2: <witness> = lookup_impl_witness %R.39b, @CppRangeForIterate [symbolic]
 // CHECK:STDOUT:   %impl.elem1.7a0bff.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element1 [symbolic]
 // CHECK:STDOUT:   %impl.elem0.73eb7f.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element0 [symbolic]
@@ -2545,7 +2545,7 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %Iterator.Op.type.b9731e.4: type = fn_type @Iterator.Op.4 [concrete]
 // CHECK:STDOUT:   %Iterator.Op.ac6aad.4: %Iterator.Op.type.b9731e.4 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.491: <witness> = custom_witness (%Iterator.Op.ac6aad.4), @Inc [concrete]
-// CHECK:STDOUT:   %facet_value.85f: %CppRangeForIterate_where.type = facet_value %MutableRange, (%custom_witness.df9cc1.2, %Copy.impl_witness.873, %custom_witness.902, %custom_witness.c08, %custom_witness.29f, %custom_witness.05b, %custom_witness.ed8, %custom_witness.491) [concrete]
+// CHECK:STDOUT:   %facet_value.85f: %CppRangeForIterate_where.type.1c721f.1 = facet_value %MutableRange, (%custom_witness.df9cc1.2, %Copy.impl_witness.873, %custom_witness.902, %custom_witness.c08, %custom_witness.29f, %custom_witness.05b, %custom_witness.ed8, %custom_witness.491) [concrete]
 // CHECK:STDOUT:   %tuple.type.dd0: type = tuple_type (%Iterator, %Iterator) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.1d8f74.10: type = fn_type @Destroy.Op.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.10: %Destroy.Op.type.1d8f74.10 = struct_value () [concrete]
@@ -2733,10 +2733,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %m.ref: ref %MutableRange = name_ref m, %m
 // CHECK:STDOUT:   %impl.elem2: %.c29a = impl_witness_access constants.%Iterate.impl_witness.5f7, element2 [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.41a]
 // CHECK:STDOUT:   %bound_method.loc68_19.1: <bound method> = bound_method %m.ref, %impl.elem2
-// CHECK:STDOUT:   %facet_value.loc68_19.1: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.902, constants.%custom_witness.c08, constants.%custom_witness.29f, constants.%custom_witness.05b, constants.%custom_witness.ed8, constants.%custom_witness.491) [concrete = constants.%facet_value.85f]
-// CHECK:STDOUT:   %.loc68_19.1: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc68_19.1 [concrete = constants.%facet_value.85f]
-// CHECK:STDOUT:   %facet_value.loc68_19.2: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.902, constants.%custom_witness.c08, constants.%custom_witness.29f, constants.%custom_witness.05b, constants.%custom_witness.ed8, constants.%custom_witness.491) [concrete = constants.%facet_value.85f]
-// CHECK:STDOUT:   %.loc68_19.2: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc68_19.2 [concrete = constants.%facet_value.85f]
+// CHECK:STDOUT:   %facet_value.loc68_19.1: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.902, constants.%custom_witness.c08, constants.%custom_witness.29f, constants.%custom_witness.05b, constants.%custom_witness.ed8, constants.%custom_witness.491) [concrete = constants.%facet_value.85f]
+// CHECK:STDOUT:   %.loc68_19.1: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc68_19.1 [concrete = constants.%facet_value.85f]
+// CHECK:STDOUT:   %facet_value.loc68_19.2: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.902, constants.%custom_witness.c08, constants.%custom_witness.29f, constants.%custom_witness.05b, constants.%custom_witness.ed8, constants.%custom_witness.491) [concrete = constants.%facet_value.85f]
+// CHECK:STDOUT:   %.loc68_19.2: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc68_19.2 [concrete = constants.%facet_value.85f]
 // CHECK:STDOUT:   %specific_fn.loc68_19.1: <specific function> = specific_function %impl.elem2, @R.as_type.as.Iterate.impl.NewCursor(constants.%facet_value.85f) [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc68_19.2: <bound method> = bound_method %m.ref, %specific_fn.loc68_19.1
 // CHECK:STDOUT:   %var: ref %tuple.type.dd0 = var_storage invalid
@@ -2749,10 +2749,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %addr: %ptr.a4f = addr_of %var
 // CHECK:STDOUT:   %impl.elem3: %.b4c = impl_witness_access constants.%Iterate.impl_witness.5f7, element3 [concrete = constants.%R.as_type.as.Iterate.impl.Next.928]
 // CHECK:STDOUT:   %bound_method.loc68_19.3: <bound method> = bound_method %m.ref, %impl.elem3
-// CHECK:STDOUT:   %facet_value.loc68_19.3: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.902, constants.%custom_witness.c08, constants.%custom_witness.29f, constants.%custom_witness.05b, constants.%custom_witness.ed8, constants.%custom_witness.491) [concrete = constants.%facet_value.85f]
-// CHECK:STDOUT:   %.loc68_19.3: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc68_19.3 [concrete = constants.%facet_value.85f]
-// CHECK:STDOUT:   %facet_value.loc68_19.4: %CppRangeForIterate_where.type = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.902, constants.%custom_witness.c08, constants.%custom_witness.29f, constants.%custom_witness.05b, constants.%custom_witness.ed8, constants.%custom_witness.491) [concrete = constants.%facet_value.85f]
-// CHECK:STDOUT:   %.loc68_19.4: %CppRangeForIterate_where.type = converted constants.%MutableRange, %facet_value.loc68_19.4 [concrete = constants.%facet_value.85f]
+// CHECK:STDOUT:   %facet_value.loc68_19.3: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.902, constants.%custom_witness.c08, constants.%custom_witness.29f, constants.%custom_witness.05b, constants.%custom_witness.ed8, constants.%custom_witness.491) [concrete = constants.%facet_value.85f]
+// CHECK:STDOUT:   %.loc68_19.3: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc68_19.3 [concrete = constants.%facet_value.85f]
+// CHECK:STDOUT:   %facet_value.loc68_19.4: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableRange, (constants.%custom_witness.df9cc1.2, constants.%Copy.impl_witness.873, constants.%custom_witness.902, constants.%custom_witness.c08, constants.%custom_witness.29f, constants.%custom_witness.05b, constants.%custom_witness.ed8, constants.%custom_witness.491) [concrete = constants.%facet_value.85f]
+// CHECK:STDOUT:   %.loc68_19.4: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableRange, %facet_value.loc68_19.4 [concrete = constants.%facet_value.85f]
 // CHECK:STDOUT:   %specific_fn.loc68_19.2: <specific function> = specific_function %impl.elem3, @R.as_type.as.Iterate.impl.Next(constants.%facet_value.85f) [concrete = constants.%R.as_type.as.Iterate.impl.Next.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc68_19.4: <bound method> = bound_method %m.ref, %specific_fn.loc68_19.2
 // CHECK:STDOUT:   %.loc68_19.5: ref %Optional.f48 = temporary_storage
@@ -2897,8 +2897,8 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %CppUnsafeDeref.lookup_impl_witness.712: <witness> = lookup_impl_witness %impl.elem0.109, @CppUnsafeDeref [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0.56a: type = impl_witness_access %CppUnsafeDeref.lookup_impl_witness.712, element0 [symbolic_self]
 // CHECK:STDOUT:   %impl.elem1.222: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.143, element1 [symbolic_self]
-// CHECK:STDOUT:   %CppRangeForIterate_where.type: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
-// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type = symbolic_binding R, 0 [symbolic]
+// CHECK:STDOUT:   %CppRangeForIterate_where.type.1c721f.1: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
+// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type.1c721f.1 = symbolic_binding R, 0 [symbolic]
 // CHECK:STDOUT:   %CppRangeForIterate.lookup_impl_witness.7e2712.2: <witness> = lookup_impl_witness %R.39b, @CppRangeForIterate [symbolic]
 // CHECK:STDOUT:   %impl.elem1.7a0bff.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element1 [symbolic]
 // CHECK:STDOUT:   %impl.elem0.73eb7f.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element0 [symbolic]
@@ -2982,7 +2982,7 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %Sentinel.Op.type.ac7e09.2: type = fn_type @Sentinel.Op.2 [concrete]
 // CHECK:STDOUT:   %Sentinel.Op.583fda.2: %Sentinel.Op.type.ac7e09.2 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.a3150e.2: <witness> = custom_witness (%Sentinel.Op.583fda.2), @Copy [concrete]
-// CHECK:STDOUT:   %facet_value.b1e: %CppRangeForIterate_where.type = facet_value %ConstRange, (%custom_witness.fef, %custom_witness.c19, %custom_witness.c2f, %custom_witness.21358e.1, %custom_witness.a3150e.1, %custom_witness.1d3, %custom_witness.aa4, %custom_witness.393, %custom_witness.21358e.2, %custom_witness.a3150e.2) [concrete]
+// CHECK:STDOUT:   %facet_value.b1e: %CppRangeForIterate_where.type.1c721f.1 = facet_value %ConstRange, (%custom_witness.fef, %custom_witness.c19, %custom_witness.c2f, %custom_witness.21358e.1, %custom_witness.a3150e.1, %custom_witness.1d3, %custom_witness.aa4, %custom_witness.393, %custom_witness.21358e.2, %custom_witness.a3150e.2) [concrete]
 // CHECK:STDOUT:   %tuple.type.df8: type = tuple_type (%Iterator, %Sentinel) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.1d8f74.8: type = fn_type @Destroy.Op.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.8: %Destroy.Op.type.1d8f74.8 = struct_value () [concrete]
@@ -3196,10 +3196,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %c.ref: %ConstRange = name_ref c, %c
 // CHECK:STDOUT:   %impl.elem2: %.da4e = impl_witness_access constants.%Iterate.impl_witness.466, element2 [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.a27]
 // CHECK:STDOUT:   %bound_method.loc45_31.1: <bound method> = bound_method %c.ref, %impl.elem2
-// CHECK:STDOUT:   %facet_value.loc45_31.1: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.c2f, constants.%custom_witness.21358e.1, constants.%custom_witness.a3150e.1, constants.%custom_witness.1d3, constants.%custom_witness.aa4, constants.%custom_witness.393, constants.%custom_witness.21358e.2, constants.%custom_witness.a3150e.2) [concrete = constants.%facet_value.b1e]
-// CHECK:STDOUT:   %.loc45_31.1: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc45_31.1 [concrete = constants.%facet_value.b1e]
-// CHECK:STDOUT:   %facet_value.loc45_31.2: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.c2f, constants.%custom_witness.21358e.1, constants.%custom_witness.a3150e.1, constants.%custom_witness.1d3, constants.%custom_witness.aa4, constants.%custom_witness.393, constants.%custom_witness.21358e.2, constants.%custom_witness.a3150e.2) [concrete = constants.%facet_value.b1e]
-// CHECK:STDOUT:   %.loc45_31.2: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc45_31.2 [concrete = constants.%facet_value.b1e]
+// CHECK:STDOUT:   %facet_value.loc45_31.1: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.c2f, constants.%custom_witness.21358e.1, constants.%custom_witness.a3150e.1, constants.%custom_witness.1d3, constants.%custom_witness.aa4, constants.%custom_witness.393, constants.%custom_witness.21358e.2, constants.%custom_witness.a3150e.2) [concrete = constants.%facet_value.b1e]
+// CHECK:STDOUT:   %.loc45_31.1: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc45_31.1 [concrete = constants.%facet_value.b1e]
+// CHECK:STDOUT:   %facet_value.loc45_31.2: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.c2f, constants.%custom_witness.21358e.1, constants.%custom_witness.a3150e.1, constants.%custom_witness.1d3, constants.%custom_witness.aa4, constants.%custom_witness.393, constants.%custom_witness.21358e.2, constants.%custom_witness.a3150e.2) [concrete = constants.%facet_value.b1e]
+// CHECK:STDOUT:   %.loc45_31.2: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc45_31.2 [concrete = constants.%facet_value.b1e]
 // CHECK:STDOUT:   %specific_fn.loc45_31.1: <specific function> = specific_function %impl.elem2, @R.as_type.as.Iterate.impl.NewCursor(constants.%facet_value.b1e) [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc45_31.2: <bound method> = bound_method %c.ref, %specific_fn.loc45_31.1
 // CHECK:STDOUT:   %var: ref %tuple.type.df8 = var_storage invalid
@@ -3211,10 +3211,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %addr.loc45: %ptr.fc0 = addr_of %var
 // CHECK:STDOUT:   %impl.elem3: %.4b8 = impl_witness_access constants.%Iterate.impl_witness.466, element3 [concrete = constants.%R.as_type.as.Iterate.impl.Next.bf3]
 // CHECK:STDOUT:   %bound_method.loc45_31.3: <bound method> = bound_method %c.ref, %impl.elem3
-// CHECK:STDOUT:   %facet_value.loc45_31.3: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.c2f, constants.%custom_witness.21358e.1, constants.%custom_witness.a3150e.1, constants.%custom_witness.1d3, constants.%custom_witness.aa4, constants.%custom_witness.393, constants.%custom_witness.21358e.2, constants.%custom_witness.a3150e.2) [concrete = constants.%facet_value.b1e]
-// CHECK:STDOUT:   %.loc45_31.3: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc45_31.3 [concrete = constants.%facet_value.b1e]
-// CHECK:STDOUT:   %facet_value.loc45_31.4: %CppRangeForIterate_where.type = facet_value constants.%ConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.c2f, constants.%custom_witness.21358e.1, constants.%custom_witness.a3150e.1, constants.%custom_witness.1d3, constants.%custom_witness.aa4, constants.%custom_witness.393, constants.%custom_witness.21358e.2, constants.%custom_witness.a3150e.2) [concrete = constants.%facet_value.b1e]
-// CHECK:STDOUT:   %.loc45_31.4: %CppRangeForIterate_where.type = converted constants.%ConstRange, %facet_value.loc45_31.4 [concrete = constants.%facet_value.b1e]
+// CHECK:STDOUT:   %facet_value.loc45_31.3: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.c2f, constants.%custom_witness.21358e.1, constants.%custom_witness.a3150e.1, constants.%custom_witness.1d3, constants.%custom_witness.aa4, constants.%custom_witness.393, constants.%custom_witness.21358e.2, constants.%custom_witness.a3150e.2) [concrete = constants.%facet_value.b1e]
+// CHECK:STDOUT:   %.loc45_31.3: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc45_31.3 [concrete = constants.%facet_value.b1e]
+// CHECK:STDOUT:   %facet_value.loc45_31.4: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%ConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.c2f, constants.%custom_witness.21358e.1, constants.%custom_witness.a3150e.1, constants.%custom_witness.1d3, constants.%custom_witness.aa4, constants.%custom_witness.393, constants.%custom_witness.21358e.2, constants.%custom_witness.a3150e.2) [concrete = constants.%facet_value.b1e]
+// CHECK:STDOUT:   %.loc45_31.4: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%ConstRange, %facet_value.loc45_31.4 [concrete = constants.%facet_value.b1e]
 // CHECK:STDOUT:   %specific_fn.loc45_31.2: <specific function> = specific_function %impl.elem3, @R.as_type.as.Iterate.impl.Next(constants.%facet_value.b1e) [concrete = constants.%R.as_type.as.Iterate.impl.Next.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc45_31.4: <bound method> = bound_method %c.ref, %specific_fn.loc45_31.2
 // CHECK:STDOUT:   %.loc45_31.5: ref %Optional.552 = temporary_storage
@@ -3665,8 +3665,8 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %CppUnsafeDeref.lookup_impl_witness.712: <witness> = lookup_impl_witness %impl.elem0.109, @CppUnsafeDeref [symbolic_self]
 // CHECK:STDOUT:   %impl.elem0.56a: type = impl_witness_access %CppUnsafeDeref.lookup_impl_witness.712, element0 [symbolic_self]
 // CHECK:STDOUT:   %impl.elem1.222: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.143, element1 [symbolic_self]
-// CHECK:STDOUT:   %CppRangeForIterate_where.type: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
-// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type = symbolic_binding R, 0 [symbolic]
+// CHECK:STDOUT:   %CppRangeForIterate_where.type.1c721f.1: type = facet_type <@CppRangeForIterate where %impl.elem0.109 impls @Destroy and %impl.elem0.109 impls @Copy and %impl.elem0.109 impls @CppUnsafeDeref and %impl.elem0.109 impls @EqWith, @EqWith(%impl.elem1.222) and %impl.elem0.109 impls @Inc and %impl.elem0.56a impls @Destroy and %impl.elem0.56a impls @Copy and %impl.elem1.222 impls @Destroy and %impl.elem1.222 impls @Copy> [concrete]
+// CHECK:STDOUT:   %R.39b: %CppRangeForIterate_where.type.1c721f.1 = symbolic_binding R, 0 [symbolic]
 // CHECK:STDOUT:   %CppRangeForIterate.lookup_impl_witness.7e2712.2: <witness> = lookup_impl_witness %R.39b, @CppRangeForIterate [symbolic]
 // CHECK:STDOUT:   %impl.elem1.7a0bff.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element1 [symbolic]
 // CHECK:STDOUT:   %impl.elem0.73eb7f.2: type = impl_witness_access %CppRangeForIterate.lookup_impl_witness.7e2712.2, element0 [symbolic]
@@ -3743,7 +3743,7 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %Iterator.Op.type.fa7609.4: type = fn_type @Iterator.Op.4 [concrete]
 // CHECK:STDOUT:   %Iterator.Op.549055.4: %Iterator.Op.type.fa7609.4 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.01a: <witness> = custom_witness (%Iterator.Op.549055.4), @Inc [concrete]
-// CHECK:STDOUT:   %facet_value.88d: %CppRangeForIterate_where.type = facet_value %MutableAndConstRange, (%custom_witness.fef, %custom_witness.c19, %custom_witness.a40, %custom_witness.04a, %custom_witness.cfc, %custom_witness.dd5, %custom_witness.c66, %custom_witness.01a) [concrete]
+// CHECK:STDOUT:   %facet_value.88d: %CppRangeForIterate_where.type.1c721f.1 = facet_value %MutableAndConstRange, (%custom_witness.fef, %custom_witness.c19, %custom_witness.a40, %custom_witness.04a, %custom_witness.cfc, %custom_witness.dd5, %custom_witness.c66, %custom_witness.01a) [concrete]
 // CHECK:STDOUT:   %tuple.type.56e: type = tuple_type (%Iterator, %Iterator) [concrete]
 // CHECK:STDOUT:   %Destroy.Op.type.1d8f74.8: type = fn_type @Destroy.Op.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.8: %Destroy.Op.type.1d8f74.8 = struct_value () [concrete]
@@ -3957,10 +3957,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %mc.ref: ref %MutableAndConstRange = name_ref mc, %mc
 // CHECK:STDOUT:   %impl.elem2: %.7e3 = impl_witness_access constants.%Iterate.impl_witness.a6e, element2 [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.96c]
 // CHECK:STDOUT:   %bound_method.loc80_32.1: <bound method> = bound_method %mc.ref, %impl.elem2
-// CHECK:STDOUT:   %facet_value.loc80_32.1: %CppRangeForIterate_where.type = facet_value constants.%MutableAndConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.a40, constants.%custom_witness.04a, constants.%custom_witness.cfc, constants.%custom_witness.dd5, constants.%custom_witness.c66, constants.%custom_witness.01a) [concrete = constants.%facet_value.88d]
-// CHECK:STDOUT:   %.loc80_32.1: %CppRangeForIterate_where.type = converted constants.%MutableAndConstRange, %facet_value.loc80_32.1 [concrete = constants.%facet_value.88d]
-// CHECK:STDOUT:   %facet_value.loc80_32.2: %CppRangeForIterate_where.type = facet_value constants.%MutableAndConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.a40, constants.%custom_witness.04a, constants.%custom_witness.cfc, constants.%custom_witness.dd5, constants.%custom_witness.c66, constants.%custom_witness.01a) [concrete = constants.%facet_value.88d]
-// CHECK:STDOUT:   %.loc80_32.2: %CppRangeForIterate_where.type = converted constants.%MutableAndConstRange, %facet_value.loc80_32.2 [concrete = constants.%facet_value.88d]
+// CHECK:STDOUT:   %facet_value.loc80_32.1: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableAndConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.a40, constants.%custom_witness.04a, constants.%custom_witness.cfc, constants.%custom_witness.dd5, constants.%custom_witness.c66, constants.%custom_witness.01a) [concrete = constants.%facet_value.88d]
+// CHECK:STDOUT:   %.loc80_32.1: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableAndConstRange, %facet_value.loc80_32.1 [concrete = constants.%facet_value.88d]
+// CHECK:STDOUT:   %facet_value.loc80_32.2: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableAndConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.a40, constants.%custom_witness.04a, constants.%custom_witness.cfc, constants.%custom_witness.dd5, constants.%custom_witness.c66, constants.%custom_witness.01a) [concrete = constants.%facet_value.88d]
+// CHECK:STDOUT:   %.loc80_32.2: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableAndConstRange, %facet_value.loc80_32.2 [concrete = constants.%facet_value.88d]
 // CHECK:STDOUT:   %specific_fn.loc80_32.1: <specific function> = specific_function %impl.elem2, @R.as_type.as.Iterate.impl.NewCursor(constants.%facet_value.88d) [concrete = constants.%R.as_type.as.Iterate.impl.NewCursor.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc80_32.2: <bound method> = bound_method %mc.ref, %specific_fn.loc80_32.1
 // CHECK:STDOUT:   %var: ref %tuple.type.56e = var_storage invalid
@@ -3973,10 +3973,10 @@ fn TestDriver(var no_begin_end: Cpp.NoBeginEnd,
 // CHECK:STDOUT:   %addr.loc80: %ptr.484 = addr_of %var
 // CHECK:STDOUT:   %impl.elem3: %.fef = impl_witness_access constants.%Iterate.impl_witness.a6e, element3 [concrete = constants.%R.as_type.as.Iterate.impl.Next.683]
 // CHECK:STDOUT:   %bound_method.loc80_32.3: <bound method> = bound_method %mc.ref, %impl.elem3
-// CHECK:STDOUT:   %facet_value.loc80_32.3: %CppRangeForIterate_where.type = facet_value constants.%MutableAndConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.a40, constants.%custom_witness.04a, constants.%custom_witness.cfc, constants.%custom_witness.dd5, constants.%custom_witness.c66, constants.%custom_witness.01a) [concrete = constants.%facet_value.88d]
-// CHECK:STDOUT:   %.loc80_32.3: %CppRangeForIterate_where.type = converted constants.%MutableAndConstRange, %facet_value.loc80_32.3 [concrete = constants.%facet_value.88d]
-// CHECK:STDOUT:   %facet_value.loc80_32.4: %CppRangeForIterate_where.type = facet_value constants.%MutableAndConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.a40, constants.%custom_witness.04a, constants.%custom_witness.cfc, constants.%custom_witness.dd5, constants.%custom_witness.c66, constants.%custom_witness.01a) [concrete = constants.%facet_value.88d]
-// CHECK:STDOUT:   %.loc80_32.4: %CppRangeForIterate_where.type = converted constants.%MutableAndConstRange, %facet_value.loc80_32.4 [concrete = constants.%facet_value.88d]
+// CHECK:STDOUT:   %facet_value.loc80_32.3: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableAndConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.a40, constants.%custom_witness.04a, constants.%custom_witness.cfc, constants.%custom_witness.dd5, constants.%custom_witness.c66, constants.%custom_witness.01a) [concrete = constants.%facet_value.88d]
+// CHECK:STDOUT:   %.loc80_32.3: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableAndConstRange, %facet_value.loc80_32.3 [concrete = constants.%facet_value.88d]
+// CHECK:STDOUT:   %facet_value.loc80_32.4: %CppRangeForIterate_where.type.1c721f.1 = facet_value constants.%MutableAndConstRange, (constants.%custom_witness.fef, constants.%custom_witness.c19, constants.%custom_witness.a40, constants.%custom_witness.04a, constants.%custom_witness.cfc, constants.%custom_witness.dd5, constants.%custom_witness.c66, constants.%custom_witness.01a) [concrete = constants.%facet_value.88d]
+// CHECK:STDOUT:   %.loc80_32.4: %CppRangeForIterate_where.type.1c721f.1 = converted constants.%MutableAndConstRange, %facet_value.loc80_32.4 [concrete = constants.%facet_value.88d]
 // CHECK:STDOUT:   %specific_fn.loc80_32.2: <specific function> = specific_function %impl.elem3, @R.as_type.as.Iterate.impl.Next(constants.%facet_value.88d) [concrete = constants.%R.as_type.as.Iterate.impl.Next.specific_fn]
 // CHECK:STDOUT:   %bound_method.loc80_32.4: <bound method> = bound_method %mc.ref, %specific_fn.loc80_32.2
 // CHECK:STDOUT:   %.loc80_32.5: ref %Optional.552 = temporary_storage

--- a/toolchain/check/testdata/named_constraint/require.carbon
+++ b/toolchain/check/testdata/named_constraint/require.carbon
@@ -1445,8 +1445,8 @@ constraint N {
 // CHECK:STDOUT:   %Z_where.type.946: type = facet_type <@Z where .Self impls @Y, @Y(%.Self.as_type.e58)> [concrete]
 // CHECK:STDOUT:   %Z_where.type.0d5: type = facet_type <@Z where .Self impls @Y, @Y(%Self.as_type.138)> [symbolic]
 // CHECK:STDOUT:   %.Self.as_type.246: type = facet_access_type %.Self.c39 [symbolic_self]
-// CHECK:STDOUT:   %facet_type: type = facet_type <@Z & @Y, @Y(%.Self.as_type.246)> [symbolic_self]
-// CHECK:STDOUT:   %T.a60: %facet_type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %facet_type.45c: type = facet_type <@Z & @Y, @Y(%.Self.as_type.246)> [symbolic_self]
+// CHECK:STDOUT:   %T.a60: %facet_type.45c = symbolic_binding T, 0 [symbolic]
 // CHECK:STDOUT:   %T.as_type: type = facet_access_type %T.a60 [symbolic]
 // CHECK:STDOUT:   %Z_where.type.92a: type = facet_type <@Z where .Self impls @Y, @Y(%T.as_type)> [symbolic]
 // CHECK:STDOUT: }
@@ -1461,7 +1461,7 @@ constraint N {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !with Self:
 // CHECK:STDOUT:   %N.WithSelf.Self.as_type.impls.Z_where.type.require.decl = require_decl @N.WithSelf.Self.as_type.impls.Z_where.type.require [concrete] {
-// CHECK:STDOUT:     require %Self.as_type.loc10_11.1 impls %Z_where.type.loc10_19.1
+// CHECK:STDOUT:     require %Self.as_type.loc10_11.1 impls %Z_where.type.loc10_19.2
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type.loc10_11.1: type = facet_access_type @N.%Self [symbolic = %Self.as_type.loc10_11.2 (constants.%Self.as_type.138)]
 // CHECK:STDOUT:     %Z.ref: type = name_ref Z, file.%Z.decl [concrete = constants.%Z.type]
@@ -1478,7 +1478,8 @@ constraint N {
 // CHECK:STDOUT:       requirement_base_facet_type %Z.ref
 // CHECK:STDOUT:       requirement_impls %.loc10_25, %Y.type
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %Z_where.type.loc10_19.1: type = facet_type <@Z where .Self impls @Y, @Y(constants.%Self.as_type.138)> [symbolic = %Z_where.type.loc10_19.2 (constants.%Z_where.type.0d5)]
+// CHECK:STDOUT:     %Z_where.type.loc10_19.1: type = facet_type <@Z where .Self impls @Y, @Y(constants.%Self.as_type.138)> [symbolic = %Z_where.type.loc10_19.3 (constants.%Z_where.type.0d5)]
+// CHECK:STDOUT:     %Z_where.type.loc10_19.2: type = facet_type <@Z where .Self impls @Y, @Y(constants.%Self.as_type.138)> [symbolic = %Z_where.type.loc10_19.3 (constants.%Z_where.type.0d5)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -1490,14 +1491,14 @@ constraint N {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @N.WithSelf.Self.as_type.impls.Z_where.type.require {
-// CHECK:STDOUT:     require @N.WithSelf.Self.as_type.impls.Z_where.type.require.%Self.as_type.loc10_11.1 impls @N.WithSelf.Self.as_type.impls.Z_where.type.require.%Z_where.type.loc10_19.1
+// CHECK:STDOUT:     require @N.WithSelf.Self.as_type.impls.Z_where.type.require.%Self.as_type.loc10_11.1 impls @N.WithSelf.Self.as_type.impls.Z_where.type.require.%Z_where.type.loc10_19.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: generic require @N.WithSelf.Self.as_type.impls.Z_where.type.require(@N.%Self: %N.type) {
 // CHECK:STDOUT:   %Self: %N.type = symbolic_binding Self, 0 [symbolic = %Self (constants.%Self.d87)]
 // CHECK:STDOUT:   %Self.as_type.loc10_11.2: type = facet_access_type %Self [symbolic = %Self.as_type.loc10_11.2 (constants.%Self.as_type.138)]
-// CHECK:STDOUT:   %Z_where.type.loc10_19.2: type = facet_type <@Z where .Self impls @Y, @Y(%Self.as_type.loc10_11.2)> [symbolic = %Z_where.type.loc10_19.2 (constants.%Z_where.type.0d5)]
+// CHECK:STDOUT:   %Z_where.type.loc10_19.3: type = facet_type <@Z where .Self impls @Y, @Y(%Self.as_type.loc10_11.2)> [symbolic = %Z_where.type.loc10_19.3 (constants.%Z_where.type.0d5)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @N.WithSelf(constants.%Self.d87) {
@@ -1507,7 +1508,7 @@ constraint N {
 // CHECK:STDOUT: specific @N.WithSelf.Self.as_type.impls.Z_where.type.require(constants.%Self.d87) {
 // CHECK:STDOUT:   %Self => constants.%Self.d87
 // CHECK:STDOUT:   %Self.as_type.loc10_11.2 => constants.%Self.as_type.138
-// CHECK:STDOUT:   %Z_where.type.loc10_19.2 => constants.%Z_where.type.0d5
+// CHECK:STDOUT:   %Z_where.type.loc10_19.3 => constants.%Z_where.type.0d5
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @N.WithSelf(constants.%T.a60) {
@@ -1517,7 +1518,7 @@ constraint N {
 // CHECK:STDOUT: specific @N.WithSelf.Self.as_type.impls.Z_where.type.require(constants.%T.a60) {
 // CHECK:STDOUT:   %Self => constants.%T.a60
 // CHECK:STDOUT:   %Self.as_type.loc10_11.2 => constants.%T.as_type
-// CHECK:STDOUT:   %Z_where.type.loc10_19.2 => constants.%Z_where.type.92a
+// CHECK:STDOUT:   %Z_where.type.loc10_19.3 => constants.%Z_where.type.92a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- require_with_specific_period_self.carbon
@@ -1554,7 +1555,7 @@ constraint N {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !with Self:
 // CHECK:STDOUT:   %N.WithSelf.Self.as_type.impls.Z_where.type.require.decl = require_decl @N.WithSelf.Self.as_type.impls.Z_where.type.require [concrete] {
-// CHECK:STDOUT:     require %Self.as_type.loc10_11.1 impls %Z_where.type.loc10_19.1
+// CHECK:STDOUT:     require %Self.as_type.loc10_11.1 impls %Z_where.type.loc10_19.2
 // CHECK:STDOUT:   } {
 // CHECK:STDOUT:     %Self.as_type.loc10_11.1: type = facet_access_type @N.%Self [symbolic = %Self.as_type.loc10_11.2 (constants.%Self.as_type)]
 // CHECK:STDOUT:     %Z.ref: type = name_ref Z, file.%Z.decl [concrete = constants.%Z.type]
@@ -1573,7 +1574,8 @@ constraint N {
 // CHECK:STDOUT:       requirement_base_facet_type %Z.ref
 // CHECK:STDOUT:       requirement_impls %C.loc10_32, %Y.type
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %Z_where.type.loc10_19.1: type = facet_type <@Z where constants.%C.e83 impls @Y, @Y(constants.%Self.as_type)> [symbolic = %Z_where.type.loc10_19.2 (constants.%Z_where.type.a0f3c6.2)]
+// CHECK:STDOUT:     %Z_where.type.loc10_19.1: type = facet_type <@Z where constants.%C.e83 impls @Y, @Y(constants.%Self.as_type)> [symbolic = %Z_where.type.loc10_19.3 (constants.%Z_where.type.a0f3c6.2)]
+// CHECK:STDOUT:     %Z_where.type.loc10_19.2: type = facet_type <@Z where constants.%C.e83 impls @Y, @Y(constants.%Self.as_type)> [symbolic = %Z_where.type.loc10_19.3 (constants.%Z_where.type.a0f3c6.2)]
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:
 // CHECK:STDOUT: !members:
@@ -1587,7 +1589,7 @@ constraint N {
 // CHECK:STDOUT:
 // CHECK:STDOUT: !requires:
 // CHECK:STDOUT:   @N.WithSelf.Self.as_type.impls.Z_where.type.require {
-// CHECK:STDOUT:     require @N.WithSelf.Self.as_type.impls.Z_where.type.require.%Self.as_type.loc10_11.1 impls @N.WithSelf.Self.as_type.impls.Z_where.type.require.%Z_where.type.loc10_19.1
+// CHECK:STDOUT:     require @N.WithSelf.Self.as_type.impls.Z_where.type.require.%Self.as_type.loc10_11.1 impls @N.WithSelf.Self.as_type.impls.Z_where.type.require.%Z_where.type.loc10_19.2
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -1595,7 +1597,7 @@ constraint N {
 // CHECK:STDOUT:   %Self: %N.type = symbolic_binding Self, 0 [symbolic = %Self (constants.%Self.d87)]
 // CHECK:STDOUT:   %Self.as_type.loc10_11.2: type = facet_access_type %Self [symbolic = %Self.as_type.loc10_11.2 (constants.%Self.as_type)]
 // CHECK:STDOUT:   %C.loc10_19: type = class_type @C, @C(%Self.as_type.loc10_11.2) [symbolic = %C.loc10_19 (constants.%C.e83)]
-// CHECK:STDOUT:   %Z_where.type.loc10_19.2: type = facet_type <@Z where %C.loc10_19 impls @Y, @Y(%Self.as_type.loc10_11.2)> [symbolic = %Z_where.type.loc10_19.2 (constants.%Z_where.type.a0f3c6.2)]
+// CHECK:STDOUT:   %Z_where.type.loc10_19.3: type = facet_type <@Z where %C.loc10_19 impls @Y, @Y(%Self.as_type.loc10_11.2)> [symbolic = %Z_where.type.loc10_19.3 (constants.%Z_where.type.a0f3c6.2)]
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @N.WithSelf(constants.%Self.d87) {
@@ -1606,7 +1608,7 @@ constraint N {
 // CHECK:STDOUT:   %Self => constants.%Self.d87
 // CHECK:STDOUT:   %Self.as_type.loc10_11.2 => constants.%Self.as_type
 // CHECK:STDOUT:   %C.loc10_19 => constants.%C.e83
-// CHECK:STDOUT:   %Z_where.type.loc10_19.2 => constants.%Z_where.type.a0f3c6.2
+// CHECK:STDOUT:   %Z_where.type.loc10_19.3 => constants.%Z_where.type.a0f3c6.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @N.WithSelf(constants.%T.013) {
@@ -1617,6 +1619,6 @@ constraint N {
 // CHECK:STDOUT:   %Self => constants.%T.013
 // CHECK:STDOUT:   %Self.as_type.loc10_11.2 => constants.%T.as_type
 // CHECK:STDOUT:   %C.loc10_19 => constants.%C.7bd
-// CHECK:STDOUT:   %Z_where.type.loc10_19.2 => constants.%Z_where.type.a0f3c6.3
+// CHECK:STDOUT:   %Z_where.type.loc10_19.3 => constants.%Z_where.type.a0f3c6.3
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/type_completion.cpp
+++ b/toolchain/check/type_completion.cpp
@@ -964,10 +964,13 @@ static auto GetSelfFacetValue(Context& context, SemIR::ConstantId self_const_id)
 
 static auto IdentifyFacetType(Context& context, SemIR::LocId loc_id,
                               SemIR::ConstantId initial_self_const_id,
-                              const SemIR::FacetType& facet_type,
+                              SemIR::TypeInstId facet_type_inst_id,
                               bool allow_partially_identified,
-                              bool initial_subst_period_self, bool diagnose)
+                              bool subst_period_self, bool diagnose)
     -> SemIR::IdentifiedFacetTypeId {
+  auto facet_type_id =
+      context.insts().GetAs<SemIR::FacetType>(facet_type_inst_id).facet_type_id;
+
   // While partially identified facet types end up in the store of
   // IdentifiedFacetTypes, we don't try to construct a key to look for them
   // here, so we will only early-out here for fully identified facet types. To
@@ -975,69 +978,55 @@ static auto IdentifyFacetType(Context& context, SemIR::LocId loc_id,
   // set of required impls that it contains, which requires us to do most of the
   // work of identifying the facet type (though we could skip the mapping of
   // constant values into specifics).
-  auto key =
-      SemIR::IdentifiedFacetTypeKey{.facet_type_id = facet_type.facet_type_id,
-                                    .self_const_id = initial_self_const_id};
+  auto key = SemIR::IdentifiedFacetTypeKey{
+      .facet_type_id = facet_type_id, .self_const_id = initial_self_const_id};
   if (auto identified_id = context.identified_facet_types().Lookup(key);
       identified_id.has_value()) {
     return identified_id;
+  }
+
+  if (subst_period_self) {
+    auto subst_id = SubstPeriodSelfInFacetType(
+        context, loc_id,
+        context.constant_values().GetInstId(initial_self_const_id),
+        context.types().GetAsTypeInstId(facet_type_inst_id));
+    facet_type_id =
+        context.insts().GetAs<SemIR::FacetType>(subst_id).facet_type_id;
   }
 
   struct SelfImplsFacetType {
     // Whether the impling of facet type should be considered as extending in
     // the resulting IdentifiedFacetType.
     bool extend;
-    // Whether we should replace `.Self` in the constraint.
-    bool subst_period_self;
     SemIR::ConstantId self;
     SemIR::FacetTypeId facet_type;
   };
 
   // Work queue.
   llvm::SmallVector<SelfImplsFacetType> work = {
-      {true, initial_subst_period_self, initial_self_const_id,
-       facet_type.facet_type_id}};
+      {true, initial_self_const_id, facet_type_id}};
 
   // Outputs for the IdentifiedFacetType.
   bool partially_identified = false;
   llvm::SmallVector<SemIR::IdentifiedFacetType::RequiredImpl> extends;
   llvm::SmallVector<SemIR::IdentifiedFacetType::RequiredImpl> impls;
 
-  // `.Self` is always replaced with the top-level self type.
-  auto period_self_replacement_id = initial_self_const_id;
-
   while (!work.empty()) {
     SelfImplsFacetType next_impls = work.pop_back_val();
     bool facet_type_extends = next_impls.extend;
-    auto subst_period_self = next_impls.subst_period_self;
     auto self_const_id = GetCanonicalFacetOrTypeValue(context, next_impls.self);
     const auto& facet_type_info =
         context.facet_types().Get(next_impls.facet_type);
 
     auto self_and_interface = [&](SemIR::SpecificInterface impls_interface)
         -> SemIR::IdentifiedFacetType::RequiredImpl {
-      auto self = self_const_id;
-      auto interface = subst_period_self
-                           ? SubstPeriodSelf(context, loc_id, impls_interface,
-                                             period_self_replacement_id)
-                           : impls_interface;
-      return {self, interface};
+      return {self_const_id, impls_interface};
     };
     auto type_and_interface =
         [&](SemIR::FacetTypeInfo::TypeImplsInterface impls)
         -> SemIR::IdentifiedFacetType::RequiredImpl {
-      auto self =
-          subst_period_self
-              ? SubstPeriodSelf(context, loc_id,
-                                context.constant_values().Get(impls.self_type),
-                                period_self_replacement_id)
-              : context.constant_values().Get(impls.self_type);
-      auto interface =
-          subst_period_self
-              ? SubstPeriodSelf(context, loc_id, impls.specific_interface,
-                                period_self_replacement_id)
-              : impls.specific_interface;
-      return {self, interface};
+      return {context.constant_values().Get(impls.self_type),
+              impls.specific_interface};
     };
 
     if (facet_type_extends) {
@@ -1068,11 +1057,6 @@ static auto IdentifyFacetType(Context& context, SemIR::LocId loc_id,
     auto self_facet = GetSelfFacetValue(context, self_const_id);
 
     for (auto extends : facet_type_info.extend_named_constraints) {
-      if (subst_period_self) {
-        extends = SubstPeriodSelf(context, loc_id, extends,
-                                  period_self_replacement_id);
-      }
-
       const auto& constraint =
           context.named_constraints().Get(extends.named_constraint_id);
 
@@ -1126,16 +1110,11 @@ static auto IdentifyFacetType(Context& context, SemIR::LocId loc_id,
                 .GetInstAs<SemIR::FacetType>(require_facet_type)
                 .facet_type_id;
         bool extend = facet_type_extends && require.extend_self;
-        work.push_back({extend, false, require_self, facet_type_id});
+        work.push_back({extend, require_self, facet_type_id});
       }
     }
 
     for (auto impls : facet_type_info.self_impls_named_constraints) {
-      if (subst_period_self) {
-        impls =
-            SubstPeriodSelf(context, loc_id, impls, period_self_replacement_id);
-      }
-
       const auto& constraint =
           context.named_constraints().Get(impls.named_constraint_id);
 
@@ -1187,21 +1166,13 @@ static auto IdentifyFacetType(Context& context, SemIR::LocId loc_id,
             context.constant_values()
                 .GetInstAs<SemIR::FacetType>(require_facet_type)
                 .facet_type_id;
-        work.push_back({false, false, require_self, facet_type_id});
+        work.push_back({false, require_self, facet_type_id});
       }
     }
 
     for (const auto& type_impls :
          facet_type_info.type_impls_named_constraints) {
       auto [self_type_inst_id, impls] = type_impls;
-      if (subst_period_self) {
-        self_type_inst_id = context.constant_values().GetInstId(SubstPeriodSelf(
-            context, loc_id, context.constant_values().Get(self_type_inst_id),
-            period_self_replacement_id));
-        impls =
-            SubstPeriodSelf(context, loc_id, impls, period_self_replacement_id);
-      }
-
       const auto& constraint =
           context.named_constraints().Get(impls.named_constraint_id);
 
@@ -1256,7 +1227,7 @@ static auto IdentifyFacetType(Context& context, SemIR::LocId loc_id,
             context.constant_values()
                 .GetInstAs<SemIR::FacetType>(require_facet_type)
                 .facet_type_id;
-        work.push_back({false, false, require_self, facet_type_id});
+        work.push_back({false, require_self, facet_type_id});
       }
     }
   }
@@ -1268,26 +1239,26 @@ static auto IdentifyFacetType(Context& context, SemIR::LocId loc_id,
 
 auto TryToIdentifyFacetType(Context& context, SemIR::LocId loc_id,
                             SemIR::ConstantId self_const_id,
-                            const SemIR::FacetType& facet_type,
+                            SemIR::TypeInstId facet_type_inst_id,
                             bool allow_partially_identified,
                             bool subst_period_self)
     -> SemIR::IdentifiedFacetTypeId {
-  return IdentifyFacetType(context, loc_id, self_const_id, facet_type,
+  return IdentifyFacetType(context, loc_id, self_const_id, facet_type_inst_id,
                            allow_partially_identified, subst_period_self,
                            /*diagnose=*/false);
 }
 
 auto RequireIdentifiedFacetType(Context& context, SemIR::LocId loc_id,
                                 SemIR::ConstantId self_const_id,
-                                const SemIR::FacetType& facet_type,
+                                SemIR::TypeInstId facet_type_inst_id,
                                 DiagnosticContextFn diagnostic_context,
                                 bool diagnose) -> SemIR::IdentifiedFacetTypeId {
   CARBON_CHECK(diagnostic_context);
   Diagnostics::ContextScope scope(&context.emitter(), diagnostic_context);
 
-  return IdentifyFacetType(context, loc_id, self_const_id, facet_type,
+  return IdentifyFacetType(context, loc_id, self_const_id, facet_type_inst_id,
                            /*allow_partially_identified=*/false,
-                           /*initial_subst_period_self=*/true, diagnose);
+                           /*subst_period_self=*/true, diagnose);
 }
 
 }  // namespace Carbon::Check

--- a/toolchain/check/type_completion.h
+++ b/toolchain/check/type_completion.h
@@ -77,7 +77,7 @@ auto RequireConcreteType(Context& context, SemIR::TypeId type_id,
 // the middle of being defined.
 auto TryToIdentifyFacetType(Context& context, SemIR::LocId loc_id,
                             SemIR::ConstantId self_const_id,
-                            const SemIR::FacetType& facet_type,
+                            SemIR::TypeInstId facet_type_inst_id,
                             bool allow_partially_identified,
                             bool subst_period_self)
     -> SemIR::IdentifiedFacetTypeId;
@@ -85,7 +85,8 @@ auto TryToIdentifyFacetType(Context& context, SemIR::LocId loc_id,
 // Requires the named constraints in the facet type to be complete, so that the
 // set of interfaces the facet type requires is known. The `self_const_id` is a
 // type or facet type expression that is the self that the FacetType is
-// constraining. Produces a set of interfaces that must be implemented for a set
+// constraining. The `facet_type_inst_id` must be a FacetType (and cannot be an
+// ErrorInst). Produces a set of interfaces that must be implemented for a set
 // of types, most of them for the `self_const_id`. Diagnoses an error and
 // returns None if any error is found.
 //
@@ -98,7 +99,7 @@ auto TryToIdentifyFacetType(Context& context, SemIR::LocId loc_id,
 // TODO: Remove `diagnose` and split into `TryIdentifyFacetType`.
 auto RequireIdentifiedFacetType(Context& context, SemIR::LocId loc_id,
                                 SemIR::ConstantId self_const_id,
-                                const SemIR::FacetType& facet_type,
+                                SemIR::TypeInstId facet_type_inst_id,
                                 DiagnosticContextFn diagnostic_context,
                                 bool diagnose = true)
     -> SemIR::IdentifiedFacetTypeId;

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -485,6 +485,10 @@ class InstStore {
     return Get(inst_id).As<InstT>();
   }
 
+  // Use `Get()` when the instruction type is known.
+  template <typename InstT, typename KnownInstT>
+  auto GetAs(KnownInstId<KnownInstT> inst_id) const = delete;
+
   // Returns the requested instruction as the specified type, if it is of that
   // type.
   template <typename InstT>

--- a/toolchain/sem_ir/type.cpp
+++ b/toolchain/sem_ir/type.cpp
@@ -47,6 +47,16 @@ auto TypeStore::TryGetTypeIdForTypeConstantId(ConstantId constant_id) const
   return TypeId::ForTypeConstant(constant_id);
 }
 
+auto TypeStore::GetTypeInstIdForTypeConstantId(ConstantId constant_id) const
+    -> TypeInstId {
+  return GetTypeInstId(GetTypeIdForTypeConstantId(constant_id));
+}
+
+auto TypeStore::TryGetTypeInstIdForTypeConstantId(ConstantId constant_id) const
+    -> TypeInstId {
+  return GetTypeInstId(TryGetTypeIdForTypeConstantId(constant_id));
+}
+
 auto TypeStore::GetTypeIdForTypeInstId(InstId inst_id) const -> TypeId {
   auto constant_id = file_->constant_values().Get(inst_id);
   CheckTypeOfConstantIsTypeType(*file_, constant_id);

--- a/toolchain/sem_ir/type.h
+++ b/toolchain/sem_ir/type.h
@@ -66,6 +66,20 @@ class TypeStore : public Yaml::Printable<TypeStore> {
   // value of type `TypeType`.
   auto TryGetTypeIdForTypeConstantId(ConstantId constant_id) const -> TypeId;
 
+  // Returns the TypeInstId for a constant that is a type value, i.e. it is a
+  // value of type `TypeType`.
+  //
+  // Facet values are of the same typishness as types, but are not themselves
+  // types, so they can not be passed here. They should be converted to a type
+  // through an `as type` conversion, that is, to a value of type `TypeType`.
+  auto GetTypeInstIdForTypeConstantId(ConstantId constant_id) const
+      -> TypeInstId;
+
+  // Like GetTypeIdForTypeConstantId() but returns None if the constant is not a
+  // value of type `TypeType`.
+  auto TryGetTypeInstIdForTypeConstantId(ConstantId constant_id) const
+      -> TypeInstId;
+
   // Returns the type ID for an instruction whose constant value is a type
   // value, i.e. it is a value of type `TypeType`.
   //


### PR DESCRIPTION
This performs `.Self` substitution in a single step, for the whole facet type, instead of doing it individually for each constraint visited in the top-level facet type. Then we don't need to track state to avoid subst in constraints that come from other named constraints.

The semir changes are because we now generate a whole other FacetType from the substitution.