### PR TITLE
Allow abstract classes to implement Core.Destroy

### DIFF
--- a/toolchain/check/custom_witness.cpp
+++ b/toolchain/check/custom_witness.cpp
@@ -143,10 +143,14 @@ static auto HasWitnessForOneField(
 // Returns true if `class_type` should impl `Destroy`.
 static auto CanDestroyClass(
     Context& context, SemIR::LocId loc_id, SemIR::ClassType class_type,
-    SemIR::SpecificInterfaceId query_specific_interface_id)
+    SemIR::SpecificInterfaceId query_specific_interface_id, bool is_partial)
     -> DestroyFormat {
-
   auto class_info = context.classes().Get(class_type.class_id);
+
+  if (!is_partial && class_info.inheritance_kind ==
+                         SemIR::Class::InheritanceKind::Abstract) {
+    return DestroyFormat::NoDestroy;
+  }
 
   // `LookupCppImpl` handles C++ types.
   if (context.name_scopes().Get(class_info.scope_id).is_cpp_scope()) {
@@ -227,7 +231,7 @@ static auto CanDestroyType(
 
     case CARBON_KIND(SemIR::ClassType class_type): {
       return CanDestroyClass(context, loc_id, class_type,
-                             query_specific_interface_id);
+                             query_specific_interface_id, /*is_partial=*/false);
     }
 
     case CARBON_KIND(SemIR::ConstType const_type): {
@@ -247,7 +251,7 @@ static auto CanDestroyType(
       auto class_type =
           context.insts().GetAs<SemIR::ClassType>(partial_type.inner_id);
       return CanDestroyClass(context, loc_id, class_type,
-                             query_specific_interface_id);
+                             query_specific_interface_id, /*is_partial=*/true);
     }
 
     case CARBON_KIND(SemIR::StructType struct_type): {
@@ -259,10 +263,21 @@ static auto CanDestroyType(
           PrepareForHasWitness(context, loc_id, query_specific_interface_id);
       bool has_witness = true;
       for (const auto& field : fields) {
-        if (!HasWitnessForRepeatedField(context, loc_id, field.type_inst_id,
-                                        query_facet_type_const_id)) {
-          has_witness = false;
-          break;
+        if (field.name_id == SemIR::NameId::Base) {
+          auto base_class_type =
+              context.insts().GetAs<SemIR::ClassType>(field.type_inst_id);
+          if (CanDestroyClass(context, loc_id, base_class_type,
+                              query_specific_interface_id,
+                              /*is_partial=*/true) == DestroyFormat::NoDestroy) {
+            has_witness = false;
+            break;
+          }
+        } else {
+          if (!HasWitnessForRepeatedField(context, loc_id, field.type_inst_id,
+                                          query_facet_type_const_id)) {
+            has_witness = false;
+            break;
+          }
         }
       }
       CleanupAfterHasWitness(context);

--- a/toolchain/check/custom_witness.cpp
+++ b/toolchain/check/custom_witness.cpp
@@ -143,13 +143,8 @@ static auto HasWitnessForOneField(
 // Returns true if `class_type` should impl `Destroy`.
 static auto CanDestroyClass(
     Context& context, SemIR::LocId loc_id, SemIR::ClassType class_type,
-    const SemIR::CompleteTypeInfo& complete_info,
-    SemIR::SpecificInterfaceId query_specific_interface_id, bool is_partial)
+    SemIR::SpecificInterfaceId query_specific_interface_id)
     -> DestroyFormat {
-  // Abstract classes can't be destroyed.
-  if (!is_partial && complete_info.IsAbstract()) {
-    return DestroyFormat::NoDestroy;
-  }
 
   auto class_info = context.classes().Get(class_type.class_id);
 
@@ -232,9 +227,7 @@ static auto CanDestroyType(
 
     case CARBON_KIND(SemIR::ClassType class_type): {
       return CanDestroyClass(context, loc_id, class_type,
-                             context.types().GetCompleteTypeInfo(type_id),
-                             query_specific_interface_id,
-                             /*is_partial=*/false);
+                             query_specific_interface_id);
     }
 
     case CARBON_KIND(SemIR::ConstType const_type): {
@@ -254,9 +247,7 @@ static auto CanDestroyType(
       auto class_type =
           context.insts().GetAs<SemIR::ClassType>(partial_type.inner_id);
       return CanDestroyClass(context, loc_id, class_type,
-                             context.types().GetCompleteTypeInfo(type_id),
-                             query_specific_interface_id,
-                             /*is_partial=*/true);
+                             query_specific_interface_id);
     }
 
     case CARBON_KIND(SemIR::StructType struct_type): {

--- a/toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
+++ b/toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
@@ -12,7 +12,7 @@
 
 library "[[@TEST_NAME]]";
 
-abstract class Otter {
+abstract class AbstractBase {
   var whisker_count: i32;
   protected var fur_status: i32;
 }

--- a/toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
+++ b/toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
@@ -2,25 +2,26 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
-//
 // AUTOUPDATE
 // TIP: To test this file alone, run:
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
 
-library "[[@TEST_NAME]]";
+abstract class AbstractBase {}
 
-abstract class AbstractBase {
-  var whisker_count: i32;
-  protected var fur_status: i32;
-}
-
-class C {
+class Derived {
   extend base: AbstractBase;
 }
 
+// @dump-sem-ir-begin
 fn Run() {
-  var _: RiverOtter = {.base = {.whisker_count = 30, .fur_status = 1}};
+  var _: Derived = {.base = {}};
+}
+// @dump-sem-ir-end
+
+fn F(T:! Core.Destroy) {}
+
+fn G() {
+  F(AbstractBase);
 }

--- a/toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
+++ b/toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
@@ -1,0 +1,26 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/int.carbon
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
+
+library "[[@TEST_NAME]]";
+
+abstract class Otter {
+  var whisker_count: i32;
+  protected var fur_status: i32;
+}
+
+class RiverOtter {
+  extend base: Otter;
+}
+
+fn Run() {
+  var _: RiverOtter = {.base = {.whisker_count = 30, .fur_status = 1}};
+}

--- a/toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
+++ b/toolchain/check/testdata/impl/custom_witness/destroy_abstract.carbon
@@ -17,8 +17,8 @@ abstract class Otter {
   protected var fur_status: i32;
 }
 
-class RiverOtter {
-  extend base: Otter;
+class C {
+  extend base: AbstractBase;
 }
 
 fn Run() {


### PR DESCRIPTION
Fixes #7169 :)

Removes the `IsAbstract` early return in `CanDestroyClass`.

Abstract classes can't be instantiated on their own, but they still show up in memory as the `base` part of a derived concrete class. So when a derived class gets destroyed, it has to recursively call `Core.Destroy` on that base to clean up its fields. That means the abstract class itself needs to be destructible too, even though nothing can ever make a standalone instance of it.

With the early return gone, `CanDestroyClass`  checks the object rep now instead of bailing out just because the class is abstract. creating an instance of abstract class directly is still blocked separately, through `RequireConcreteType`, so this change only affects whether it can act as a destructible base. It does not let you instantiate one on its own

 I also added a regression test `destroy_abstract.carbon` covering the `Otter` case from the issue.