### PR TITLE
Run clangd-tidy in pre-commit (via prek)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,6 +132,12 @@ repos:
         language: python
         args: ['-i']
         additional_dependencies: ['clang-format==21.1.8']
+      - id: clangd-tidy
+        name: clangd-tidy
+        entry: clangd-tidy
+        types_or: [c++, def]
+        language: python
+        additional_dependencies: ['clangd-tidy==1.1.0.post2']
 
   - repo: local
     hooks:


### PR DESCRIPTION
This will catch clangd-tidy errors locally before pushing, instead of having to wait to find out about them from the bots.