### PR TITLE
Fix placement of global let conversion in SemIR

### DIFF
--- a/toolchain/check/pattern_match.cpp
+++ b/toolchain/check/pattern_match.cpp
@@ -667,13 +667,6 @@ auto MatchContext::DoVarPreWorkImpl(State state,
       return scrutinee_id;
     }
     case CARBON_KIND(LocalState* _): {
-      // TODO: Find a more efficient way to put these insts in the global_init
-      // block (or drop the distinction between the global_init block and the
-      // file scope?)
-      if (UseGlobalInit(context_)) {
-        context_.global_init().Resume();
-      }
-
       // In a `var`/`let` declaration, the `VarStorage` inst is created before
       // we start pattern matching.
       auto storage_id =
@@ -689,9 +682,6 @@ auto MatchContext::DoVarPreWorkImpl(State state,
                                {.lhs_id = storage_id, .rhs_id = init_id});
       }
 
-      if (UseGlobalInit(context_)) {
-        context_.global_init().Suspend();
-      }
       return storage_id;
     }
     case CARBON_KIND(CallerState* _): {
@@ -1194,11 +1184,17 @@ auto CallerPatternMatch(Context& context, SemIR::SpecificId specific_id,
 
 auto LocalPatternMatch(Context& context, SemIR::InstId pattern_id,
                        SemIR::InstId scrutinee_id) -> void {
+  if (UseGlobalInit(context)) {
+    context.global_init().Resume();
+  }
   LocalState state;
   MatchContext match(context);
   match.Match(&state,
               {.pattern_id = pattern_id,
                .work = MatchContext::PreWork{.scrutinee_id = scrutinee_id}});
+  if (UseGlobalInit(context)) {
+    context.global_init().Suspend();
+  }
 }
 
 }  // namespace Carbon::Check


### PR DESCRIPTION
When a global `let` declaration requires an implicit conversion to the type of the pattern, the conversion was previously performed in the `file` block because `LocalPatternMatch` was executed outside the `global_init()` block stack. Since the initializer of a global `let` is evaluated while `global_init` is resumed (meaning the initializer instructions are inside `@__global_init`), the conversion instructions in the `file` block ended up consuming values from inside the `@__global_init` function block.

This resulted in the converted global `let` initializers always being considered non-constant, which led to compiler crashes during the lowering phase for declarations like `let a: i32 = 0 as i8;` followed by a use of `a`.

### Changes
*   Updated `LocalPatternMatch` in `toolchain/check/pattern_match.cpp` to resume the `global_init` block stack before matching, and suspend it afterward, if `UseGlobalInit(context)` is true. This correctly places all conversion and name binding instructions (`wrapper_binding`) within the `@__global_init` function scope.
*   Cleaned up `DoVarPreWorkImpl` in `pattern_match.cpp` by removing local `Resume` and `Suspend` calls on `global_init` since they are now handled globally for the entire matching session in `LocalPatternMatch`.

### Closes
Closes #7371