### PR TITLE
Add separators between files in LLVM IR dumps

### DIFF
--- a/toolchain/driver/compile_driver.cpp
+++ b/toolchain/driver/compile_driver.cpp
@@ -308,8 +308,10 @@ auto CompilationUnit::RunOptimize(
 auto CompilationUnit::PostLower() -> void {
   CARBON_CHECK(module_, "Must call RunLower first");
   if (options_->dump_llvm_ir && IncludeInDumps()) {
+    *driver_env_->output_stream << "; ---\n";
     module_->print(*driver_env_->output_stream, /*AAW=*/nullptr,
                    /*ShouldPreserveUseListOrder=*/true);
+    *driver_env_->output_stream << "\n";
   }
 }
 

--- a/toolchain/driver/testdata/compile/optimize/clang_no_optimize_twice.carbon
+++ b/toolchain/driver/testdata/compile/optimize/clang_no_optimize_twice.carbon
@@ -26,6 +26,7 @@ fn Call() -> i32 {
   return Cpp.g();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'foo.carbon'
 // CHECK:STDOUT: source_filename = "foo.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -78,3 +79,4 @@ fn Call() -> i32 {
 // CHECK:STDOUT: !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !15 = !DILocation(line: 13, column: 10, scope: !11)
 // CHECK:STDOUT: !16 = !DILocation(line: 13, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/driver/testdata/compile/optimize/optimize_debug.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_debug.carbon
@@ -34,6 +34,7 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'foo.carbon'
 // CHECK:STDOUT: source_filename = "foo.carbon"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
@@ -140,3 +141,4 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !41, type: !7)
 // CHECK:STDOUT: !44 = !DILocation(line: 17, column: 3, scope: !41)
+// CHECK:STDOUT:

--- a/toolchain/driver/testdata/compile/optimize/optimize_default.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_default.carbon
@@ -34,6 +34,7 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'foo.carbon'
 // CHECK:STDOUT: source_filename = "foo.carbon"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
@@ -140,3 +141,4 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !41, type: !7)
 // CHECK:STDOUT: !44 = !DILocation(line: 17, column: 3, scope: !41)
+// CHECK:STDOUT:

--- a/toolchain/driver/testdata/compile/optimize/optimize_none.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_none.carbon
@@ -34,6 +34,7 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'foo.carbon'
 // CHECK:STDOUT: source_filename = "foo.carbon"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
@@ -183,3 +184,4 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !56 = !{!57}
 // CHECK:STDOUT: !57 = !DILocalVariable(arg: 1, scope: !55, type: !7)
 // CHECK:STDOUT: !58 = !DILocation(line: 59, column: 28, scope: !55)
+// CHECK:STDOUT:

--- a/toolchain/driver/testdata/compile/optimize/optimize_size.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_size.carbon
@@ -34,6 +34,7 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'foo.carbon'
 // CHECK:STDOUT: source_filename = "foo.carbon"
 // CHECK:STDOUT:
@@ -183,3 +184,4 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !56 = !{!57}
 // CHECK:STDOUT: !57 = !DILocalVariable(arg: 1, scope: !55, type: !7)
 // CHECK:STDOUT: !58 = !DILocation(line: 59, column: 28, scope: !55)
+// CHECK:STDOUT:

--- a/toolchain/driver/testdata/compile/optimize/optimize_speed.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_speed.carbon
@@ -34,6 +34,7 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'foo.carbon'
 // CHECK:STDOUT: source_filename = "foo.carbon"
 // CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
@@ -158,3 +159,4 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !44 = !{!45}
 // CHECK:STDOUT: !45 = !DILocalVariable(arg: 1, scope: !43, type: !7)
 // CHECK:STDOUT: !46 = !DILocation(line: 17, column: 3, scope: !43)
+// CHECK:STDOUT:

--- a/toolchain/driver/testdata/stdin.carbon
+++ b/toolchain/driver/testdata/stdin.carbon
@@ -102,6 +102,7 @@
 // CHECK:STDOUT:   package: <namespace> = namespace [concrete] {}
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = '-'
 // CHECK:STDOUT: source_filename = "-"
 // CHECK:STDOUT:
@@ -112,3 +113,4 @@
 // CHECK:STDOUT: !1 = !DIFile(filename: "-", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/alias/var.carbon
+++ b/toolchain/lower/testdata/alias/var.carbon
@@ -17,6 +17,7 @@ fn F() -> i32 {
   return b;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var.carbon'
 // CHECK:STDOUT: source_filename = "var.carbon"
 // CHECK:STDOUT:
@@ -57,3 +58,4 @@ fn F() -> i32 {
 // CHECK:STDOUT: !12 = !{null}
 // CHECK:STDOUT: !13 = !DILocation(line: 13, column: 1, scope: !10)
 // CHECK:STDOUT: !14 = !DILocation(line: 0, scope: !10)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/array_in_place.carbon
+++ b/toolchain/lower/testdata/array/array_in_place.carbon
@@ -16,6 +16,7 @@ fn G() {
   var _: array((i32, i32, i32), 2) = (F(), F());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'array_in_place.carbon'
 // CHECK:STDOUT: source_filename = "array_in_place.carbon"
 // CHECK:STDOUT:
@@ -91,3 +92,4 @@ fn G() {
 // CHECK:STDOUT: !27 = !{!28}
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 1, scope: !26, type: !22)
 // CHECK:STDOUT: !29 = !DILocation(line: 16, column: 3, scope: !26)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/assign_return_value.carbon
+++ b/toolchain/lower/testdata/array/assign_return_value.carbon
@@ -16,6 +16,7 @@ fn Run() {
   var _: array(i32, 2) = F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'assign_return_value.carbon'
 // CHECK:STDOUT: source_filename = "assign_return_value.carbon"
 // CHECK:STDOUT:
@@ -117,3 +118,4 @@ fn Run() {
 // CHECK:STDOUT: !30 = !{!31}
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !7)
 // CHECK:STDOUT: !32 = !DILocation(line: 16, column: 3, scope: !29)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/base.carbon
+++ b/toolchain/lower/testdata/array/base.carbon
@@ -18,6 +18,7 @@ fn Run() {
   var _: array(i32, 3) = d;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'base.carbon'
 // CHECK:STDOUT: source_filename = "base.carbon"
 // CHECK:STDOUT:
@@ -184,3 +185,4 @@ fn Run() {
 // CHECK:STDOUT: !49 = !{!50}
 // CHECK:STDOUT: !50 = !DILocalVariable(arg: 1, scope: !48, type: !28)
 // CHECK:STDOUT: !51 = !DILocation(line: 14, column: 3, scope: !48)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/field.carbon
+++ b/toolchain/lower/testdata/array/field.carbon
@@ -25,6 +25,7 @@ class A {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'field.carbon'
 // CHECK:STDOUT: source_filename = "field.carbon"
 // CHECK:STDOUT:
@@ -95,3 +96,4 @@ class A {
 // CHECK:STDOUT: !22 = !DILocation(line: 23, column: 5, scope: !19)
 // CHECK:STDOUT: !23 = !DILocation(line: 24, column: 12, scope: !19)
 // CHECK:STDOUT: !24 = !DILocation(line: 24, column: 5, scope: !19)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/function_param.carbon
+++ b/toolchain/lower/testdata/array/function_param.carbon
@@ -18,6 +18,7 @@ fn G() -> i32 {
   return F((1, 2, 3), 1);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'function_param.carbon'
 // CHECK:STDOUT: source_filename = "function_param.carbon"
 // CHECK:STDOUT:
@@ -98,3 +99,4 @@ fn G() -> i32 {
 // CHECK:STDOUT: !29 = !{!30}
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !26, type: !8)
 // CHECK:STDOUT: !31 = !DILocation(line: 18, column: 12, scope: !26)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/global.carbon
+++ b/toolchain/lower/testdata/array/global.carbon
@@ -19,6 +19,7 @@ fn Get() -> ref array(i32, 4) {
   return a;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'global_array_reference.carbon'
 // CHECK:STDOUT: source_filename = "global_array_reference.carbon"
 // CHECK:STDOUT:
@@ -62,3 +63,4 @@ fn Get() -> ref array(i32, 4) {
 // CHECK:STDOUT: !11 = !{null}
 // CHECK:STDOUT: !12 = !DILocation(line: 3, column: 1, scope: !9)
 // CHECK:STDOUT: !13 = !DILocation(line: 0, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/iterate.carbon
+++ b/toolchain/lower/testdata/array/iterate.carbon
@@ -19,6 +19,7 @@ fn F() {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'iterate.carbon'
 // CHECK:STDOUT: source_filename = "iterate.carbon"
 // CHECK:STDOUT:
@@ -363,3 +364,4 @@ fn F() {
 // CHECK:STDOUT: !134 = !{!135}
 // CHECK:STDOUT: !135 = !DILocalVariable(arg: 1, scope: !133, type: !15)
 // CHECK:STDOUT: !136 = !DILocation(line: 59, column: 28, scope: !133)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/array/layout.carbon
+++ b/toolchain/lower/testdata/array/layout.carbon
@@ -30,6 +30,7 @@ library "[[@TEST_NAME]]";
 
 var c: array(Core.Int(257), 5) = (1, 2, 3, 4, 5);
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'element_tail_padding.carbon'
 // CHECK:STDOUT: source_filename = "element_tail_padding.carbon"
 // CHECK:STDOUT:
@@ -113,6 +114,8 @@ var c: array(Core.Int(257), 5) = (1, 2, 3, 4, 5);
 // CHECK:STDOUT: !30 = !{!31}
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !25)
 // CHECK:STDOUT: !32 = !DILocation(line: 9, column: 3, scope: !29)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'constant_with_padding.carbon'
 // CHECK:STDOUT: source_filename = "constant_with_padding.carbon"
 // CHECK:STDOUT:
@@ -145,3 +148,4 @@ var c: array(Core.Int(257), 5) = (1, 2, 3, 4, 5);
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 3, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/basics/empty.carbon
+++ b/toolchain/lower/testdata/basics/empty.carbon
@@ -10,6 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/basics/empty.carbon
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'empty.carbon'
 // CHECK:STDOUT: source_filename = "empty.carbon"
 // CHECK:STDOUT:
@@ -20,3 +21,4 @@
 // CHECK:STDOUT: !1 = !DIFile(filename: "empty.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/bool.carbon
+++ b/toolchain/lower/testdata/builtins/bool.carbon
@@ -23,6 +23,7 @@ fn IfEq(a: Bool(), b: Bool()) -> Bool() {
   return false;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'bool.carbon'
 // CHECK:STDOUT: source_filename = "bool.carbon"
 // CHECK:STDOUT:
@@ -85,3 +86,4 @@ fn IfEq(a: Bool(), b: Bool()) -> Bool() {
 // CHECK:STDOUT: !24 = !DILocation(line: 22, column: 6, scope: !19)
 // CHECK:STDOUT: !25 = !DILocation(line: 22, column: 19, scope: !19)
 // CHECK:STDOUT: !26 = !DILocation(line: 23, column: 3, scope: !19)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/char.carbon
+++ b/toolchain/lower/testdata/builtins/char.carbon
@@ -19,6 +19,7 @@ fn Example() -> char {
   return c;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -75,3 +76,4 @@ fn Example() -> char {
 // CHECK:STDOUT: !18 = !{!19}
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !20 = !DILocation(line: 5, column: 3, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/cpp.carbon
+++ b/toolchain/lower/testdata/builtins/cpp.carbon
@@ -39,6 +39,7 @@ fn Test() {
   TakePointerSize(MakePointerSize((1, 2, 3, 4)));
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'std_initializer_list_make.carbon'
 // CHECK:STDOUT: source_filename = "std_initializer_list_make.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -146,3 +147,4 @@ fn Test() {
 // CHECK:STDOUT: !32 = !{!33}
 // CHECK:STDOUT: !33 = !DILocalVariable(arg: 1, scope: !28, type: !31)
 // CHECK:STDOUT: !34 = !DILocation(line: 26, column: 35, scope: !28)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/float.carbon
+++ b/toolchain/lower/testdata/builtins/float.carbon
@@ -79,6 +79,7 @@ fn TestF64(a: f64, b: f64) -> f64 { return F64(a, b); }
 fn F128(a: f128, b: f128) -> f128 = "float.add";
 fn TestF128(a: f128, b: f128) -> f128 { return F128(a, b); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -238,6 +239,8 @@ fn TestF128(a: f128, b: f128) -> f128 { return F128(a, b); }
 // CHECK:STDOUT: !71 = !DILocalVariable(arg: 2, scope: !68, type: !7)
 // CHECK:STDOUT: !72 = !DILocation(line: 35, column: 51, scope: !68)
 // CHECK:STDOUT: !73 = !DILocation(line: 35, column: 44, scope: !68)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'compound_assign.carbon'
 // CHECK:STDOUT: source_filename = "compound_assign.carbon"
 // CHECK:STDOUT:
@@ -313,6 +316,8 @@ fn TestF128(a: f128, b: f128) -> f128 { return F128(a, b); }
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 2, scope: !25, type: !7)
 // CHECK:STDOUT: !29 = !DILocation(line: 14, column: 34, scope: !25)
 // CHECK:STDOUT: !30 = !DILocation(line: 14, column: 1, scope: !25)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'types.carbon'
 // CHECK:STDOUT: source_filename = "types.carbon"
 // CHECK:STDOUT:
@@ -380,3 +385,4 @@ fn TestF128(a: f128, b: f128) -> f128 { return F128(a, b); }
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 2, scope: !25, type: !7)
 // CHECK:STDOUT: !29 = !DILocation(line: 14, column: 48, scope: !25)
 // CHECK:STDOUT: !30 = !DILocation(line: 14, column: 41, scope: !25)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/float_to_float.carbon
+++ b/toolchain/lower/testdata/builtins/float_to_float.carbon
@@ -22,6 +22,7 @@ fn TestConvertF64ToF32(a: f64) -> f32 { return ConvertF64ToF32(a); }
 fn ConvertF16ToF128(a: f16) -> f128 = "float.convert";
 fn TestConvertF16ToF128(a: f16) -> f128 { return ConvertF16ToF128(a); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'float_to_float.carbon'
 // CHECK:STDOUT: source_filename = "float_to_float.carbon"
 // CHECK:STDOUT:
@@ -73,3 +74,4 @@ fn TestConvertF16ToF128(a: f16) -> f128 { return ConvertF16ToF128(a); }
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !20 = !DILocation(line: 10, column: 50, scope: !17)
 // CHECK:STDOUT: !21 = !DILocation(line: 10, column: 43, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/float_to_int.carbon
+++ b/toolchain/lower/testdata/builtins/float_to_int.carbon
@@ -31,6 +31,7 @@ fn TestConvertF128ToI64(a: f128) -> i64 { return ConvertF128ToI64(a); }
 fn ConvertF128ToU64(a: f128) -> u64 = "float.convert_int";
 fn TestConvertF128ToU64(a: f128) -> u64 { return ConvertF128ToU64(a); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'float_to_int.carbon'
 // CHECK:STDOUT: source_filename = "float_to_int.carbon"
 // CHECK:STDOUT:
@@ -128,3 +129,4 @@ fn TestConvertF128ToU64(a: f128) -> u64 { return ConvertF128ToU64(a); }
 // CHECK:STDOUT: !44 = !DILocalVariable(arg: 1, scope: !39, type: !8)
 // CHECK:STDOUT: !45 = !DILocation(line: 19, column: 50, scope: !39)
 // CHECK:STDOUT: !46 = !DILocation(line: 19, column: 43, scope: !39)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/int.carbon
+++ b/toolchain/lower/testdata/builtins/int.carbon
@@ -222,6 +222,7 @@ fn TestInt32ToUint64(a: i32) -> u64 { return Int32ToUint64(a); }
 fn TestUint32ToInt64(a: u32) -> i64 { return Uint32ToInt64(a); }
 fn TestUint32ToUint64(a: u32) -> u64 { return Uint32ToUint64(a); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -490,6 +491,8 @@ fn TestUint32ToUint64(a: u32) -> u64 { return Uint32ToUint64(a); }
 // CHECK:STDOUT: !124 = !DILocalVariable(arg: 2, scope: !121, type: !7)
 // CHECK:STDOUT: !125 = !DILocation(line: 59, column: 51, scope: !121)
 // CHECK:STDOUT: !126 = !DILocation(line: 59, column: 44, scope: !121)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'compound_assign.carbon'
 // CHECK:STDOUT: source_filename = "compound_assign.carbon"
 // CHECK:STDOUT:
@@ -750,6 +753,8 @@ fn TestUint32ToUint64(a: u32) -> u64 { return Uint32ToUint64(a); }
 // CHECK:STDOUT: !105 = !DILocalVariable(arg: 2, scope: !100, type: !94)
 // CHECK:STDOUT: !106 = !DILocation(line: 50, column: 48, scope: !100)
 // CHECK:STDOUT: !107 = !DILocation(line: 50, column: 1, scope: !100)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'mixed_shift.carbon'
 // CHECK:STDOUT: source_filename = "mixed_shift.carbon"
 // CHECK:STDOUT:
@@ -916,6 +921,8 @@ fn TestUint32ToUint64(a: u32) -> u64 { return Uint32ToUint64(a); }
 // CHECK:STDOUT: !75 = !DILocalVariable(arg: 2, scope: !72, type: !37)
 // CHECK:STDOUT: !76 = !DILocation(line: 32, column: 59, scope: !72)
 // CHECK:STDOUT: !77 = !DILocation(line: 32, column: 52, scope: !72)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'mixed_compare.carbon'
 // CHECK:STDOUT: source_filename = "mixed_compare.carbon"
 // CHECK:STDOUT:
@@ -1087,6 +1094,8 @@ fn TestUint32ToUint64(a: u32) -> u64 { return Uint32ToUint64(a); }
 // CHECK:STDOUT: !76 = !DILocalVariable(arg: 2, scope: !73, type: !9)
 // CHECK:STDOUT: !77 = !DILocation(line: 26, column: 54, scope: !73)
 // CHECK:STDOUT: !78 = !DILocation(line: 26, column: 47, scope: !73)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'convert.carbon'
 // CHECK:STDOUT: source_filename = "convert.carbon"
 // CHECK:STDOUT:
@@ -1265,3 +1274,4 @@ fn TestUint32ToUint64(a: u32) -> u64 { return Uint32ToUint64(a); }
 // CHECK:STDOUT: !87 = !DILocalVariable(arg: 1, scope: !83, type: !14)
 // CHECK:STDOUT: !88 = !DILocation(line: 35, column: 47, scope: !83)
 // CHECK:STDOUT: !89 = !DILocation(line: 35, column: 40, scope: !83)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/int_literal.carbon
+++ b/toolchain/lower/testdata/builtins/int_literal.carbon
@@ -28,6 +28,7 @@ fn IntMin() -> i32 {
   return -0x8000_0000;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'int_literal.carbon'
 // CHECK:STDOUT: source_filename = "int_literal.carbon"
 // CHECK:STDOUT:
@@ -80,3 +81,4 @@ fn IntMin() -> i32 {
 // CHECK:STDOUT: !17 = !DILocation(line: 24, column: 3, scope: !16)
 // CHECK:STDOUT: !18 = distinct !DISubprogram(name: "IntMin", linkageName: "_CIntMin.Main", scope: null, file: !1, line: 27, type: !12, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !19 = !DILocation(line: 28, column: 3, scope: !18)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/int_to_float.carbon
+++ b/toolchain/lower/testdata/builtins/int_to_float.carbon
@@ -31,6 +31,7 @@ fn TestConvertI64ToF128(a: i64) -> f128 { return ConvertI64ToF128(a); }
 fn ConvertU64ToF128(a: u64) -> f128 = "int.convert_float";
 fn TestConvertU64ToF128(a: u64) -> f128 { return ConvertU64ToF128(a); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'int_to_float.carbon'
 // CHECK:STDOUT: source_filename = "int_to_float.carbon"
 // CHECK:STDOUT:
@@ -128,3 +129,4 @@ fn TestConvertU64ToF128(a: u64) -> f128 { return ConvertU64ToF128(a); }
 // CHECK:STDOUT: !44 = !DILocalVariable(arg: 1, scope: !39, type: !42)
 // CHECK:STDOUT: !45 = !DILocation(line: 19, column: 50, scope: !39)
 // CHECK:STDOUT: !46 = !DILocation(line: 19, column: 43, scope: !39)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/maybe_unformed.carbon
+++ b/toolchain/lower/testdata/builtins/maybe_unformed.carbon
@@ -55,6 +55,7 @@ fn PassAdapterBool() {
   TakeAdapterBool(MakeAdapterBool());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'maybe_unformed.carbon'
 // CHECK:STDOUT: source_filename = "maybe_unformed.carbon"
 // CHECK:STDOUT:
@@ -251,3 +252,4 @@ fn PassAdapterBool() {
 // CHECK:STDOUT: !66 = !{!67}
 // CHECK:STDOUT: !67 = !DILocalVariable(arg: 1, scope: !65, type: !14)
 // CHECK:STDOUT: !68 = !DILocation(line: 55, column: 19, scope: !65)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/method_vs_nonmethod.carbon
+++ b/toolchain/lower/testdata/builtins/method_vs_nonmethod.carbon
@@ -16,6 +16,7 @@ fn AddMethod(self: i32, b: i32) -> i32 = "int.sadd";
 fn TestAddNonmethod(a: i32, b: i32) -> i32 { return AddNonmethod(a, b); }
 fn TestAddMethod(a: i32, b: i32) -> i32 { return a.(AddMethod)(b); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'method_vs_nonmethod.carbon'
 // CHECK:STDOUT: source_filename = "method_vs_nonmethod.carbon"
 // CHECK:STDOUT:
@@ -57,3 +58,4 @@ fn TestAddMethod(a: i32, b: i32) -> i32 { return a.(AddMethod)(b); }
 // CHECK:STDOUT: !16 = !DILocalVariable(arg: 2, scope: !13, type: !7)
 // CHECK:STDOUT: !17 = !DILocation(line: 17, column: 50, scope: !13)
 // CHECK:STDOUT: !18 = !DILocation(line: 17, column: 43, scope: !13)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/no_op.carbon
+++ b/toolchain/lower/testdata/builtins/no_op.carbon
@@ -33,6 +33,7 @@ fn J() {
   NoOp2(I());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'no_op.carbon'
 // CHECK:STDOUT: source_filename = "no_op.carbon"
 // CHECK:STDOUT:
@@ -95,3 +96,4 @@ fn J() {
 // CHECK:STDOUT: !13 = distinct !DISubprogram(name: "J", linkageName: "_CJ.Main", scope: null, file: !1, line: 32, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !14 = !DILocation(line: 33, column: 9, scope: !13)
 // CHECK:STDOUT: !15 = !DILocation(line: 32, column: 1, scope: !13)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/overloaded_operator.carbon
+++ b/toolchain/lower/testdata/builtins/overloaded_operator.carbon
@@ -14,6 +14,7 @@ fn AddThreeIntegers(a: i32, b: i32, c: i32) -> i32 {
   return a + b + c;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'overloaded_operator.carbon'
 // CHECK:STDOUT: source_filename = "overloaded_operator.carbon"
 // CHECK:STDOUT:
@@ -44,3 +45,4 @@ fn AddThreeIntegers(a: i32, b: i32, c: i32) -> i32 {
 // CHECK:STDOUT: !11 = !DILocalVariable(arg: 3, scope: !4, type: !7)
 // CHECK:STDOUT: !12 = !DILocation(line: 14, column: 10, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/pointer.carbon
+++ b/toolchain/lower/testdata/builtins/pointer.carbon
@@ -24,6 +24,7 @@ fn Check(p: MakeUnformed(C*)) -> bool {
   return IsNull(p);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'pointer.carbon'
 // CHECK:STDOUT: source_filename = "pointer.carbon"
 // CHECK:STDOUT:
@@ -61,3 +62,4 @@ fn Check(p: MakeUnformed(C*)) -> bool {
 // CHECK:STDOUT: !13 = !DILocalVariable(arg: 1, scope: !9, type: !7)
 // CHECK:STDOUT: !14 = !DILocation(line: 24, column: 10, scope: !9)
 // CHECK:STDOUT: !15 = !DILocation(line: 24, column: 3, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/print_read.carbon
+++ b/toolchain/lower/testdata/builtins/print_read.carbon
@@ -27,6 +27,7 @@ fn Main() {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'print_read.carbon'
 // CHECK:STDOUT: source_filename = "print_read.carbon"
 // CHECK:STDOUT:
@@ -89,3 +90,4 @@ fn Main() {
 // CHECK:STDOUT: !13 = !DILocation(line: 24, column: 5, scope: !4)
 // CHECK:STDOUT: !14 = !DILocation(line: 22, column: 3, scope: !4)
 // CHECK:STDOUT: !15 = !DILocation(line: 18, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/types.carbon
+++ b/toolchain/lower/testdata/builtins/types.carbon
@@ -33,6 +33,7 @@ fn Uses() {
   BoolParam(false);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'types.carbon'
 // CHECK:STDOUT: source_filename = "types.carbon"
 // CHECK:STDOUT:
@@ -67,3 +68,4 @@ fn Uses() {
 // CHECK:STDOUT: !8 = !DILocation(line: 32, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 33, column: 3, scope: !4)
 // CHECK:STDOUT: !10 = !DILocation(line: 30, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/builtins/uint.carbon
+++ b/toolchain/lower/testdata/builtins/uint.carbon
@@ -64,6 +64,7 @@ fn TestGreater(a: u64, b: u64) -> bool { return Greater(a, b); }
 fn GreaterEq(a: u64, b: u64) -> bool = "int.greater_eq";
 fn TestGreaterEq(a: u64, b: u64) -> bool { return GreaterEq(a, b); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'uint.carbon'
 // CHECK:STDOUT: source_filename = "uint.carbon"
 // CHECK:STDOUT:
@@ -316,3 +317,4 @@ fn TestGreaterEq(a: u64, b: u64) -> bool { return GreaterEq(a, b); }
 // CHECK:STDOUT: !115 = !DILocalVariable(arg: 2, scope: !112, type: !7)
 // CHECK:STDOUT: !116 = !DILocation(line: 65, column: 51, scope: !112)
 // CHECK:STDOUT: !117 = !DILocation(line: 65, column: 44, scope: !112)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/choice/basic.carbon
+++ b/toolchain/lower/testdata/choice/basic.carbon
@@ -22,6 +22,7 @@ fn F() {
   let unused local_vehicle: VehicleType = VehicleType.Car;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -59,3 +60,4 @@ fn F() {
 // CHECK:STDOUT: !7 = !DILocation(line: 21, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !1, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !9 = !DILocation(line: 0, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/adapt.carbon
+++ b/toolchain/lower/testdata/class/adapt.carbon
@@ -57,6 +57,7 @@ fn DoStuff(a: Int) -> Int {
   return a;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'adapt_class.carbon'
 // CHECK:STDOUT: source_filename = "adapt_class.carbon"
 // CHECK:STDOUT:
@@ -181,6 +182,8 @@ fn DoStuff(a: Int) -> Int {
 // CHECK:STDOUT: !45 = !{!46}
 // CHECK:STDOUT: !46 = !DILocalVariable(arg: 1, scope: !44, type: !7)
 // CHECK:STDOUT: !47 = !DILocation(line: 27, column: 3, scope: !44)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'adapt_int.carbon'
 // CHECK:STDOUT: source_filename = "adapt_int.carbon"
 // CHECK:STDOUT:
@@ -218,3 +221,4 @@ fn DoStuff(a: Int) -> Int {
 // CHECK:STDOUT: !13 = !DILocalVariable(arg: 1, scope: !11, type: !7)
 // CHECK:STDOUT: !14 = !DILocation(line: 13, column: 10, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 13, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/base.carbon
+++ b/toolchain/lower/testdata/class/base.carbon
@@ -32,6 +32,7 @@ fn Convert(p: Derived*) -> Base* {
   return p;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'base.carbon'
 // CHECK:STDOUT: source_filename = "base.carbon"
 // CHECK:STDOUT:
@@ -102,3 +103,4 @@ fn Convert(p: Derived*) -> Base* {
 // CHECK:STDOUT: !21 = !{!22}
 // CHECK:STDOUT: !22 = !DILocalVariable(arg: 1, scope: !20, type: !7)
 // CHECK:STDOUT: !23 = !DILocation(line: 32, column: 3, scope: !20)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/basic.carbon
+++ b/toolchain/lower/testdata/class/basic.carbon
@@ -22,6 +22,7 @@ fn Run() {
   var _: C = F(c);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -100,3 +101,4 @@ fn Run() {
 // CHECK:STDOUT: !26 = !{!27}
 // CHECK:STDOUT: !27 = !DILocalVariable(arg: 1, scope: !25, type: !21)
 // CHECK:STDOUT: !28 = !DILocation(line: 22, column: 3, scope: !25)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/convert.carbon
+++ b/toolchain/lower/testdata/class/convert.carbon
@@ -25,6 +25,7 @@ fn DoIt() {
   Consume(w);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'convert.carbon'
 // CHECK:STDOUT: source_filename = "convert.carbon"
 // CHECK:STDOUT:
@@ -128,3 +129,4 @@ fn DoIt() {
 // CHECK:STDOUT: !38 = !{!39}
 // CHECK:STDOUT: !39 = !DILocalVariable(arg: 1, scope: !37, type: !8)
 // CHECK:STDOUT: !40 = !DILocation(line: 24, column: 3, scope: !37)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/field.carbon
+++ b/toolchain/lower/testdata/class/field.carbon
@@ -68,6 +68,7 @@ fn Run() {
   var _: Use = {.a = &o, .b = {.v = 42}};
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -160,6 +161,8 @@ fn Run() {
 // CHECK:STDOUT: !35 = !{!36}
 // CHECK:STDOUT: !36 = !DILocalVariable(arg: 1, scope: !34, type: !8)
 // CHECK:STDOUT: !37 = !DILocation(line: 14, column: 3, scope: !34)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'inplace_init_with_nonconst.carbon'
 // CHECK:STDOUT: source_filename = "inplace_init_with_nonconst.carbon"
 // CHECK:STDOUT:
@@ -241,6 +244,8 @@ fn Run() {
 // CHECK:STDOUT: !24 = !{!25}
 // CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !23, type: !15)
 // CHECK:STDOUT: !26 = !DILocation(line: 15, column: 3, scope: !23)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'implicit_init_with_nonempty_nonconst.carbon'
 // CHECK:STDOUT: source_filename = "implicit_init_with_nonempty_nonconst.carbon"
 // CHECK:STDOUT:
@@ -346,3 +351,4 @@ fn Run() {
 // CHECK:STDOUT: !35 = !{!36}
 // CHECK:STDOUT: !36 = !DILocalVariable(arg: 1, scope: !34, type: !22)
 // CHECK:STDOUT: !37 = !DILocation(line: 17, column: 3, scope: !34)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/field_initializer.carbon
+++ b/toolchain/lower/testdata/class/field_initializer.carbon
@@ -19,6 +19,7 @@ class C {
 
 var c: C = {};
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'field_initializer.carbon'
 // CHECK:STDOUT: source_filename = "field_initializer.carbon"
 // CHECK:STDOUT:
@@ -51,3 +52,4 @@ var c: C = {};
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 7, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/generic.carbon
+++ b/toolchain/lower/testdata/class/generic.carbon
@@ -102,6 +102,7 @@ fn AccessTuple() -> (i32, i32, i32) {
   return c.GetT();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'classes.carbon'
 // CHECK:STDOUT: source_filename = "classes.carbon"
 // CHECK:STDOUT:
@@ -112,6 +113,8 @@ fn AccessTuple() -> (i32, i32, i32) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "classes.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'create.carbon'
 // CHECK:STDOUT: source_filename = "create.carbon"
 // CHECK:STDOUT:
@@ -157,6 +160,8 @@ fn AccessTuple() -> (i32, i32, i32) {
 // CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CreateAdapter", linkageName: "_CCreateAdapter.Create", scope: null, file: !1, line: 10, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !12 = !DILocation(line: 11, column: 10, scope: !11)
 // CHECK:STDOUT: !13 = !DILocation(line: 11, column: 3, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'create_generic.carbon'
 // CHECK:STDOUT: source_filename = "create_generic.carbon"
 // CHECK:STDOUT:
@@ -280,6 +285,8 @@ fn AccessTuple() -> (i32, i32, i32) {
 // CHECK:STDOUT: !45 = !DILocation(line: 53, column: 12, scope: !38)
 // CHECK:STDOUT: !46 = !DILocation(line: 53, column: 26, scope: !38)
 // CHECK:STDOUT: !47 = !DILocation(line: 53, column: 5, scope: !38)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'access.carbon'
 // CHECK:STDOUT: source_filename = "access.carbon"
 // CHECK:STDOUT:
@@ -557,3 +564,4 @@ fn AccessTuple() -> (i32, i32, i32) {
 // CHECK:STDOUT: !99 = !DILocation(line: 59, column: 26, scope: !93)
 // CHECK:STDOUT: !100 = !DILocation(line: 59, column: 39, scope: !93)
 // CHECK:STDOUT: !101 = !DILocation(line: 59, column: 5, scope: !93)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/import.carbon
+++ b/toolchain/lower/testdata/class/import.carbon
@@ -27,6 +27,7 @@ fn Run() {
   C.F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
 // CHECK:STDOUT:
@@ -39,6 +40,8 @@ fn Run() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "a.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'b.carbon'
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
@@ -66,3 +69,4 @@ fn Run() {
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 4, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 3, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/method.carbon
+++ b/toolchain/lower/testdata/class/method.carbon
@@ -22,6 +22,7 @@ fn F(p: C*) {
   (*p).Set(n);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'method.carbon'
 // CHECK:STDOUT: source_filename = "method.carbon"
 // CHECK:STDOUT:
@@ -55,3 +56,4 @@ fn F(p: C*) {
 // CHECK:STDOUT: !10 = !DILocation(line: 21, column: 16, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 22, column: 3, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 20, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/self.carbon
+++ b/toolchain/lower/testdata/class/self.carbon
@@ -25,6 +25,7 @@ fn C.Set(ref self: C) {
   self.a = 1;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'self.carbon'
 // CHECK:STDOUT: source_filename = "self.carbon"
 // CHECK:STDOUT:
@@ -69,3 +70,4 @@ fn C.Set(ref self: C) {
 // CHECK:STDOUT: !17 = !DILocalVariable(arg: 1, scope: !13, type: !8)
 // CHECK:STDOUT: !18 = !DILocation(line: 25, column: 3, scope: !13)
 // CHECK:STDOUT: !19 = !DILocation(line: 24, column: 1, scope: !13)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/static.carbon
+++ b/toolchain/lower/testdata/class/static.carbon
@@ -41,6 +41,7 @@ fn Run() -> i32 {
   return Cpp.F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'static.carbon'
 // CHECK:STDOUT: source_filename = "static.carbon"
 // CHECK:STDOUT:
@@ -83,6 +84,8 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !11 = !DILocation(line: 4, column: 10, scope: !10)
 // CHECK:STDOUT: !12 = !DILocation(line: 5, column: 10, scope: !10)
 // CHECK:STDOUT: !13 = !DILocation(line: 0, scope: !10)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'static_export.carbon'
 // CHECK:STDOUT: source_filename = "static_export.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -166,3 +169,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !30 = !{null}
 // CHECK:STDOUT: !31 = !DILocation(line: 5, column: 10, scope: !28)
 // CHECK:STDOUT: !32 = !DILocation(line: 0, scope: !28)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/value_access.carbon
+++ b/toolchain/lower/testdata/class/value_access.carbon
@@ -21,6 +21,7 @@ fn F(c: C) -> i32 {
   return c.a.1;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'value_access.carbon'
 // CHECK:STDOUT: source_filename = "value_access.carbon"
 // CHECK:STDOUT:
@@ -69,3 +70,4 @@ fn F(c: C) -> i32 {
 // CHECK:STDOUT: !10 = !DILocalVariable(arg: 1, scope: !4, type: !8)
 // CHECK:STDOUT: !11 = !DILocation(line: 21, column: 10, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 21, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/class/virtual.carbon
+++ b/toolchain/lower/testdata/class/virtual.carbon
@@ -212,6 +212,7 @@ fn Use() {
   p->F({});
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'classes.carbon'
 // CHECK:STDOUT: source_filename = "classes.carbon"
 // CHECK:STDOUT:
@@ -262,6 +263,8 @@ fn Use() {
 // CHECK:STDOUT: !16 = !{!17}
 // CHECK:STDOUT: !17 = !DILocalVariable(arg: 1, scope: !15, type: !7)
 // CHECK:STDOUT: !18 = !DILocation(line: 14, column: 3, scope: !15)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'create.carbon'
 // CHECK:STDOUT: source_filename = "create.carbon"
 // CHECK:STDOUT:
@@ -407,6 +410,8 @@ fn Use() {
 // CHECK:STDOUT: !40 = !DILocalVariable(arg: 1, scope: !38, type: !18)
 // CHECK:STDOUT: !41 = !DILocation(line: 16, column: 3, scope: !38)
 // CHECK:STDOUT: !42 = !DILocation(line: 15, column: 1, scope: !38)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'create_named_ctor.carbon'
 // CHECK:STDOUT: source_filename = "create_named_ctor.carbon"
 // CHECK:STDOUT:
@@ -509,6 +514,8 @@ fn Use() {
 // CHECK:STDOUT: !24 = !DILocation(line: 27, column: 10, scope: !23)
 // CHECK:STDOUT: !25 = !DILocation(line: 27, column: 19, scope: !23)
 // CHECK:STDOUT: !26 = !DILocation(line: 27, column: 3, scope: !23)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'member_init.carbon'
 // CHECK:STDOUT: source_filename = "member_init.carbon"
 // CHECK:STDOUT:
@@ -618,6 +625,8 @@ fn Use() {
 // CHECK:STDOUT: !34 = !{!35}
 // CHECK:STDOUT: !35 = !DILocalVariable(arg: 1, scope: !33, type: !7)
 // CHECK:STDOUT: !36 = !DILocation(line: 13, column: 3, scope: !33)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'member_brace_init.carbon'
 // CHECK:STDOUT: source_filename = "member_brace_init.carbon"
 // CHECK:STDOUT:
@@ -708,6 +717,8 @@ fn Use() {
 // CHECK:STDOUT: !27 = !{!28}
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 1, scope: !26, type: !14)
 // CHECK:STDOUT: !29 = !DILocation(line: 13, column: 3, scope: !26)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call.carbon'
 // CHECK:STDOUT: source_filename = "call.carbon"
 // CHECK:STDOUT:
@@ -745,6 +756,8 @@ fn Use() {
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
 // CHECK:STDOUT: !10 = !DILocation(line: 9, column: 3, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 8, column: 1, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_impl.carbon'
 // CHECK:STDOUT: source_filename = "call_impl.carbon"
 // CHECK:STDOUT:
@@ -858,6 +871,8 @@ fn Use() {
 // CHECK:STDOUT: !32 = !{!33}
 // CHECK:STDOUT: !33 = !DILocalVariable(arg: 1, scope: !31, type: !7)
 // CHECK:STDOUT: !34 = !DILocation(line: 14, column: 3, scope: !31)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'generic_noop.carbon'
 // CHECK:STDOUT: source_filename = "generic_noop.carbon"
 // CHECK:STDOUT:
@@ -868,6 +883,8 @@ fn Use() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "generic_noop.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'generic_use.carbon'
 // CHECK:STDOUT: source_filename = "generic_use.carbon"
 // CHECK:STDOUT:
@@ -1011,6 +1028,8 @@ fn Use() {
 // CHECK:STDOUT: !46 = !DILocalVariable(arg: 1, scope: !44, type: !15)
 // CHECK:STDOUT: !47 = !DILocation(line: 6, column: 5, scope: !44)
 // CHECK:STDOUT: !48 = !DILocation(line: 5, column: 3, scope: !44)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'generic_base.carbon'
 // CHECK:STDOUT: source_filename = "generic_base.carbon"
 // CHECK:STDOUT:
@@ -1096,6 +1115,8 @@ fn Use() {
 // CHECK:STDOUT: !29 = !{!30}
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !28, type: !12)
 // CHECK:STDOUT: !31 = !DILocation(line: 5, column: 3, scope: !28)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'thunk.carbon'
 // CHECK:STDOUT: source_filename = "thunk.carbon"
 // CHECK:STDOUT:
@@ -1267,3 +1288,4 @@ fn Use() {
 // CHECK:STDOUT: !51 = !{!52}
 // CHECK:STDOUT: !52 = !DILocalVariable(arg: 1, scope: !50, type: !7)
 // CHECK:STDOUT: !53 = !DILocation(line: 23, column: 3, scope: !50)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/debug/nodebug.carbon
+++ b/toolchain/lower/testdata/debug/nodebug.carbon
@@ -14,6 +14,7 @@
 fn F() {
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nodebug.carbon'
 // CHECK:STDOUT: source_filename = "nodebug.carbon"
 // CHECK:STDOUT:
@@ -24,3 +25,4 @@ fn F() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/for/bindings.carbon
+++ b/toolchain/lower/testdata/for/bindings.carbon
@@ -31,6 +31,7 @@ fn For() {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'bindings.carbon'
 // CHECK:STDOUT: source_filename = "bindings.carbon"
 // CHECK:STDOUT:
@@ -311,3 +312,4 @@ fn For() {
 // CHECK:STDOUT: !99 = !DILocation(line: 63, column: 12, scope: !94)
 // CHECK:STDOUT: !100 = !DILocation(line: 63, column: 26, scope: !94)
 // CHECK:STDOUT: !101 = !DILocation(line: 63, column: 5, scope: !94)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/for/break_continue.carbon
+++ b/toolchain/lower/testdata/for/break_continue.carbon
@@ -24,6 +24,7 @@ fn For() {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'break_continue.carbon'
 // CHECK:STDOUT: source_filename = "break_continue.carbon"
 // CHECK:STDOUT:
@@ -408,3 +409,4 @@ fn For() {
 // CHECK:STDOUT: !147 = !{!148}
 // CHECK:STDOUT: !148 = !DILocalVariable(arg: 1, scope: !146, type: !22)
 // CHECK:STDOUT: !149 = !DILocation(line: 59, column: 28, scope: !146)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/for/for.carbon
+++ b/toolchain/lower/testdata/for/for.carbon
@@ -24,6 +24,7 @@ fn For() {
   H();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'for.carbon'
 // CHECK:STDOUT: source_filename = "for.carbon"
 // CHECK:STDOUT:
@@ -392,3 +393,4 @@ fn For() {
 // CHECK:STDOUT: !143 = !{!144}
 // CHECK:STDOUT: !144 = !DILocalVariable(arg: 1, scope: !142, type: !18)
 // CHECK:STDOUT: !145 = !DILocation(line: 59, column: 28, scope: !142)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/empty_struct.carbon
+++ b/toolchain/lower/testdata/function/call/empty_struct.carbon
@@ -18,6 +18,7 @@ fn Main() {
   var _: {} = Echo({});
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'
 // CHECK:STDOUT: source_filename = "empty_struct.carbon"
 // CHECK:STDOUT:
@@ -57,3 +58,4 @@ fn Main() {
 // CHECK:STDOUT: !9 = !DILocation(line: 18, column: 3, scope: !8)
 // CHECK:STDOUT: !10 = !DILocation(line: 18, column: 15, scope: !8)
 // CHECK:STDOUT: !11 = !DILocation(line: 17, column: 1, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/empty_tuple.carbon
+++ b/toolchain/lower/testdata/function/call/empty_tuple.carbon
@@ -18,6 +18,7 @@ fn Main() {
   var _: () = Echo(());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'empty_tuple.carbon'
 // CHECK:STDOUT: source_filename = "empty_tuple.carbon"
 // CHECK:STDOUT:
@@ -57,3 +58,4 @@ fn Main() {
 // CHECK:STDOUT: !9 = !DILocation(line: 18, column: 3, scope: !8)
 // CHECK:STDOUT: !10 = !DILocation(line: 18, column: 15, scope: !8)
 // CHECK:STDOUT: !11 = !DILocation(line: 17, column: 1, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/form.carbon
+++ b/toolchain/lower/testdata/function/call/form.carbon
@@ -65,6 +65,7 @@ fn G() {
   let unused x: i32 = F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'ref_form_param.carbon'
 // CHECK:STDOUT: source_filename = "ref_form_param.carbon"
 // CHECK:STDOUT:
@@ -113,6 +114,8 @@ fn G() {
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !10, type: !13)
 // CHECK:STDOUT: !16 = !DILocation(line: 6, column: 3, scope: !10)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var_form_param.carbon'
 // CHECK:STDOUT: source_filename = "var_form_param.carbon"
 // CHECK:STDOUT:
@@ -161,6 +164,8 @@ fn G() {
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !10, type: !13)
 // CHECK:STDOUT: !16 = !DILocation(line: 3, column: 6, scope: !10)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'val_form_param.carbon'
 // CHECK:STDOUT: source_filename = "val_form_param.carbon"
 // CHECK:STDOUT:
@@ -187,6 +192,8 @@ fn G() {
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 6, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 5, column: 1, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'ref_return_form.carbon'
 // CHECK:STDOUT: source_filename = "ref_return_form.carbon"
 // CHECK:STDOUT:
@@ -213,6 +220,8 @@ fn G() {
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 6, column: 27, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 5, column: 1, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var_return_form.carbon'
 // CHECK:STDOUT: source_filename = "var_return_form.carbon"
 // CHECK:STDOUT:
@@ -261,6 +270,8 @@ fn G() {
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !10, type: !13)
 // CHECK:STDOUT: !16 = !DILocation(line: 6, column: 14, scope: !10)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'val_return_form.carbon'
 // CHECK:STDOUT: source_filename = "val_return_form.carbon"
 // CHECK:STDOUT:
@@ -287,3 +298,4 @@ fn G() {
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 6, column: 23, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 5, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/i32.carbon
+++ b/toolchain/lower/testdata/function/call/i32.carbon
@@ -18,6 +18,7 @@ fn Main() {
   var _: i32 = Echo(1);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'i32.carbon'
 // CHECK:STDOUT: source_filename = "i32.carbon"
 // CHECK:STDOUT:
@@ -76,3 +77,4 @@ fn Main() {
 // CHECK:STDOUT: !20 = !{!21}
 // CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !22 = !DILocation(line: 18, column: 3, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/implicit_empty_tuple_as_arg.carbon
+++ b/toolchain/lower/testdata/function/call/implicit_empty_tuple_as_arg.carbon
@@ -19,6 +19,7 @@ fn Main() {
   var _: () = Bar(Foo());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'implicit_empty_tuple_as_arg.carbon'
 // CHECK:STDOUT: source_filename = "implicit_empty_tuple_as_arg.carbon"
 // CHECK:STDOUT:
@@ -73,3 +74,4 @@ fn Main() {
 // CHECK:STDOUT: !12 = !DILocation(line: 19, column: 19, scope: !10)
 // CHECK:STDOUT: !13 = !DILocation(line: 19, column: 15, scope: !10)
 // CHECK:STDOUT: !14 = !DILocation(line: 18, column: 1, scope: !10)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/params_one.carbon
+++ b/toolchain/lower/testdata/function/call/params_one.carbon
@@ -16,6 +16,7 @@ fn Main() {
   Foo(1);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'params_one.carbon'
 // CHECK:STDOUT: source_filename = "params_one.carbon"
 // CHECK:STDOUT:
@@ -53,3 +54,4 @@ fn Main() {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 16, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 15, column: 1, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/params_one_comma.carbon
+++ b/toolchain/lower/testdata/function/call/params_one_comma.carbon
@@ -17,6 +17,7 @@ fn Main() {
   Foo(1,);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'params_one_comma.carbon'
 // CHECK:STDOUT: source_filename = "params_one_comma.carbon"
 // CHECK:STDOUT:
@@ -56,3 +57,4 @@ fn Main() {
 // CHECK:STDOUT: !14 = !DILocation(line: 16, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 17, column: 3, scope: !11)
 // CHECK:STDOUT: !16 = !DILocation(line: 15, column: 1, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/params_two.carbon
+++ b/toolchain/lower/testdata/function/call/params_two.carbon
@@ -16,6 +16,7 @@ fn Main() {
   Foo(1, 2);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'params_two.carbon'
 // CHECK:STDOUT: source_filename = "params_two.carbon"
 // CHECK:STDOUT:
@@ -54,3 +55,4 @@ fn Main() {
 // CHECK:STDOUT: !14 = !{null}
 // CHECK:STDOUT: !15 = !DILocation(line: 16, column: 3, scope: !12)
 // CHECK:STDOUT: !16 = !DILocation(line: 15, column: 1, scope: !12)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/params_two_comma.carbon
+++ b/toolchain/lower/testdata/function/call/params_two_comma.carbon
@@ -17,6 +17,7 @@ fn Main() {
   Foo(1, 2,);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'params_two_comma.carbon'
 // CHECK:STDOUT: source_filename = "params_two_comma.carbon"
 // CHECK:STDOUT:
@@ -57,3 +58,4 @@ fn Main() {
 // CHECK:STDOUT: !15 = !DILocation(line: 16, column: 3, scope: !12)
 // CHECK:STDOUT: !16 = !DILocation(line: 17, column: 3, scope: !12)
 // CHECK:STDOUT: !17 = !DILocation(line: 15, column: 1, scope: !12)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/params_zero.carbon
+++ b/toolchain/lower/testdata/function/call/params_zero.carbon
@@ -16,6 +16,7 @@ fn Main() {
   Foo();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'params_zero.carbon'
 // CHECK:STDOUT: source_filename = "params_zero.carbon"
 // CHECK:STDOUT:
@@ -48,3 +49,4 @@ fn Main() {
 // CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Main", linkageName: "_CMain.Main", scope: null, file: !1, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !9 = !DILocation(line: 16, column: 3, scope: !8)
 // CHECK:STDOUT: !10 = !DILocation(line: 15, column: 1, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/ref_param.carbon
+++ b/toolchain/lower/testdata/function/call/ref_param.carbon
@@ -17,6 +17,7 @@ fn Main() {
   DoNothing(ref a);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'ref_param.carbon'
 // CHECK:STDOUT: source_filename = "ref_param.carbon"
 // CHECK:STDOUT:
@@ -73,3 +74,4 @@ fn Main() {
 // CHECK:STDOUT: !18 = !{!19}
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !20 = !DILocation(line: 16, column: 3, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/ref_return.carbon
+++ b/toolchain/lower/testdata/function/call/ref_return.carbon
@@ -19,6 +19,7 @@ fn Main() {
   Echo(ref a) = 1;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'ref_return.carbon'
 // CHECK:STDOUT: source_filename = "ref_return.carbon"
 // CHECK:STDOUT:
@@ -79,3 +80,4 @@ fn Main() {
 // CHECK:STDOUT: !21 = !{!22}
 // CHECK:STDOUT: !22 = !DILocalVariable(arg: 1, scope: !18, type: !8)
 // CHECK:STDOUT: !23 = !DILocation(line: 18, column: 3, scope: !18)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/return_implicit.carbon
+++ b/toolchain/lower/testdata/function/call/return_implicit.carbon
@@ -18,6 +18,7 @@ fn Main() {
   var _: () = MakeImplicitEmptyTuple();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'return_implicit.carbon'
 // CHECK:STDOUT: source_filename = "return_implicit.carbon"
 // CHECK:STDOUT:
@@ -57,3 +58,4 @@ fn Main() {
 // CHECK:STDOUT: !9 = !DILocation(line: 18, column: 3, scope: !8)
 // CHECK:STDOUT: !10 = !DILocation(line: 18, column: 15, scope: !8)
 // CHECK:STDOUT: !11 = !DILocation(line: 17, column: 1, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/struct_param.carbon
+++ b/toolchain/lower/testdata/function/call/struct_param.carbon
@@ -16,6 +16,7 @@ fn Main() {
   F({}, {.a = 1}, {.a = 2, .b = 3});
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'struct_param.carbon'
 // CHECK:STDOUT: source_filename = "struct_param.carbon"
 // CHECK:STDOUT:
@@ -56,3 +57,4 @@ fn Main() {
 // CHECK:STDOUT: !14 = !{null}
 // CHECK:STDOUT: !15 = !DILocation(line: 16, column: 3, scope: !12)
 // CHECK:STDOUT: !16 = !DILocation(line: 15, column: 1, scope: !12)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/tuple_param.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param.carbon
@@ -16,6 +16,7 @@ fn Main() {
   F((), (1,), (2, 3));
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'tuple_param.carbon'
 // CHECK:STDOUT: source_filename = "tuple_param.carbon"
 // CHECK:STDOUT:
@@ -56,3 +57,4 @@ fn Main() {
 // CHECK:STDOUT: !14 = !{null}
 // CHECK:STDOUT: !15 = !DILocation(line: 16, column: 3, scope: !12)
 // CHECK:STDOUT: !16 = !DILocation(line: 15, column: 1, scope: !12)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
+++ b/toolchain/lower/testdata/function/call/tuple_param_with_return_slot.carbon
@@ -18,6 +18,7 @@ fn Main() {
   F((), (1,), (2, 3));
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'tuple_param_with_return_slot.carbon'
 // CHECK:STDOUT: source_filename = "tuple_param_with_return_slot.carbon"
 // CHECK:STDOUT:
@@ -105,3 +106,4 @@ fn Main() {
 // CHECK:STDOUT: !31 = !{!32}
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !28, type: !7)
 // CHECK:STDOUT: !33 = !DILocation(line: 18, column: 3, scope: !28)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/call/var_param.carbon
+++ b/toolchain/lower/testdata/function/call/var_param.carbon
@@ -17,6 +17,7 @@ fn Main() {
   DoNothing(a);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var_param.carbon'
 // CHECK:STDOUT: source_filename = "var_param.carbon"
 // CHECK:STDOUT:
@@ -75,3 +76,4 @@ fn Main() {
 // CHECK:STDOUT: !19 = !{!20}
 // CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !18, type: !7)
 // CHECK:STDOUT: !21 = !DILocation(line: 16, column: 3, scope: !18)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/declaration/simple.carbon
+++ b/toolchain/lower/testdata/function/declaration/simple.carbon
@@ -18,6 +18,7 @@ class A;
 fn H(n: A);
 fn I() -> A;
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'simple.carbon'
 // CHECK:STDOUT: source_filename = "simple.carbon"
 // CHECK:STDOUT:
@@ -51,3 +52,4 @@ fn I() -> A;
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
 // CHECK:STDOUT: !10 = !DILocation(line: 15, column: 16, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 15, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/definition/destroy.carbon
+++ b/toolchain/lower/testdata/function/definition/destroy.carbon
@@ -72,6 +72,7 @@ fn InitLet() {
   G();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'let_param.carbon'
 // CHECK:STDOUT: source_filename = "let_param.carbon"
 // CHECK:STDOUT:
@@ -134,6 +135,8 @@ fn InitLet() {
 // CHECK:STDOUT: !19 = !{!20}
 // CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !18, type: !7)
 // CHECK:STDOUT: !21 = !DILocation(line: 12, column: 5, scope: !18)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var_param.carbon'
 // CHECK:STDOUT: source_filename = "var_param.carbon"
 // CHECK:STDOUT:
@@ -199,6 +202,8 @@ fn InitLet() {
 // CHECK:STDOUT: !19 = !{!20}
 // CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !18, type: !7)
 // CHECK:STDOUT: !21 = !DILocation(line: 6, column: 6, scope: !18)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'return_slot.carbon'
 // CHECK:STDOUT: source_filename = "return_slot.carbon"
 // CHECK:STDOUT:
@@ -292,3 +297,4 @@ fn InitLet() {
 // CHECK:STDOUT: !26 = !DILocation(line: 22, column: 14, scope: !25)
 // CHECK:STDOUT: !27 = !DILocation(line: 23, column: 3, scope: !25)
 // CHECK:STDOUT: !28 = !DILocation(line: 21, column: 1, scope: !25)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/definition/empty_struct.carbon
+++ b/toolchain/lower/testdata/function/definition/empty_struct.carbon
@@ -13,6 +13,7 @@
 fn Echo(_: {}) {
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'empty_struct.carbon'
 // CHECK:STDOUT: source_filename = "empty_struct.carbon"
 // CHECK:STDOUT:
@@ -35,3 +36,4 @@ fn Echo(_: {}) {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/definition/eval_musteval.carbon
+++ b/toolchain/lower/testdata/function/definition/eval_musteval.carbon
@@ -43,6 +43,7 @@ fn F() -> i32 {
   return MustEval(1);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'eval.carbon'
 // CHECK:STDOUT: source_filename = "eval.carbon"
 // CHECK:STDOUT:
@@ -90,6 +91,8 @@ fn F() -> i32 {
 // CHECK:STDOUT: !17 = !DILocalVariable(arg: 1, scope: !15, type: !7)
 // CHECK:STDOUT: !18 = !DILocation(line: 16, column: 10, scope: !15)
 // CHECK:STDOUT: !19 = !DILocation(line: 16, column: 3, scope: !15)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'musteval.carbon'
 // CHECK:STDOUT: source_filename = "musteval.carbon"
 // CHECK:STDOUT:
@@ -113,3 +116,4 @@ fn F() -> i32 {
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 11, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/definition/params_one.carbon
+++ b/toolchain/lower/testdata/function/definition/params_one.carbon
@@ -12,6 +12,7 @@
 
 fn Foo(_: i32) {}
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'params_one.carbon'
 // CHECK:STDOUT: source_filename = "params_one.carbon"
 // CHECK:STDOUT:
@@ -37,3 +38,4 @@ fn Foo(_: i32) {}
 // CHECK:STDOUT: !8 = !{!9}
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
 // CHECK:STDOUT: !10 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/definition/params_two.carbon
+++ b/toolchain/lower/testdata/function/definition/params_two.carbon
@@ -12,6 +12,7 @@
 
 fn Foo(_: i32, _: i32) {}
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'params_two.carbon'
 // CHECK:STDOUT: source_filename = "params_two.carbon"
 // CHECK:STDOUT:
@@ -38,3 +39,4 @@ fn Foo(_: i32, _: i32) {}
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
 // CHECK:STDOUT: !10 = !DILocalVariable(arg: 2, scope: !4, type: !7)
 // CHECK:STDOUT: !11 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/definition/params_zero.carbon
+++ b/toolchain/lower/testdata/function/definition/params_zero.carbon
@@ -12,6 +12,7 @@
 
 fn Foo() {}
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'params_zero.carbon'
 // CHECK:STDOUT: source_filename = "params_zero.carbon"
 // CHECK:STDOUT:
@@ -34,3 +35,4 @@ fn Foo() {}
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/definition/raw_name.carbon
+++ b/toolchain/lower/testdata/function/definition/raw_name.carbon
@@ -13,6 +13,7 @@
 fn r#self() {}
 
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'raw_name.carbon'
 // CHECK:STDOUT: source_filename = "raw_name.carbon"
 // CHECK:STDOUT:
@@ -35,3 +36,4 @@ fn r#self() {}
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 13, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/definition/var_param.carbon
+++ b/toolchain/lower/testdata/function/definition/var_param.carbon
@@ -28,6 +28,7 @@ fn Call() {
   LetThenVar(1, {});
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var_param.carbon'
 // CHECK:STDOUT: source_filename = "var_param.carbon"
 // CHECK:STDOUT:
@@ -191,3 +192,4 @@ fn Call() {
 // CHECK:STDOUT: !56 = !{!57}
 // CHECK:STDOUT: !57 = !DILocalVariable(arg: 1, scope: !55, type: !7)
 // CHECK:STDOUT: !58 = !DILocation(line: 20, column: 15, scope: !55)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call.carbon
+++ b/toolchain/lower/testdata/function/generic/call.carbon
@@ -29,6 +29,7 @@ fn G() {
   F(i32);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call.carbon'
 // CHECK:STDOUT: source_filename = "call.carbon"
 // CHECK:STDOUT:
@@ -188,3 +189,4 @@ fn G() {
 // CHECK:STDOUT: !54 = !{!55}
 // CHECK:STDOUT: !55 = !DILocalVariable(arg: 1, scope: !53, type: !22)
 // CHECK:STDOUT: !56 = !DILocation(line: 13, column: 1, scope: !53)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic.carbon
@@ -55,6 +55,7 @@ fn M() {
   let _: f64 = G(p);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_basic.carbon'
 // CHECK:STDOUT: source_filename = "call_basic.carbon"
 // CHECK:STDOUT:
@@ -391,3 +392,4 @@ fn M() {
 // CHECK:STDOUT: !114 = !DILocalVariable(arg: 1, scope: !112, type: !7)
 // CHECK:STDOUT: !115 = !DILocation(line: 23, column: 10, scope: !112)
 // CHECK:STDOUT: !116 = !DILocation(line: 23, column: 3, scope: !112)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
+++ b/toolchain/lower/testdata/function/generic/call_basic_depth.carbon
@@ -36,6 +36,7 @@ fn M() -> i32 {
   return m;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_basic_depth.carbon'
 // CHECK:STDOUT: source_filename = "call_basic_depth.carbon"
 // CHECK:STDOUT:
@@ -143,3 +144,4 @@ fn M() -> i32 {
 // CHECK:STDOUT: !37 = !DILocalVariable(arg: 1, scope: !35, type: !7)
 // CHECK:STDOUT: !38 = !DILocation(line: 20, column: 3, scope: !35)
 // CHECK:STDOUT: !39 = !DILocation(line: 21, column: 3, scope: !35)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_dedup_ptr.carbon
+++ b/toolchain/lower/testdata/function/generic/call_dedup_ptr.carbon
@@ -23,6 +23,7 @@ fn M() {
   F(ptr_i8);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_dedup_ptr.carbon'
 // CHECK:STDOUT: source_filename = "call_dedup_ptr.carbon"
 // CHECK:STDOUT:
@@ -90,3 +91,4 @@ fn M() {
 // CHECK:STDOUT: !21 = !{!22}
 // CHECK:STDOUT: !22 = !DILocalVariable(arg: 1, scope: !17, type: !20)
 // CHECK:STDOUT: !23 = !DILocation(line: 14, column: 3, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_deref_ptr.carbon
+++ b/toolchain/lower/testdata/function/generic/call_deref_ptr.carbon
@@ -40,6 +40,7 @@ fn M() {
   F(ptr_f64);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_deref_ptr.carbon'
 // CHECK:STDOUT: source_filename = "call_deref_ptr.carbon"
 // CHECK:STDOUT:
@@ -212,3 +213,4 @@ fn M() {
 // CHECK:STDOUT: !65 = !{!66}
 // CHECK:STDOUT: !66 = !DILocalVariable(arg: 1, scope: !64, type: !24)
 // CHECK:STDOUT: !67 = !DILocation(line: 23, column: 3, scope: !64)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_different_associated_const.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_associated_const.carbon
@@ -37,6 +37,7 @@ fn H() {
   G(D);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_different_associated_const.carbon'
 // CHECK:STDOUT: source_filename = "call_different_associated_const.carbon"
 // CHECK:STDOUT:
@@ -94,3 +95,4 @@ fn H() {
 // CHECK:STDOUT: !13 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.1ba7ae4c6ee83247", scope: null, file: !1, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !14 = !DILocation(line: 23, column: 3, scope: !13)
 // CHECK:STDOUT: !15 = !DILocation(line: 22, column: 1, scope: !13)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_different_impls.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_impls.carbon
@@ -33,6 +33,7 @@ fn Run() {
   G(Y);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_different_impls.carbon'
 // CHECK:STDOUT: source_filename = "call_different_impls.carbon"
 // CHECK:STDOUT:
@@ -109,3 +110,4 @@ fn Run() {
 // CHECK:STDOUT: !22 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.0b241ec84a68877b", scope: null, file: !1, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !23 = !DILocation(line: 29, column: 15, scope: !22)
 // CHECK:STDOUT: !24 = !DILocation(line: 29, column: 1, scope: !22)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_different_impls_with_const.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_impls_with_const.carbon
@@ -42,6 +42,7 @@ fn Run() {
   G(Y);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_different_impls_with_const.carbon'
 // CHECK:STDOUT: source_filename = "call_different_impls_with_const.carbon"
 // CHECK:STDOUT:
@@ -149,3 +150,4 @@ fn Run() {
 // CHECK:STDOUT: !31 = distinct !DISubprogram(name: "G", linkageName: "_CG.Main.89fa38d00ffc0e46", scope: null, file: !1, line: 36, type: !27, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !32 = !DILocation(line: 37, column: 16, scope: !31)
 // CHECK:STDOUT: !33 = !DILocation(line: 36, column: 1, scope: !31)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_different_specific.carbon
+++ b/toolchain/lower/testdata/function/generic/call_different_specific.carbon
@@ -44,6 +44,7 @@ fn M(ptr_i32: i32*, ptr_f64: f64*) {
   F(ptr_f64);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_different_specific.carbon'
 // CHECK:STDOUT: source_filename = "call_different_specific.carbon"
 // CHECK:STDOUT:
@@ -207,3 +208,4 @@ fn M(ptr_i32: i32*, ptr_f64: f64*) {
 // CHECK:STDOUT: !64 = !{!65}
 // CHECK:STDOUT: !65 = !DILocalVariable(arg: 1, scope: !63, type: !7)
 // CHECK:STDOUT: !66 = !DILocation(line: 30, column: 3, scope: !63)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_impl_function.carbon
+++ b/toolchain/lower/testdata/function/generic/call_impl_function.carbon
@@ -43,6 +43,7 @@ fn G() {
 }
 
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_impl_function.carbon'
 // CHECK:STDOUT: source_filename = "call_impl_function.carbon"
 // CHECK:STDOUT:
@@ -94,3 +95,4 @@ fn G() {
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !20 = !DILocation(line: 36, column: 10, scope: !17)
 // CHECK:STDOUT: !21 = !DILocation(line: 36, column: 3, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_method.carbon
+++ b/toolchain/lower/testdata/function/generic/call_method.carbon
@@ -22,6 +22,7 @@ fn CallF() -> i32 {
   return c.F(n);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_method.carbon'
 // CHECK:STDOUT: source_filename = "call_method.carbon"
 // CHECK:STDOUT:
@@ -109,3 +110,4 @@ fn CallF() -> i32 {
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !26, type: !22)
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 2, scope: !26, type: !7)
 // CHECK:STDOUT: !32 = !DILocation(line: 15, column: 5, scope: !26)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_recursive_basic.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_basic.carbon
@@ -40,6 +40,7 @@ fn M() {
   F(c, 0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_recursive_basic.carbon'
 // CHECK:STDOUT: source_filename = "call_recursive_basic.carbon"
 // CHECK:STDOUT:
@@ -276,3 +277,4 @@ fn M() {
 // CHECK:STDOUT: !88 = !DILocation(line: 25, column: 15, scope: !80)
 // CHECK:STDOUT: !89 = !DILocation(line: 25, column: 10, scope: !80)
 // CHECK:STDOUT: !90 = !DILocation(line: 25, column: 3, scope: !80)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_recursive_diamond.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_diamond.carbon
@@ -56,6 +56,7 @@ fn M() {
   A(ptr_f64, 0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_recursive_diamond.carbon'
 // CHECK:STDOUT: source_filename = "call_recursive_diamond.carbon"
 // CHECK:STDOUT:
@@ -401,3 +402,4 @@ fn M() {
 // CHECK:STDOUT: !137 = !DILocation(line: 44, column: 15, scope: !133)
 // CHECK:STDOUT: !138 = !DILocation(line: 44, column: 10, scope: !133)
 // CHECK:STDOUT: !139 = !DILocation(line: 44, column: 3, scope: !133)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_recursive_impl.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_impl.carbon
@@ -41,6 +41,7 @@ fn Run() {
   G(Y, 0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_recursive_impl.carbon'
 // CHECK:STDOUT: source_filename = "call_recursive_impl.carbon"
 // CHECK:STDOUT:
@@ -151,3 +152,4 @@ fn Run() {
 // CHECK:STDOUT: !38 = !DILocation(line: 36, column: 15, scope: !31)
 // CHECK:STDOUT: !39 = !DILocation(line: 36, column: 10, scope: !31)
 // CHECK:STDOUT: !40 = !DILocation(line: 36, column: 3, scope: !31)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_recursive_mutual.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_mutual.carbon
@@ -41,6 +41,7 @@ fn M() {
   F(ptr_f64, 0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_recursive_mutual.carbon'
 // CHECK:STDOUT: source_filename = "call_recursive_mutual.carbon"
 // CHECK:STDOUT:
@@ -285,3 +286,4 @@ fn M() {
 // CHECK:STDOUT: !95 = !DILocation(line: 29, column: 15, scope: !88)
 // CHECK:STDOUT: !96 = !DILocation(line: 29, column: 10, scope: !88)
 // CHECK:STDOUT: !97 = !DILocation(line: 29, column: 3, scope: !88)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_recursive_reorder.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_reorder.carbon
@@ -31,6 +31,7 @@ fn M() {
   F(ptr_f64, ptr_bool, 0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_recursive_reorder.carbon'
 // CHECK:STDOUT: source_filename = "call_recursive_reorder.carbon"
 // CHECK:STDOUT:
@@ -153,3 +154,4 @@ fn M() {
 // CHECK:STDOUT: !44 = !DILocation(line: 19, column: 18, scope: !34)
 // CHECK:STDOUT: !45 = !DILocation(line: 19, column: 10, scope: !34)
 // CHECK:STDOUT: !46 = !DILocation(line: 19, column: 3, scope: !34)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_recursive_reorder_more.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_reorder_more.carbon
@@ -52,6 +52,7 @@ fn M() {
   F(ptr_bool, ptr_bool, ptr_bool, 0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_recursive_reorder_more.carbon'
 // CHECK:STDOUT: source_filename = "call_recursive_reorder_more.carbon"
 // CHECK:STDOUT:
@@ -469,3 +470,4 @@ fn M() {
 // CHECK:STDOUT: !182 = !DILocation(line: 19, column: 21, scope: !173)
 // CHECK:STDOUT: !183 = !DILocation(line: 19, column: 10, scope: !173)
 // CHECK:STDOUT: !184 = !DILocation(line: 19, column: 3, scope: !173)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_recursive_sccs_deep.carbon
+++ b/toolchain/lower/testdata/function/generic/call_recursive_sccs_deep.carbon
@@ -82,6 +82,7 @@ fn M() {
   A(ptr_f64, 0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_recursive_sccs_deep.carbon'
 // CHECK:STDOUT: source_filename = "call_recursive_sccs_deep.carbon"
 // CHECK:STDOUT:
@@ -584,3 +585,4 @@ fn M() {
 // CHECK:STDOUT: !207 = !DILocation(line: 69, column: 15, scope: !203)
 // CHECK:STDOUT: !208 = !DILocation(line: 69, column: 10, scope: !203)
 // CHECK:STDOUT: !209 = !DILocation(line: 69, column: 3, scope: !203)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
+++ b/toolchain/lower/testdata/function/generic/call_specific_in_class.carbon
@@ -44,6 +44,7 @@ fn M() {
   F(C);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_specific_in_class.carbon'
 // CHECK:STDOUT: source_filename = "call_specific_in_class.carbon"
 // CHECK:STDOUT:
@@ -324,3 +325,4 @@ fn M() {
 // CHECK:STDOUT: !112 = !DILocalVariable(arg: 1, scope: !110, type: !7)
 // CHECK:STDOUT: !113 = !DILocalVariable(arg: 2, scope: !110, type: !7)
 // CHECK:STDOUT: !114 = !DILocation(line: 19, column: 5, scope: !110)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/cross_library_name_collision_private.carbon
+++ b/toolchain/lower/testdata/function/generic/cross_library_name_collision_private.carbon
@@ -51,6 +51,7 @@ fn Run() {
   let _: i32 = Lib2CallF(1 as i32, 2 as i32);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'lib1.carbon'
 // CHECK:STDOUT: source_filename = "lib1.carbon"
 // CHECK:STDOUT:
@@ -61,6 +62,8 @@ fn Run() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "lib1.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'lib2.carbon'
 // CHECK:STDOUT: source_filename = "lib2.carbon"
 // CHECK:STDOUT:
@@ -71,6 +74,8 @@ fn Run() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "lib2.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'todo_use.carbon'
 // CHECK:STDOUT: source_filename = "todo_use.carbon"
 // CHECK:STDOUT:
@@ -139,3 +144,4 @@ fn Run() {
 // CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !7)
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 2, scope: !27, type: !7)
 // CHECK:STDOUT: !31 = !DILocation(line: 5, column: 3, scope: !27)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/import.carbon
+++ b/toolchain/lower/testdata/function/generic/import.carbon
@@ -56,6 +56,7 @@ fn Call() -> i32 {
   return *p;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'indirectly_imported.carbon'
 // CHECK:STDOUT: source_filename = "indirectly_imported.carbon"
 // CHECK:STDOUT:
@@ -80,6 +81,8 @@ fn Call() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 6, column: 1, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'directly_imported.carbon'
 // CHECK:STDOUT: source_filename = "directly_imported.carbon"
 // CHECK:STDOUT:
@@ -104,6 +107,8 @@ fn Call() -> i32 {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 8, column: 1, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use.carbon'
 // CHECK:STDOUT: source_filename = "use.carbon"
 // CHECK:STDOUT:
@@ -202,3 +207,4 @@ fn Call() -> i32 {
 // CHECK:STDOUT: !35 = !DILocation(line: 9, column: 3, scope: !31)
 // CHECK:STDOUT: !36 = !DILocation(line: 10, column: 3, scope: !31)
 // CHECK:STDOUT: !37 = !DILocation(line: 11, column: 3, scope: !31)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/import_core_witness.carbon
+++ b/toolchain/lower/testdata/function/generic/import_core_witness.carbon
@@ -28,6 +28,7 @@ fn Run() {
   F(0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'lib.carbon'
 // CHECK:STDOUT: source_filename = "lib.carbon"
 // CHECK:STDOUT:
@@ -53,6 +54,8 @@ fn Run() {
 // CHECK:STDOUT: !8 = !{!9}
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
 // CHECK:STDOUT: !10 = !DILocation(line: 7, column: 3, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'main.carbon'
 // CHECK:STDOUT: source_filename = "main.carbon"
 // CHECK:STDOUT:
@@ -99,3 +102,4 @@ fn Run() {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !10)
 // CHECK:STDOUT: !15 = !DILocation(line: 4, column: 1, scope: !10)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/import_unused_def.carbon
+++ b/toolchain/lower/testdata/function/generic/import_unused_def.carbon
@@ -40,6 +40,7 @@ fn Main() {
   GenericF(0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
 // CHECK:STDOUT:
@@ -87,6 +88,8 @@ fn Main() {
 // CHECK:STDOUT: !18 = !{!19}
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !20 = !DILocation(line: 18, column: 3, scope: !17)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'b.carbon'
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
@@ -148,3 +151,4 @@ fn Main() {
 // CHECK:STDOUT: !18 = !DILocation(line: 18, column: 16, scope: !9)
 // CHECK:STDOUT: !19 = !DILocation(line: 19, column: 10, scope: !9)
 // CHECK:STDOUT: !20 = !DILocation(line: 19, column: 3, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/local_function.carbon
+++ b/toolchain/lower/testdata/function/generic/local_function.carbon
@@ -23,6 +23,7 @@ fn Run() -> i32 {
   return F(i32, 0);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'local_function.carbon'
 // CHECK:STDOUT: source_filename = "local_function.carbon"
 // CHECK:STDOUT:
@@ -72,3 +73,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !18 = !{!19}
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !20 = !DILocation(line: 18, column: 21, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/reverse_canonical.carbon
+++ b/toolchain/lower/testdata/function/generic/reverse_canonical.carbon
@@ -47,6 +47,7 @@ fn Main() {
   first(x, x, y);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'reverse_canonical.carbon'
 // CHECK:STDOUT: source_filename = "reverse_canonical.carbon"
 // CHECK:STDOUT:
@@ -275,3 +276,4 @@ fn Main() {
 // CHECK:STDOUT: !95 = !DILocalVariable(arg: 2, scope: !92, type: !17)
 // CHECK:STDOUT: !96 = !DILocalVariable(arg: 3, scope: !92, type: !17)
 // CHECK:STDOUT: !97 = !DILocation(line: 40, column: 1, scope: !92)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/self_canonical.carbon
+++ b/toolchain/lower/testdata/function/generic/self_canonical.carbon
@@ -82,6 +82,7 @@ fn Main_method_no_template () {
   first_function(local1);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'self_canonical.carbon'
 // CHECK:STDOUT: source_filename = "self_canonical.carbon"
 // CHECK:STDOUT:
@@ -236,3 +237,4 @@ fn Main_method_no_template () {
 // CHECK:STDOUT: !58 = !DILocation(line: 40, column: 19, scope: !49)
 // CHECK:STDOUT: !59 = !DILocation(line: 40, column: 3, scope: !49)
 // CHECK:STDOUT: !60 = !DILocation(line: 35, column: 1, scope: !49)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/type_param.carbon
+++ b/toolchain/lower/testdata/function/generic/type_param.carbon
@@ -15,6 +15,7 @@ fn F(T:! type) {
   let _: T = *p;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'type_param.carbon'
 // CHECK:STDOUT: source_filename = "type_param.carbon"
 // CHECK:STDOUT:
@@ -25,3 +26,4 @@ fn F(T:! type) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "type_param.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/function/generic/type_representation.carbon
+++ b/toolchain/lower/testdata/function/generic/type_representation.carbon
@@ -74,6 +74,7 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
   return F(a);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'type_representation.carbon'
 // CHECK:STDOUT: source_filename = "type_representation.carbon"
 // CHECK:STDOUT:
@@ -380,3 +381,4 @@ fn F_nested_tuple(a: ((i32, i32), X)) -> ((i32, i32), X) {
 // CHECK:STDOUT: !114 = !DILocation(line: 18, column: 14, scope: !110)
 // CHECK:STDOUT: !115 = !DILocation(line: 19, column: 10, scope: !110)
 // CHECK:STDOUT: !116 = !DILocation(line: 19, column: 3, scope: !110)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/global/class_obj.carbon
+++ b/toolchain/lower/testdata/global/class_obj.carbon
@@ -13,6 +13,7 @@ class A {}
 
 var a: A = {};
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'class_obj.carbon'
 // CHECK:STDOUT: source_filename = "class_obj.carbon"
 // CHECK:STDOUT:
@@ -45,3 +46,4 @@ var a: A = {};
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 14, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/global/class_with_fun.carbon
+++ b/toolchain/lower/testdata/global/class_with_fun.carbon
@@ -17,6 +17,7 @@ fn ret_a() -> A {
 
 var a: A = {};
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'class_with_fun.carbon'
 // CHECK:STDOUT: source_filename = "class_with_fun.carbon"
 // CHECK:STDOUT:
@@ -61,3 +62,4 @@ var a: A = {};
 // CHECK:STDOUT: !11 = !{null}
 // CHECK:STDOUT: !12 = !DILocation(line: 18, column: 1, scope: !9)
 // CHECK:STDOUT: !13 = !DILocation(line: 0, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/global/decl.carbon
+++ b/toolchain/lower/testdata/global/decl.carbon
@@ -11,6 +11,7 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/global/decl.carbon
 var a: i32;
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'decl.carbon'
 // CHECK:STDOUT: source_filename = "decl.carbon"
 // CHECK:STDOUT:
@@ -38,3 +39,4 @@ var a: i32;
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/global/simple_init.carbon
+++ b/toolchain/lower/testdata/global/simple_init.carbon
@@ -11,6 +11,7 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/global/simple_init.carbon
 var a: i32 = 0;
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'simple_init.carbon'
 // CHECK:STDOUT: source_filename = "simple_init.carbon"
 // CHECK:STDOUT:
@@ -38,3 +39,4 @@ var a: i32 = 0;
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/global/simple_with_fun.carbon
+++ b/toolchain/lower/testdata/global/simple_with_fun.carbon
@@ -16,6 +16,7 @@ fn test_a() -> i32 {
 
 var a: i32 = test_a();
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'simple_with_fun.carbon'
 // CHECK:STDOUT: source_filename = "simple_with_fun.carbon"
 // CHECK:STDOUT:
@@ -56,3 +57,4 @@ var a: i32 = test_a();
 // CHECK:STDOUT: !12 = !DILocation(line: 17, column: 14, scope: !9)
 // CHECK:STDOUT: !13 = !DILocation(line: 17, column: 1, scope: !9)
 // CHECK:STDOUT: !14 = !DILocation(line: 0, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/global/use.carbon
+++ b/toolchain/lower/testdata/global/use.carbon
@@ -17,6 +17,7 @@ fn F() -> i32 {
   return a;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use.carbon'
 // CHECK:STDOUT: source_filename = "use.carbon"
 // CHECK:STDOUT:
@@ -62,3 +63,4 @@ fn F() -> i32 {
 // CHECK:STDOUT: !14 = !DILocation(line: 14, column: 14, scope: !10)
 // CHECK:STDOUT: !15 = !DILocation(line: 14, column: 1, scope: !10)
 // CHECK:STDOUT: !16 = !DILocation(line: 0, scope: !10)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/if/else.carbon
+++ b/toolchain/lower/testdata/if/else.carbon
@@ -23,6 +23,7 @@ fn If(b: bool) {
   H();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'else.carbon'
 // CHECK:STDOUT: source_filename = "else.carbon"
 // CHECK:STDOUT:
@@ -91,3 +92,4 @@ fn If(b: bool) {
 // CHECK:STDOUT: !21 = !DILocation(line: 21, column: 5, scope: !12)
 // CHECK:STDOUT: !22 = !DILocation(line: 23, column: 3, scope: !12)
 // CHECK:STDOUT: !23 = !DILocation(line: 17, column: 1, scope: !12)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/if/no_else.carbon
+++ b/toolchain/lower/testdata/if/no_else.carbon
@@ -20,6 +20,7 @@ fn If(b: bool) {
   G();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'no_else.carbon'
 // CHECK:STDOUT: source_filename = "no_else.carbon"
 // CHECK:STDOUT:
@@ -75,3 +76,4 @@ fn If(b: bool) {
 // CHECK:STDOUT: !18 = !DILocation(line: 17, column: 3, scope: !10)
 // CHECK:STDOUT: !19 = !DILocation(line: 20, column: 3, scope: !10)
 // CHECK:STDOUT: !20 = !DILocation(line: 16, column: 1, scope: !10)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/if_expr/basic.carbon
+++ b/toolchain/lower/testdata/if_expr/basic.carbon
@@ -17,6 +17,7 @@ fn Select(b: bool) -> i32 {
   return if b then F() else G();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -76,3 +77,4 @@ fn Select(b: bool) -> i32 {
 // CHECK:STDOUT: !18 = !DILocation(line: 17, column: 20, scope: !11)
 // CHECK:STDOUT: !19 = !DILocation(line: 17, column: 29, scope: !11)
 // CHECK:STDOUT: !20 = !DILocation(line: 17, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/if_expr/empty_block.carbon
+++ b/toolchain/lower/testdata/if_expr/empty_block.carbon
@@ -14,6 +14,7 @@ fn Select(b: bool, c: bool, d: bool) -> i32 {
   return if b then if c then 1 as i32 else 2 else if d then 3 as i32 else 4;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'empty_block.carbon'
 // CHECK:STDOUT: source_filename = "empty_block.carbon"
 // CHECK:STDOUT:
@@ -75,3 +76,4 @@ fn Select(b: bool, c: bool, d: bool) -> i32 {
 // CHECK:STDOUT: !14 = !DILocation(line: 14, column: 20, scope: !4)
 // CHECK:STDOUT: !15 = !DILocation(line: 14, column: 51, scope: !4)
 // CHECK:STDOUT: !16 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/assoc_fn_alias.carbon
+++ b/toolchain/lower/testdata/impl/assoc_fn_alias.carbon
@@ -29,6 +29,7 @@ fn Call(a: A) -> i32 {
   return a.F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'assoc_fn_alias.carbon'
 // CHECK:STDOUT: source_filename = "assoc_fn_alias.carbon"
 // CHECK:STDOUT:
@@ -70,3 +71,4 @@ fn Call(a: A) -> i32 {
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !13, type: !8)
 // CHECK:STDOUT: !16 = !DILocation(line: 29, column: 10, scope: !13)
 // CHECK:STDOUT: !17 = !DILocation(line: 29, column: 3, scope: !13)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/extend_impl.carbon
+++ b/toolchain/lower/testdata/impl/extend_impl.carbon
@@ -30,6 +30,7 @@ fn InstanceAccess(a: A) -> i32 {
   return a.F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'extend_impl.carbon'
 // CHECK:STDOUT: source_filename = "extend_impl.carbon"
 // CHECK:STDOUT:
@@ -78,3 +79,4 @@ fn InstanceAccess(a: A) -> i32 {
 // CHECK:STDOUT: !17 = !DILocalVariable(arg: 1, scope: !12, type: !15)
 // CHECK:STDOUT: !18 = !DILocation(line: 30, column: 10, scope: !12)
 // CHECK:STDOUT: !19 = !DILocation(line: 30, column: 3, scope: !12)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/impl.carbon
+++ b/toolchain/lower/testdata/impl/impl.carbon
@@ -83,6 +83,7 @@ impl C(B) as I {
   fn F() {}
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'impl.carbon'
 // CHECK:STDOUT: source_filename = "impl.carbon"
 // CHECK:STDOUT:
@@ -124,6 +125,8 @@ impl C(B) as I {
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !13, type: !8)
 // CHECK:STDOUT: !16 = !DILocation(line: 19, column: 10, scope: !13)
 // CHECK:STDOUT: !17 = !DILocation(line: 19, column: 3, scope: !13)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'generic_impls.carbon'
 // CHECK:STDOUT: source_filename = "generic_impls.carbon"
 // CHECK:STDOUT:
@@ -222,6 +225,8 @@ impl C(B) as I {
 // CHECK:STDOUT: !33 = !{!34}
 // CHECK:STDOUT: !34 = !DILocalVariable(arg: 1, scope: !32, type: !7)
 // CHECK:STDOUT: !35 = !DILocation(line: 21, column: 3, scope: !32)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'generic_class_impls.carbon'
 // CHECK:STDOUT: source_filename = "generic_class_impls.carbon"
 // CHECK:STDOUT:
@@ -252,3 +257,4 @@ impl C(B) as I {
 // CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = distinct !DISubprogram(name: "F", linkageName: "_CF.C.a6a60dfee2d7d273.Main:I.Main", scope: null, file: !1, line: 18, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !9 = !DILocation(line: 18, column: 3, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/import.carbon
+++ b/toolchain/lower/testdata/impl/import.carbon
@@ -36,6 +36,7 @@ fn Call(a: A) -> i32 {
   return a.(I.F)();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'impl_def.carbon'
 // CHECK:STDOUT: source_filename = "impl_def.carbon"
 // CHECK:STDOUT:
@@ -65,6 +66,8 @@ fn Call(a: A) -> i32 {
 // CHECK:STDOUT: !10 = !DILocalVariable(arg: 1, scope: !4, type: !8)
 // CHECK:STDOUT: !11 = !DILocation(line: 14, column: 12, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 14, column: 5, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'impl_use.carbon'
 // CHECK:STDOUT: source_filename = "impl_use.carbon"
 // CHECK:STDOUT:
@@ -95,3 +98,4 @@ fn Call(a: A) -> i32 {
 // CHECK:STDOUT: !10 = !DILocalVariable(arg: 1, scope: !4, type: !8)
 // CHECK:STDOUT: !11 = !DILocation(line: 5, column: 10, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 5, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/import_facet.carbon
+++ b/toolchain/lower/testdata/impl/import_facet.carbon
@@ -52,6 +52,7 @@ fn F(d: D(i32)) -> i32* {
   return d.(I.GetI)().GetC();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
 // CHECK:STDOUT:
@@ -62,6 +63,8 @@ fn F(d: D(i32)) -> i32* {
 // CHECK:STDOUT: !1 = !DIFile(filename: "a.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'b.carbon'
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
@@ -72,6 +75,8 @@ fn F(d: D(i32)) -> i32* {
 // CHECK:STDOUT: !1 = !DIFile(filename: "b.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'c.carbon'
 // CHECK:STDOUT: source_filename = "c.carbon"
 // CHECK:STDOUT:
@@ -82,6 +87,8 @@ fn F(d: D(i32)) -> i32* {
 // CHECK:STDOUT: !1 = !DIFile(filename: "c.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'd.carbon'
 // CHECK:STDOUT: source_filename = "d.carbon"
 // CHECK:STDOUT:
@@ -161,3 +168,4 @@ fn F(d: D(i32)) -> i32* {
 // CHECK:STDOUT: !27 = !DILocation(line: 5, column: 5, scope: !23)
 // CHECK:STDOUT: !28 = !DILocation(line: 6, column: 12, scope: !23)
 // CHECK:STDOUT: !29 = !DILocation(line: 6, column: 5, scope: !23)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/import_thunk.carbon
+++ b/toolchain/lower/testdata/impl/import_thunk.carbon
@@ -66,6 +66,7 @@ fn Test(a: A) -> C {
   return X.(I.F)(a);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'thunk.carbon'
 // CHECK:STDOUT: source_filename = "thunk.carbon"
 // CHECK:STDOUT:
@@ -193,6 +194,8 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: !44 = !{!45}
 // CHECK:STDOUT: !45 = !DILocalVariable(arg: 1, scope: !43, type: !7)
 // CHECK:STDOUT: !46 = !DILocation(line: 20, column: 3, scope: !43)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_thunk.carbon'
 // CHECK:STDOUT: source_filename = "call_thunk.carbon"
 // CHECK:STDOUT:
@@ -282,6 +285,8 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: !27 = !{!28}
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 1, scope: !26, type: !7)
 // CHECK:STDOUT: !29 = !DILocation(line: 7, column: 10, scope: !26)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'thunk_for_imported_interface.carbon'
 // CHECK:STDOUT: source_filename = "thunk_for_imported_interface.carbon"
 // CHECK:STDOUT:
@@ -381,6 +386,8 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: !32 = !{!33}
 // CHECK:STDOUT: !33 = !DILocalVariable(arg: 1, scope: !31, type: !7)
 // CHECK:STDOUT: !34 = !DILocation(line: 9, column: 3, scope: !31)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_thunk_for_imported_interface.carbon'
 // CHECK:STDOUT: source_filename = "call_thunk_for_imported_interface.carbon"
 // CHECK:STDOUT:
@@ -470,3 +477,4 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: !27 = !{!28}
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 1, scope: !26, type: !7)
 // CHECK:STDOUT: !29 = !DILocation(line: 8, column: 10, scope: !26)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/instance_method.carbon
+++ b/toolchain/lower/testdata/impl/instance_method.carbon
@@ -28,6 +28,7 @@ fn Call(a: A*) -> A* {
   return (*a).Get();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'instance_method.carbon'
 // CHECK:STDOUT: source_filename = "instance_method.carbon"
 // CHECK:STDOUT:
@@ -65,3 +66,4 @@ fn Call(a: A*) -> A* {
 // CHECK:STDOUT: !13 = !DILocalVariable(arg: 1, scope: !11, type: !7)
 // CHECK:STDOUT: !14 = !DILocation(line: 28, column: 10, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 28, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/period_self.carbon
+++ b/toolchain/lower/testdata/impl/period_self.carbon
@@ -41,6 +41,7 @@ fn G(a: A(B)) {
   F(a);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'library_with_period_self_in_impl.carbon'
 // CHECK:STDOUT: source_filename = "library_with_period_self_in_impl.carbon"
 // CHECK:STDOUT:
@@ -51,6 +52,8 @@ fn G(a: A(B)) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "library_with_period_self_in_impl.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_period_self_in_impl.carbon'
 // CHECK:STDOUT: source_filename = "import_period_self_in_impl.carbon"
 // CHECK:STDOUT:
@@ -103,3 +106,4 @@ fn G(a: A(B)) {
 // CHECK:STDOUT: !22 = !DILocalVariable(arg: 1, scope: !18, type: !7)
 // CHECK:STDOUT: !23 = !DILocation(line: 13, column: 12, scope: !18)
 // CHECK:STDOUT: !24 = !DILocation(line: 13, column: 5, scope: !18)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/impl/thunk.carbon
+++ b/toolchain/lower/testdata/impl/thunk.carbon
@@ -70,6 +70,7 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
   return CallGeneric(c, b);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'thunk.carbon'
 // CHECK:STDOUT: source_filename = "thunk.carbon"
 // CHECK:STDOUT:
@@ -220,6 +221,8 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
 // CHECK:STDOUT: !50 = !DILocation(line: 24, column: 10, scope: !47)
 // CHECK:STDOUT: !51 = !DILocation(line: 24, column: 19, scope: !47)
 // CHECK:STDOUT: !52 = !DILocation(line: 24, column: 3, scope: !47)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'generic_thunk.carbon'
 // CHECK:STDOUT: source_filename = "generic_thunk.carbon"
 // CHECK:STDOUT:
@@ -367,3 +370,4 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
 // CHECK:STDOUT: !50 = !DILocalVariable(arg: 2, scope: !47, type: !7)
 // CHECK:STDOUT: !51 = !DILocation(line: 18, column: 3, scope: !47)
 // CHECK:STDOUT: !52 = !DILocation(line: 0, scope: !47)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/index/array_element_access.carbon
+++ b/toolchain/lower/testdata/index/array_element_access.carbon
@@ -20,6 +20,7 @@ fn Run() {
   var _: i32 = B()[1];
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'array_element_access.carbon'
 // CHECK:STDOUT: source_filename = "array_element_access.carbon"
 // CHECK:STDOUT:
@@ -164,3 +165,4 @@ fn Run() {
 // CHECK:STDOUT: !39 = !{!40}
 // CHECK:STDOUT: !40 = !DILocalVariable(arg: 1, scope: !38, type: !7)
 // CHECK:STDOUT: !41 = !DILocation(line: 17, column: 26, scope: !38)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interface/assoc.carbon
+++ b/toolchain/lower/testdata/interface/assoc.carbon
@@ -16,6 +16,7 @@ interface I {
 
 fn F() { I.Assoc; }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'assoc.carbon'
 // CHECK:STDOUT: source_filename = "assoc.carbon"
 // CHECK:STDOUT:
@@ -38,3 +39,4 @@ fn F() { I.Assoc; }
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 17, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interface/basic.carbon
+++ b/toolchain/lower/testdata/interface/basic.carbon
@@ -22,6 +22,7 @@ fn G() -> I;
 
 fn H() -> I { return G(); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -61,3 +62,4 @@ fn H() -> I { return G(); }
 // CHECK:STDOUT: !13 = !{!7}
 // CHECK:STDOUT: !14 = !DILocation(line: 23, column: 22, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 23, column: 15, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interface/mangle_declared_class.carbon
+++ b/toolchain/lower/testdata/interface/mangle_declared_class.carbon
@@ -26,6 +26,7 @@ impl D as N {
   fn F() {}
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'mangle_declared_class.carbon'
 // CHECK:STDOUT: source_filename = "mangle_declared_class.carbon"
 // CHECK:STDOUT:
@@ -56,3 +57,4 @@ impl D as N {
 // CHECK:STDOUT: !7 = !DILocation(line: 18, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = distinct !DISubprogram(name: "F", linkageName: "_CF.D.Main:I.Main", scope: null, file: !1, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !9 = !DILocation(line: 26, column: 3, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interface/where.carbon
+++ b/toolchain/lower/testdata/interface/where.carbon
@@ -55,6 +55,7 @@ fn G() {
   let unused t: type = type where D impls J(.Self);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -77,6 +78,8 @@ fn G() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 12, column: 3, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'no_period_self_dependence.carbon'
 // CHECK:STDOUT: source_filename = "no_period_self_dependence.carbon"
 // CHECK:STDOUT:
@@ -124,3 +127,4 @@ fn G() {
 // CHECK:STDOUT: !17 = !{!18}
 // CHECK:STDOUT: !18 = !DILocalVariable(arg: 1, scope: !16, type: !7)
 // CHECK:STDOUT: !19 = !DILocation(line: 16, column: 3, scope: !16)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/array.carbon
+++ b/toolchain/lower/testdata/interop/cpp/array.carbon
@@ -28,6 +28,7 @@ int H() {
 }
 ''';
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'array_value_param.carbon'
 // CHECK:STDOUT: source_filename = "array_value_param.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -136,3 +137,4 @@ int H() {
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !27, type: !22)
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 2, scope: !27, type: !21)
 // CHECK:STDOUT: !33 = !DILocation(line: 5, column: 1, scope: !27)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/clang_code_generator_callbacks.carbon
+++ b/toolchain/lower/testdata/interop/cpp/clang_code_generator_callbacks.carbon
@@ -70,6 +70,7 @@ void f2() {
 }
 ''';
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'clang_code_generator_callbacks.carbon'
 // CHECK:STDOUT: source_filename = "clang_code_generator_callbacks.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -144,3 +145,4 @@ void f2() {
 // CHECK:STDOUT: !15 = !{!"_ZTS1S", !8, i64 0}
 // CHECK:STDOUT: !16 = !{!17, !17, i64 0}
 // CHECK:STDOUT: !17 = !{!"p1 _ZTS2t2", !13, i64 0}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/export/class.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/export/class.carbon
@@ -94,6 +94,7 @@ fn G() {
   Cpp.F(ref c);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'pointer.carbon'
 // CHECK:STDOUT: source_filename = "pointer.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -148,6 +149,8 @@ fn G() {
 // CHECK:STDOUT: !16 = !{null}
 // CHECK:STDOUT: !17 = !DILocation(line: 15, column: 13, scope: !14)
 // CHECK:STDOUT: !18 = !DILocation(line: 15, column: 1, scope: !14)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'layout.carbon'
 // CHECK:STDOUT: source_filename = "layout.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -446,6 +449,8 @@ fn G() {
 // CHECK:STDOUT: !73 = !{!74}
 // CHECK:STDOUT: !74 = !DILocalVariable(arg: 1, scope: !72, type: !21)
 // CHECK:STDOUT: !75 = !DILocation(line: 23, column: 1, scope: !72)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'field.carbon'
 // CHECK:STDOUT: source_filename = "field.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -570,3 +575,4 @@ fn G() {
 // CHECK:STDOUT: !45 = !DILocation(line: 19, column: 14, scope: !41)
 // CHECK:STDOUT: !46 = !DILocation(line: 20, column: 3, scope: !41)
 // CHECK:STDOUT: !47 = !DILocation(line: 18, column: 1, scope: !41)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/export/mangle.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/export/mangle.carbon
@@ -26,6 +26,7 @@ void f1(Carbon::Other::Class1*) {
 
 ''';
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'other.carbon'
 // CHECK:STDOUT: source_filename = "other.carbon"
 // CHECK:STDOUT:
@@ -36,6 +37,8 @@ void f1(Carbon::Other::Class1*) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "other.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'namespace.carbon'
 // CHECK:STDOUT: source_filename = "namespace.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -69,3 +72,4 @@ void f1(Carbon::Other::Class1*) {
 // CHECK:STDOUT: !11 = !{!12, !12, i64 0}
 // CHECK:STDOUT: !12 = !{!"p1 _ZTSN6Carbon5Other6Class1E", !13, i64 0}
 // CHECK:STDOUT: !13 = !{!"any pointer", !9, i64 0}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/export/method.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/export/method.carbon
@@ -63,6 +63,7 @@ void CallF() {
 
 fn CallCallF() { Cpp.CallF(); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'method.carbon'
 // CHECK:STDOUT: source_filename = "method.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -179,6 +180,8 @@ fn CallCallF() { Cpp.CallF(); }
 // CHECK:STDOUT: !30 = !{!31}
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !17)
 // CHECK:STDOUT: !32 = !DILocation(line: 6, column: 3, scope: !29)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'method_with_args_and_return.carbon'
 // CHECK:STDOUT: source_filename = "method_with_args_and_return.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -321,6 +324,8 @@ fn CallCallF() { Cpp.CallF(); }
 // CHECK:STDOUT: !43 = !{!17}
 // CHECK:STDOUT: !44 = !DILocation(line: 18, column: 32, scope: !41)
 // CHECK:STDOUT: !45 = !DILocation(line: 18, column: 25, scope: !41)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'static.carbon'
 // CHECK:STDOUT: source_filename = "static.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -413,3 +418,4 @@ fn CallCallF() { Cpp.CallF(); }
 // CHECK:STDOUT: !28 = distinct !DISubprogram(name: "CallCallF", linkageName: "_CCallCallF.Main", scope: null, file: !1, line: 15, type: !12, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !29 = !DILocation(line: 15, column: 18, scope: !28)
 // CHECK:STDOUT: !30 = !DILocation(line: 15, column: 1, scope: !28)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/alignment.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/alignment.carbon
@@ -56,6 +56,7 @@ fn Packed(n: i32) {
   Cpp.Take(ref a);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'alignment.carbon'
 // CHECK:STDOUT: source_filename = "alignment.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -246,3 +247,4 @@ fn Packed(n: i32) {
 // CHECK:STDOUT: !58 = distinct !DISubprogram(name: "Op", linkageName: "_COp.51f3fb62cb986374:DefaultOrUnformed.Core.3e10857902c69c1a", scope: null, file: !52, line: 9, type: !25, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !59 = !DILocation(line: 9, column: 28, scope: !58)
 // CHECK:STDOUT: !60 = !DILocation(line: 9, column: 21, scope: !58)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/base.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/base.carbon
@@ -58,6 +58,7 @@ fn Call(b: Cpp.B*) {
   b->f();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'convert.carbon'
 // CHECK:STDOUT: source_filename = "convert.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -112,6 +113,8 @@ fn Call(b: Cpp.B*) {
 // CHECK:STDOUT: !23 = !DILocation(line: 13, column: 13, scope: !18)
 // CHECK:STDOUT: !24 = !DILocation(line: 13, column: 3, scope: !18)
 // CHECK:STDOUT: !25 = !DILocation(line: 12, column: 1, scope: !18)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'access_field.carbon'
 // CHECK:STDOUT: source_filename = "access_field.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -152,6 +155,8 @@ fn Call(b: Cpp.B*) {
 // CHECK:STDOUT: !17 = !DILocalVariable(arg: 1, scope: !11, type: !15)
 // CHECK:STDOUT: !18 = !DILocation(line: 7, column: 10, scope: !11)
 // CHECK:STDOUT: !19 = !DILocation(line: 7, column: 3, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_method.carbon'
 // CHECK:STDOUT: source_filename = "call_method.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -205,3 +210,4 @@ fn Call(b: Cpp.B*) {
 // CHECK:STDOUT: !19 = !{!20, !20, i64 0}
 // CHECK:STDOUT: !20 = !{!"p1 _ZTS1A", !21, i64 0}
 // CHECK:STDOUT: !21 = !{!"any pointer", !9, i64 0}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/constructor.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/constructor.carbon
@@ -167,6 +167,7 @@ fn Four() {
   let _: Cpp.C = (5, 6, 7, 8);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_default.carbon'
 // CHECK:STDOUT: source_filename = "import_default.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -267,6 +268,8 @@ fn Four() {
 // CHECK:STDOUT: !22 = !{!23, !8, i64 0}
 // CHECK:STDOUT: !23 = !{!"_ZTS1C", !8, i64 0, !8, i64 4}
 // CHECK:STDOUT: !24 = !{!23, !8, i64 4}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'implicit_default.carbon'
 // CHECK:STDOUT: source_filename = "implicit_default.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -366,6 +369,8 @@ fn Four() {
 // CHECK:STDOUT: !29 = !{!30, !8, i64 0}
 // CHECK:STDOUT: !30 = !{!"_ZTS1C", !8, i64 0, !8, i64 4}
 // CHECK:STDOUT: !31 = !{!30, !8, i64 4}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'defaulted_default.carbon'
 // CHECK:STDOUT: source_filename = "defaulted_default.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -524,6 +529,8 @@ fn Four() {
 // CHECK:STDOUT: !40 = !{!"_ZTS26ImplicitlyDefaultedDefault", !8, i64 0}
 // CHECK:STDOUT: !41 = !{!42, !8, i64 0}
 // CHECK:STDOUT: !42 = !{!"_ZTS26ExplicitlyDefaultedDefault", !8, i64 0}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_copy.carbon'
 // CHECK:STDOUT: source_filename = "call_copy.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -600,6 +607,8 @@ fn Four() {
 // CHECK:STDOUT: !24 = !{!25}
 // CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !22, type: !14)
 // CHECK:STDOUT: !26 = !DILocation(line: 5, column: 3, scope: !22)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_c1_in_thunk.carbon'
 // CHECK:STDOUT: source_filename = "call_c1_in_thunk.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -690,6 +699,8 @@ fn Four() {
 // CHECK:STDOUT: !18 = !{!"any pointer", !9, i64 0}
 // CHECK:STDOUT: !19 = !{!20, !20, i64 0}
 // CHECK:STDOUT: !20 = !{!"vtable pointer", !10, i64 0}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_multi_argument.carbon'
 // CHECK:STDOUT: source_filename = "call_multi_argument.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -1029,3 +1040,4 @@ fn Four() {
 // CHECK:STDOUT: !34 = !DILocation(line: 28, column: 18, scope: !33)
 // CHECK:STDOUT: !35 = !DILocation(line: 29, column: 18, scope: !33)
 // CHECK:STDOUT: !36 = !DILocation(line: 27, column: 1, scope: !33)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/conversion.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/conversion.carbon
@@ -76,6 +76,7 @@ fn ConvertToValue(b: Cpp.B) {
   let unused a: Cpp.int = b;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'class_to_class.carbon'
 // CHECK:STDOUT: source_filename = "class_to_class.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -167,6 +168,8 @@ fn ConvertToValue(b: Cpp.B) {
 // CHECK:STDOUT: !27 = !DILocalVariable(arg: 1, scope: !25, type: !14)
 // CHECK:STDOUT: !28 = !DILocation(line: 20, column: 25, scope: !25)
 // CHECK:STDOUT: !29 = !DILocation(line: 19, column: 1, scope: !25)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'class_to_enum.carbon'
 // CHECK:STDOUT: source_filename = "class_to_enum.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -280,6 +283,8 @@ fn ConvertToValue(b: Cpp.B) {
 // CHECK:STDOUT: !32 = !DILocation(line: 20, column: 25, scope: !29)
 // CHECK:STDOUT: !33 = !DILocation(line: 21, column: 25, scope: !29)
 // CHECK:STDOUT: !34 = !DILocation(line: 19, column: 1, scope: !29)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'class_to_int.carbon'
 // CHECK:STDOUT: source_filename = "class_to_int.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -368,3 +373,4 @@ fn ConvertToValue(b: Cpp.B) {
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !30, type: !14)
 // CHECK:STDOUT: !33 = !DILocation(line: 16, column: 27, scope: !30)
 // CHECK:STDOUT: !34 = !DILocation(line: 15, column: 1, scope: !30)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/copy_vs_move.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/copy_vs_move.carbon
@@ -108,6 +108,7 @@ fn PassTemporary() {
   Cpp.pass(Cpp.make());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'copyable.carbon'
 // CHECK:STDOUT: source_filename = "copyable.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -241,6 +242,8 @@ fn PassTemporary() {
 // CHECK:STDOUT: !36 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !1, type: !15, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !37 = !DILocation(line: 14, column: 23, scope: !36)
 // CHECK:STDOUT: !38 = !DILocation(line: 0, scope: !36)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'copy_or_move.carbon'
 // CHECK:STDOUT: source_filename = "copy_or_move.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -394,6 +397,8 @@ fn PassTemporary() {
 // CHECK:STDOUT: !37 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !1, type: !15, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !38 = !DILocation(line: 16, column: 25, scope: !37)
 // CHECK:STDOUT: !39 = !DILocation(line: 0, scope: !37)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'move_only.carbon'
 // CHECK:STDOUT: source_filename = "move_only.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -502,3 +507,4 @@ fn PassTemporary() {
 // CHECK:STDOUT: !23 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !1, type: !15, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !24 = !DILocation(line: 20, column: 23, scope: !23)
 // CHECK:STDOUT: !25 = !DILocation(line: 0, scope: !23)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/dynamic.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/dynamic.carbon
@@ -45,6 +45,7 @@ fn DoThing() {
   Cpp.Use(ref d);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'dynamic_base_from_cpp.carbon'
 // CHECK:STDOUT: source_filename = "dynamic_base_from_cpp.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -290,3 +291,4 @@ fn DoThing() {
 // CHECK:STDOUT: !61 = !{!"vtable pointer", !10, i64 0}
 // CHECK:STDOUT: !62 = !{!63, !63, i64 0}
 // CHECK:STDOUT: !63 = !{!"p1 _ZTS11FurtherBase", !13, i64 0}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/field.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/field.carbon
@@ -108,6 +108,7 @@ fn AccessP(a: Cpp.A) -> i32 {
   return *a.p;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'access_struct.carbon'
 // CHECK:STDOUT: source_filename = "access_struct.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -160,6 +161,8 @@ fn AccessP(a: Cpp.A) -> i32 {
 // CHECK:STDOUT: !22 = !DILocalVariable(arg: 1, scope: !20, type: !15)
 // CHECK:STDOUT: !23 = !DILocation(line: 13, column: 10, scope: !20)
 // CHECK:STDOUT: !24 = !DILocation(line: 13, column: 3, scope: !20)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'assign_struct.carbon'
 // CHECK:STDOUT: source_filename = "assign_struct.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -211,6 +214,8 @@ fn AccessP(a: Cpp.A) -> i32 {
 // CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !19, type: !14)
 // CHECK:STDOUT: !22 = !DILocation(line: 13, column: 3, scope: !19)
 // CHECK:STDOUT: !23 = !DILocation(line: 12, column: 1, scope: !19)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'access_union.carbon'
 // CHECK:STDOUT: source_filename = "access_union.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -263,6 +268,8 @@ fn AccessP(a: Cpp.A) -> i32 {
 // CHECK:STDOUT: !22 = !DILocalVariable(arg: 1, scope: !20, type: !15)
 // CHECK:STDOUT: !23 = !DILocation(line: 11, column: 10, scope: !20)
 // CHECK:STDOUT: !24 = !DILocation(line: 11, column: 3, scope: !20)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'assign_union.carbon'
 // CHECK:STDOUT: source_filename = "assign_union.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -314,6 +321,8 @@ fn AccessP(a: Cpp.A) -> i32 {
 // CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !19, type: !14)
 // CHECK:STDOUT: !22 = !DILocation(line: 11, column: 3, scope: !19)
 // CHECK:STDOUT: !23 = !DILocation(line: 10, column: 1, scope: !19)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'access_anon_union.carbon'
 // CHECK:STDOUT: source_filename = "access_anon_union.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -368,3 +377,4 @@ fn AccessP(a: Cpp.A) -> i32 {
 // CHECK:STDOUT: !23 = !DILocation(line: 11, column: 11, scope: !20)
 // CHECK:STDOUT: !24 = !DILocation(line: 11, column: 10, scope: !20)
 // CHECK:STDOUT: !25 = !DILocation(line: 11, column: 3, scope: !20)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/method.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/method.carbon
@@ -88,6 +88,7 @@ fn F(ref r: Cpp.A) {
   r.f(1, 2);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_by_val.carbon'
 // CHECK:STDOUT: source_filename = "call_by_val.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -175,6 +176,8 @@ fn F(ref r: Cpp.A) {
 // CHECK:STDOUT: !25 = !{!26, !8, i64 8}
 // CHECK:STDOUT: !26 = !{!"_ZTS1A", !27, i64 0, !8, i64 8}
 // CHECK:STDOUT: !27 = !{!"_ZTS4Base"}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_by_ref.carbon'
 // CHECK:STDOUT: source_filename = "call_by_ref.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -249,6 +252,8 @@ fn F(ref r: Cpp.A) {
 // CHECK:STDOUT: !23 = !{!24, !8, i64 8}
 // CHECK:STDOUT: !24 = !{!"_ZTS1A", !25, i64 0, !8, i64 8}
 // CHECK:STDOUT: !25 = !{!"_ZTS4Base"}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_virtual.carbon'
 // CHECK:STDOUT: source_filename = "call_virtual.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -308,6 +313,8 @@ fn F(ref r: Cpp.A) {
 // CHECK:STDOUT: !17 = !DILocation(line: 7, column: 3, scope: !11)
 // CHECK:STDOUT: !18 = !DILocation(line: 8, column: 3, scope: !11)
 // CHECK:STDOUT: !19 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_thunk.carbon'
 // CHECK:STDOUT: source_filename = "call_thunk.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -422,6 +429,8 @@ fn F(ref r: Cpp.A) {
 // CHECK:STDOUT: !33 = !{!34}
 // CHECK:STDOUT: !34 = !DILocalVariable(arg: 1, scope: !29, type: !32)
 // CHECK:STDOUT: !35 = !DILocation(line: 8, column: 14, scope: !29)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_with_ref_self.carbon'
 // CHECK:STDOUT: source_filename = "call_with_ref_self.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -462,3 +471,4 @@ fn F(ref r: Cpp.A) {
 // CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !11, type: !14)
 // CHECK:STDOUT: !17 = !DILocation(line: 12, column: 3, scope: !11)
 // CHECK:STDOUT: !18 = !DILocation(line: 11, column: 1, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/virtual_base.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/virtual_base.carbon
@@ -62,6 +62,7 @@ fn AccessD(d: Cpp.D) -> i32 {
   return d.d;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_diamond.carbon'
 // CHECK:STDOUT: source_filename = "use_diamond.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -221,3 +222,4 @@ fn AccessD(d: Cpp.D) -> i32 {
 // CHECK:STDOUT: !28 = !DILocation(line: 16, column: 3, scope: !20)
 // CHECK:STDOUT: !29 = !{!30, !30, i64 0}
 // CHECK:STDOUT: !30 = !{!"vtable pointer", !10, i64 0}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/virtual_fn.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/virtual_fn.carbon
@@ -49,6 +49,7 @@ void delete_new_Base() {
 }
 ''';
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'override_virtual_dtor.carbon'
 // CHECK:STDOUT: source_filename = "override_virtual_dtor.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -418,3 +419,4 @@ void delete_new_Base() {
 // CHECK:STDOUT: !58 = !{!59}
 // CHECK:STDOUT: !59 = !DILocalVariable(arg: 1, scope: !57, type: !25)
 // CHECK:STDOUT: !60 = !DILocation(line: 19, column: 3, scope: !57)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/cpp_compat_int.carbon
+++ b/toolchain/lower/testdata/interop/cpp/cpp_compat_int.carbon
@@ -38,6 +38,7 @@ fn DoubleULong64(ul64: Core.CppCompat.ULongLong64) -> u64 {
   return 2 * (ul64 as u64);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'primitives.carbon'
 // CHECK:STDOUT: source_filename = "primitives.carbon"
 // CHECK:STDOUT:
@@ -110,3 +111,4 @@ fn DoubleULong64(ul64: Core.CppCompat.ULongLong64) -> u64 {
 // CHECK:STDOUT: !33 = !DILocalVariable(arg: 1, scope: !28, type: !31)
 // CHECK:STDOUT: !34 = !DILocation(line: 25, column: 10, scope: !28)
 // CHECK:STDOUT: !35 = !DILocation(line: 25, column: 3, scope: !28)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/debug_info.carbon
+++ b/toolchain/lower/testdata/interop/cpp/debug_info.carbon
@@ -22,6 +22,7 @@ fn Call() -> i32 {
   return Cpp.f();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'debug_info.carbon'
 // CHECK:STDOUT: source_filename = "debug_info.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -68,3 +69,4 @@ fn Call() -> i32 {
 // CHECK:STDOUT: !18 = distinct !DISubprogram(name: "Call", linkageName: "_CCall.Main", scope: null, file: !3, line: 21, type: !14, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !19 = !DILocation(line: 22, column: 10, scope: !18)
 // CHECK:STDOUT: !20 = !DILocation(line: 22, column: 3, scope: !18)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/enum.carbon
+++ b/toolchain/lower/testdata/interop/cpp/enum.carbon
@@ -156,6 +156,7 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
   return CompareGeneric(a, b);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'pass_as_arg.carbon'
 // CHECK:STDOUT: source_filename = "pass_as_arg.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -254,6 +255,8 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: !30 = !{!"any pointer", !9, i64 0}
 // CHECK:STDOUT: !31 = !{!32, !32, i64 0}
 // CHECK:STDOUT: !32 = !{!"_ZTSN1C1EE", !9, i64 0}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'convert.carbon'
 // CHECK:STDOUT: source_filename = "convert.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -344,6 +347,8 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: !31 = !{!"any pointer", !9, i64 0}
 // CHECK:STDOUT: !32 = !{!33, !33, i64 0}
 // CHECK:STDOUT: !33 = !{!"_ZTSN1C1EE", !9, i64 0}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_bitmask.carbon'
 // CHECK:STDOUT: source_filename = "use_bitmask.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -420,6 +425,8 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: !32 = !DILocation(line: 20, column: 12, scope: !19)
 // CHECK:STDOUT: !33 = !DILocation(line: 20, column: 3, scope: !19)
 // CHECK:STDOUT: !34 = !DILocation(line: 13, column: 1, scope: !19)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'compare.carbon'
 // CHECK:STDOUT: source_filename = "compare.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -485,6 +492,8 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 2, scope: !27, type: !15)
 // CHECK:STDOUT: !31 = !DILocation(line: 11, column: 10, scope: !27)
 // CHECK:STDOUT: !32 = !DILocation(line: 11, column: 3, scope: !27)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'compare_class.carbon'
 // CHECK:STDOUT: source_filename = "compare_class.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -796,3 +805,4 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: !111 = !DILocalVariable(arg: 2, scope: !108, type: !14)
 // CHECK:STDOUT: !112 = !DILocation(line: 30, column: 10, scope: !108)
 // CHECK:STDOUT: !113 = !DILocation(line: 30, column: 3, scope: !108)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/extern_c.carbon
+++ b/toolchain/lower/testdata/interop/cpp/extern_c.carbon
@@ -102,6 +102,7 @@ fn MyF() {
   Cpp.foo();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_extern_c_function.carbon'
 // CHECK:STDOUT: source_filename = "import_extern_c_function.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -139,6 +140,8 @@ fn MyF() {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'extern_c_function_with_cpp_overload_set.carbon'
 // CHECK:STDOUT: source_filename = "extern_c_function_with_cpp_overload_set.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -180,6 +183,8 @@ fn MyF() {
 // CHECK:STDOUT: !14 = !DILocation(line: 10, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 11, column: 3, scope: !11)
 // CHECK:STDOUT: !16 = !DILocation(line: 9, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_extern_c_variable.carbon'
 // CHECK:STDOUT: source_filename = "import_extern_c_variable.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -217,6 +222,8 @@ fn MyF() {
 // CHECK:STDOUT: !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !15 = !DILocation(line: 7, column: 10, scope: !11)
 // CHECK:STDOUT: !16 = !DILocation(line: 7, column: 3, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_extern_c_with_special_name.carbon'
 // CHECK:STDOUT: source_filename = "import_extern_c_with_special_name.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -283,6 +290,8 @@ fn MyF() {
 // CHECK:STDOUT: !20 = !{!21, !21, i64 0}
 // CHECK:STDOUT: !21 = !{!"p1 _ZTS1X", !22, i64 0}
 // CHECK:STDOUT: !22 = !{!"any pointer", !9, i64 0}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_extern_c_with_asm_label.carbon'
 // CHECK:STDOUT: source_filename = "import_extern_c_with_asm_label.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -320,3 +329,4 @@ fn MyF() {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/function/export/function.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/export/function.carbon
@@ -62,6 +62,7 @@ inline void G2() {
 
 fn H() { Cpp.G2(); }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'other.carbon'
 // CHECK:STDOUT: source_filename = "other.carbon"
 // CHECK:STDOUT:
@@ -130,6 +131,8 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: !27 = !DISubroutineType(types: !28)
 // CHECK:STDOUT: !28 = !{!18}
 // CHECK:STDOUT: !29 = !DILocation(line: 13, column: 3, scope: !26)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'function.carbon'
 // CHECK:STDOUT: source_filename = "function.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -290,6 +293,8 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: !39 = !{!40}
 // CHECK:STDOUT: !40 = !DILocalVariable(arg: 1, scope: !38, type: !30)
 // CHECK:STDOUT: !41 = !DILocation(line: 12, column: 1, scope: !38)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'single_file.carbon'
 // CHECK:STDOUT: source_filename = "single_file.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -368,3 +373,4 @@ fn H() { Cpp.G2(); }
 // CHECK:STDOUT: !17 = distinct !DISubprogram(name: "H", linkageName: "_CH.Main", scope: null, file: !1, line: 20, type: !12, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !18 = !DILocation(line: 20, column: 10, scope: !17)
 // CHECK:STDOUT: !19 = !DILocation(line: 20, column: 1, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/function/import/cpp_run.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/import/cpp_run.carbon
@@ -22,6 +22,7 @@ fn Run() {
   Cpp.N.Run();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'carbon_run.carbon'
 // CHECK:STDOUT: source_filename = "carbon_run.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -64,3 +65,4 @@ fn Run() {
 // CHECK:STDOUT: !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !15 = !DILocation(line: 9, column: 3, scope: !11)
 // CHECK:STDOUT: !16 = !DILocation(line: 8, column: 1, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/function/import/function_decl.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/import/function_decl.carbon
@@ -132,6 +132,7 @@ fn MyF() -> i32 {
   return value;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_function_decl.carbon'
 // CHECK:STDOUT: source_filename = "import_function_decl.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -169,6 +170,8 @@ fn MyF() -> i32 {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_inline_function_decl.carbon'
 // CHECK:STDOUT: source_filename = "import_inline_function_decl.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -212,6 +215,8 @@ fn MyF() -> i32 {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_inline_used_function_decl.carbon'
 // CHECK:STDOUT: source_filename = "import_inline_used_function_decl.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -260,6 +265,8 @@ fn MyF() -> i32 {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_multiple_inline_function_decls.carbon'
 // CHECK:STDOUT: source_filename = "import_multiple_inline_function_decls.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -323,6 +330,8 @@ fn MyF() -> i32 {
 // CHECK:STDOUT: !15 = !DILocation(line: 8, column: 3, scope: !11)
 // CHECK:STDOUT: !16 = !DILocation(line: 9, column: 3, scope: !11)
 // CHECK:STDOUT: !17 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_inline_recursive_function_decl.carbon'
 // CHECK:STDOUT: source_filename = "import_inline_recursive_function_decl.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -376,6 +385,8 @@ fn MyF() -> i32 {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 8, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call_with_default_args.carbon'
 // CHECK:STDOUT: source_filename = "call_with_default_args.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -492,3 +503,4 @@ fn MyF() -> i32 {
 // CHECK:STDOUT: !29 = !{!30}
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !26, type: !14)
 // CHECK:STDOUT: !31 = !DILocation(line: 11, column: 3, scope: !26)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/function/import/function_in_template.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/import/function_in_template.carbon
@@ -30,6 +30,7 @@ fn F() {
   //@dump-sem-ir-end
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_class_template.carbon'
 // CHECK:STDOUT: source_filename = "use_class_template.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -75,3 +76,4 @@ fn F() {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 8, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/function/import/import_inline.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/import/import_inline.carbon
@@ -24,6 +24,7 @@ fn Call() -> i32 {
   return n;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_inline.carbon'
 // CHECK:STDOUT: source_filename = "import_inline.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -96,3 +97,4 @@ fn Call() -> i32 {
 // CHECK:STDOUT: !25 = !{!26}
 // CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !22, type: !17)
 // CHECK:STDOUT: !27 = !DILocation(line: 22, column: 3, scope: !22)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/function/import/parameters.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/import/parameters.carbon
@@ -108,6 +108,7 @@ fn PassValueExpr(y: Cpp.Y) {
   Cpp.pass_struct(y);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_ints.carbon'
 // CHECK:STDOUT: source_filename = "import_ints.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -355,6 +356,8 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: !75 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !1, type: !12, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !76 = !DILocation(line: 14, column: 1, scope: !75)
 // CHECK:STDOUT: !77 = !DILocation(line: 0, scope: !75)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_struct.carbon'
 // CHECK:STDOUT: source_filename = "import_struct.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -474,6 +477,8 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: !31 = !DIFile(filename: "min_prelude/parts/default.carbon", directory: "")
 // CHECK:STDOUT: !32 = !DILocation(line: 9, column: 28, scope: !30)
 // CHECK:STDOUT: !33 = !DILocation(line: 9, column: 21, scope: !30)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_class_with_nontrivial_copy.carbon'
 // CHECK:STDOUT: source_filename = "import_class_with_nontrivial_copy.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -581,3 +586,4 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !27, type: !30)
 // CHECK:STDOUT: !33 = !DILocation(line: 21, column: 3, scope: !27)
 // CHECK:STDOUT: !34 = !DILocation(line: 20, column: 1, scope: !27)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/function/import/return.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/import/return.carbon
@@ -112,6 +112,7 @@ fn Call(x: Cpp.D) -> Cpp.C {
   return Cpp.f(x);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_ints.carbon'
 // CHECK:STDOUT: source_filename = "import_ints.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -547,6 +548,8 @@ fn Call(x: Cpp.D) -> Cpp.C {
 // CHECK:STDOUT: !152 = !{!153}
 // CHECK:STDOUT: !153 = !DILocalVariable(arg: 1, scope: !149, type: !34)
 // CHECK:STDOUT: !154 = !DILocation(line: 35, column: 3, scope: !149)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_class.carbon'
 // CHECK:STDOUT: source_filename = "import_class.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -641,6 +644,8 @@ fn Call(x: Cpp.D) -> Cpp.C {
 // CHECK:STDOUT: !26 = !DILocation(line: 13, column: 3, scope: !25)
 // CHECK:STDOUT: !27 = !DILocation(line: 13, column: 18, scope: !25)
 // CHECK:STDOUT: !28 = !DILocation(line: 12, column: 1, scope: !25)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'indirect_return_with_args.carbon'
 // CHECK:STDOUT: source_filename = "indirect_return_with_args.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -705,3 +710,4 @@ fn Call(x: Cpp.D) -> Cpp.C {
 // CHECK:STDOUT: !21 = !{!"any pointer", !9, i64 0}
 // CHECK:STDOUT: !22 = !{!23, !23, i64 0}
 // CHECK:STDOUT: !23 = !{!"p1 _ZTS1C", !21, i64 0}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/globals.carbon
+++ b/toolchain/lower/testdata/interop/cpp/globals.carbon
@@ -154,6 +154,7 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
   return &Cpp.X.static_tmpl(Cpp.Y);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_global.carbon'
 // CHECK:STDOUT: source_filename = "import_global.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -190,6 +191,8 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_inline.carbon'
 // CHECK:STDOUT: source_filename = "import_inline.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -306,6 +309,8 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 3, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 6, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'todo_import_thread_local.carbon'
 // CHECK:STDOUT: source_filename = "todo_import_thread_local.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -416,6 +421,8 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: !20 = !DILocation(line: 14, column: 10, scope: !16)
 // CHECK:STDOUT: !21 = !DILocation(line: 14, column: 3, scope: !16)
 // CHECK:STDOUT: !22 = !{!"branch_weights", i32 1, i32 1023}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_static.carbon'
 // CHECK:STDOUT: source_filename = "import_static.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -455,6 +462,8 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !15 = !DILocation(line: 7, column: 10, scope: !11)
 // CHECK:STDOUT: !16 = !DILocation(line: 7, column: 3, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_var_template.carbon'
 // CHECK:STDOUT: source_filename = "import_var_template.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -506,6 +515,8 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: !19 = !{!20}
 // CHECK:STDOUT: !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !21 = !DILocation(line: 11, column: 3, scope: !17)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_static_template.carbon'
 // CHECK:STDOUT: source_filename = "import_static_template.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -557,3 +568,4 @@ fn ReadStaticVarTemplateWithConstructor() -> Cpp.Y* {
 // CHECK:STDOUT: !19 = !{!20}
 // CHECK:STDOUT: !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !21 = !DILocation(line: 11, column: 3, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/issue7142.carbon
+++ b/toolchain/lower/testdata/interop/cpp/issue7142.carbon
@@ -27,6 +27,7 @@ void f() {
 }
 ''';
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'issue7142.carbon'
 // CHECK:STDOUT: source_filename = "issue7142.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -144,3 +145,4 @@ void f() {
 // CHECK:STDOUT: !36 = !{!37}
 // CHECK:STDOUT: !37 = !DILocalVariable(arg: 1, scope: !35, type: !16)
 // CHECK:STDOUT: !38 = !DILocation(line: 15, column: 1, scope: !35)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/nullptr.carbon
+++ b/toolchain/lower/testdata/interop/cpp/nullptr.carbon
@@ -49,6 +49,7 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
   return Cpp.nullptr;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'simple.carbon'
 // CHECK:STDOUT: source_filename = "simple.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -300,3 +301,4 @@ fn ConvertNullptrConstant() -> Core.Optional(i32*) {
 // CHECK:STDOUT: !79 = distinct !DISubprogram(name: "None", linkageName: "_CNone.Optional.Core.a636f8d928e21310", scope: null, file: !80, line: 30, type: !50, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !80 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !81 = !DILocation(line: 31, column: 5, scope: !79)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/operators.carbon
+++ b/toolchain/lower/testdata/interop/cpp/operators.carbon
@@ -74,6 +74,7 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
   CheckOrderedWith(x, y);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'eq_with.carbon'
 // CHECK:STDOUT: source_filename = "eq_with.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -280,6 +281,8 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
 // CHECK:STDOUT: !46 = !DILocation(line: 18, column: 1, scope: !40)
 // CHECK:STDOUT: !47 = !{!48, !8, i64 0}
 // CHECK:STDOUT: !48 = !{!"_ZTS1A", !8, i64 0}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'ordered_with.carbon'
 // CHECK:STDOUT: source_filename = "ordered_with.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -619,3 +622,4 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
 // CHECK:STDOUT: !58 = !DILocation(line: 26, column: 1, scope: !50)
 // CHECK:STDOUT: !59 = !{!60, !8, i64 0}
 // CHECK:STDOUT: !60 = !{!"_ZTS1A", !8, i64 0}
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/pointer.carbon
+++ b/toolchain/lower/testdata/interop/cpp/pointer.carbon
@@ -102,6 +102,7 @@ fn Convert() {
   Cpp.take(Cpp.make());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nonnull.carbon'
 // CHECK:STDOUT: source_filename = "nonnull.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -203,6 +204,8 @@ fn Convert() {
 // CHECK:STDOUT: !32 = distinct !DISubprogram(name: "ReturnPtrWithThunk", linkageName: "_CReturnPtrWithThunk.Main", scope: null, file: !1, line: 26, type: !20, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !33 = !DILocation(line: 27, column: 10, scope: !32)
 // CHECK:STDOUT: !34 = !DILocation(line: 27, column: 3, scope: !32)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nullable.carbon'
 // CHECK:STDOUT: source_filename = "nullable.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -430,6 +433,8 @@ fn Convert() {
 // CHECK:STDOUT: !79 = !DILocation(line: 169, column: 5, scope: !75)
 // CHECK:STDOUT: !80 = !DILocation(line: 167, column: 18, scope: !75)
 // CHECK:STDOUT: !81 = !DILocation(line: 170, column: 5, scope: !75)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'add_const.carbon'
 // CHECK:STDOUT: source_filename = "add_const.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -681,3 +686,4 @@ fn Convert() {
 // CHECK:STDOUT: !95 = !DILocation(line: 169, column: 5, scope: !91)
 // CHECK:STDOUT: !96 = !DILocation(line: 167, column: 18, scope: !91)
 // CHECK:STDOUT: !97 = !DILocation(line: 170, column: 5, scope: !91)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/reference.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reference.carbon
@@ -128,6 +128,7 @@ fn GetRefs() {
   let ref _: const i32 = Cpp.ReturnConstIntRef();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'pass_references.carbon'
 // CHECK:STDOUT: source_filename = "pass_references.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -314,6 +315,8 @@ fn GetRefs() {
 // CHECK:STDOUT: !44 = !DIFile(filename: "min_prelude/parts/default.carbon", directory: "")
 // CHECK:STDOUT: !45 = !DILocation(line: 9, column: 28, scope: !43)
 // CHECK:STDOUT: !46 = !DILocation(line: 9, column: 21, scope: !43)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'pass_references_via_thunk.carbon'
 // CHECK:STDOUT: source_filename = "pass_references_via_thunk.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -527,6 +530,8 @@ fn GetRefs() {
 // CHECK:STDOUT: !46 = !DIFile(filename: "min_prelude/parts/default.carbon", directory: "")
 // CHECK:STDOUT: !47 = !DILocation(line: 9, column: 28, scope: !45)
 // CHECK:STDOUT: !48 = !DILocation(line: 9, column: 21, scope: !45)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'return_references.carbon'
 // CHECK:STDOUT: source_filename = "return_references.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -584,6 +589,8 @@ fn GetRefs() {
 // CHECK:STDOUT: !18 = !DILocation(line: 22, column: 20, scope: !11)
 // CHECK:STDOUT: !19 = !DILocation(line: 23, column: 26, scope: !11)
 // CHECK:STDOUT: !20 = !DILocation(line: 16, column: 1, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'return_references_via_thunk.carbon'
 // CHECK:STDOUT: source_filename = "return_references_via_thunk.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -692,3 +699,4 @@ fn GetRefs() {
 // CHECK:STDOUT: !18 = !DILocation(line: 23, column: 20, scope: !11)
 // CHECK:STDOUT: !19 = !DILocation(line: 24, column: 26, scope: !11)
 // CHECK:STDOUT: !20 = !DILocation(line: 17, column: 1, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/std_initializer_list.carbon
+++ b/toolchain/lower/testdata/interop/cpp/std_initializer_list.carbon
@@ -111,6 +111,7 @@ fn InitNontrivialDtor() {
   WithinLifetime();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_pointer_pointer.carbon'
 // CHECK:STDOUT: source_filename = "use_pointer_pointer.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -359,6 +360,8 @@ fn InitNontrivialDtor() {
 // CHECK:STDOUT: !53 = !{!54}
 // CHECK:STDOUT: !54 = !DILocalVariable(arg: 1, scope: !52, type: !28)
 // CHECK:STDOUT: !55 = !DILocation(line: 23, column: 58, scope: !52)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_pointer_size.carbon'
 // CHECK:STDOUT: source_filename = "use_pointer_size.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -608,3 +611,4 @@ fn InitNontrivialDtor() {
 // CHECK:STDOUT: !55 = !{!56}
 // CHECK:STDOUT: !56 = !DILocalVariable(arg: 1, scope: !54, type: !28)
 // CHECK:STDOUT: !57 = !DILocation(line: 23, column: 58, scope: !54)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/template.carbon
+++ b/toolchain/lower/testdata/interop/cpp/template.carbon
@@ -89,6 +89,7 @@ fn Call3() {
   //@dump-sem-ir-end
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'call.carbon'
 // CHECK:STDOUT: source_filename = "call.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -195,6 +196,8 @@ fn Call3() {
 // CHECK:STDOUT: !32 = !{!33, !33, i64 0}
 // CHECK:STDOUT: !33 = !{!"p1 _ZTS5Class", !34, i64 0}
 // CHECK:STDOUT: !34 = !{!"any pointer", !9, i64 0}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'variadic.carbon'
 // CHECK:STDOUT: source_filename = "variadic.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -256,6 +259,8 @@ fn Call3() {
 // CHECK:STDOUT: !19 = distinct !DISubprogram(name: "Call3", linkageName: "_CCall3.Main", scope: null, file: !1, line: 21, type: !12, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !20 = !DILocation(line: 23, column: 3, scope: !19)
 // CHECK:STDOUT: !21 = !DILocation(line: 21, column: 1, scope: !19)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'variadic_thunk.carbon'
 // CHECK:STDOUT: source_filename = "variadic_thunk.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -384,3 +389,4 @@ fn Call3() {
 // CHECK:STDOUT: !25 = !DILocation(line: 24, column: 11, scope: !24)
 // CHECK:STDOUT: !26 = !DILocation(line: 24, column: 3, scope: !24)
 // CHECK:STDOUT: !27 = !DILocation(line: 22, column: 1, scope: !24)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/thunks.carbon
+++ b/toolchain/lower/testdata/interop/cpp/thunks.carbon
@@ -97,6 +97,7 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
   var unused b2: Cpp.AnonCollide = b;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'multiple_thunks_in_one_class.carbon'
 // CHECK:STDOUT: source_filename = "multiple_thunks_in_one_class.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -191,6 +192,8 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
 // CHECK:STDOUT: !31 = !{!32}
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !30, type: !14)
 // CHECK:STDOUT: !33 = !DILocation(line: 5, column: 3, scope: !30)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'thunks_for_distinct_specializations.carbon'
 // CHECK:STDOUT: source_filename = "thunks_for_distinct_specializations.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -320,6 +323,8 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
 // CHECK:STDOUT: !36 = !{!37}
 // CHECK:STDOUT: !37 = !DILocalVariable(arg: 1, scope: !35, type: !14)
 // CHECK:STDOUT: !38 = !DILocation(line: 8, column: 3, scope: !35)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'thunks_for_anonymous_namespace_collision.carbon'
 // CHECK:STDOUT: source_filename = "thunks_for_anonymous_namespace_collision.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -482,3 +487,4 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
 // CHECK:STDOUT: !36 = !{!37}
 // CHECK:STDOUT: !37 = !DILocalVariable(arg: 1, scope: !35, type: !14)
 // CHECK:STDOUT: !38 = !DILocation(line: 8, column: 3, scope: !35)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/void.carbon
+++ b/toolchain/lower/testdata/interop/cpp/void.carbon
@@ -56,6 +56,7 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
   return p unsafe as const i32*;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'pass.carbon'
 // CHECK:STDOUT: source_filename = "pass.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -380,6 +381,8 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: !123 = !DILocation(line: 169, column: 5, scope: !119)
 // CHECK:STDOUT: !124 = !DILocation(line: 167, column: 18, scope: !119)
 // CHECK:STDOUT: !125 = !DILocation(line: 170, column: 5, scope: !119)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'receive.carbon'
 // CHECK:STDOUT: source_filename = "receive.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -440,3 +443,4 @@ fn ConvertFromConstVoidPtr(p: const Cpp.void*) -> const i32* {
 // CHECK:STDOUT: !24 = !{!25}
 // CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !23, type: !14)
 // CHECK:STDOUT: !26 = !DILocation(line: 15, column: 3, scope: !23)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/let/copy_value_rep.carbon
+++ b/toolchain/lower/testdata/let/copy_value_rep.carbon
@@ -22,6 +22,7 @@ fn Run() -> i32 {
   return n;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'copy_value_rep.carbon'
 // CHECK:STDOUT: source_filename = "copy_value_rep.carbon"
 // CHECK:STDOUT:
@@ -102,3 +103,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !27 = !{!28}
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 1, scope: !26, type: !22)
 // CHECK:STDOUT: !29 = !DILocation(line: 18, column: 3, scope: !26)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/let/global.carbon
+++ b/toolchain/lower/testdata/let/global.carbon
@@ -20,6 +20,7 @@ fn F() {
   Sink(c);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'global.carbon'
 // CHECK:STDOUT: source_filename = "global.carbon"
 // CHECK:STDOUT:
@@ -58,3 +59,4 @@ fn F() {
 // CHECK:STDOUT: !8 = !DILocation(line: 19, column: 1, scope: !4)
 // CHECK:STDOUT: !9 = distinct !DISubprogram(name: "__global_init", linkageName: "_C__global_init.Main", scope: null, file: !1, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !10 = !DILocation(line: 0, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/let/local.carbon
+++ b/toolchain/lower/testdata/let/local.carbon
@@ -33,6 +33,7 @@ fn CallF() {
   // F(c);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'local.carbon'
 // CHECK:STDOUT: source_filename = "local.carbon"
 // CHECK:STDOUT:
@@ -56,6 +57,8 @@ fn CallF() {
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 6, column: 3, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'symbolic.carbon'
 // CHECK:STDOUT: source_filename = "symbolic.carbon"
 // CHECK:STDOUT:
@@ -91,3 +94,4 @@ fn CallF() {
 // CHECK:STDOUT: !12 = !DISubroutineType(types: !13)
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 1, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/let/tuple.carbon
+++ b/toolchain/lower/testdata/let/tuple.carbon
@@ -17,6 +17,7 @@ fn F() -> i32 {
   return c.1.(1);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'tuple.carbon'
 // CHECK:STDOUT: source_filename = "tuple.carbon"
 // CHECK:STDOUT:
@@ -144,3 +145,4 @@ fn F() -> i32 {
 // CHECK:STDOUT: !31 = !{!32}
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !30, type: !26)
 // CHECK:STDOUT: !33 = !DILocation(line: 14, column: 3, scope: !30)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/namespace/function.carbon
+++ b/toolchain/lower/testdata/namespace/function.carbon
@@ -23,6 +23,7 @@ fn Bar() {
   Foo.Baz();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'function.carbon'
 // CHECK:STDOUT: source_filename = "function.carbon"
 // CHECK:STDOUT:
@@ -63,3 +64,4 @@ fn Bar() {
 // CHECK:STDOUT: !10 = distinct !DISubprogram(name: "Bar", linkageName: "_CBar.Main", scope: null, file: !1, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !11 = !DILocation(line: 23, column: 3, scope: !10)
 // CHECK:STDOUT: !12 = !DILocation(line: 22, column: 1, scope: !10)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/namespace/namespace_run.carbon
+++ b/toolchain/lower/testdata/namespace/namespace_run.carbon
@@ -18,6 +18,7 @@ fn Run() {
     Foo.Run();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'namespace_run.carbon'
 // CHECK:STDOUT: source_filename = "namespace_run.carbon"
 // CHECK:STDOUT:
@@ -53,3 +54,4 @@ fn Run() {
 // CHECK:STDOUT: !11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !12 = !DILocation(line: 18, column: 5, scope: !8)
 // CHECK:STDOUT: !13 = !DILocation(line: 17, column: 1, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/namespace/nested.carbon
+++ b/toolchain/lower/testdata/namespace/nested.carbon
@@ -20,6 +20,7 @@ fn Foo.Bar.Baz() {
   Foo.Bar.Wiz();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nested.carbon'
 // CHECK:STDOUT: source_filename = "nested.carbon"
 // CHECK:STDOUT:
@@ -52,3 +53,4 @@ fn Foo.Bar.Baz() {
 // CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Baz", linkageName: "_CBaz.Bar.Foo.Main", scope: null, file: !1, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !9 = !DILocation(line: 20, column: 3, scope: !8)
 // CHECK:STDOUT: !10 = !DILocation(line: 19, column: 1, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/and.carbon
+++ b/toolchain/lower/testdata/operators/and.carbon
@@ -17,6 +17,7 @@ fn And() -> bool {
   return F() and G();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'and.carbon'
 // CHECK:STDOUT: source_filename = "and.carbon"
 // CHECK:STDOUT:
@@ -67,3 +68,4 @@ fn And() -> bool {
 // CHECK:STDOUT: !12 = !DILocation(line: 17, column: 10, scope: !11)
 // CHECK:STDOUT: !13 = !DILocation(line: 17, column: 18, scope: !11)
 // CHECK:STDOUT: !14 = !DILocation(line: 17, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/and_empty_block.carbon
+++ b/toolchain/lower/testdata/operators/and_empty_block.carbon
@@ -16,6 +16,7 @@ fn And(b: bool, c: bool) -> bool {
   return b and c;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'and_empty_block.carbon'
 // CHECK:STDOUT: source_filename = "and_empty_block.carbon"
 // CHECK:STDOUT:
@@ -50,3 +51,4 @@ fn And(b: bool, c: bool) -> bool {
 // CHECK:STDOUT: !10 = !DILocalVariable(arg: 2, scope: !4, type: !7)
 // CHECK:STDOUT: !11 = !DILocation(line: 16, column: 10, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/arithmetic.carbon
+++ b/toolchain/lower/testdata/operators/arithmetic.carbon
@@ -36,6 +36,7 @@ fn sub_u32(a: u32, b: u32) -> u32 { return a - b; }
 fn div_i16(a: i16, b: i16) -> i16 { return a / b; }
 fn div_u16(a: u16, b: u16) -> u16 { return a / b; }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'arithmetic.carbon'
 // CHECK:STDOUT: source_filename = "arithmetic.carbon"
 // CHECK:STDOUT:
@@ -244,3 +245,4 @@ fn div_u16(a: u16, b: u16) -> u16 { return a / b; }
 // CHECK:STDOUT: !99 = !DILocalVariable(arg: 2, scope: !93, type: !96)
 // CHECK:STDOUT: !100 = !DILocation(line: 37, column: 44, scope: !93)
 // CHECK:STDOUT: !101 = !DILocation(line: 37, column: 37, scope: !93)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/assignment.carbon
+++ b/toolchain/lower/testdata/operators/assignment.carbon
@@ -22,6 +22,7 @@ fn G() -> (i32, i32) {
   return b;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'assignment.carbon'
 // CHECK:STDOUT: source_filename = "assignment.carbon"
 // CHECK:STDOUT:
@@ -119,3 +120,4 @@ fn G() -> (i32, i32) {
 // CHECK:STDOUT: !30 = !{!31}
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !27, type: !21)
 // CHECK:STDOUT: !32 = !DILocation(line: 20, column: 3, scope: !27)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/increment.carbon
+++ b/toolchain/lower/testdata/operators/increment.carbon
@@ -19,6 +19,7 @@ fn IncrSigned() {
   ++from;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'increment.carbon'
 // CHECK:STDOUT: source_filename = "increment.carbon"
 // CHECK:STDOUT:
@@ -117,3 +118,4 @@ fn IncrSigned() {
 // CHECK:STDOUT: !39 = !{!40}
 // CHECK:STDOUT: !40 = !DILocalVariable(arg: 1, scope: !38, type: !13)
 // CHECK:STDOUT: !41 = !DILocation(line: 59, column: 28, scope: !38)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/not.carbon
+++ b/toolchain/lower/testdata/operators/not.carbon
@@ -14,6 +14,7 @@ fn Not(b: bool) -> bool {
   return not b;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'not.carbon'
 // CHECK:STDOUT: source_filename = "not.carbon"
 // CHECK:STDOUT:
@@ -41,3 +42,4 @@ fn Not(b: bool) -> bool {
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
 // CHECK:STDOUT: !10 = !DILocation(line: 14, column: 10, scope: !4)
 // CHECK:STDOUT: !11 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/or.carbon
+++ b/toolchain/lower/testdata/operators/or.carbon
@@ -17,6 +17,7 @@ fn Or() -> bool {
   return F() or G();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'or.carbon'
 // CHECK:STDOUT: source_filename = "or.carbon"
 // CHECK:STDOUT:
@@ -68,3 +69,4 @@ fn Or() -> bool {
 // CHECK:STDOUT: !12 = !DILocation(line: 17, column: 10, scope: !11)
 // CHECK:STDOUT: !13 = !DILocation(line: 17, column: 17, scope: !11)
 // CHECK:STDOUT: !14 = !DILocation(line: 17, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/or_empty_block.carbon
+++ b/toolchain/lower/testdata/operators/or_empty_block.carbon
@@ -16,6 +16,7 @@ fn Or(b: bool, c: bool) -> bool {
   return b or c;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'or_empty_block.carbon'
 // CHECK:STDOUT: source_filename = "or_empty_block.carbon"
 // CHECK:STDOUT:
@@ -51,3 +52,4 @@ fn Or(b: bool, c: bool) -> bool {
 // CHECK:STDOUT: !10 = !DILocalVariable(arg: 2, scope: !4, type: !7)
 // CHECK:STDOUT: !11 = !DILocation(line: 16, column: 10, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/overloaded.carbon
+++ b/toolchain/lower/testdata/operators/overloaded.carbon
@@ -30,6 +30,7 @@ fn Calculate(a: Number, b: Number) -> Number {
   return -a * b;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'overloaded.carbon'
 // CHECK:STDOUT: source_filename = "overloaded.carbon"
 // CHECK:STDOUT:
@@ -168,3 +169,4 @@ fn Calculate(a: Number, b: Number) -> Number {
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !41, type: !7)
 // CHECK:STDOUT: !44 = !DILocation(line: 30, column: 10, scope: !41)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/operators/string_indexing.carbon
+++ b/toolchain/lower/testdata/operators/string_indexing.carbon
@@ -20,6 +20,7 @@ fn F2(index: i64) -> char {
     return c;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'string_indexing.carbon'
 // CHECK:STDOUT: source_filename = "string_indexing.carbon"
 // CHECK:STDOUT:
@@ -64,3 +65,4 @@ fn F2(index: i64) -> char {
 // CHECK:STDOUT: !14 = !DILocalVariable(arg: 1, scope: !9, type: !12)
 // CHECK:STDOUT: !15 = !DILocation(line: 19, column: 19, scope: !9)
 // CHECK:STDOUT: !16 = !DILocation(line: 20, column: 5, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/packages/cross_package_call.carbon
+++ b/toolchain/lower/testdata/packages/cross_package_call.carbon
@@ -41,6 +41,7 @@ fn CallCAsI() {
   (A.C as A.I).F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
 // CHECK:STDOUT:
@@ -84,6 +85,8 @@ fn CallCAsI() {
 // CHECK:STDOUT: !14 = !DILocation(line: 7, column: 26, scope: !8)
 // CHECK:STDOUT: !15 = distinct !DISubprogram(name: "F", linkageName: "_CF.C.A:I.A", scope: null, file: !1, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !16 = !DILocation(line: 16, column: 3, scope: !15)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'b.carbon'
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
@@ -137,3 +140,4 @@ fn CallCAsI() {
 // CHECK:STDOUT: !15 = distinct !DISubprogram(name: "CallCAsI", linkageName: "_CCallCAsI.Main", scope: null, file: !1, line: 8, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !16 = !DILocation(line: 9, column: 3, scope: !15)
 // CHECK:STDOUT: !17 = !DILocation(line: 8, column: 1, scope: !15)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/packages/imported_package_mangle.carbon
+++ b/toolchain/lower/testdata/packages/imported_package_mangle.carbon
@@ -89,6 +89,7 @@ fn G() {
   (array(C, 2) as I).F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
 // CHECK:STDOUT:
@@ -111,6 +112,8 @@ fn G() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 10, column: 3, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'b.carbon'
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
@@ -147,6 +150,8 @@ fn G() {
 // CHECK:STDOUT: !10 = distinct !DISubprogram(name: "F", linkageName: "_CF.b11ad1d729c16944:I.A.91a8a89714fbc21c", scope: null, file: !11, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !11 = !DIFile(filename: "a.carbon", directory: "")
 // CHECK:STDOUT: !12 = !DILocation(line: 14, column: 3, scope: !10)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'c.carbon'
 // CHECK:STDOUT: source_filename = "c.carbon"
 // CHECK:STDOUT:
@@ -243,3 +248,4 @@ fn G() {
 // CHECK:STDOUT: !28 = !DILocation(line: 32, column: 3, scope: !27)
 // CHECK:STDOUT: !29 = distinct !DISubprogram(name: "F", linkageName: "_CF.c2375ae0b92fd5ec:I.C.91a8a89714fbc21c", scope: null, file: !1, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !30 = !DILocation(line: 16, column: 3, scope: !29)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/packages/imported_package_mangle_string.carbon
+++ b/toolchain/lower/testdata/packages/imported_package_mangle_string.carbon
@@ -41,6 +41,7 @@ fn G() {
   (array(A.N.D, 1) as A.I).F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
 // CHECK:STDOUT:
@@ -71,6 +72,8 @@ fn G() {
 // CHECK:STDOUT: !7 = !DILocation(line: 10, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = distinct !DISubprogram(name: "F", linkageName: "_CF.{array_type,{int_value,{Core.IntLiteral},1},{class_type,D,N,A,!invalid,!invalid}}:I.A", scope: null, file: !1, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !9 = !DILocation(line: 17, column: 3, scope: !8)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'b.carbon'
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
@@ -101,3 +104,4 @@ fn G() {
 // CHECK:STDOUT: !7 = !DILocation(line: 5, column: 3, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 6, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 4, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/packages/imported_type_completeness.carbon
+++ b/toolchain/lower/testdata/packages/imported_type_completeness.carbon
@@ -92,6 +92,7 @@ fn CallF() {
   F(C, {} as C);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'require_completion_in_call.carbon'
 // CHECK:STDOUT: source_filename = "require_completion_in_call.carbon"
 // CHECK:STDOUT:
@@ -102,6 +103,8 @@ fn CallF() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "require_completion_in_call.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_without_completion_in_call.carbon'
 // CHECK:STDOUT: source_filename = "use_without_completion_in_call.carbon"
 // CHECK:STDOUT:
@@ -188,6 +191,8 @@ fn CallF() {
 // CHECK:STDOUT: !30 = !{!31}
 // CHECK:STDOUT: !31 = !DIBasicType(name: "int", size: 456, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !32 = !DILocation(line: 12, column: 5, scope: !28)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'require_completion_in_vtable.carbon'
 // CHECK:STDOUT: source_filename = "require_completion_in_vtable.carbon"
 // CHECK:STDOUT:
@@ -198,6 +203,8 @@ fn CallF() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "require_completion_in_vtable.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_without_completion_in_vtable.carbon'
 // CHECK:STDOUT: source_filename = "use_without_completion_in_vtable.carbon"
 // CHECK:STDOUT:
@@ -231,6 +238,8 @@ fn CallF() {
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 9, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'require_completion_in_virtual_call.carbon'
 // CHECK:STDOUT: source_filename = "require_completion_in_virtual_call.carbon"
 // CHECK:STDOUT:
@@ -256,6 +265,8 @@ fn CallF() {
 // CHECK:STDOUT: !8 = !{!9}
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
 // CHECK:STDOUT: !10 = !DILocation(line: 7, column: 3, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_without_completion_in_virtual_call.carbon'
 // CHECK:STDOUT: source_filename = "use_without_completion_in_virtual_call.carbon"
 // CHECK:STDOUT:
@@ -387,3 +398,4 @@ fn CallF() {
 // CHECK:STDOUT: !47 = !DILocalVariable(arg: 1, scope: !42, type: !13)
 // CHECK:STDOUT: !48 = !DILocalVariable(arg: 2, scope: !42, type: !13)
 // CHECK:STDOUT: !49 = !DILocation(line: 7, column: 60, scope: !42)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/packages/private_external_mangle.carbon
+++ b/toolchain/lower/testdata/packages/private_external_mangle.carbon
@@ -65,6 +65,7 @@ fn F() {
   CallInB({});
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'private_call_a.carbon'
 // CHECK:STDOUT: source_filename = "private_call_a.carbon"
 // CHECK:STDOUT:
@@ -101,6 +102,8 @@ fn F() {
 // CHECK:STDOUT: !9 = distinct !DISubprogram(name: "Call", linkageName: "_CCall.C.Main.df01d416cc5a0873", scope: null, file: !1, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !10 = !DILocation(line: 12, column: 5, scope: !9)
 // CHECK:STDOUT: !11 = !DILocation(line: 11, column: 3, scope: !9)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'private_call_b.carbon'
 // CHECK:STDOUT: source_filename = "private_call_b.carbon"
 // CHECK:STDOUT:
@@ -137,6 +140,8 @@ fn F() {
 // CHECK:STDOUT: !9 = distinct !DISubprogram(name: "Call", linkageName: "_CCall.C.Main.df01d416cc5a0873", scope: null, file: !1, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !10 = !DILocation(line: 12, column: 5, scope: !9)
 // CHECK:STDOUT: !11 = !DILocation(line: 11, column: 3, scope: !9)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_a_and_b.carbon'
 // CHECK:STDOUT: source_filename = "use_a_and_b.carbon"
 // CHECK:STDOUT:
@@ -200,3 +205,4 @@ fn F() {
 // CHECK:STDOUT: !17 = !DILocation(line: 17, column: 3, scope: !15)
 // CHECK:STDOUT: !18 = !DILocation(line: 18, column: 3, scope: !15)
 // CHECK:STDOUT: !19 = !DILocation(line: 16, column: 1, scope: !15)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/packages/separate_compilation_witness.carbon
+++ b/toolchain/lower/testdata/packages/separate_compilation_witness.carbon
@@ -113,6 +113,7 @@ fn CallGeneric() {
   Generic((), Make(), Make());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'owner.carbon'
 // CHECK:STDOUT: source_filename = "owner.carbon"
 // CHECK:STDOUT:
@@ -170,6 +171,8 @@ fn CallGeneric() {
 // CHECK:STDOUT: !22 = !DILocation(line: 15, column: 18, scope: !15)
 // CHECK:STDOUT: !23 = !DILocation(line: 15, column: 12, scope: !15)
 // CHECK:STDOUT: !24 = !DILocation(line: 15, column: 5, scope: !15)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'owner.impl.carbon'
 // CHECK:STDOUT: source_filename = "owner.impl.carbon"
 // CHECK:STDOUT:
@@ -246,6 +249,8 @@ fn CallGeneric() {
 // CHECK:STDOUT: !28 = !{!29}
 // CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !7)
 // CHECK:STDOUT: !30 = !DILocation(line: 5, column: 15, scope: !27)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'direct_same_package.carbon'
 // CHECK:STDOUT: source_filename = "direct_same_package.carbon"
 // CHECK:STDOUT:
@@ -322,6 +327,8 @@ fn CallGeneric() {
 // CHECK:STDOUT: !28 = !{!29}
 // CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !7)
 // CHECK:STDOUT: !30 = !DILocation(line: 7, column: 15, scope: !27)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'generic_same_package.carbon'
 // CHECK:STDOUT: source_filename = "generic_same_package.carbon"
 // CHECK:STDOUT:
@@ -376,6 +383,8 @@ fn CallGeneric() {
 // CHECK:STDOUT: !19 = !{!20}
 // CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !18, type: !14)
 // CHECK:STDOUT: !21 = !DILocation(line: 6, column: 15, scope: !18)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'indirect_same_package.carbon'
 // CHECK:STDOUT: source_filename = "indirect_same_package.carbon"
 // CHECK:STDOUT:
@@ -484,6 +493,8 @@ fn CallGeneric() {
 // CHECK:STDOUT: !36 = !DILocation(line: 6, column: 15, scope: !29)
 // CHECK:STDOUT: !37 = !DILocation(line: 6, column: 10, scope: !29)
 // CHECK:STDOUT: !38 = !DILocation(line: 6, column: 3, scope: !29)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'direct_different_package.carbon'
 // CHECK:STDOUT: source_filename = "direct_different_package.carbon"
 // CHECK:STDOUT:
@@ -560,6 +571,8 @@ fn CallGeneric() {
 // CHECK:STDOUT: !28 = !{!29}
 // CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !7)
 // CHECK:STDOUT: !30 = !DILocation(line: 7, column: 15, scope: !27)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'indirect_different_package_via_generic_in_same_package.carbon'
 // CHECK:STDOUT: source_filename = "indirect_different_package_via_generic_in_same_package.carbon"
 // CHECK:STDOUT:
@@ -668,6 +681,8 @@ fn CallGeneric() {
 // CHECK:STDOUT: !36 = !DILocation(line: 6, column: 15, scope: !29)
 // CHECK:STDOUT: !37 = !DILocation(line: 6, column: 10, scope: !29)
 // CHECK:STDOUT: !38 = !DILocation(line: 6, column: 3, scope: !29)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'generic_different_package.carbon'
 // CHECK:STDOUT: source_filename = "generic_different_package.carbon"
 // CHECK:STDOUT:
@@ -722,6 +737,8 @@ fn CallGeneric() {
 // CHECK:STDOUT: !19 = !{!20}
 // CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !18, type: !14)
 // CHECK:STDOUT: !21 = !DILocation(line: 6, column: 15, scope: !18)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'indirect_different_package_via_generic_in_different_package.carbon'
 // CHECK:STDOUT: source_filename = "indirect_different_package_via_generic_in_different_package.carbon"
 // CHECK:STDOUT:
@@ -830,3 +847,4 @@ fn CallGeneric() {
 // CHECK:STDOUT: !36 = !DILocation(line: 6, column: 15, scope: !29)
 // CHECK:STDOUT: !37 = !DILocation(line: 6, column: 10, scope: !29)
 // CHECK:STDOUT: !38 = !DILocation(line: 6, column: 3, scope: !29)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/pointer/address_of_field.carbon
+++ b/toolchain/lower/testdata/pointer/address_of_field.carbon
@@ -17,6 +17,7 @@ fn F() {
   G(&s.b);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'address_of_field.carbon'
 // CHECK:STDOUT: source_filename = "address_of_field.carbon"
 // CHECK:STDOUT:
@@ -88,3 +89,4 @@ fn F() {
 // CHECK:STDOUT: !23 = !{!24}
 // CHECK:STDOUT: !24 = !DILocalVariable(arg: 1, scope: !19, type: !22)
 // CHECK:STDOUT: !25 = !DILocation(line: 16, column: 3, scope: !19)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/pointer/address_of_unused.carbon
+++ b/toolchain/lower/testdata/pointer/address_of_unused.carbon
@@ -15,6 +15,7 @@ fn F() {
   &n;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'address_of_unused.carbon'
 // CHECK:STDOUT: source_filename = "address_of_unused.carbon"
 // CHECK:STDOUT:
@@ -59,3 +60,4 @@ fn F() {
 // CHECK:STDOUT: !13 = !{!14}
 // CHECK:STDOUT: !14 = !DILocalVariable(arg: 1, scope: !9, type: !12)
 // CHECK:STDOUT: !15 = !DILocation(line: 14, column: 3, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/pointer/basic.carbon
+++ b/toolchain/lower/testdata/pointer/basic.carbon
@@ -19,6 +19,7 @@ fn F() -> i32 {
   return G(&n);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'basic.carbon'
 // CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
@@ -80,3 +81,4 @@ fn F() -> i32 {
 // CHECK:STDOUT: !22 = !{!23}
 // CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !19, type: !7)
 // CHECK:STDOUT: !24 = !DILocation(line: 18, column: 3, scope: !19)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/pointer/convert.carbon
+++ b/toolchain/lower/testdata/pointer/convert.carbon
@@ -14,6 +14,7 @@ fn UnsafeAs(p: i32*) -> i64* {
   return p unsafe as i64*;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'convert.carbon'
 // CHECK:STDOUT: source_filename = "convert.carbon"
 // CHECK:STDOUT:
@@ -39,3 +40,4 @@ fn UnsafeAs(p: i32*) -> i64* {
 // CHECK:STDOUT: !8 = !{!9}
 // CHECK:STDOUT: !9 = !DILocalVariable(arg: 1, scope: !4, type: !7)
 // CHECK:STDOUT: !10 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
+++ b/toolchain/lower/testdata/pointer/pointer_to_pointer.carbon
@@ -17,6 +17,7 @@ fn F(p: i32**) -> i32 {
   return **c;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'pointer_to_pointer.carbon'
 // CHECK:STDOUT: source_filename = "pointer_to_pointer.carbon"
 // CHECK:STDOUT:
@@ -70,3 +71,4 @@ fn F(p: i32**) -> i32 {
 // CHECK:STDOUT: !16 = !DILocation(line: 17, column: 11, scope: !4)
 // CHECK:STDOUT: !17 = !DILocation(line: 17, column: 10, scope: !4)
 // CHECK:STDOUT: !18 = !DILocation(line: 17, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/bool.carbon
+++ b/toolchain/lower/testdata/primitives/bool.carbon
@@ -24,6 +24,7 @@ fn LoadStore(p: bool*, b: bool) -> bool {
   return v;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'bool.carbon'
 // CHECK:STDOUT: source_filename = "bool.carbon"
 // CHECK:STDOUT:
@@ -74,3 +75,4 @@ fn LoadStore(p: bool*, b: bool) -> bool {
 // CHECK:STDOUT: !17 = !DILocation(line: 22, column: 17, scope: !11)
 // CHECK:STDOUT: !18 = !DILocation(line: 23, column: 3, scope: !11)
 // CHECK:STDOUT: !19 = !DILocation(line: 24, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/char.carbon
+++ b/toolchain/lower/testdata/primitives/char.carbon
@@ -104,6 +104,7 @@ fn AddSubUInt32(c: char, i: u32) {
   Discard(c - i);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'char.carbon'
 // CHECK:STDOUT: source_filename = "char.carbon"
 // CHECK:STDOUT:
@@ -1011,3 +1012,4 @@ fn AddSubUInt32(c: char, i: u32) {
 // CHECK:STDOUT: !451 = !{!452}
 // CHECK:STDOUT: !452 = !DILocalVariable(arg: 1, scope: !448, type: !7)
 // CHECK:STDOUT: !453 = !DILocation(line: 60, column: 29, scope: !448)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/char_literals.carbon
+++ b/toolchain/lower/testdata/primitives/char_literals.carbon
@@ -77,6 +77,7 @@ fn AddSubInt8() {
   Discard('x' - (1 as i8));
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'char_literals.carbon'
 // CHECK:STDOUT: source_filename = "char_literals.carbon"
 // CHECK:STDOUT:
@@ -403,3 +404,4 @@ fn AddSubInt8() {
 // CHECK:STDOUT: !147 = !{!148}
 // CHECK:STDOUT: !148 = !DILocalVariable(arg: 1, scope: !144, type: !7)
 // CHECK:STDOUT: !149 = !DILocation(line: 60, column: 29, scope: !144)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/int_types.carbon
+++ b/toolchain/lower/testdata/primitives/int_types.carbon
@@ -45,6 +45,7 @@ fn ImplicitWidenUnsignedToSigned(a: u8) -> i32 { return a; }
 fn ImplicitWidenCustom(a: Core.Int(4)) -> Core.Int(5) { return a; }
 fn ImplicitWidenUnsignedCustom(a: Core.UInt(4)) -> Core.UInt(5) { return a; }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'pass_and_return.carbon'
 // CHECK:STDOUT: source_filename = "pass_and_return.carbon"
 // CHECK:STDOUT:
@@ -109,6 +110,8 @@ fn ImplicitWidenUnsignedCustom(a: Core.UInt(4)) -> Core.UInt(5) { return a; }
 // CHECK:STDOUT: !29 = !{!30}
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !25, type: !28)
 // CHECK:STDOUT: !31 = !DILocation(line: 7, column: 36, scope: !25)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'load_and_store.carbon'
 // CHECK:STDOUT: source_filename = "load_and_store.carbon"
 // CHECK:STDOUT:
@@ -160,6 +163,8 @@ fn ImplicitWidenUnsignedCustom(a: Core.UInt(4)) -> Core.UInt(5) { return a; }
 // CHECK:STDOUT: !22 = !DILocation(line: 11, column: 25, scope: !15)
 // CHECK:STDOUT: !23 = !DILocation(line: 12, column: 3, scope: !15)
 // CHECK:STDOUT: !24 = !DILocation(line: 13, column: 3, scope: !15)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'convert.carbon'
 // CHECK:STDOUT: source_filename = "convert.carbon"
 // CHECK:STDOUT:
@@ -392,3 +397,4 @@ fn ImplicitWidenUnsignedCustom(a: Core.UInt(4)) -> Core.UInt(5) { return a; }
 // CHECK:STDOUT: !110 = !{!111}
 // CHECK:STDOUT: !111 = !DILocalVariable(arg: 1, scope: !107, type: !38)
 // CHECK:STDOUT: !112 = !DILocation(line: 60, column: 29, scope: !107)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/numeric_literals.carbon
+++ b/toolchain/lower/testdata/primitives/numeric_literals.carbon
@@ -29,6 +29,7 @@ fn F() {
   );
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'numeric_literals.carbon'
 // CHECK:STDOUT: source_filename = "numeric_literals.carbon"
 // CHECK:STDOUT:
@@ -133,3 +134,4 @@ fn F() {
 // CHECK:STDOUT: !31 = !{!32}
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !30, type: !15)
 // CHECK:STDOUT: !33 = !DILocation(line: 16, column: 3, scope: !30)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/optional.carbon
+++ b/toolchain/lower/testdata/primitives/optional.carbon
@@ -57,6 +57,7 @@ fn F(c: Core.Optional(C*)) -> Core.Optional(C*) {
   return c;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'convert.carbon'
 // CHECK:STDOUT: source_filename = "convert.carbon"
 // CHECK:STDOUT:
@@ -593,6 +594,8 @@ fn F(c: Core.Optional(C*)) -> Core.Optional(C*) {
 // CHECK:STDOUT: !218 = !{!219}
 // CHECK:STDOUT: !219 = !DILocalVariable(arg: 1, scope: !216, type: !7)
 // CHECK:STDOUT: !220 = !DILocation(line: 23, column: 25, scope: !216)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'copy.carbon'
 // CHECK:STDOUT: source_filename = "copy.carbon"
 // CHECK:STDOUT:
@@ -712,6 +715,8 @@ fn F(c: Core.Optional(C*)) -> Core.Optional(C*) {
 // CHECK:STDOUT: !48 = !{!7}
 // CHECK:STDOUT: !49 = !DILocation(line: 128, column: 5, scope: !46)
 // CHECK:STDOUT: !50 = !DILocation(line: 129, column: 5, scope: !46)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'copy_pointer.carbon'
 // CHECK:STDOUT: source_filename = "copy_pointer.carbon"
 // CHECK:STDOUT:
@@ -749,3 +754,4 @@ fn F(c: Core.Optional(C*)) -> Core.Optional(C*) {
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !12, type: !7)
 // CHECK:STDOUT: !16 = !DILocation(line: 51, column: 5, scope: !12)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/string.carbon
+++ b/toolchain/lower/testdata/primitives/string.carbon
@@ -35,6 +35,7 @@ fn Copy(s: str) -> str {
   return s;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'string.carbon'
 // CHECK:STDOUT: source_filename = "string.carbon"
 // CHECK:STDOUT:
@@ -103,3 +104,4 @@ fn Copy(s: str) -> str {
 // CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !15, type: !18)
 // CHECK:STDOUT: !21 = !DILocation(line: 35, column: 10, scope: !15)
 // CHECK:STDOUT: !22 = !DILocation(line: 35, column: 3, scope: !15)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/type_values.carbon
+++ b/toolchain/lower/testdata/primitives/type_values.carbon
@@ -25,6 +25,7 @@ fn F64() -> type {
   return f64;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'type_values.carbon'
 // CHECK:STDOUT: source_filename = "type_values.carbon"
 // CHECK:STDOUT:
@@ -66,3 +67,4 @@ fn F64() -> type {
 // CHECK:STDOUT: !10 = !DILocation(line: 21, column: 3, scope: !9)
 // CHECK:STDOUT: !11 = distinct !DISubprogram(name: "F64", linkageName: "_CF64.Main", scope: null, file: !1, line: 24, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !12 = !DILocation(line: 25, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/primitives/zero.carbon
+++ b/toolchain/lower/testdata/primitives/zero.carbon
@@ -14,6 +14,7 @@ fn Main() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'zero.carbon'
 // CHECK:STDOUT: source_filename = "zero.carbon"
 // CHECK:STDOUT:
@@ -37,3 +38,4 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/return/code_after_return.carbon
+++ b/toolchain/lower/testdata/return/code_after_return.carbon
@@ -17,6 +17,7 @@ fn Main() {
   F();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'code_after_return.carbon'
 // CHECK:STDOUT: source_filename = "code_after_return.carbon"
 // CHECK:STDOUT:
@@ -47,3 +48,4 @@ fn Main() {
 // CHECK:STDOUT: !7 = !DILocation(line: 13, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = distinct !DISubprogram(name: "Main", linkageName: "_CMain.Main", scope: null, file: !1, line: 15, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !9 = !DILocation(line: 16, column: 3, scope: !8)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/return/function_ids_in_different_files.carbon
+++ b/toolchain/lower/testdata/return/function_ids_in_different_files.carbon
@@ -25,6 +25,7 @@ fn G() {
   F({});
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'a.carbon'
 // CHECK:STDOUT: source_filename = "a.carbon"
 // CHECK:STDOUT:
@@ -35,6 +36,8 @@ fn G() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "a.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'b.carbon'
 // CHECK:STDOUT: source_filename = "b.carbon"
 // CHECK:STDOUT:
@@ -67,3 +70,4 @@ fn G() {
 // CHECK:STDOUT: !9 = distinct !DISubprogram(name: "F", linkageName: "_CF.Main.6944efcfbb6a8360", scope: null, file: !10, line: 2, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !10 = !DIFile(filename: "a.carbon", directory: "")
 // CHECK:STDOUT: !11 = !DILocation(line: 4, column: 3, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/return/no_return_from_run.carbon
+++ b/toolchain/lower/testdata/return/no_return_from_run.carbon
@@ -18,6 +18,7 @@ fn Foo() {
   Run();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'no_return_from_run.carbon'
 // CHECK:STDOUT: source_filename = "no_return_from_run.carbon"
 // CHECK:STDOUT:
@@ -53,3 +54,4 @@ fn Foo() {
 // CHECK:STDOUT: !11 = !{null}
 // CHECK:STDOUT: !12 = !DILocation(line: 18, column: 3, scope: !9)
 // CHECK:STDOUT: !13 = !DILocation(line: 17, column: 1, scope: !9)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/return/no_value.carbon
+++ b/toolchain/lower/testdata/return/no_value.carbon
@@ -14,6 +14,7 @@ fn Main() {
   return;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'no_value.carbon'
 // CHECK:STDOUT: source_filename = "no_value.carbon"
 // CHECK:STDOUT:
@@ -36,3 +37,4 @@ fn Main() {
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/return/return_var.carbon
+++ b/toolchain/lower/testdata/return/return_var.carbon
@@ -21,6 +21,7 @@ fn Make() -> C {
   return var;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'return_var.carbon'
 // CHECK:STDOUT: source_filename = "return_var.carbon"
 // CHECK:STDOUT:
@@ -49,3 +50,4 @@ fn Make() -> C {
 // CHECK:STDOUT: !7 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !8 = !DILocation(line: 20, column: 7, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 21, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/return/return_var_byval.carbon
+++ b/toolchain/lower/testdata/return/return_var_byval.carbon
@@ -15,6 +15,7 @@ fn Main() -> i32 {
   return var;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'return_var_byval.carbon'
 // CHECK:STDOUT: source_filename = "return_var_byval.carbon"
 // CHECK:STDOUT:
@@ -61,3 +62,4 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !11, type: !7)
 // CHECK:STDOUT: !16 = !DILocation(line: 14, column: 12, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/return/value.carbon
+++ b/toolchain/lower/testdata/return/value.carbon
@@ -14,6 +14,7 @@ fn Main() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'value.carbon'
 // CHECK:STDOUT: source_filename = "value.carbon"
 // CHECK:STDOUT:
@@ -37,3 +38,4 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/return/var.carbon
+++ b/toolchain/lower/testdata/return/var.carbon
@@ -15,6 +15,7 @@ fn Main() -> i32 {
   return x;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var.carbon'
 // CHECK:STDOUT: source_filename = "var.carbon"
 // CHECK:STDOUT:
@@ -61,3 +62,4 @@ fn Main() -> i32 {
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !11, type: !7)
 // CHECK:STDOUT: !16 = !DILocation(line: 14, column: 3, scope: !11)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/empty.carbon
+++ b/toolchain/lower/testdata/struct/empty.carbon
@@ -16,6 +16,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'empty.carbon'
 // CHECK:STDOUT: source_filename = "empty.carbon"
 // CHECK:STDOUT:
@@ -52,3 +53,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
 // CHECK:STDOUT: !10 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/layout.carbon
+++ b/toolchain/lower/testdata/struct/layout.carbon
@@ -73,6 +73,7 @@ fn F() {
   G(&insert_padding.b);
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'no_padding.carbon'
 // CHECK:STDOUT: source_filename = "no_padding.carbon"
 // CHECK:STDOUT:
@@ -143,6 +144,8 @@ fn F() {
 // CHECK:STDOUT: !26 = !{!27}
 // CHECK:STDOUT: !27 = !DILocalVariable(arg: 1, scope: !22, type: !25)
 // CHECK:STDOUT: !28 = !DILocation(line: 7, column: 3, scope: !22)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'avoid_tail_padding.carbon'
 // CHECK:STDOUT: source_filename = "avoid_tail_padding.carbon"
 // CHECK:STDOUT:
@@ -205,6 +208,8 @@ fn F() {
 // CHECK:STDOUT: !22 = !{!23}
 // CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !18, type: !21)
 // CHECK:STDOUT: !24 = !DILocation(line: 7, column: 3, scope: !18)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'use_tail_padding.carbon'
 // CHECK:STDOUT: source_filename = "use_tail_padding.carbon"
 // CHECK:STDOUT:
@@ -282,6 +287,8 @@ fn F() {
 // CHECK:STDOUT: !28 = !{!29}
 // CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !23)
 // CHECK:STDOUT: !30 = !DILocation(line: 8, column: 3, scope: !27)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'implicit_padding.carbon'
 // CHECK:STDOUT: source_filename = "implicit_padding.carbon"
 // CHECK:STDOUT:
@@ -359,6 +366,8 @@ fn F() {
 // CHECK:STDOUT: !28 = !{!29}
 // CHECK:STDOUT: !29 = !DILocalVariable(arg: 1, scope: !27, type: !23)
 // CHECK:STDOUT: !30 = !DILocation(line: 8, column: 3, scope: !27)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'insert_padding.carbon'
 // CHECK:STDOUT: source_filename = "insert_padding.carbon"
 // CHECK:STDOUT:
@@ -431,3 +440,4 @@ fn F() {
 // CHECK:STDOUT: !26 = !{!27}
 // CHECK:STDOUT: !27 = !DILocalVariable(arg: 1, scope: !25, type: !21)
 // CHECK:STDOUT: !28 = !DILocation(line: 9, column: 3, scope: !25)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/member_access.carbon
+++ b/toolchain/lower/testdata/struct/member_access.carbon
@@ -17,6 +17,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'member_access.carbon'
 // CHECK:STDOUT: source_filename = "member_access.carbon"
 // CHECK:STDOUT:
@@ -111,3 +112,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !29 = !{!30}
 // CHECK:STDOUT: !30 = !DILocalVariable(arg: 1, scope: !28, type: !24)
 // CHECK:STDOUT: !31 = !DILocation(line: 14, column: 3, scope: !28)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/nested_struct.carbon
+++ b/toolchain/lower/testdata/struct/nested_struct.carbon
@@ -15,6 +15,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nested_struct.carbon'
 // CHECK:STDOUT: source_filename = "nested_struct.carbon"
 // CHECK:STDOUT:
@@ -38,3 +39,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/nested_struct_in_place.carbon
+++ b/toolchain/lower/testdata/struct/nested_struct_in_place.carbon
@@ -16,6 +16,7 @@ fn G() {
   var _: {.a: (i32, i32, i32), .b: (i32, i32, i32)} = {.a = F(), .b = F()};
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nested_struct_in_place.carbon'
 // CHECK:STDOUT: source_filename = "nested_struct_in_place.carbon"
 // CHECK:STDOUT:
@@ -91,3 +92,4 @@ fn G() {
 // CHECK:STDOUT: !27 = !{!28}
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 1, scope: !26, type: !22)
 // CHECK:STDOUT: !29 = !DILocation(line: 16, column: 3, scope: !26)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/one_entry.carbon
+++ b/toolchain/lower/testdata/struct/one_entry.carbon
@@ -16,6 +16,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'one_entry.carbon'
 // CHECK:STDOUT: source_filename = "one_entry.carbon"
 // CHECK:STDOUT:
@@ -86,3 +87,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !22 = !{!23}
 // CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !18, type: !21)
 // CHECK:STDOUT: !24 = !DILocation(line: 15, column: 3, scope: !18)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/partially_const.carbon
+++ b/toolchain/lower/testdata/struct/partially_const.carbon
@@ -14,6 +14,7 @@ fn Make(n: i32) -> {.a: i32, .b: i32, .c: i32} {
   return {.a = 0, .b = n, .c = 0};
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'partially_const.carbon'
 // CHECK:STDOUT: source_filename = "partially_const.carbon"
 // CHECK:STDOUT:
@@ -47,3 +48,4 @@ fn Make(n: i32) -> {.a: i32, .b: i32, .c: i32} {
 // CHECK:STDOUT: !10 = !DILocalVariable(arg: 1, scope: !4, type: !8)
 // CHECK:STDOUT: !11 = !DILocation(line: 14, column: 10, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 14, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/struct/two_entries.carbon
+++ b/toolchain/lower/testdata/struct/two_entries.carbon
@@ -16,6 +16,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'two_entries.carbon'
 // CHECK:STDOUT: source_filename = "two_entries.carbon"
 // CHECK:STDOUT:
@@ -98,3 +99,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !23 = !{!24}
 // CHECK:STDOUT: !24 = !DILocalVariable(arg: 1, scope: !19, type: !22)
 // CHECK:STDOUT: !25 = !DILocation(line: 15, column: 3, scope: !19)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/access/element_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/element_access.carbon
@@ -17,6 +17,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'element_access.carbon'
 // CHECK:STDOUT: source_filename = "element_access.carbon"
 // CHECK:STDOUT:
@@ -103,3 +104,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !25 = !{!26}
 // CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !21, type: !24)
 // CHECK:STDOUT: !27 = !DILocation(line: 14, column: 3, scope: !21)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/access/return_value_access.carbon
+++ b/toolchain/lower/testdata/tuple/access/return_value_access.carbon
@@ -16,6 +16,7 @@ fn Run() {
   var _: i32 = F().1;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'return_value_access.carbon'
 // CHECK:STDOUT: source_filename = "return_value_access.carbon"
 // CHECK:STDOUT:
@@ -102,3 +103,4 @@ fn Run() {
 // CHECK:STDOUT: !26 = !{!27}
 // CHECK:STDOUT: !27 = !DILocalVariable(arg: 1, scope: !23, type: !7)
 // CHECK:STDOUT: !28 = !DILocation(line: 16, column: 16, scope: !23)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/empty.carbon
+++ b/toolchain/lower/testdata/tuple/empty.carbon
@@ -16,6 +16,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'empty.carbon'
 // CHECK:STDOUT: source_filename = "empty.carbon"
 // CHECK:STDOUT:
@@ -52,3 +53,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !8 = !DILocation(line: 14, column: 3, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 15, column: 3, scope: !4)
 // CHECK:STDOUT: !10 = !DILocation(line: 16, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/nested_tuple.carbon
+++ b/toolchain/lower/testdata/tuple/nested_tuple.carbon
@@ -15,6 +15,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nested_tuple.carbon'
 // CHECK:STDOUT: source_filename = "nested_tuple.carbon"
 // CHECK:STDOUT:
@@ -38,3 +39,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 15, column: 3, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/nested_tuple_in_place.carbon
+++ b/toolchain/lower/testdata/tuple/nested_tuple_in_place.carbon
@@ -16,6 +16,7 @@ fn G() {
   var _: ((i32, i32, i32), (i32, i32, i32)) = (F(), F());
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nested_tuple_in_place.carbon'
 // CHECK:STDOUT: source_filename = "nested_tuple_in_place.carbon"
 // CHECK:STDOUT:
@@ -91,3 +92,4 @@ fn G() {
 // CHECK:STDOUT: !27 = !{!28}
 // CHECK:STDOUT: !28 = !DILocalVariable(arg: 1, scope: !26, type: !22)
 // CHECK:STDOUT: !29 = !DILocation(line: 16, column: 3, scope: !26)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/one_entry.carbon
+++ b/toolchain/lower/testdata/tuple/one_entry.carbon
@@ -16,6 +16,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'one_entry.carbon'
 // CHECK:STDOUT: source_filename = "one_entry.carbon"
 // CHECK:STDOUT:
@@ -86,3 +87,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !22 = !{!23}
 // CHECK:STDOUT: !23 = !DILocalVariable(arg: 1, scope: !18, type: !21)
 // CHECK:STDOUT: !24 = !DILocation(line: 15, column: 3, scope: !18)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/two_entries.carbon
+++ b/toolchain/lower/testdata/tuple/two_entries.carbon
@@ -16,6 +16,7 @@ fn Run() -> i32 {
   return 0;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'two_entries.carbon'
 // CHECK:STDOUT: source_filename = "two_entries.carbon"
 // CHECK:STDOUT:
@@ -98,3 +99,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !23 = !{!24}
 // CHECK:STDOUT: !24 = !DILocalVariable(arg: 1, scope: !19, type: !22)
 // CHECK:STDOUT: !25 = !DILocation(line: 15, column: 3, scope: !19)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/value_formation.carbon
+++ b/toolchain/lower/testdata/tuple/value_formation.carbon
@@ -18,6 +18,7 @@ fn F() {
   G((a, b));
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'value_formation.carbon'
 // CHECK:STDOUT: source_filename = "value_formation.carbon"
 // CHECK:STDOUT:
@@ -123,3 +124,4 @@ fn F() {
 // CHECK:STDOUT: !25 = !{!26}
 // CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !21, type: !24)
 // CHECK:STDOUT: !27 = !DILocation(line: 17, column: 3, scope: !21)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/tuple/value_forwarding.carbon
+++ b/toolchain/lower/testdata/tuple/value_forwarding.carbon
@@ -16,6 +16,7 @@ fn F(a: (i32, i32, i32), b: (i32, i32, i32)) {
   G((a, b));
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'value_forwarding.carbon'
 // CHECK:STDOUT: source_filename = "value_forwarding.carbon"
 // CHECK:STDOUT:
@@ -57,3 +58,4 @@ fn F(a: (i32, i32, i32), b: (i32, i32, i32)) {
 // CHECK:STDOUT: !11 = !DILocation(line: 16, column: 5, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 16, column: 3, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 15, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/var/export.carbon
+++ b/toolchain/lower/testdata/var/export.carbon
@@ -27,6 +27,7 @@ fn Run() -> i32 {
   return Cpp.Get();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var_export.carbon'
 // CHECK:STDOUT: source_filename = "var_export.carbon"
 // CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
@@ -85,3 +86,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !19 = !{null}
 // CHECK:STDOUT: !20 = !DILocation(line: 5, column: 1, scope: !17)
 // CHECK:STDOUT: !21 = !DILocation(line: 0, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/var/global.carbon
+++ b/toolchain/lower/testdata/var/global.carbon
@@ -50,6 +50,7 @@ package Other;
 
 var a: i32 = 1;
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'simple.carbon'
 // CHECK:STDOUT: source_filename = "simple.carbon"
 // CHECK:STDOUT:
@@ -88,6 +89,8 @@ var a: i32 = 1;
 // CHECK:STDOUT: !11 = !{null}
 // CHECK:STDOUT: !12 = !DILocation(line: 4, column: 1, scope: !9)
 // CHECK:STDOUT: !13 = !DILocation(line: 0, scope: !9)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'var_in_tuple.carbon'
 // CHECK:STDOUT: source_filename = "var_in_tuple.carbon"
 // CHECK:STDOUT:
@@ -137,6 +140,8 @@ var a: i32 = 1;
 // CHECK:STDOUT: !14 = !DILocation(line: 4, column: 6, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 4, column: 18, scope: !11)
 // CHECK:STDOUT: !16 = !DILocation(line: 0, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'tuple_in_var.carbon'
 // CHECK:STDOUT: source_filename = "tuple_in_var.carbon"
 // CHECK:STDOUT:
@@ -191,6 +196,8 @@ var a: i32 = 1;
 // CHECK:STDOUT: !13 = !{null}
 // CHECK:STDOUT: !14 = !DILocation(line: 4, column: 1, scope: !11)
 // CHECK:STDOUT: !15 = !DILocation(line: 0, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'unnamed.carbon'
 // CHECK:STDOUT: source_filename = "unnamed.carbon"
 // CHECK:STDOUT:
@@ -230,6 +237,8 @@ var a: i32 = 1;
 // CHECK:STDOUT: !7 = !DILocation(line: 4, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 5, column: 1, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'not_main_package.carbon'
 // CHECK:STDOUT: source_filename = "not_main_package.carbon"
 // CHECK:STDOUT:
@@ -257,3 +266,4 @@ var a: i32 = 1;
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 4, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/var/import.carbon
+++ b/toolchain/lower/testdata/var/import.carbon
@@ -48,6 +48,7 @@ fn W() -> i32 { return w; }
 fn Y() -> i32 { return y; }
 fn Z() -> i32 { return z; }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'simple.carbon'
 // CHECK:STDOUT: source_filename = "simple.carbon"
 // CHECK:STDOUT:
@@ -75,6 +76,8 @@ fn Z() -> i32 { return z; }
 // CHECK:STDOUT: !6 = !{null}
 // CHECK:STDOUT: !7 = !DILocation(line: 4, column: 1, scope: !4)
 // CHECK:STDOUT: !8 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_simple.carbon'
 // CHECK:STDOUT: source_filename = "import_simple.carbon"
 // CHECK:STDOUT:
@@ -102,6 +105,8 @@ fn Z() -> i32 { return z; }
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !8 = !DILocation(line: 7, column: 10, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 7, column: 3, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'tuple_pattern.carbon'
 // CHECK:STDOUT: source_filename = "tuple_pattern.carbon"
 // CHECK:STDOUT:
@@ -144,6 +149,8 @@ fn Z() -> i32 { return z; }
 // CHECK:STDOUT: !8 = !DILocation(line: 6, column: 14, scope: !4)
 // CHECK:STDOUT: !9 = !DILocation(line: 8, column: 1, scope: !4)
 // CHECK:STDOUT: !10 = !DILocation(line: 0, scope: !4)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'import_tuple_pattern.carbon'
 // CHECK:STDOUT: source_filename = "import_tuple_pattern.carbon"
 // CHECK:STDOUT:
@@ -206,3 +213,4 @@ fn Z() -> i32 { return z; }
 // CHECK:STDOUT: !16 = distinct !DISubprogram(name: "Z", linkageName: "_CZ.Main", scope: null, file: !1, line: 10, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !17 = !DILocation(line: 10, column: 24, scope: !16)
 // CHECK:STDOUT: !18 = !DILocation(line: 10, column: 17, scope: !16)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/var/local.carbon
+++ b/toolchain/lower/testdata/var/local.carbon
@@ -30,6 +30,7 @@ fn G() -> (i32, i32, i32) {
   return a;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'simple.carbon'
 // CHECK:STDOUT: source_filename = "simple.carbon"
 // CHECK:STDOUT:
@@ -76,6 +77,8 @@ fn G() -> (i32, i32, i32) {
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !11, type: !7)
 // CHECK:STDOUT: !16 = !DILocation(line: 5, column: 3, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'eval_init_in_place.carbon'
 // CHECK:STDOUT: source_filename = "eval_init_in_place.carbon"
 // CHECK:STDOUT:
@@ -167,3 +170,4 @@ fn G() -> (i32, i32, i32) {
 // CHECK:STDOUT: !24 = !{!25}
 // CHECK:STDOUT: !25 = !DILocalVariable(arg: 1, scope: !21, type: !7)
 // CHECK:STDOUT: !26 = !DILocation(line: 7, column: 3, scope: !21)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/var/nested.carbon
+++ b/toolchain/lower/testdata/var/nested.carbon
@@ -19,6 +19,7 @@ fn Run() -> i32 {
   return a;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'nested.carbon'
 // CHECK:STDOUT: source_filename = "nested.carbon"
 // CHECK:STDOUT:
@@ -91,3 +92,4 @@ fn Run() -> i32 {
 // CHECK:STDOUT: !20 = !{!21}
 // CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !17, type: !7)
 // CHECK:STDOUT: !22 = !DILocation(line: 16, column: 5, scope: !17)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/var/param.carbon
+++ b/toolchain/lower/testdata/var/param.carbon
@@ -46,6 +46,7 @@ fn G() {
   F({});
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'with_cleanup.carbon'
 // CHECK:STDOUT: source_filename = "with_cleanup.carbon"
 // CHECK:STDOUT:
@@ -99,6 +100,8 @@ fn G() {
 // CHECK:STDOUT: !15 = !{!16}
 // CHECK:STDOUT: !16 = !DILocalVariable(arg: 1, scope: !11, type: !14)
 // CHECK:STDOUT: !17 = !DILocation(line: 13, column: 6, scope: !11)
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'struct_literal_cleanup.carbon'
 // CHECK:STDOUT: source_filename = "struct_literal_cleanup.carbon"
 // CHECK:STDOUT:
@@ -154,3 +157,4 @@ fn G() {
 // CHECK:STDOUT: !14 = !{!15}
 // CHECK:STDOUT: !15 = !DILocalVariable(arg: 1, scope: !10, type: !13)
 // CHECK:STDOUT: !16 = !DILocation(line: 11, column: 6, scope: !10)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/var/uninitialized.carbon
+++ b/toolchain/lower/testdata/var/uninitialized.carbon
@@ -19,6 +19,7 @@ fn Run() {
   var unused f: i32*;
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'uninitialized.carbon'
 // CHECK:STDOUT: source_filename = "uninitialized.carbon"
 // CHECK:STDOUT:
@@ -98,3 +99,4 @@ fn Run() {
 // CHECK:STDOUT: !25 = !{!26}
 // CHECK:STDOUT: !26 = !DILocalVariable(arg: 1, scope: !22, type: !7)
 // CHECK:STDOUT: !27 = !DILocation(line: 14, column: 3, scope: !22)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/while/break_continue.carbon
+++ b/toolchain/lower/testdata/while/break_continue.carbon
@@ -21,6 +21,7 @@ fn While() {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'break_continue.carbon'
 // CHECK:STDOUT: source_filename = "break_continue.carbon"
 // CHECK:STDOUT:
@@ -85,3 +86,4 @@ fn While() {
 // CHECK:STDOUT: !14 = !DILocation(line: 20, column: 16, scope: !4)
 // CHECK:STDOUT: !15 = !DILocation(line: 18, column: 3, scope: !4)
 // CHECK:STDOUT: !16 = !DILocation(line: 17, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/while/preheader.carbon
+++ b/toolchain/lower/testdata/while/preheader.carbon
@@ -30,6 +30,7 @@ fn While() {
   }
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'preheader.carbon'
 // CHECK:STDOUT: source_filename = "preheader.carbon"
 // CHECK:STDOUT:
@@ -98,3 +99,4 @@ fn While() {
 // CHECK:STDOUT: !16 = !DILocation(line: 27, column: 5, scope: !4)
 // CHECK:STDOUT: !17 = !DILocation(line: 26, column: 3, scope: !4)
 // CHECK:STDOUT: !18 = !DILocation(line: 21, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/while/unreachable_end.carbon
+++ b/toolchain/lower/testdata/while/unreachable_end.carbon
@@ -25,6 +25,7 @@ fn While() {
   H();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'unreachable_end.carbon'
 // CHECK:STDOUT: source_filename = "unreachable_end.carbon"
 // CHECK:STDOUT:
@@ -74,3 +75,4 @@ fn While() {
 // CHECK:STDOUT: !11 = !DILocation(line: 23, column: 5, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 25, column: 3, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 19, column: 1, scope: !4)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/while/while.carbon
+++ b/toolchain/lower/testdata/while/while.carbon
@@ -24,6 +24,7 @@ fn While() {
   H();
 }
 
+// CHECK:STDOUT: ; ---
 // CHECK:STDOUT: ; ModuleID = 'while.carbon'
 // CHECK:STDOUT: source_filename = "while.carbon"
 // CHECK:STDOUT:
@@ -73,3 +74,4 @@ fn While() {
 // CHECK:STDOUT: !11 = !DILocation(line: 21, column: 3, scope: !4)
 // CHECK:STDOUT: !12 = !DILocation(line: 24, column: 3, scope: !4)
 // CHECK:STDOUT: !13 = !DILocation(line: 19, column: 1, scope: !4)
+// CHECK:STDOUT:


### PR DESCRIPTION
Each file dump now starts with a `; ---` comment and ends with a blank line. This makes it easier to visually scan the dump for a file of interest. The comment format is somewhat arbitrary; I chose `---` to align with the `--- filename.carbon` separator in SemIR dumps, but without the filename, because that appears on each of the next two lines already.
