### PR TITLE
Remove typed_nodes.h from tree.h and node_stack.h

### DIFF
--- a/toolchain/check/node_stack.h
+++ b/toolchain/check/node_stack.h
@@ -10,7 +10,6 @@
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/parse/node_kind.h"
 #include "toolchain/parse/tree.h"
-#include "toolchain/parse/typed_nodes.h"
 #include "toolchain/sem_ir/id_kind.h"
 #include "toolchain/sem_ir/ids.h"
 

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -17,7 +17,6 @@
 #include "toolchain/lex/tokenized_buffer.h"
 #include "toolchain/parse/node_ids.h"
 #include "toolchain/parse/node_kind.h"
-#include "toolchain/parse/typed_nodes.h"
 
 namespace Carbon::Parse {
 

--- a/toolchain/parse/tree_and_subtrees.cpp
+++ b/toolchain/parse/tree_and_subtrees.cpp
@@ -9,6 +9,7 @@
 
 #include "toolchain/base/fixed_size_value_store.h"
 #include "toolchain/lex/token_index.h"
+#include "toolchain/parse/typed_nodes.h"
 
 namespace Carbon::Parse {
 


### PR DESCRIPTION
Remove toolchain/parse/typed_nodes.h from transitive imports of tree.h and node_stack.h to reduce compile-time overhead in toolchain/check.

Add an explicit include of typed_nodes.h to tree_and_subtrees.cpp where it is needed for instantiating templates.

Assisted-by: Antigravity with Gemini