### PR TITLE
Reduce Clang header exposure in lower library

### DIFF
--- a/toolchain/lower/context.cpp
+++ b/toolchain/lower/context.cpp
@@ -5,6 +5,7 @@
 #include "toolchain/lower/context.h"
 
 #include "clang/Basic/SourceManager.h"
+#include "clang/CodeGen/ModuleBuilder.h"
 #include "common/check.h"
 #include "common/growing_range.h"
 #include "common/raw_string_ostream.h"

--- a/toolchain/lower/context.h
+++ b/toolchain/lower/context.h
@@ -20,6 +20,10 @@
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst_namer.h"
 
+namespace clang {
+class CodeGenerator;
+}
+
 namespace Carbon::Lower {
 
 class FileContext;

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -5,8 +5,6 @@
 #ifndef CARBON_TOOLCHAIN_LOWER_FILE_CONTEXT_H_
 #define CARBON_TOOLCHAIN_LOWER_FILE_CONTEXT_H_
 
-#include "clang/CodeGen/ModuleBuilder.h"
-#include "clang/Lex/PreprocessorOptions.h"
 #include "toolchain/lower/context.h"
 #include "toolchain/lower/specific_coalescer.h"
 #include "toolchain/lower/type.h"
@@ -14,6 +12,11 @@
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst_namer.h"
+
+namespace clang {
+class CodeGenerator;
+class FunctionDecl;
+}  // namespace clang
 
 namespace Carbon::Lower {
 


### PR DESCRIPTION
Remove clang/CodeGen/ModuleBuilder.h from toolchain/lower/file_context.h to reduce transitive dependencies. Forward declare clang::CodeGenerator and clang::FunctionDecl instead.

Add an explicit include of ModuleBuilder.h to context.cpp where the complete types are required.

Assisted-by: Antigravity with Gemini