### PR TITLE
Remove the ImplicitOnly option from SubstPeriodSelf

### DIFF
--- a/toolchain/check/impl_lookup.cpp
+++ b/toolchain/check/impl_lookup.cpp
@@ -555,10 +555,10 @@ static auto VerifyQueryFacetTypeConstraints(
 
       auto lhs_id = context.constant_values().GetInstId(SubstPeriodSelf(
           context, loc_id, context.constant_values().Get(rewrite.lhs_id),
-          query_self_const_id, SubstPeriodSelfBehaviour::All, rebuild));
+          query_self_const_id, rebuild));
       auto rhs_id = context.constant_values().GetInstId(SubstPeriodSelf(
           context, loc_id, context.constant_values().Get(rewrite.rhs_id),
-          query_self_const_id, SubstPeriodSelfBehaviour::All, rebuild));
+          query_self_const_id, rebuild));
 
       if (lhs_id != rhs_id) {
         // TODO: Provide a diagnostic note and location for which rewrite

--- a/toolchain/check/period_self.cpp
+++ b/toolchain/check/period_self.cpp
@@ -73,16 +73,11 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
   explicit SubstPeriodSelfCallbacks(
       Context* context, SemIR::LocId loc_id,
       SemIR::ConstantId period_self_replacement_id,
-      SubstPeriodSelfBehaviour behaviour, SubstPeriodSelfRebuildInst rebuild)
+      SubstPeriodSelfRebuildInst rebuild)
       : SubstInstCallbacks(context),
         loc_id_(loc_id),
         period_self_replacement_id_(period_self_replacement_id),
-        behaviour_(behaviour),
         rebuild_callback_(rebuild) {}
-
-  virtual ~SubstPeriodSelfCallbacks() {
-    CARBON_CHECK(designator_states_.empty());
-  }
 
   auto Subst(SemIR::InstId& inst_id) -> SubstResult override {
     // FacetTypes are concrete even if they have `.Self` inside them, but we
@@ -97,59 +92,13 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
       return FullySubstituted;
     }
 
-    // Look for implicit use of `.Self` in designators: `.X` is really
-    // `.Self.X`.
-    if (auto access =
-            context().insts().TryGetAs<SemIR::ImplWitnessAccess>(inst_id)) {
-      if (auto witness = context().insts().TryGetAs<SemIR::LookupImplWitness>(
-              access->witness_id)) {
-        // Canonicalization not necessary; we are working with the constant
-        // value already, and the query self in a witness is already
-        // canonicalized.
-        if (IsPeriodSelf(context(), witness->query_self_inst_id,
-                         /*canonicalize=*/false)) {
-          // We are entering a designator. We watch for the witness next.
-          designator_states_.push_back(WitnessNext);
-          return SubstOperands;
-        }
-      }
-    }
-
-    if (GetDesignatorState() == WitnessNext) {
-      if (auto witness =
-              context().insts().TryGetAs<SemIR::LookupImplWitness>(inst_id)) {
-        // The query self comes next, before the specific interface. This
-        // deepnds on the order of the operands in the LookupImplWitness, and
-        // that Subst visits them in top to bottom order.
-        designator_states_.back() = WitnessSelfNext;
-        return SubstOperands;
-      }
-    }
-
     // Canonicalization not necessary; we are working with the constant
     // value already, and the query self in a witness is already
     // canonicalized.
     if (auto period_self = TryGetAsPeriodSelf(context(), inst_id,
                                               /*canonicalize=*/false)) {
-      bool is_implicit_self_in_desigator = false;
-      if (GetDesignatorState() == WitnessSelfNext) {
-        is_implicit_self_in_desigator = true;
-        designator_states_.back() = RebuildNext;
-      }
-
-      if (period_self->is_frozen) {
-        return FullySubstituted;
-      }
-
-      switch (behaviour_) {
-        case SubstPeriodSelfBehaviour::All:
-          inst_id = GetReplacement(inst_id);
-          break;
-        case SubstPeriodSelfBehaviour::ImplicitOnly:
-          if (is_implicit_self_in_desigator) {
-            inst_id = GetReplacement(inst_id);
-          }
-          break;
+      if (!period_self->is_frozen) {
+        inst_id = GetReplacement(inst_id);
       }
       return FullySubstituted;
     }
@@ -159,7 +108,6 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
 
   auto Rebuild(SemIR::InstId orig_inst_id, SemIR::Inst new_inst)
       -> SemIR::InstId override {
-    TryPopDesignatorState(orig_inst_id);
     if (rebuild_callback_) {
       if (auto inst_id = rebuild_callback_(new_inst); inst_id.has_value()) {
         return inst_id;
@@ -168,27 +116,7 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
     return RebuildNewInst(SemIR::LocId(orig_inst_id), new_inst);
   }
 
-  auto ReuseUnchanged(SemIR::InstId orig_inst_id) -> SemIR::InstId override {
-    TryPopDesignatorState(orig_inst_id);
-    return orig_inst_id;
-  }
-
  private:
-  enum DesignatorState {
-    // We are not inside a designator.
-    None,
-    // We are looking for the LookupImplWitness of a designator next.
-    WitnessNext,
-    // We are looking for `.Self`, the next one will be the query self of the
-    // LookupImplWitness of a designator. This is the implicit use of `.Self`.
-    WitnessSelfNext,
-    // We have seen the query self of the designator, and are now looking for
-    // the designator to be rebuilt with the replacement. Any other `.Self` that
-    // we find are explicit uses of `.Self`, such as in the designator's
-    // specific interface.
-    RebuildNext,
-  };
-
   auto GetReplacement(SemIR::InstId period_self) -> SemIR::InstId {
     auto period_self_type_id = context().insts().Get(period_self).type_id();
     CARBON_CHECK(context().types().Is<SemIR::FacetType>(period_self_type_id));
@@ -290,32 +218,8 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
             }));
   }
 
-  auto GetDesignatorState() const -> DesignatorState {
-    return designator_states_.empty() ? DesignatorState::None
-                                      : designator_states_.back();
-  }
-
-  auto TryPopDesignatorState(SemIR::InstId orig_inst_id) -> void {
-    if (GetDesignatorState() == RebuildNext) {
-      if (auto access = context().insts().TryGetAs<SemIR::ImplWitnessAccess>(
-              orig_inst_id)) {
-        if (auto witness = context().insts().TryGetAs<SemIR::LookupImplWitness>(
-                access->witness_id)) {
-          // Canonicalization not necessary; we are working with the constant
-          // value already, and the query self in a witness is already
-          // canonicalized.
-          if (IsPeriodSelf(context(), witness->query_self_inst_id,
-                           /*canonicalize=*/false)) {
-            designator_states_.pop_back();
-          }
-        }
-      }
-    }
-  }
-
   SemIR::LocId loc_id_;
   SemIR::ConstantId period_self_replacement_id_;
-  SubstPeriodSelfBehaviour behaviour_;
   SubstPeriodSelfRebuildInst rebuild_callback_;
 
   // The last output of GetReplacement().
@@ -323,14 +227,11 @@ class SubstPeriodSelfCallbacks : public SubstInstCallbacks {
   // The type of the last output of GetReplacement(). If the type of `.Self`
   // matches, we can reuse the `cached_replacement_id_`.
   SemIR::TypeId cached_replacement_type_id_ = SemIR::TypeId::None;
-
-  llvm::SmallVector<DesignatorState> designator_states_;
 };
 
 auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
                      SemIR::ConstantId const_id,
                      SemIR::ConstantId period_self_replacement_id,
-                     SubstPeriodSelfBehaviour behaviour,
                      SubstPeriodSelfRebuildInst rebuild) -> SemIR::ConstantId {
   // Don't replace `.Self` with itself; that is cyclical.
   //
@@ -343,8 +244,8 @@ auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
     return const_id;
   }
 
-  SubstPeriodSelfCallbacks callbacks(
-      &context, loc_id, period_self_replacement_id, behaviour, rebuild);
+  SubstPeriodSelfCallbacks callbacks(&context, loc_id,
+                                     period_self_replacement_id, rebuild);
   auto subst_id = SubstInst(
       context, context.constant_values().GetInstId(const_id), callbacks);
   return context.constant_values().Get(subst_id);
@@ -353,8 +254,7 @@ auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
 static auto SubstPeriodSelfInSpecific(
     Context& context, SemIR::LocId loc_id, SemIR::SpecificId specific_id,
     SemIR::ConstantId period_self_replacement_id,
-    SubstPeriodSelfBehaviour behaviour, SubstPeriodSelfRebuildInst rebuild)
-    -> SemIR::SpecificId {
+    SubstPeriodSelfRebuildInst rebuild) -> SemIR::SpecificId {
   if (!specific_id.has_value()) {
     return specific_id;
   }
@@ -368,7 +268,7 @@ static auto SubstPeriodSelfInSpecific(
   for (auto& arg_id : args) {
     auto const_id = context.constant_values().Get(arg_id);
     const_id = SubstPeriodSelf(context, loc_id, const_id,
-                               period_self_replacement_id, behaviour, rebuild);
+                               period_self_replacement_id, rebuild);
     arg_id = context.constant_values().GetInstId(const_id);
   }
   return MakeSpecific(context, loc_id, specific.generic_id, args);
@@ -377,23 +277,21 @@ static auto SubstPeriodSelfInSpecific(
 auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
                      SemIR::SpecificInterface interface,
                      SemIR::ConstantId period_self_replacement_id,
-                     SubstPeriodSelfBehaviour behaviour,
                      SubstPeriodSelfRebuildInst rebuild)
     -> SemIR::SpecificInterface {
   interface.specific_id =
       SubstPeriodSelfInSpecific(context, loc_id, interface.specific_id,
-                                period_self_replacement_id, behaviour, rebuild);
+                                period_self_replacement_id, rebuild);
   return interface;
 }
 auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
                      SemIR::SpecificNamedConstraint constraint,
                      SemIR::ConstantId period_self_replacement_id,
-                     SubstPeriodSelfBehaviour behaviour,
                      SubstPeriodSelfRebuildInst rebuild)
     -> SemIR::SpecificNamedConstraint {
   constraint.specific_id =
       SubstPeriodSelfInSpecific(context, loc_id, constraint.specific_id,
-                                period_self_replacement_id, behaviour, rebuild);
+                                period_self_replacement_id, rebuild);
   return constraint;
 }
 
@@ -415,33 +313,30 @@ auto SubstPeriodSelfInFacetType(Context& context, SemIR::LocId loc_id,
       context.facet_types().Get(orig_facet_type.facet_type_id);
 
   auto replace_interface = [&](SemIR::SpecificInterface si) {
-    return SubstPeriodSelf(context, loc_id, si, period_self_replacement_id,
-                           SubstPeriodSelfBehaviour::All);
+    return SubstPeriodSelf(context, loc_id, si, period_self_replacement_id);
   };
   auto replace_constraint = [&](SemIR::SpecificNamedConstraint sc) {
-    return SubstPeriodSelf(context, loc_id, sc, period_self_replacement_id,
-                           SubstPeriodSelfBehaviour::All);
+    return SubstPeriodSelf(context, loc_id, sc, period_self_replacement_id);
   };
   auto replace_type_impls_interface =
       [&](SemIR::FacetTypeInfo::TypeImplsInterface impls)
       -> SemIR::FacetTypeInfo::TypeImplsInterface {
-    auto self = SubstPeriodSelf(
-        context, loc_id, context.constant_values().Get(impls.self_type),
-        period_self_replacement_id, SubstPeriodSelfBehaviour::All);
+    auto self = SubstPeriodSelf(context, loc_id,
+                                context.constant_values().Get(impls.self_type),
+                                period_self_replacement_id);
     auto interface = SubstPeriodSelf(context, loc_id, impls.specific_interface,
-                                     period_self_replacement_id,
-                                     SubstPeriodSelfBehaviour::All);
+                                     period_self_replacement_id);
     return {context.constant_values().GetInstId(self), interface};
   };
   auto replace_type_impls_constraint =
       [&](SemIR::FacetTypeInfo::TypeImplsNamedConstraint impls)
       -> SemIR::FacetTypeInfo::TypeImplsNamedConstraint {
-    auto self = SubstPeriodSelf(
-        context, loc_id, context.constant_values().Get(impls.self_type),
-        period_self_replacement_id, SubstPeriodSelfBehaviour::All);
-    auto constraint = SubstPeriodSelf(
-        context, loc_id, impls.specific_named_constraint,
-        period_self_replacement_id, SubstPeriodSelfBehaviour::All);
+    auto self = SubstPeriodSelf(context, loc_id,
+                                context.constant_values().Get(impls.self_type),
+                                period_self_replacement_id);
+    auto constraint =
+        SubstPeriodSelf(context, loc_id, impls.specific_named_constraint,
+                        period_self_replacement_id);
     return {context.constant_values().GetInstId(self), constraint};
   };
   auto replace_rewrite = [&](SemIR::FacetTypeInfo::RewriteConstraint r)

--- a/toolchain/check/period_self.h
+++ b/toolchain/check/period_self.h
@@ -21,44 +21,35 @@ namespace Carbon::Check {
 auto MakePeriodSelfFacetValue(Context& context, SemIR::LocId loc_id,
                               SemIR::TypeId self_type_id) -> SemIR::InstId;
 
-enum class SubstPeriodSelfBehaviour {
-  ImplicitOnly,
-  All,
-};
-
 using SubstPeriodSelfRebuildInst =
     llvm::function_ref<auto(SemIR::Inst)->SemIR::InstId>;
 
 // Replace `.Self` references in `const_id` with `period_self_replacement_id`.
 //
-// The `behaviour` specifies if all `.Self` are replaced or just implicit use in
-// designators. The `rebuild` callback can optionally be specified to override
-// how an instruction is re-constructed to form an InstId after replacement. It
-// can return None to fall back to the default of evaluating the inst.
-auto SubstPeriodSelf(
-    Context& context, SemIR::LocId loc_id, SemIR::ConstantId const_id,
-    SemIR::ConstantId period_self_replacement_id,
-    SubstPeriodSelfBehaviour behaviour = SubstPeriodSelfBehaviour::All,
-    SubstPeriodSelfRebuildInst rebuild = nullptr) -> SemIR::ConstantId;
+// The `rebuild` callback can optionally be specified to override how an
+// instruction is re-constructed to form an InstId after replacement. It can
+// return None to fall back to the default of evaluating the inst.
+auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
+                     SemIR::ConstantId const_id,
+                     SemIR::ConstantId period_self_replacement_id,
+                     SubstPeriodSelfRebuildInst rebuild = nullptr)
+    -> SemIR::ConstantId;
 
 // Replace `.Self` references in the specific of the interface or named
 // constraint with `period_self_replacement_id`.
 //
-// The `behaviour` specifies if all `.Self` are replaced or just implicit use in
-// designators. The `rebuild` callback can optionally be specified to override
-// how an instruction is re-constructed to form an InstId after replacement. It
-// can return None to fall back to the default of evaluating the inst.
-auto SubstPeriodSelf(
-    Context& context, SemIR::LocId loc_id, SemIR::SpecificInterface interface,
-    SemIR::ConstantId period_self_replacement_id,
-    SubstPeriodSelfBehaviour behaviour = SubstPeriodSelfBehaviour::All,
-    SubstPeriodSelfRebuildInst rebuild = nullptr) -> SemIR::SpecificInterface;
-auto SubstPeriodSelf(
-    Context& context, SemIR::LocId loc_id,
-    SemIR::SpecificNamedConstraint constraint,
-    SemIR::ConstantId period_self_replacement_id,
-    SubstPeriodSelfBehaviour behaviour = SubstPeriodSelfBehaviour::All,
-    SubstPeriodSelfRebuildInst rebuild = nullptr)
+// The `rebuild` callback can optionally be specified to override how an
+// instruction is re-constructed to form an InstId after replacement. It can
+// return None to fall back to the default of evaluating the inst.
+auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
+                     SemIR::SpecificInterface interface,
+                     SemIR::ConstantId period_self_replacement_id,
+                     SubstPeriodSelfRebuildInst rebuild = nullptr)
+    -> SemIR::SpecificInterface;
+auto SubstPeriodSelf(Context& context, SemIR::LocId loc_id,
+                     SemIR::SpecificNamedConstraint constraint,
+                     SemIR::ConstantId period_self_replacement_id,
+                     SubstPeriodSelfRebuildInst rebuild = nullptr)
     -> SemIR::SpecificNamedConstraint;
 
 // Replace `.Self` references with the self-type. The `facet_type_inst_id` must


### PR DESCRIPTION
The implicit/explicit `.Self` concept is a heuristic at best, so we should avoid relying on it. The ImplicitOnly option is no longer used, as it was used to remove/disambiguate `.Self` in nested facet types, but we have banned nesting `where` on the RHS of a `where`. So we no longer have to worry about ambiguous `.Self`.

We can remove all the designator tracking heuristics in `.Self` substitution as well now, as they were used for the now-removed ExplicitOnly (removed in https://github.com/carbon-language/carbon-lang/pull/7460) and ImplicitOnly options.