### PR TITLE
Nvim setup fixes (POSIX Compatbility, Clang includes and Treesitter Querys)

### DIFF
--- a/utils/nvim/carbon.lua
+++ b/utils/nvim/carbon.lua
@@ -19,7 +19,7 @@ local util = require 'lspconfig.util'
 if not configs.carbon then
   configs.carbon = {
     default_config = {
-      cmd = { "./bazel-bin/toolchain/carbon language-server" },
+      cmd = { "./bazel-bin/toolchain/carbon","language-server" },
       filetypes = { "carbon" },
       root_dir = util.find_git_ancestor,
     }

--- a/utils/nvim/setup.sh
+++ b/utils/nvim/setup.sh
@@ -4,7 +4,7 @@
 # Exceptions. See /LICENSE for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-set -xeuo pipefail
+set -xeu
 
 ROOT="$(git rev-parse --show-toplevel)"
 
@@ -22,4 +22,4 @@ grep 'require "carbon"' ~/.config/nvim/init.lua || echo 'require "carbon"' >> ~/
 # build tree_sitter
 cd utils/tree_sitter
 tree-sitter generate
-clang -o ~/.config/nvim/parser/carbon.so -shared src/parser.c src/scanner.c -I ./src -Os -fPIC
+clang -o ~/.config/nvim/parser/carbon.so -shared src/parser.c src/scanner.c -I "$ROOT" -I ./src -Os -fPIC

--- a/utils/tree_sitter/queries/highlights.scm
+++ b/utils/tree_sitter/queries/highlights.scm
@@ -81,7 +81,7 @@
 [
   "abstract"
   ; "adapt"
-  "addr"
+  ; "addr"
   "alias"
   "and"
   "api"
@@ -123,6 +123,7 @@
   ; "partial"
   ; "private"
   ; "protected"
+  "ref"
   "require"
   "return"
   "returned"


### PR DESCRIPTION
###Description

This pr addresses several issues in the nvim setup tooling, namely:
1) lsp invocation: this is more idiomatic (and in general should work on more systems)
2) steup.sh
2.1)  removed -o pipefail. This is not standard posix, and as such will fail  on strict posix shells. As there is no pipes in this script it is safe to remove
2.2) added -I "$ROOT" so clang can find all the headers it needs
3) updated highlights.scm to match grammar.js so it no longer crashes on loading a .carbon file
