### PR TITLE
update llvm to 615644763ffc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -83,8 +83,8 @@ git_override(
     build_file_content = "# empty",
     # We pin to specific upstream commits and try to track top-of-tree
     # reasonably closely rather than pinning to a specific release.
-    # HEAD as of 2026-07-07.
-    commit = "1a5376e062e3f3b99ffce25e24e53182202e06b9",
+    # HEAD as of 2026-07-09.
+    commit = "615644763ffcfc939bda59e9f3e71d6e7d9fd264",
     patch_cmds = ["echo \"module(name='llvm-raw')\" > MODULE.bazel"],
     patch_strip = 1,
     patches = [
@@ -94,6 +94,7 @@ git_override(
         "//bazel/llvm_project:0005_Introduce_basic_sources_exporting_for_libcxx_and_libcxxabi.patch",
         "//bazel/llvm_project:0009_Introduce_starlark_exporting_compiler-rt_build_information.patch",
         "//bazel/llvm_project:0010_Exclude_addtf3_cpp_from_compiler_rt_builtins.patch",
+        "//bazel/llvm_project:0011_Temporarily_remove_reference_to_hermetic_toolchain.patch",
     ],
     remote = "https://github.com/llvm/llvm-project.git",
 )

--- a/bazel/llvm_project/0011_Temporarily_remove_reference_to_hermetic_toolchain.patch
+++ b/bazel/llvm_project/0011_Temporarily_remove_reference_to_hermetic_toolchain.patch
@@ -1,0 +1,24 @@
+Temporarily undo
+https://github.com/llvm/llvm-project/pull/207295
+Which introduces a dependency on the hermetic llvm
+toolchain. A fix-forward is in progress, at which
+point we can remove this patch.
+---
+--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
++++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
+@@ -48,7 +48,6 @@
+ 
+ backtrace_defines = select({
+     "@platforms//os:windows": [],
+-    "@llvm//platforms/config:musl": [],
+     "//conditions:default": [
+         "HAVE_BACKTRACE=1",
+         "BACKTRACE_HEADER=<execinfo.h>",
+@@ -56,7 +55,6 @@
+ })
+ 
+ mallinfo_defines = select({
+-    "@llvm//platforms/config:gnu": ["HAVE_MALLINFO=1"],
+     "//conditions:default": [],
+ })
+ 

--- a/toolchain/check/cpp/call.cpp
+++ b/toolchain/check/cpp/call.cpp
@@ -310,7 +310,7 @@ static auto BuildTemplateId(Context& context, SemIR::LocId loc_id,
           dyn_cast<clang::VarTemplateDecl>(template_decl)) {
     auto decl_result = context.clang_sema().CheckVarTemplateId(
         var_template_decl, /*TemplateLoc=*/clang::SourceLocation(), loc,
-        arg_list);
+        arg_list, /*SetWrittenArgs=*/false);
     return decl_result.isInvalid()
                ? SemIR::ErrorInst::InstId
                : ImportCppDecl(context, loc_id,

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -864,11 +864,10 @@ auto ExportFunctionSpecializationToCpp(
   auto* template_arg_list = clang::TemplateArgumentList::CreateCopy(
       context.ast_context(), template_args);
   function_decl->setFunctionTemplateSpecialization(
-      context.ast_context(), function_template_decl, template_arg_list,
+      function_template_decl, template_arg_list,
       /*InsertPos=*/nullptr, clang::TSK_ExplicitSpecialization,
-      /*TemplateParams=*/nullptr, /*TemplateArgsAsWritten=*/nullptr,
-      /*PointOfInstantiation=*/clang::SourceLocation(),
-      /*AddSpecialization=*/true);
+      /*TemplateArgsAsWritten=*/nullptr,
+      /*PointOfInstantiation=*/clang::SourceLocation());
 
   return true;
 }


### PR DESCRIPTION
* Fixes some build issues in clang headers that have changed upstream
* Adds patch 0011 to work around an upstream commit that broke Bazel builds