### PR TITLE
Some slight tweaks to comments in/on WitnessQueryMatchesInterface

### DIFF
--- a/toolchain/check/impl.cpp
+++ b/toolchain/check/impl.cpp
@@ -390,7 +390,8 @@ auto AddImpl(Context& context, const SemIR::Impl& impl,
   return impl_id;
 }
 
-// Returns whether the `LookupImplWitness` of `witness_id` matches `interface`.
+// Returns whether the `LookupImplWitness` of `witness_id` is for the same
+// specific interface as the impl decl's `impl_interface`.
 static auto WitnessQueryMatchesInterface(
     Context& context, SemIR::LocId loc_id, SemIR::InstId impl_self,
     SemIR::InstId access_witness_id,
@@ -401,12 +402,8 @@ static auto WitnessQueryMatchesInterface(
       context.specific_interfaces().Get(lookup.query_specific_interface_id);
 
   // The `impl_interface` comes from an IdentifiedFacetType so it has `.Self`
-  // replaced. The access comes from a rewrite constraint, which do not have
-  // `.Self` replaced, so we need to do that here.
-  //
-  // TODO: Do this more eagerly as soon as we know the full decl before we
-  // construct the witness table from it? We do replace `.Self` in the facet
-  // type, but we don't replace the designators.
+  // replaced. The access comes from the LHS of a rewrite constraint, which do
+  // not have `.Self` replaced, so we need to do that here.
   access_interface = SubstPeriodSelf(context, loc_id, access_interface,
                                      context.constant_values().Get(impl_self));
   return access_interface == impl_interface;


### PR DESCRIPTION
I attempted the TODO as stated but we can't remove the `.Self` from the LHS of a rewrite right now, without causing evaluation to run and potentially find a concrete value to replace the access with, which then breaks the association with the associated constant. There's a separate TODO about that in SubstPeriodSelfInFacetType.