### PR TITLE
Add extern template declarations for ValueStore in inst.h and entity_name.h

### DIFF
--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -92,6 +92,7 @@ cc_library(
         "cpp_file.cpp",
         "cpp_initializer_list.cpp",
         "cpp_overload_set.cpp",
+        "entity_name.cpp",
         "facet_type_info.cpp",
         "field.cpp",
         "file.cpp",

--- a/toolchain/sem_ir/entity_name.cpp
+++ b/toolchain/sem_ir/entity_name.cpp
@@ -1,0 +1,12 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/sem_ir/entity_name.h"
+
+#include "toolchain/base/value_store_impl.h"
+
+namespace Carbon {
+template class ValueStore<SemIR::EntityNameId, SemIR::EntityName,
+                          Tag<SemIR::CheckIRId>>;
+}  // namespace Carbon

--- a/toolchain/sem_ir/entity_name.h
+++ b/toolchain/sem_ir/entity_name.h
@@ -142,4 +142,9 @@ inline auto EntityNameStore::MakeCanonical(EntityNameId id) -> EntityNameId {
 
 }  // namespace Carbon::SemIR
 
+namespace Carbon {
+extern template class ValueStore<SemIR::EntityNameId, SemIR::EntityName,
+                                 Tag<SemIR::CheckIRId>>;
+}  // namespace Carbon
+
 #endif  // CARBON_TOOLCHAIN_SEM_IR_ENTITY_NAME_H_

--- a/toolchain/sem_ir/inst.cpp
+++ b/toolchain/sem_ir/inst.cpp
@@ -169,4 +169,5 @@ template class ValueStore<SemIR::InstBlockId,
                           Tag<SemIR::CheckIRId>>;
 template class BlockValueStore<SemIR::InstBlockId, SemIR::InstId,
                                Tag<SemIR::CheckIRId>>;
+template class ValueStore<SemIR::InstId, SemIR::Inst, Tag<SemIR::CheckIRId>>;
 }  // namespace Carbon

--- a/toolchain/sem_ir/inst.h
+++ b/toolchain/sem_ir/inst.h
@@ -718,6 +718,8 @@ extern template class ValueStore<SemIR::InstBlockId,
                                  Tag<SemIR::CheckIRId>>;
 extern template class BlockValueStore<SemIR::InstBlockId, SemIR::InstId,
                                       Tag<SemIR::CheckIRId>>;
+extern template class ValueStore<SemIR::InstId, SemIR::Inst,
+                                 Tag<SemIR::CheckIRId>>;
 }  // namespace Carbon
 
 #endif  // CARBON_TOOLCHAIN_SEM_IR_INST_H_


### PR DESCRIPTION
Add extern template declarations and explicit template instantiations for ValueStore<InstId, Inst> and ValueStore<EntityNameId, EntityName> to prevent redundant template instantiations.

Place them in their respective domain files (inst.h/cpp and entity_name.h/cpp) to maintain modularity.

Assisted-by: Antigravity with Gemini