### PR TITLE
prevent clangd_tidy github workflow from checking generated files

### DIFF
--- a/.github/workflows/clangd_tidy.yaml
+++ b/.github/workflows/clangd_tidy.yaml
@@ -64,9 +64,11 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
+          predicate-quantifier: 'every'
           filters: |
             has_cpp:
               - added|modified: '{**/*.cpp,**/*.h}'
+              - '!**/*.tpl.h'
           list-files: 'shell'
 
       - uses: ./.github/actions/build-setup-common


### PR DESCRIPTION
This prevents an issue when trying to check in changes top bazel-generated template files,
which aren't actually valid C++, making clangd_tidy issue errors and block the commit.
