### PR TITLE
Fix ImportCppType doc

### DIFF
--- a/toolchain/check/cpp/import.h
+++ b/toolchain/check/cpp/import.h
@@ -79,10 +79,14 @@ inline auto ImportCppFunctionDecl(Context& context, SemIR::LocId loc_id,
       SemIR::ClangDeclKey::ForFunctionDecl(clang_decl, signature_id));
 }
 
-// Imports a function declaration from Clang to Carbon. If successful, returns
-// the new Carbon function declaration `InstId`. If the declaration was already
-// imported, returns the mapped instruction. All unimported dependencies are
-// imported first.
+// Imports a type from Clang to Carbon. Returns a `TypeExpr` which contains
+// both a `TypeId` and `TypeInstId`. All unimported dependencies are imported
+// first.
+//
+// If a failure is diagnosed, the `TypeId` will be `ErrorInst::TypeId` and
+// the `TypeInstId` will be `ErrorInst::InstId`. Types that are not yet
+// supported may instead return `TypeId::None` and `TypeInstId::None`.
+// Callers should handle both cases.
 auto ImportCppType(Context& context, SemIR::LocId loc_id, clang::QualType type)
     -> TypeExpr;
 


### PR DESCRIPTION
Fixup for #6474. The previous doc was accidentally copied from ImportCppFunctionDecl.
