### PR TITLE
Reduce Clang header exposure in check_unit.h

### DIFF
--- a/toolchain/check/check_unit.cpp
+++ b/toolchain/check/check_unit.cpp
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <utility>
 
+#include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Sema/Sema.h"
 #include "common/growing_range.h"
 #include "common/pretty_stack_trace_function.h"

--- a/toolchain/check/check_unit.h
+++ b/toolchain/check/check_unit.h
@@ -5,7 +5,6 @@
 #ifndef CARBON_TOOLCHAIN_CHECK_CHECK_UNIT_H_
 #define CARBON_TOOLCHAIN_CHECK_CHECK_UNIT_H_
 
-#include "clang/Frontend/CompilerInvocation.h"
 #include "common/map.h"
 #include "llvm/ADT/SmallVector.h"
 #include "toolchain/check/check.h"
@@ -13,6 +12,10 @@
 #include "toolchain/check/diagnostic_emitter.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/sem_ir/ids.h"
+
+namespace clang {
+class CompilerInvocation;
+}
 
 namespace Carbon::Check {
 


### PR DESCRIPTION
Remove clang/Frontend/CompilerInvocation.h from check_unit.h and forward declare clang::CompilerInvocation instead to reduce header exposure.

Add an explicit include of CompilerInvocation.h to check_unit.cpp.

Assisted-by: Antigravity with Gemini