### PR TITLE
move Core//range into prelude

### DIFF
--- a/bazel/carbon_rules/defs.bzl
+++ b/bazel/carbon_rules/defs.bzl
@@ -318,7 +318,7 @@ _carbon_binary_internal = rule(
         ),
         "srcs": attr.label_list(allow_files = [".carbon"]),
         "_cc_toolchain": attr.label(default = "//toolchain/install:carbon_stage1_cc_toolchain"),
-        "_default_deps": attr.label_list(default = [Label("//core:io"), Label("//core:range")]),
+        "_default_deps": attr.label_list(default = [Label("//core:io")]),
     },
     executable = True,
     fragments = ["cpp"],

--- a/core/BUILD
+++ b/core/BUILD
@@ -63,9 +63,3 @@ carbon_library(
     impls = ["io.impl.carbon"],
     visibility = ["//visibility:public"],
 )
-
-carbon_library(
-    name = "range",
-    api = "range.carbon",
-    visibility = ["//visibility:public"],
-)

--- a/core/prelude.carbon
+++ b/core/prelude.carbon
@@ -11,4 +11,5 @@ export import library "prelude/default";
 export import library "prelude/destroy";
 export import library "prelude/iterate";
 export import library "prelude/operators";
+export import library "prelude/range";
 export import library "prelude/types";

--- a/core/prelude/range.carbon
+++ b/core/prelude/range.carbon
@@ -2,10 +2,13 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// TODO: This library is not part of the design. Either write a matching
-// proposal or remove this.
+package Core library "prelude/range";
 
-package Core library "range";
+import library "prelude/iterate";
+import library "prelude/operators";
+import library "prelude/types/int";
+import library "prelude/types/int_literal";
+import library "prelude/types/optional";
 
 class IntRange(N: IntLiteral) {
   fn Make(start: Int(N), end: Int(N)) -> Self {

--- a/examples/advent2024/day10_common.carbon
+++ b/examples/advent2024/day10_common.carbon
@@ -7,7 +7,6 @@
 library "day10_common";
 
 import Core library "io";
-import Core library "range";
 import library "io_utils";
 
 class Terrain {

--- a/examples/advent2024/day10_part1.carbon
+++ b/examples/advent2024/day10_part1.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/10
 
 import Core library "io";
-import Core library "range";
 
 import library "day10_common";
 import library "io_utils";

--- a/examples/advent2024/day10_part2.carbon
+++ b/examples/advent2024/day10_part2.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/10
 
 import Core library "io";
-import Core library "range";
 
 import library "day10_common";
 import library "io_utils";

--- a/examples/advent2024/day11_part2.carbon
+++ b/examples/advent2024/day11_part2.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/11
 
 import Core library "io";
-import Core library "range";
 
 import library "day11_common";
 import library "io_utils";

--- a/examples/advent2024/day12_common.carbon
+++ b/examples/advent2024/day12_common.carbon
@@ -7,7 +7,6 @@
 library "day12_common";
 
 import Core library "io";
-import Core library "range";
 import library "io_utils";
 
 class Map {

--- a/examples/advent2024/day12_part1.carbon
+++ b/examples/advent2024/day12_part1.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/12
 
 import Core library "io";
-import Core library "range";
 
 import library "day12_common";
 import library "io_utils";

--- a/examples/advent2024/day12_part2.carbon
+++ b/examples/advent2024/day12_part2.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/12
 
 import Core library "io";
-import Core library "range";
 
 import library "day12_common";
 import library "io_utils";

--- a/examples/advent2024/day14_part2.carbon
+++ b/examples/advent2024/day14_part2.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/14
 
 import Core library "io";
-import Core library "range";
 
 import library "day14_common";
 import library "io_utils";

--- a/examples/advent2024/day1_common.carbon
+++ b/examples/advent2024/day1_common.carbon
@@ -6,8 +6,6 @@
 
 library "day1_common";
 
-import Core library "range";
-
 import library "io_utils";
 
 // Read a sequence of lines each containing a pair of numbers into two arrays.

--- a/examples/advent2024/day1_part1.carbon
+++ b/examples/advent2024/day1_part1.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/1
 
 import Core library "io";
-import Core library "range";
 
 import library "day1_common";
 import library "sort";

--- a/examples/advent2024/day4_part1.carbon
+++ b/examples/advent2024/day4_part1.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/4
 
 import Core library "io";
-import Core library "range";
 
 import library "day4_common";
 import library "io_utils";

--- a/examples/advent2024/day4_part2.carbon
+++ b/examples/advent2024/day4_part2.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/4
 
 import Core library "io";
-import Core library "range";
 
 import library "day4_common";
 import library "io_utils";

--- a/examples/advent2024/day5_common.carbon
+++ b/examples/advent2024/day5_common.carbon
@@ -6,8 +6,6 @@
 
 library "day5_common";
 
-import Core library "range";
-
 import library "io_utils";
 
 fn PageMask(page: i32) -> Core.UInt(100) {

--- a/examples/advent2024/day8_common.carbon
+++ b/examples/advent2024/day8_common.carbon
@@ -7,7 +7,6 @@
 library "day8_common";
 
 import Core library "io";
-import Core library "range";
 import library "io_utils";
 
 class Grid {

--- a/examples/advent2024/day8_part1.carbon
+++ b/examples/advent2024/day8_part1.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/8
 
 import Core library "io";
-import Core library "range";
 
 import library "day8_common";
 import library "io_utils";

--- a/examples/advent2024/day8_part2.carbon
+++ b/examples/advent2024/day8_part2.carbon
@@ -5,7 +5,6 @@
 // https://adventofcode.com/2024/day/8
 
 import Core library "io";
-import Core library "range";
 
 import library "day8_common";
 import library "io_utils";

--- a/examples/advent2024/day9_common.carbon
+++ b/examples/advent2024/day9_common.carbon
@@ -7,7 +7,6 @@
 library "day9_common";
 
 import Core library "io";
-import Core library "range";
 import library "io_utils";
 
 class SectorList {

--- a/examples/advent2024/io_utils.carbon
+++ b/examples/advent2024/io_utils.carbon
@@ -5,7 +5,6 @@
 library "io_utils";
 
 import Core library "io";
-import Core library "range";
 
 class EOFType {}
 

--- a/examples/sieve.carbon
+++ b/examples/sieve.carbon
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import Core library "io";
-import Core library "range";
 
 // Compute and return the number of primes less than 1000.
 

--- a/toolchain/driver/testdata/compile/optimize/optimize_debug.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_debug.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// ARGS: compile --optimize=debug foo.carbon --target=x86_64-unknown-linux-gnu --phase=optimize --dump-llvm-ir --exclude-dump-file-prefix=%{core} --include-carbon-core
+// ARGS: compile --optimize=debug foo.carbon --target=x86_64-unknown-linux-gnu --phase=optimize --dump-llvm-ir --exclude-dump-file-prefix=%{core}
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -11,9 +11,6 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/compile/optimize/optimize_debug.carbon
 
 // --- foo.carbon
-
-import Core library "range";
-
 fn Rand() -> i32;
 
 fn NoInlineWithOz() -> i32 {
@@ -44,18 +41,18 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CNoInlineWithOz.Main() local_unnamed_addr #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Rand.call.loc7_15 = tail call i32 @_CRand.Main() #0, !dbg !8
-// CHECK:STDOUT:   %Rand.call.loc7_24 = tail call i32 @_CRand.Main() #0, !dbg !9
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc7_24, %Rand.call.loc7_15, !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_15 = tail call i32 @_CRand.Main() #0, !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_24 = tail call i32 @_CRand.Main() #0, !dbg !9
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc4_24, %Rand.call.loc4_15, !dbg !8
 // CHECK:STDOUT:   ret i32 %Int.as.AddWith.impl.Op.call, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CCallNoInlineWithOptSize.Main() local_unnamed_addr #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Rand.call.loc7_15.i = tail call i32 @_CRand.Main() #0, !dbg !12
-// CHECK:STDOUT:   %Rand.call.loc7_24.i = tail call i32 @_CRand.Main() #0, !dbg !14
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call.i = add i32 %Rand.call.loc7_24.i, %Rand.call.loc7_15.i, !dbg !12
+// CHECK:STDOUT:   %Rand.call.loc4_15.i = tail call i32 @_CRand.Main() #0, !dbg !12
+// CHECK:STDOUT:   %Rand.call.loc4_24.i = tail call i32 @_CRand.Main() #0, !dbg !14
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call.i = add i32 %Rand.call.loc4_24.i, %Rand.call.loc4_15.i, !dbg !12
 // CHECK:STDOUT:   ret i32 %Int.as.AddWith.impl.Op.call.i, !dbg !15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -67,10 +64,10 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: while.body:                                       ; preds = %entry, %while.body
 // CHECK:STDOUT:   %n.var.03 = phi i32 [ 0, %entry ], [ %1, %while.body ]
 // CHECK:STDOUT:   %0 = zext nneg i32 %n.var.03 to i64, !dbg !23
-// CHECK:STDOUT:   %.loc19_11.array.index = getelementptr inbounds nuw [4 x i8], ptr %a, i64 %0, !dbg !23
-// CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call = load i32, ptr %.loc19_11.array.index, align 4, !dbg !23
+// CHECK:STDOUT:   %.loc16_11.array.index = getelementptr inbounds nuw [4 x i8], ptr %a, i64 %0, !dbg !23
+// CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call = load i32, ptr %.loc16_11.array.index, align 4, !dbg !23
 // CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call1 = shl i32 %Int.as.MulAssignWith.impl.Op.call, 1, !dbg !23
-// CHECK:STDOUT:   store i32 %Int.as.MulAssignWith.impl.Op.call1, ptr %.loc19_11.array.index, align 4, !dbg !23
+// CHECK:STDOUT:   store i32 %Int.as.MulAssignWith.impl.Op.call1, ptr %.loc16_11.array.index, align 4, !dbg !23
 // CHECK:STDOUT:   %1 = add nuw nsw i32 %n.var.03, 1, !dbg !24
 // CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.call = icmp samesign ult i32 %n.var.03, 65535, !dbg !39
 // CHECK:STDOUT:   br i1 %Int.as.OrderedWith.impl.Less.call, label %while.body, label %while.done, !dbg !22
@@ -81,7 +78,7 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: ; uselistorder directives
 // CHECK:STDOUT:   uselistorder label %while.body, { 1, 0 }
 // CHECK:STDOUT:   uselistorder i32 %n.var.03, { 0, 2, 1 }
-// CHECK:STDOUT:   uselistorder ptr %.loc19_11.array.index, { 1, 0 }
+// CHECK:STDOUT:   uselistorder ptr %.loc16_11.array.index, { 1, 0 }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
@@ -100,26 +97,26 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "foo.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 6, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 3, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !8 = !DILocation(line: 7, column: 10, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 7, column: 19, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 7, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 10, type: !5, spFlags: DISPFlagDefinition, unit: !0)
-// CHECK:STDOUT: !12 = !DILocation(line: 7, column: 10, scope: !4, inlinedAt: !13)
-// CHECK:STDOUT: !13 = distinct !DILocation(line: 12, column: 10, scope: !11)
-// CHECK:STDOUT: !14 = !DILocation(line: 7, column: 19, scope: !4, inlinedAt: !13)
-// CHECK:STDOUT: !15 = !DILocation(line: 12, column: 3, scope: !11)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 15, type: !17, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+// CHECK:STDOUT: !8 = !DILocation(line: 4, column: 10, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 4, column: 19, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 4, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 7, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !12 = !DILocation(line: 4, column: 10, scope: !4, inlinedAt: !13)
+// CHECK:STDOUT: !13 = distinct !DILocation(line: 9, column: 10, scope: !11)
+// CHECK:STDOUT: !14 = !DILocation(line: 4, column: 19, scope: !4, inlinedAt: !13)
+// CHECK:STDOUT: !15 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 12, type: !17, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
 // CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
 // CHECK:STDOUT: !18 = !{null, !19}
 // CHECK:STDOUT: !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !20 = !{!21}
 // CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !16, type: !19)
-// CHECK:STDOUT: !22 = !DILocation(line: 18, column: 9, scope: !16)
-// CHECK:STDOUT: !23 = !DILocation(line: 19, column: 5, scope: !16)
+// CHECK:STDOUT: !22 = !DILocation(line: 15, column: 9, scope: !16)
+// CHECK:STDOUT: !23 = !DILocation(line: 16, column: 5, scope: !16)
 // CHECK:STDOUT: !24 = !DILocation(line: 331, column: 3, scope: !25, inlinedAt: !32)
 // CHECK:STDOUT: !25 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:AddAssignWith.6f9e8c1abf8bb3ea.Core:Int.9452f4c51951679b.Core:AddAssignWith.bcc2a64c00f3554f.Core.224cb1ed5cb3f064", scope: null, file: !26, line: 331, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !29)
 // CHECK:STDOUT: !26 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
@@ -134,11 +131,11 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !35 = !{null, !7}
 // CHECK:STDOUT: !36 = !{!37}
 // CHECK:STDOUT: !37 = !DILocalVariable(arg: 1, scope: !33, type: !7)
-// CHECK:STDOUT: !38 = distinct !DILocation(line: 20, column: 5, scope: !16)
-// CHECK:STDOUT: !39 = !DILocation(line: 18, column: 10, scope: !16)
-// CHECK:STDOUT: !40 = !DILocation(line: 15, column: 1, scope: !16)
-// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 17, type: !34, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
+// CHECK:STDOUT: !38 = distinct !DILocation(line: 17, column: 5, scope: !16)
+// CHECK:STDOUT: !39 = !DILocation(line: 15, column: 10, scope: !16)
+// CHECK:STDOUT: !40 = !DILocation(line: 12, column: 1, scope: !16)
+// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 14, type: !34, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !41, type: !7)
-// CHECK:STDOUT: !44 = !DILocation(line: 17, column: 3, scope: !41)
+// CHECK:STDOUT: !44 = !DILocation(line: 14, column: 3, scope: !41)
 // CHECK:STDOUT:

--- a/toolchain/driver/testdata/compile/optimize/optimize_default.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_default.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// ARGS: compile foo.carbon --target=x86_64-unknown-linux-gnu --phase=optimize --dump-llvm-ir --exclude-dump-file-prefix=%{core} --include-carbon-core
+// ARGS: compile foo.carbon --target=x86_64-unknown-linux-gnu --phase=optimize --dump-llvm-ir --exclude-dump-file-prefix=%{core}
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -11,9 +11,6 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/compile/optimize/optimize_default.carbon
 
 // --- foo.carbon
-
-import Core library "range";
-
 fn Rand() -> i32;
 
 fn NoInlineWithOz() -> i32 {
@@ -44,18 +41,18 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CNoInlineWithOz.Main() local_unnamed_addr #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Rand.call.loc7_15 = tail call i32 @_CRand.Main() #0, !dbg !8
-// CHECK:STDOUT:   %Rand.call.loc7_24 = tail call i32 @_CRand.Main() #0, !dbg !9
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc7_24, %Rand.call.loc7_15, !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_15 = tail call i32 @_CRand.Main() #0, !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_24 = tail call i32 @_CRand.Main() #0, !dbg !9
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc4_24, %Rand.call.loc4_15, !dbg !8
 // CHECK:STDOUT:   ret i32 %Int.as.AddWith.impl.Op.call, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CCallNoInlineWithOptSize.Main() local_unnamed_addr #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Rand.call.loc7_15.i = tail call i32 @_CRand.Main() #0, !dbg !12
-// CHECK:STDOUT:   %Rand.call.loc7_24.i = tail call i32 @_CRand.Main() #0, !dbg !14
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call.i = add i32 %Rand.call.loc7_24.i, %Rand.call.loc7_15.i, !dbg !12
+// CHECK:STDOUT:   %Rand.call.loc4_15.i = tail call i32 @_CRand.Main() #0, !dbg !12
+// CHECK:STDOUT:   %Rand.call.loc4_24.i = tail call i32 @_CRand.Main() #0, !dbg !14
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call.i = add i32 %Rand.call.loc4_24.i, %Rand.call.loc4_15.i, !dbg !12
 // CHECK:STDOUT:   ret i32 %Int.as.AddWith.impl.Op.call.i, !dbg !15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -67,10 +64,10 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: while.body:                                       ; preds = %entry, %while.body
 // CHECK:STDOUT:   %n.var.03 = phi i32 [ 0, %entry ], [ %1, %while.body ]
 // CHECK:STDOUT:   %0 = zext nneg i32 %n.var.03 to i64, !dbg !23
-// CHECK:STDOUT:   %.loc19_11.array.index = getelementptr inbounds nuw [4 x i8], ptr %a, i64 %0, !dbg !23
-// CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call = load i32, ptr %.loc19_11.array.index, align 4, !dbg !23
+// CHECK:STDOUT:   %.loc16_11.array.index = getelementptr inbounds nuw [4 x i8], ptr %a, i64 %0, !dbg !23
+// CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call = load i32, ptr %.loc16_11.array.index, align 4, !dbg !23
 // CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call1 = shl i32 %Int.as.MulAssignWith.impl.Op.call, 1, !dbg !23
-// CHECK:STDOUT:   store i32 %Int.as.MulAssignWith.impl.Op.call1, ptr %.loc19_11.array.index, align 4, !dbg !23
+// CHECK:STDOUT:   store i32 %Int.as.MulAssignWith.impl.Op.call1, ptr %.loc16_11.array.index, align 4, !dbg !23
 // CHECK:STDOUT:   %1 = add nuw nsw i32 %n.var.03, 1, !dbg !24
 // CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.call = icmp samesign ult i32 %n.var.03, 65535, !dbg !39
 // CHECK:STDOUT:   br i1 %Int.as.OrderedWith.impl.Less.call, label %while.body, label %while.done, !dbg !22
@@ -81,7 +78,7 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: ; uselistorder directives
 // CHECK:STDOUT:   uselistorder label %while.body, { 1, 0 }
 // CHECK:STDOUT:   uselistorder i32 %n.var.03, { 0, 2, 1 }
-// CHECK:STDOUT:   uselistorder ptr %.loc19_11.array.index, { 1, 0 }
+// CHECK:STDOUT:   uselistorder ptr %.loc16_11.array.index, { 1, 0 }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
@@ -100,26 +97,26 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "foo.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 6, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 3, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !8 = !DILocation(line: 7, column: 10, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 7, column: 19, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 7, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 10, type: !5, spFlags: DISPFlagDefinition, unit: !0)
-// CHECK:STDOUT: !12 = !DILocation(line: 7, column: 10, scope: !4, inlinedAt: !13)
-// CHECK:STDOUT: !13 = distinct !DILocation(line: 12, column: 10, scope: !11)
-// CHECK:STDOUT: !14 = !DILocation(line: 7, column: 19, scope: !4, inlinedAt: !13)
-// CHECK:STDOUT: !15 = !DILocation(line: 12, column: 3, scope: !11)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 15, type: !17, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+// CHECK:STDOUT: !8 = !DILocation(line: 4, column: 10, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 4, column: 19, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 4, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 7, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !12 = !DILocation(line: 4, column: 10, scope: !4, inlinedAt: !13)
+// CHECK:STDOUT: !13 = distinct !DILocation(line: 9, column: 10, scope: !11)
+// CHECK:STDOUT: !14 = !DILocation(line: 4, column: 19, scope: !4, inlinedAt: !13)
+// CHECK:STDOUT: !15 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 12, type: !17, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
 // CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
 // CHECK:STDOUT: !18 = !{null, !19}
 // CHECK:STDOUT: !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !20 = !{!21}
 // CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !16, type: !19)
-// CHECK:STDOUT: !22 = !DILocation(line: 18, column: 9, scope: !16)
-// CHECK:STDOUT: !23 = !DILocation(line: 19, column: 5, scope: !16)
+// CHECK:STDOUT: !22 = !DILocation(line: 15, column: 9, scope: !16)
+// CHECK:STDOUT: !23 = !DILocation(line: 16, column: 5, scope: !16)
 // CHECK:STDOUT: !24 = !DILocation(line: 331, column: 3, scope: !25, inlinedAt: !32)
 // CHECK:STDOUT: !25 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:AddAssignWith.6f9e8c1abf8bb3ea.Core:Int.9452f4c51951679b.Core:AddAssignWith.bcc2a64c00f3554f.Core.224cb1ed5cb3f064", scope: null, file: !26, line: 331, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !29)
 // CHECK:STDOUT: !26 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
@@ -134,11 +131,11 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !35 = !{null, !7}
 // CHECK:STDOUT: !36 = !{!37}
 // CHECK:STDOUT: !37 = !DILocalVariable(arg: 1, scope: !33, type: !7)
-// CHECK:STDOUT: !38 = distinct !DILocation(line: 20, column: 5, scope: !16)
-// CHECK:STDOUT: !39 = !DILocation(line: 18, column: 10, scope: !16)
-// CHECK:STDOUT: !40 = !DILocation(line: 15, column: 1, scope: !16)
-// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 17, type: !34, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
+// CHECK:STDOUT: !38 = distinct !DILocation(line: 17, column: 5, scope: !16)
+// CHECK:STDOUT: !39 = !DILocation(line: 15, column: 10, scope: !16)
+// CHECK:STDOUT: !40 = !DILocation(line: 12, column: 1, scope: !16)
+// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 14, type: !34, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !41, type: !7)
-// CHECK:STDOUT: !44 = !DILocation(line: 17, column: 3, scope: !41)
+// CHECK:STDOUT: !44 = !DILocation(line: 14, column: 3, scope: !41)
 // CHECK:STDOUT:

--- a/toolchain/driver/testdata/compile/optimize/optimize_none.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_none.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// ARGS: compile --optimize=none foo.carbon --target=x86_64-unknown-linux-gnu --phase=optimize --dump-llvm-ir --exclude-dump-file-prefix=%{core} --include-carbon-core
+// ARGS: compile --optimize=none foo.carbon --target=x86_64-unknown-linux-gnu --phase=optimize --dump-llvm-ir --exclude-dump-file-prefix=%{core}
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -11,9 +11,6 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/compile/optimize/optimize_none.carbon
 
 // --- foo.carbon
-
-import Core library "range";
-
 fn Rand() -> i32;
 
 fn NoInlineWithOz() -> i32 {
@@ -44,9 +41,9 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: ; Function Attrs: noinline nounwind optnone
 // CHECK:STDOUT: define i32 @_CNoInlineWithOz.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Rand.call.loc7_15 = call i32 @_CRand.Main(), !dbg !8
-// CHECK:STDOUT:   %Rand.call.loc7_24 = call i32 @_CRand.Main(), !dbg !9
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc7_15, %Rand.call.loc7_24, !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_15 = call i32 @_CRand.Main(), !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_24 = call i32 @_CRand.Main(), !dbg !9
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc4_15, %Rand.call.loc4_24, !dbg !8
 // CHECK:STDOUT:   ret i32 %Int.as.AddWith.impl.Op.call, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -66,16 +63,16 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT:   br label %while.cond, !dbg !21
 // CHECK:STDOUT:
 // CHECK:STDOUT: while.cond:                                       ; preds = %while.body, %entry
-// CHECK:STDOUT:   %.loc18_10 = load i32, ptr %n.var, align 4, !dbg !22
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.call = icmp slt i32 %.loc18_10, 65536, !dbg !22
+// CHECK:STDOUT:   %.loc15_10 = load i32, ptr %n.var, align 4, !dbg !22
+// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.call = icmp slt i32 %.loc15_10, 65536, !dbg !22
 // CHECK:STDOUT:   br i1 %Int.as.OrderedWith.impl.Less.call, label %while.body, label %while.done, !dbg !21
 // CHECK:STDOUT:
 // CHECK:STDOUT: while.body:                                       ; preds = %while.cond
-// CHECK:STDOUT:   %.loc19_10 = load i32, ptr %n.var, align 4, !dbg !23
-// CHECK:STDOUT:   %.loc19_11.array.index = getelementptr inbounds [65536 x i32], ptr %a, i32 0, i32 %.loc19_10, !dbg !24
-// CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call = load i32, ptr %.loc19_11.array.index, align 4, !dbg !24
+// CHECK:STDOUT:   %.loc16_10 = load i32, ptr %n.var, align 4, !dbg !23
+// CHECK:STDOUT:   %.loc16_11.array.index = getelementptr inbounds [65536 x i32], ptr %a, i32 0, i32 %.loc16_10, !dbg !24
+// CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call = load i32, ptr %.loc16_11.array.index, align 4, !dbg !24
 // CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call1 = mul i32 %Int.as.MulAssignWith.impl.Op.call, 2, !dbg !24
-// CHECK:STDOUT:   store i32 %Int.as.MulAssignWith.impl.Op.call1, ptr %.loc19_11.array.index, align 4, !dbg !24
+// CHECK:STDOUT:   store i32 %Int.as.MulAssignWith.impl.Op.call1, ptr %.loc16_11.array.index, align 4, !dbg !24
 // CHECK:STDOUT:   call void @"_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8"(ptr %n.var), !dbg !25
 // CHECK:STDOUT:   br label %while.cond, !dbg !26
 // CHECK:STDOUT:
@@ -129,36 +126,36 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "foo.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 6, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 3, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !8 = !DILocation(line: 7, column: 10, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 7, column: 19, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 7, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 10, type: !5, spFlags: DISPFlagDefinition, unit: !0)
-// CHECK:STDOUT: !12 = !DILocation(line: 12, column: 10, scope: !11)
-// CHECK:STDOUT: !13 = !DILocation(line: 12, column: 3, scope: !11)
-// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 15, type: !15, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !18)
+// CHECK:STDOUT: !8 = !DILocation(line: 4, column: 10, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 4, column: 19, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 4, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 7, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !12 = !DILocation(line: 9, column: 10, scope: !11)
+// CHECK:STDOUT: !13 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 12, type: !15, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !18)
 // CHECK:STDOUT: !15 = !DISubroutineType(types: !16)
 // CHECK:STDOUT: !16 = !{null, !17}
 // CHECK:STDOUT: !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !18 = !{!19}
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !14, type: !17)
-// CHECK:STDOUT: !20 = !DILocation(line: 17, column: 3, scope: !14)
-// CHECK:STDOUT: !21 = !DILocation(line: 18, column: 9, scope: !14)
-// CHECK:STDOUT: !22 = !DILocation(line: 18, column: 10, scope: !14)
-// CHECK:STDOUT: !23 = !DILocation(line: 19, column: 10, scope: !14)
-// CHECK:STDOUT: !24 = !DILocation(line: 19, column: 5, scope: !14)
-// CHECK:STDOUT: !25 = !DILocation(line: 20, column: 5, scope: !14)
-// CHECK:STDOUT: !26 = !DILocation(line: 18, column: 3, scope: !14)
-// CHECK:STDOUT: !27 = !DILocation(line: 15, column: 1, scope: !14)
-// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 17, type: !29, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !31)
+// CHECK:STDOUT: !20 = !DILocation(line: 14, column: 3, scope: !14)
+// CHECK:STDOUT: !21 = !DILocation(line: 15, column: 9, scope: !14)
+// CHECK:STDOUT: !22 = !DILocation(line: 15, column: 10, scope: !14)
+// CHECK:STDOUT: !23 = !DILocation(line: 16, column: 10, scope: !14)
+// CHECK:STDOUT: !24 = !DILocation(line: 16, column: 5, scope: !14)
+// CHECK:STDOUT: !25 = !DILocation(line: 17, column: 5, scope: !14)
+// CHECK:STDOUT: !26 = !DILocation(line: 15, column: 3, scope: !14)
+// CHECK:STDOUT: !27 = !DILocation(line: 12, column: 1, scope: !14)
+// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 14, type: !29, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !31)
 // CHECK:STDOUT: !29 = !DISubroutineType(types: !30)
 // CHECK:STDOUT: !30 = !{null, !7}
 // CHECK:STDOUT: !31 = !{!32}
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !28, type: !7)
-// CHECK:STDOUT: !33 = !DILocation(line: 17, column: 3, scope: !28)
+// CHECK:STDOUT: !33 = !DILocation(line: 14, column: 3, scope: !28)
 // CHECK:STDOUT: !34 = distinct !DISubprogram(name: "Op", linkageName: "_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8", scope: null, file: !35, line: 396, type: !29, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !36)
 // CHECK:STDOUT: !35 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
 // CHECK:STDOUT: !36 = !{!37}

--- a/toolchain/driver/testdata/compile/optimize/optimize_size.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_size.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// ARGS: compile --optimize=size foo.carbon --target=x86_64-unknown-linux-gnu --phase=lower --dump-llvm-ir --exclude-dump-file-prefix=%{core} --include-carbon-core
+// ARGS: compile --optimize=size foo.carbon --target=x86_64-unknown-linux-gnu --phase=lower --dump-llvm-ir --exclude-dump-file-prefix=%{core}
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -11,9 +11,6 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/compile/optimize/optimize_size.carbon
 
 // --- foo.carbon
-
-import Core library "range";
-
 fn Rand() -> i32;
 
 fn NoInlineWithOz() -> i32 {
@@ -43,9 +40,9 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: ; Function Attrs: minsize nounwind optsize
 // CHECK:STDOUT: define i32 @_CNoInlineWithOz.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Rand.call.loc7_15 = call i32 @_CRand.Main(), !dbg !8
-// CHECK:STDOUT:   %Rand.call.loc7_24 = call i32 @_CRand.Main(), !dbg !9
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc7_15, %Rand.call.loc7_24, !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_15 = call i32 @_CRand.Main(), !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_24 = call i32 @_CRand.Main(), !dbg !9
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc4_15, %Rand.call.loc4_24, !dbg !8
 // CHECK:STDOUT:   ret i32 %Int.as.AddWith.impl.Op.call, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -65,16 +62,16 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT:   br label %while.cond, !dbg !21
 // CHECK:STDOUT:
 // CHECK:STDOUT: while.cond:                                       ; preds = %while.body, %entry
-// CHECK:STDOUT:   %.loc18_10 = load i32, ptr %n.var, align 4, !dbg !22
-// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.call = icmp slt i32 %.loc18_10, 65536, !dbg !22
+// CHECK:STDOUT:   %.loc15_10 = load i32, ptr %n.var, align 4, !dbg !22
+// CHECK:STDOUT:   %Int.as.OrderedWith.impl.Less.call = icmp slt i32 %.loc15_10, 65536, !dbg !22
 // CHECK:STDOUT:   br i1 %Int.as.OrderedWith.impl.Less.call, label %while.body, label %while.done, !dbg !21
 // CHECK:STDOUT:
 // CHECK:STDOUT: while.body:                                       ; preds = %while.cond
-// CHECK:STDOUT:   %.loc19_10 = load i32, ptr %n.var, align 4, !dbg !23
-// CHECK:STDOUT:   %.loc19_11.array.index = getelementptr inbounds [65536 x i32], ptr %a, i32 0, i32 %.loc19_10, !dbg !24
-// CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call = load i32, ptr %.loc19_11.array.index, align 4, !dbg !24
+// CHECK:STDOUT:   %.loc16_10 = load i32, ptr %n.var, align 4, !dbg !23
+// CHECK:STDOUT:   %.loc16_11.array.index = getelementptr inbounds [65536 x i32], ptr %a, i32 0, i32 %.loc16_10, !dbg !24
+// CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call = load i32, ptr %.loc16_11.array.index, align 4, !dbg !24
 // CHECK:STDOUT:   %Int.as.MulAssignWith.impl.Op.call1 = mul i32 %Int.as.MulAssignWith.impl.Op.call, 2, !dbg !24
-// CHECK:STDOUT:   store i32 %Int.as.MulAssignWith.impl.Op.call1, ptr %.loc19_11.array.index, align 4, !dbg !24
+// CHECK:STDOUT:   store i32 %Int.as.MulAssignWith.impl.Op.call1, ptr %.loc16_11.array.index, align 4, !dbg !24
 // CHECK:STDOUT:   call void @"_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8"(ptr %n.var), !dbg !25
 // CHECK:STDOUT:   br label %while.cond, !dbg !26
 // CHECK:STDOUT:
@@ -129,36 +126,36 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "foo.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 6, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 3, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !8 = !DILocation(line: 7, column: 10, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 7, column: 19, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 7, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 10, type: !5, spFlags: DISPFlagDefinition, unit: !0)
-// CHECK:STDOUT: !12 = !DILocation(line: 12, column: 10, scope: !11)
-// CHECK:STDOUT: !13 = !DILocation(line: 12, column: 3, scope: !11)
-// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 15, type: !15, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !18)
+// CHECK:STDOUT: !8 = !DILocation(line: 4, column: 10, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 4, column: 19, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 4, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 7, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !12 = !DILocation(line: 9, column: 10, scope: !11)
+// CHECK:STDOUT: !13 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 12, type: !15, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !18)
 // CHECK:STDOUT: !15 = !DISubroutineType(types: !16)
 // CHECK:STDOUT: !16 = !{null, !17}
 // CHECK:STDOUT: !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !18 = !{!19}
 // CHECK:STDOUT: !19 = !DILocalVariable(arg: 1, scope: !14, type: !17)
-// CHECK:STDOUT: !20 = !DILocation(line: 17, column: 3, scope: !14)
-// CHECK:STDOUT: !21 = !DILocation(line: 18, column: 9, scope: !14)
-// CHECK:STDOUT: !22 = !DILocation(line: 18, column: 10, scope: !14)
-// CHECK:STDOUT: !23 = !DILocation(line: 19, column: 10, scope: !14)
-// CHECK:STDOUT: !24 = !DILocation(line: 19, column: 5, scope: !14)
-// CHECK:STDOUT: !25 = !DILocation(line: 20, column: 5, scope: !14)
-// CHECK:STDOUT: !26 = !DILocation(line: 18, column: 3, scope: !14)
-// CHECK:STDOUT: !27 = !DILocation(line: 15, column: 1, scope: !14)
-// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 17, type: !29, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !31)
+// CHECK:STDOUT: !20 = !DILocation(line: 14, column: 3, scope: !14)
+// CHECK:STDOUT: !21 = !DILocation(line: 15, column: 9, scope: !14)
+// CHECK:STDOUT: !22 = !DILocation(line: 15, column: 10, scope: !14)
+// CHECK:STDOUT: !23 = !DILocation(line: 16, column: 10, scope: !14)
+// CHECK:STDOUT: !24 = !DILocation(line: 16, column: 5, scope: !14)
+// CHECK:STDOUT: !25 = !DILocation(line: 17, column: 5, scope: !14)
+// CHECK:STDOUT: !26 = !DILocation(line: 15, column: 3, scope: !14)
+// CHECK:STDOUT: !27 = !DILocation(line: 12, column: 1, scope: !14)
+// CHECK:STDOUT: !28 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 14, type: !29, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !31)
 // CHECK:STDOUT: !29 = !DISubroutineType(types: !30)
 // CHECK:STDOUT: !30 = !{null, !7}
 // CHECK:STDOUT: !31 = !{!32}
 // CHECK:STDOUT: !32 = !DILocalVariable(arg: 1, scope: !28, type: !7)
-// CHECK:STDOUT: !33 = !DILocation(line: 17, column: 3, scope: !28)
+// CHECK:STDOUT: !33 = !DILocation(line: 14, column: 3, scope: !28)
 // CHECK:STDOUT: !34 = distinct !DISubprogram(name: "Op", linkageName: "_COp.Int.9452f4c51951679b.Core:Inc.Core.be1e879c1ad406d8", scope: null, file: !35, line: 396, type: !29, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !36)
 // CHECK:STDOUT: !35 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
 // CHECK:STDOUT: !36 = !{!37}

--- a/toolchain/driver/testdata/compile/optimize/optimize_speed.carbon
+++ b/toolchain/driver/testdata/compile/optimize/optimize_speed.carbon
@@ -2,7 +2,7 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// ARGS: compile --optimize=speed foo.carbon --target=x86_64-unknown-linux-gnu --phase=optimize --dump-llvm-ir --exclude-dump-file-prefix=%{core} --include-carbon-core
+// ARGS: compile --optimize=speed foo.carbon --target=x86_64-unknown-linux-gnu --phase=optimize --dump-llvm-ir --exclude-dump-file-prefix=%{core}
 //
 // AUTOUPDATE
 // TIP: To test this file alone, run:
@@ -11,9 +11,6 @@
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/driver/testdata/compile/optimize/optimize_speed.carbon
 
 // --- foo.carbon
-
-import Core library "range";
-
 fn Rand() -> i32;
 
 fn NoInlineWithOz() -> i32 {
@@ -44,18 +41,18 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CNoInlineWithOz.Main() local_unnamed_addr #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Rand.call.loc7_15 = tail call i32 @_CRand.Main() #0, !dbg !8
-// CHECK:STDOUT:   %Rand.call.loc7_24 = tail call i32 @_CRand.Main() #0, !dbg !9
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc7_24, %Rand.call.loc7_15, !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_15 = tail call i32 @_CRand.Main() #0, !dbg !8
+// CHECK:STDOUT:   %Rand.call.loc4_24 = tail call i32 @_CRand.Main() #0, !dbg !9
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call = add i32 %Rand.call.loc4_24, %Rand.call.loc4_15, !dbg !8
 // CHECK:STDOUT:   ret i32 %Int.as.AddWith.impl.Op.call, !dbg !10
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define i32 @_CCallNoInlineWithOptSize.Main() local_unnamed_addr #0 !dbg !11 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %Rand.call.loc7_15.i = tail call i32 @_CRand.Main() #0, !dbg !12
-// CHECK:STDOUT:   %Rand.call.loc7_24.i = tail call i32 @_CRand.Main() #0, !dbg !14
-// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call.i = add i32 %Rand.call.loc7_24.i, %Rand.call.loc7_15.i, !dbg !12
+// CHECK:STDOUT:   %Rand.call.loc4_15.i = tail call i32 @_CRand.Main() #0, !dbg !12
+// CHECK:STDOUT:   %Rand.call.loc4_24.i = tail call i32 @_CRand.Main() #0, !dbg !14
+// CHECK:STDOUT:   %Int.as.AddWith.impl.Op.call.i = add i32 %Rand.call.loc4_24.i, %Rand.call.loc4_15.i, !dbg !12
 // CHECK:STDOUT:   ret i32 %Int.as.AddWith.impl.Op.call.i, !dbg !15
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -116,25 +113,25 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !1 = !DIFile(filename: "foo.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 6, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "NoInlineWithOz", linkageName: "_CNoInlineWithOz.Main", scope: null, file: !1, line: 3, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{!7}
 // CHECK:STDOUT: !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-// CHECK:STDOUT: !8 = !DILocation(line: 7, column: 10, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 7, column: 19, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 7, column: 3, scope: !4)
-// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 10, type: !5, spFlags: DISPFlagDefinition, unit: !0)
-// CHECK:STDOUT: !12 = !DILocation(line: 7, column: 10, scope: !4, inlinedAt: !13)
-// CHECK:STDOUT: !13 = distinct !DILocation(line: 12, column: 10, scope: !11)
-// CHECK:STDOUT: !14 = !DILocation(line: 7, column: 19, scope: !4, inlinedAt: !13)
-// CHECK:STDOUT: !15 = !DILocation(line: 12, column: 3, scope: !11)
-// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 15, type: !17, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+// CHECK:STDOUT: !8 = !DILocation(line: 4, column: 10, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 4, column: 19, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 4, column: 3, scope: !4)
+// CHECK:STDOUT: !11 = distinct !DISubprogram(name: "CallNoInlineWithOptSize", linkageName: "_CCallNoInlineWithOptSize.Main", scope: null, file: !1, line: 7, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !12 = !DILocation(line: 4, column: 10, scope: !4, inlinedAt: !13)
+// CHECK:STDOUT: !13 = distinct !DILocation(line: 9, column: 10, scope: !11)
+// CHECK:STDOUT: !14 = !DILocation(line: 4, column: 19, scope: !4, inlinedAt: !13)
+// CHECK:STDOUT: !15 = !DILocation(line: 9, column: 3, scope: !11)
+// CHECK:STDOUT: !16 = distinct !DISubprogram(name: "VectorizedWithOptSpeed", linkageName: "_CVectorizedWithOptSpeed.Main", scope: null, file: !1, line: 12, type: !17, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
 // CHECK:STDOUT: !17 = !DISubroutineType(types: !18)
 // CHECK:STDOUT: !18 = !{null, !19}
 // CHECK:STDOUT: !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !20 = !{!21}
 // CHECK:STDOUT: !21 = !DILocalVariable(arg: 1, scope: !16, type: !19)
-// CHECK:STDOUT: !22 = !DILocation(line: 18, column: 9, scope: !16)
+// CHECK:STDOUT: !22 = !DILocation(line: 15, column: 9, scope: !16)
 // CHECK:STDOUT: !23 = !DILocation(line: 331, column: 3, scope: !24, inlinedAt: !31)
 // CHECK:STDOUT: !24 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:AddAssignWith.6f9e8c1abf8bb3ea.Core:Int.9452f4c51951679b.Core:AddAssignWith.bcc2a64c00f3554f.Core.224cb1ed5cb3f064", scope: null, file: !25, line: 331, type: !26, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !28)
 // CHECK:STDOUT: !25 = !DIFile(filename: "{{.*}}/prelude/types/int.carbon", directory: "")
@@ -149,14 +146,14 @@ fn VectorizedWithOptSpeed(a: array(i32, 65536)*) {
 // CHECK:STDOUT: !34 = !{null, !7}
 // CHECK:STDOUT: !35 = !{!36}
 // CHECK:STDOUT: !36 = !DILocalVariable(arg: 1, scope: !32, type: !7)
-// CHECK:STDOUT: !37 = distinct !DILocation(line: 20, column: 5, scope: !16)
-// CHECK:STDOUT: !38 = !DILocation(line: 19, column: 5, scope: !16)
+// CHECK:STDOUT: !37 = distinct !DILocation(line: 17, column: 5, scope: !16)
+// CHECK:STDOUT: !38 = !DILocation(line: 16, column: 5, scope: !16)
 // CHECK:STDOUT: !39 = distinct !{!39, !40, !41}
 // CHECK:STDOUT: !40 = !{!"llvm.loop.isvectorized", i32 1}
 // CHECK:STDOUT: !41 = !{!"llvm.loop.unroll.runtime.disable"}
-// CHECK:STDOUT: !42 = !DILocation(line: 15, column: 1, scope: !16)
-// CHECK:STDOUT: !43 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 17, type: !33, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !44)
+// CHECK:STDOUT: !42 = !DILocation(line: 12, column: 1, scope: !16)
+// CHECK:STDOUT: !43 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !1, line: 14, type: !33, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !44)
 // CHECK:STDOUT: !44 = !{!45}
 // CHECK:STDOUT: !45 = !DILocalVariable(arg: 1, scope: !43, type: !7)
-// CHECK:STDOUT: !46 = !DILocation(line: 17, column: 3, scope: !43)
+// CHECK:STDOUT: !46 = !DILocation(line: 14, column: 3, scope: !43)
 // CHECK:STDOUT:

--- a/toolchain/lower/testdata/for/break_continue.carbon
+++ b/toolchain/lower/testdata/for/break_continue.carbon
@@ -2,7 +2,6 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --include-carbon-core
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/full.carbon
 //
 // AUTOUPDATE
@@ -10,8 +9,6 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/for/break_continue.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/for/break_continue.carbon
-
-import Core library "range";
 
 fn F() -> bool;
 fn G() -> bool;
@@ -38,53 +35,53 @@ fn For() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CFor.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc21_32.1.temp = alloca { i32, i32 }, align 4, !dbg !7
+// CHECK:STDOUT:   %.loc18_32.1.temp = alloca { i32, i32 }, align 4, !dbg !7
 // CHECK:STDOUT:   %var = alloca i32, align 4, !dbg !8
-// CHECK:STDOUT:   %.loc21_33.1.temp = alloca <{ i32, i1 }>, align 4, !dbg !8
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc21_32.1.temp), !dbg !7
-// CHECK:STDOUT:   call void @_CRange.Core(ptr %.loc21_32.1.temp, i32 100), !dbg !7
-// CHECK:STDOUT:   %IntRange.as.Iterate.impl.NewCursor.call = call i32 @"_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc21_32.1.temp), !dbg !8
+// CHECK:STDOUT:   %.loc18_33.1.temp = alloca <{ i32, i1 }>, align 4, !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_32.1.temp), !dbg !7
+// CHECK:STDOUT:   call void @_CRange.Core(ptr %.loc18_32.1.temp, i32 100), !dbg !7
+// CHECK:STDOUT:   %IntRange.as.Iterate.impl.NewCursor.call = call i32 @"_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc18_32.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %var), !dbg !8
 // CHECK:STDOUT:   store i32 %IntRange.as.Iterate.impl.NewCursor.call, ptr %var, align 4, !dbg !8
 // CHECK:STDOUT:   br label %for.next, !dbg !8
 // CHECK:STDOUT:
-// CHECK:STDOUT: for.next:                                         ; preds = %if.else.loc23, %if.then.loc23, %entry
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc21_33.1.temp), !dbg !8
-// CHECK:STDOUT:   call void @"_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc21_33.1.temp, ptr %.loc21_32.1.temp, ptr %var), !dbg !8
-// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.329ac87584bc77f7(ptr %.loc21_33.1.temp), !dbg !8
+// CHECK:STDOUT: for.next:                                         ; preds = %if.else.loc20, %if.then.loc20, %entry
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc18_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc18_33.1.temp, ptr %.loc18_32.1.temp, ptr %var), !dbg !8
+// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.329ac87584bc77f7(ptr %.loc18_33.1.temp), !dbg !8
 // CHECK:STDOUT:   br i1 %Optional.HasValue.call, label %for.body, label %for.done, !dbg !8
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.body:                                         ; preds = %for.next
-// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.329ac87584bc77f7(ptr %.loc21_33.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.329ac87584bc77f7(ptr %.loc18_33.1.temp), !dbg !8
 // CHECK:STDOUT:   %F.call = call i1 @_CF.Main(), !dbg !9
-// CHECK:STDOUT:   br i1 %F.call, label %if.then.loc22, label %if.else.loc22, !dbg !10
+// CHECK:STDOUT:   br i1 %F.call, label %if.then.loc19, label %if.else.loc19, !dbg !10
 // CHECK:STDOUT:
-// CHECK:STDOUT: if.then.loc22:                                    ; preds = %for.body
+// CHECK:STDOUT: if.then.loc19:                                    ; preds = %for.body
 // CHECK:STDOUT:   br label %for.done, !dbg !11
 // CHECK:STDOUT:
-// CHECK:STDOUT: if.else.loc22:                                    ; preds = %for.body
+// CHECK:STDOUT: if.else.loc19:                                    ; preds = %for.body
 // CHECK:STDOUT:   %G.call = call i1 @_CG.Main(), !dbg !12
-// CHECK:STDOUT:   br i1 %G.call, label %if.then.loc23, label %if.else.loc23, !dbg !13
+// CHECK:STDOUT:   br i1 %G.call, label %if.then.loc20, label %if.else.loc20, !dbg !13
 // CHECK:STDOUT:
-// CHECK:STDOUT: if.then.loc23:                                    ; preds = %if.else.loc22
-// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc21_33.1.temp), !dbg !8
+// CHECK:STDOUT: if.then.loc20:                                    ; preds = %if.else.loc19
+// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc18_33.1.temp), !dbg !8
 // CHECK:STDOUT:   br label %for.next, !dbg !14
 // CHECK:STDOUT:
-// CHECK:STDOUT: if.else.loc23:                                    ; preds = %if.else.loc22
+// CHECK:STDOUT: if.else.loc20:                                    ; preds = %if.else.loc19
 // CHECK:STDOUT:   call void @_CH.Main(), !dbg !15
-// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc21_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc18_33.1.temp), !dbg !8
 // CHECK:STDOUT:   br label %for.next, !dbg !16
 // CHECK:STDOUT:
-// CHECK:STDOUT: for.done:                                         ; preds = %if.then.loc22, %for.next
-// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc21_33.1.temp), !dbg !8
+// CHECK:STDOUT: for.done:                                         ; preds = %if.then.loc19, %for.next
+// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc18_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.5e27612b9dd31a14:core.Destroy.Core"(ptr %var), !dbg !8
-// CHECK:STDOUT:   call void @"_COp.0d5da2659ce22e5f:core.Destroy.Core"(ptr %.loc21_32.1.temp), !dbg !7
+// CHECK:STDOUT:   call void @"_COp.0d5da2659ce22e5f:core.Destroy.Core"(ptr %.loc18_32.1.temp), !dbg !7
 // CHECK:STDOUT:   ret void, !dbg !17
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_CRange.Core(ptr sret({ i32, i32 }), i32)
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @"_COp.5168ce3c64c7e43f:core.Destroy.Core"(ptr)
+// CHECK:STDOUT: declare void @"_COp.1155b488c23b5086:core.Destroy.Core"(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define weak_odr void @"_COp.5e27612b9dd31a14:core.Destroy.Core"(ptr %self) #0 !dbg !18 {
@@ -181,8 +178,6 @@ fn For() {
 // CHECK:STDOUT:   ret i32 %1, !dbg !93
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @"_COp.1155b488c23b5086:core.Destroy.Core"(ptr)
-// CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_CInclusiveRange.Core(ptr sret({ i32, i32 }), i32, i32)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
@@ -269,83 +264,83 @@ fn For() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "break_continue.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "For", linkageName: "_CFor.Main", scope: null, file: !1, line: 20, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "For", linkageName: "_CFor.Main", scope: null, file: !1, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 21, column: 18, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 21, column: 7, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 22, column: 9, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 22, column: 8, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 22, column: 16, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 23, column: 9, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 23, column: 8, scope: !4)
-// CHECK:STDOUT: !14 = !DILocation(line: 23, column: 16, scope: !4)
-// CHECK:STDOUT: !15 = !DILocation(line: 24, column: 5, scope: !4)
-// CHECK:STDOUT: !16 = !DILocation(line: 21, column: 3, scope: !4)
-// CHECK:STDOUT: !17 = !DILocation(line: 20, column: 1, scope: !4)
-// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !19, line: 15, type: !20, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !23)
-// CHECK:STDOUT: !19 = !DIFile(filename: "{{.*}}/range.carbon", directory: "")
+// CHECK:STDOUT: !7 = !DILocation(line: 18, column: 18, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 18, column: 7, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 19, column: 9, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 19, column: 8, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 19, column: 16, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 20, column: 9, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 20, column: 8, scope: !4)
+// CHECK:STDOUT: !14 = !DILocation(line: 20, column: 16, scope: !4)
+// CHECK:STDOUT: !15 = !DILocation(line: 21, column: 5, scope: !4)
+// CHECK:STDOUT: !16 = !DILocation(line: 18, column: 3, scope: !4)
+// CHECK:STDOUT: !17 = !DILocation(line: 17, column: 1, scope: !4)
+// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !19, line: 18, type: !20, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !23)
+// CHECK:STDOUT: !19 = !DIFile(filename: "{{.*}}/prelude/range.carbon", directory: "")
 // CHECK:STDOUT: !20 = !DISubroutineType(types: !21)
 // CHECK:STDOUT: !21 = !{null, !22}
 // CHECK:STDOUT: !22 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !23 = !{!24}
 // CHECK:STDOUT: !24 = !DILocalVariable(arg: 1, scope: !18, type: !22)
-// CHECK:STDOUT: !25 = !DILocation(line: 15, column: 39, scope: !18)
-// CHECK:STDOUT: !26 = distinct !DISubprogram(name: "Op", linkageName: "_COp.94ba1c30d421702e:core.Destroy.Core", scope: null, file: !1, line: 21, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !30)
+// CHECK:STDOUT: !25 = !DILocation(line: 18, column: 39, scope: !18)
+// CHECK:STDOUT: !26 = distinct !DISubprogram(name: "Op", linkageName: "_COp.94ba1c30d421702e:core.Destroy.Core", scope: null, file: !1, line: 18, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !30)
 // CHECK:STDOUT: !27 = !DISubroutineType(types: !28)
 // CHECK:STDOUT: !28 = !{null, !29}
 // CHECK:STDOUT: !29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !30 = !{!31}
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !26, type: !29)
-// CHECK:STDOUT: !32 = !DILocation(line: 21, column: 7, scope: !26)
-// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0fc9634857315db2:core.Destroy.Core", scope: null, file: !1, line: 21, type: !20, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !34)
+// CHECK:STDOUT: !32 = !DILocation(line: 18, column: 7, scope: !26)
+// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0fc9634857315db2:core.Destroy.Core", scope: null, file: !1, line: 18, type: !20, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !34)
 // CHECK:STDOUT: !34 = !{!35}
 // CHECK:STDOUT: !35 = !DILocalVariable(arg: 1, scope: !33, type: !22)
-// CHECK:STDOUT: !36 = !DILocation(line: 21, column: 7, scope: !33)
-// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "Op", linkageName: "_COp.69700c1fc1b2744c:core.Destroy.Core", scope: null, file: !1, line: 21, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !38)
+// CHECK:STDOUT: !36 = !DILocation(line: 18, column: 7, scope: !33)
+// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "Op", linkageName: "_COp.69700c1fc1b2744c:core.Destroy.Core", scope: null, file: !1, line: 18, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !38)
 // CHECK:STDOUT: !38 = !{!39}
 // CHECK:STDOUT: !39 = !DILocalVariable(arg: 1, scope: !37, type: !29)
-// CHECK:STDOUT: !40 = !DILocation(line: 21, column: 7, scope: !37)
-// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.278d9a31079e7ff2:core.Destroy.Core", scope: null, file: !1, line: 21, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
+// CHECK:STDOUT: !40 = !DILocation(line: 18, column: 7, scope: !37)
+// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.278d9a31079e7ff2:core.Destroy.Core", scope: null, file: !1, line: 18, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !41, type: !29)
-// CHECK:STDOUT: !44 = !DILocation(line: 21, column: 7, scope: !41)
-// CHECK:STDOUT: !45 = distinct !DISubprogram(name: "Op", linkageName: "_COp.f9d363db90f1ff8b:core.Destroy.Core", scope: null, file: !1, line: 21, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !46)
+// CHECK:STDOUT: !44 = !DILocation(line: 18, column: 7, scope: !41)
+// CHECK:STDOUT: !45 = distinct !DISubprogram(name: "Op", linkageName: "_COp.f9d363db90f1ff8b:core.Destroy.Core", scope: null, file: !1, line: 18, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !46)
 // CHECK:STDOUT: !46 = !{!47}
 // CHECK:STDOUT: !47 = !DILocalVariable(arg: 1, scope: !45, type: !29)
-// CHECK:STDOUT: !48 = !DILocation(line: 21, column: 7, scope: !45)
-// CHECK:STDOUT: !49 = distinct !DISubprogram(name: "Op", linkageName: "_COp.db43fa38232c28dd:core.Destroy.Core", scope: null, file: !1, line: 21, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !50)
+// CHECK:STDOUT: !48 = !DILocation(line: 18, column: 7, scope: !45)
+// CHECK:STDOUT: !49 = distinct !DISubprogram(name: "Op", linkageName: "_COp.db43fa38232c28dd:core.Destroy.Core", scope: null, file: !1, line: 18, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !50)
 // CHECK:STDOUT: !50 = !{!51}
 // CHECK:STDOUT: !51 = !DILocalVariable(arg: 1, scope: !49, type: !29)
-// CHECK:STDOUT: !52 = !DILocation(line: 21, column: 18, scope: !49)
-// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0d5da2659ce22e5f:core.Destroy.Core", scope: null, file: !1, line: 21, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !54)
+// CHECK:STDOUT: !52 = !DILocation(line: 18, column: 18, scope: !49)
+// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0d5da2659ce22e5f:core.Destroy.Core", scope: null, file: !1, line: 18, type: !27, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !54)
 // CHECK:STDOUT: !54 = !{!55}
 // CHECK:STDOUT: !55 = !DILocalVariable(arg: 1, scope: !53, type: !29)
-// CHECK:STDOUT: !56 = !DILocation(line: 21, column: 18, scope: !53)
-// CHECK:STDOUT: !57 = distinct !DISubprogram(name: "NewCursor", linkageName: "_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8", scope: null, file: !19, line: 16, type: !58, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !60)
+// CHECK:STDOUT: !56 = !DILocation(line: 18, column: 18, scope: !53)
+// CHECK:STDOUT: !57 = distinct !DISubprogram(name: "NewCursor", linkageName: "_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8", scope: null, file: !19, line: 19, type: !58, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !60)
 // CHECK:STDOUT: !58 = !DISubroutineType(types: !59)
 // CHECK:STDOUT: !59 = !{!22, !29}
 // CHECK:STDOUT: !60 = !{!61}
 // CHECK:STDOUT: !61 = !DILocalVariable(arg: 1, scope: !57, type: !29)
-// CHECK:STDOUT: !62 = !DILocation(line: 16, column: 43, scope: !57)
-// CHECK:STDOUT: !63 = !DILocation(line: 16, column: 36, scope: !57)
-// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "Next", linkageName: "_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8", scope: null, file: !19, line: 17, type: !65, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !67)
+// CHECK:STDOUT: !62 = !DILocation(line: 19, column: 43, scope: !57)
+// CHECK:STDOUT: !63 = !DILocation(line: 19, column: 36, scope: !57)
+// CHECK:STDOUT: !64 = distinct !DISubprogram(name: "Next", linkageName: "_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8", scope: null, file: !19, line: 20, type: !65, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !67)
 // CHECK:STDOUT: !65 = !DISubroutineType(types: !66)
 // CHECK:STDOUT: !66 = !{!29, !29, !29}
 // CHECK:STDOUT: !67 = !{!68, !69}
 // CHECK:STDOUT: !68 = !DILocalVariable(arg: 1, scope: !64, type: !29)
 // CHECK:STDOUT: !69 = !DILocalVariable(arg: 2, scope: !64, type: !29)
-// CHECK:STDOUT: !70 = !DILocation(line: 18, column: 7, scope: !64)
-// CHECK:STDOUT: !71 = !DILocation(line: 18, column: 27, scope: !64)
-// CHECK:STDOUT: !72 = !DILocation(line: 19, column: 19, scope: !64)
-// CHECK:STDOUT: !73 = !DILocation(line: 19, column: 11, scope: !64)
-// CHECK:STDOUT: !74 = !DILocation(line: 19, column: 10, scope: !64)
-// CHECK:STDOUT: !75 = !DILocation(line: 20, column: 9, scope: !64)
-// CHECK:STDOUT: !76 = !DILocation(line: 21, column: 38, scope: !64)
-// CHECK:STDOUT: !77 = !DILocation(line: 21, column: 16, scope: !64)
-// CHECK:STDOUT: !78 = !DILocation(line: 21, column: 9, scope: !64)
-// CHECK:STDOUT: !79 = !DILocation(line: 23, column: 16, scope: !64)
-// CHECK:STDOUT: !80 = !DILocation(line: 23, column: 9, scope: !64)
+// CHECK:STDOUT: !70 = !DILocation(line: 21, column: 7, scope: !64)
+// CHECK:STDOUT: !71 = !DILocation(line: 21, column: 27, scope: !64)
+// CHECK:STDOUT: !72 = !DILocation(line: 22, column: 19, scope: !64)
+// CHECK:STDOUT: !73 = !DILocation(line: 22, column: 11, scope: !64)
+// CHECK:STDOUT: !74 = !DILocation(line: 22, column: 10, scope: !64)
+// CHECK:STDOUT: !75 = !DILocation(line: 23, column: 9, scope: !64)
+// CHECK:STDOUT: !76 = !DILocation(line: 24, column: 38, scope: !64)
+// CHECK:STDOUT: !77 = !DILocation(line: 24, column: 16, scope: !64)
+// CHECK:STDOUT: !78 = !DILocation(line: 24, column: 9, scope: !64)
+// CHECK:STDOUT: !79 = !DILocation(line: 26, column: 16, scope: !64)
+// CHECK:STDOUT: !80 = !DILocation(line: 26, column: 9, scope: !64)
 // CHECK:STDOUT: !81 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.329ac87584bc77f7", scope: null, file: !82, line: 36, type: !83, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !85)
 // CHECK:STDOUT: !82 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !83 = !DISubroutineType(types: !84)

--- a/toolchain/lower/testdata/for/for.carbon
+++ b/toolchain/lower/testdata/for/for.carbon
@@ -2,7 +2,6 @@
 // Exceptions. See /LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// EXTRA-ARGS: --include-carbon-core
 // INCLUDE-FILE: toolchain/testing/testdata/min_prelude/full.carbon
 //
 // AUTOUPDATE
@@ -10,8 +9,6 @@
 // TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/for/for.carbon
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/for/for.carbon
-
-import Core library "range";
 
 fn F();
 fn G();
@@ -38,40 +35,40 @@ fn For() {
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define void @_CFor.Main() #0 !dbg !4 {
 // CHECK:STDOUT: entry:
-// CHECK:STDOUT:   %.loc22_32.1.temp = alloca { i32, i32 }, align 4, !dbg !7
+// CHECK:STDOUT:   %.loc19_32.1.temp = alloca { i32, i32 }, align 4, !dbg !7
 // CHECK:STDOUT:   %var = alloca i32, align 4, !dbg !8
-// CHECK:STDOUT:   %.loc22_33.1.temp = alloca <{ i32, i1 }>, align 4, !dbg !8
+// CHECK:STDOUT:   %.loc19_33.1.temp = alloca <{ i32, i1 }>, align 4, !dbg !8
 // CHECK:STDOUT:   call void @_CF.Main(), !dbg !9
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_32.1.temp), !dbg !7
-// CHECK:STDOUT:   call void @_CRange.Core(ptr %.loc22_32.1.temp, i32 100), !dbg !7
-// CHECK:STDOUT:   %IntRange.as.Iterate.impl.NewCursor.call = call i32 @"_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc22_32.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc19_32.1.temp), !dbg !7
+// CHECK:STDOUT:   call void @_CRange.Core(ptr %.loc19_32.1.temp, i32 100), !dbg !7
+// CHECK:STDOUT:   %IntRange.as.Iterate.impl.NewCursor.call = call i32 @"_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc19_32.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %var), !dbg !8
 // CHECK:STDOUT:   store i32 %IntRange.as.Iterate.impl.NewCursor.call, ptr %var, align 4, !dbg !8
 // CHECK:STDOUT:   br label %for.next, !dbg !8
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.next:                                         ; preds = %for.body, %entry
-// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc22_33.1.temp), !dbg !8
-// CHECK:STDOUT:   call void @"_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc22_33.1.temp, ptr %.loc22_32.1.temp, ptr %var), !dbg !8
-// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.329ac87584bc77f7(ptr %.loc22_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.loc19_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8"(ptr %.loc19_33.1.temp, ptr %.loc19_32.1.temp, ptr %var), !dbg !8
+// CHECK:STDOUT:   %Optional.HasValue.call = call i1 @_CHasValue.Optional.Core.329ac87584bc77f7(ptr %.loc19_33.1.temp), !dbg !8
 // CHECK:STDOUT:   br i1 %Optional.HasValue.call, label %for.body, label %for.done, !dbg !8
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.body:                                         ; preds = %for.next
-// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.329ac87584bc77f7(ptr %.loc22_33.1.temp), !dbg !8
+// CHECK:STDOUT:   %Optional.Get.call = call i32 @_CGet.Optional.Core.329ac87584bc77f7(ptr %.loc19_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @_CG.Main(), !dbg !10
-// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc22_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc19_33.1.temp), !dbg !8
 // CHECK:STDOUT:   br label %for.next, !dbg !11
 // CHECK:STDOUT:
 // CHECK:STDOUT: for.done:                                         ; preds = %for.next
-// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc22_33.1.temp), !dbg !8
+// CHECK:STDOUT:   call void @"_COp.f9d363db90f1ff8b:core.Destroy.Core"(ptr %.loc19_33.1.temp), !dbg !8
 // CHECK:STDOUT:   call void @"_COp.5e27612b9dd31a14:core.Destroy.Core"(ptr %var), !dbg !8
-// CHECK:STDOUT:   call void @"_COp.0d5da2659ce22e5f:core.Destroy.Core"(ptr %.loc22_32.1.temp), !dbg !7
+// CHECK:STDOUT:   call void @"_COp.0d5da2659ce22e5f:core.Destroy.Core"(ptr %.loc19_32.1.temp), !dbg !7
 // CHECK:STDOUT:   call void @_CH.Main(), !dbg !12
 // CHECK:STDOUT:   ret void, !dbg !13
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_CRange.Core(ptr sret({ i32, i32 }), i32)
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @"_COp.5168ce3c64c7e43f:core.Destroy.Core"(ptr)
+// CHECK:STDOUT: declare void @"_COp.1155b488c23b5086:core.Destroy.Core"(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
 // CHECK:STDOUT: define weak_odr void @"_COp.5e27612b9dd31a14:core.Destroy.Core"(ptr %self) #0 !dbg !14 {
@@ -168,8 +165,6 @@ fn For() {
 // CHECK:STDOUT:   ret i32 %1, !dbg !89
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: declare void @"_COp.1155b488c23b5086:core.Destroy.Core"(ptr)
-// CHECK:STDOUT:
 // CHECK:STDOUT: declare void @_CInclusiveRange.Core(ptr sret({ i32, i32 }), i32, i32)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: nounwind
@@ -256,79 +251,79 @@ fn For() {
 // CHECK:STDOUT: !1 = !DIFile(filename: "for.carbon", directory: "")
 // CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "For", linkageName: "_CFor.Main", scope: null, file: !1, line: 20, type: !5, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "For", linkageName: "_CFor.Main", scope: null, file: !1, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !0)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{null}
-// CHECK:STDOUT: !7 = !DILocation(line: 22, column: 18, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 22, column: 7, scope: !4)
-// CHECK:STDOUT: !9 = !DILocation(line: 21, column: 3, scope: !4)
-// CHECK:STDOUT: !10 = !DILocation(line: 23, column: 5, scope: !4)
-// CHECK:STDOUT: !11 = !DILocation(line: 22, column: 3, scope: !4)
-// CHECK:STDOUT: !12 = !DILocation(line: 25, column: 3, scope: !4)
-// CHECK:STDOUT: !13 = !DILocation(line: 20, column: 1, scope: !4)
-// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !15, line: 15, type: !16, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
-// CHECK:STDOUT: !15 = !DIFile(filename: "{{.*}}/range.carbon", directory: "")
+// CHECK:STDOUT: !7 = !DILocation(line: 19, column: 18, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 19, column: 7, scope: !4)
+// CHECK:STDOUT: !9 = !DILocation(line: 18, column: 3, scope: !4)
+// CHECK:STDOUT: !10 = !DILocation(line: 20, column: 5, scope: !4)
+// CHECK:STDOUT: !11 = !DILocation(line: 19, column: 3, scope: !4)
+// CHECK:STDOUT: !12 = !DILocation(line: 22, column: 3, scope: !4)
+// CHECK:STDOUT: !13 = !DILocation(line: 17, column: 1, scope: !4)
+// CHECK:STDOUT: !14 = distinct !DISubprogram(name: "Op", linkageName: "_COp.5e27612b9dd31a14:core.Destroy.Core", scope: null, file: !15, line: 18, type: !16, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+// CHECK:STDOUT: !15 = !DIFile(filename: "{{.*}}/prelude/range.carbon", directory: "")
 // CHECK:STDOUT: !16 = !DISubroutineType(types: !17)
 // CHECK:STDOUT: !17 = !{null, !18}
 // CHECK:STDOUT: !18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 // CHECK:STDOUT: !19 = !{!20}
 // CHECK:STDOUT: !20 = !DILocalVariable(arg: 1, scope: !14, type: !18)
-// CHECK:STDOUT: !21 = !DILocation(line: 15, column: 39, scope: !14)
-// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "Op", linkageName: "_COp.94ba1c30d421702e:core.Destroy.Core", scope: null, file: !1, line: 22, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !26)
+// CHECK:STDOUT: !21 = !DILocation(line: 18, column: 39, scope: !14)
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "Op", linkageName: "_COp.94ba1c30d421702e:core.Destroy.Core", scope: null, file: !1, line: 19, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !26)
 // CHECK:STDOUT: !23 = !DISubroutineType(types: !24)
 // CHECK:STDOUT: !24 = !{null, !25}
 // CHECK:STDOUT: !25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 // CHECK:STDOUT: !26 = !{!27}
 // CHECK:STDOUT: !27 = !DILocalVariable(arg: 1, scope: !22, type: !25)
-// CHECK:STDOUT: !28 = !DILocation(line: 22, column: 7, scope: !22)
-// CHECK:STDOUT: !29 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0fc9634857315db2:core.Destroy.Core", scope: null, file: !1, line: 22, type: !16, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !30)
+// CHECK:STDOUT: !28 = !DILocation(line: 19, column: 7, scope: !22)
+// CHECK:STDOUT: !29 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0fc9634857315db2:core.Destroy.Core", scope: null, file: !1, line: 19, type: !16, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !30)
 // CHECK:STDOUT: !30 = !{!31}
 // CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !18)
-// CHECK:STDOUT: !32 = !DILocation(line: 22, column: 7, scope: !29)
-// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "Op", linkageName: "_COp.69700c1fc1b2744c:core.Destroy.Core", scope: null, file: !1, line: 22, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !34)
+// CHECK:STDOUT: !32 = !DILocation(line: 19, column: 7, scope: !29)
+// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "Op", linkageName: "_COp.69700c1fc1b2744c:core.Destroy.Core", scope: null, file: !1, line: 19, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !34)
 // CHECK:STDOUT: !34 = !{!35}
 // CHECK:STDOUT: !35 = !DILocalVariable(arg: 1, scope: !33, type: !25)
-// CHECK:STDOUT: !36 = !DILocation(line: 22, column: 7, scope: !33)
-// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "Op", linkageName: "_COp.278d9a31079e7ff2:core.Destroy.Core", scope: null, file: !1, line: 22, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !38)
+// CHECK:STDOUT: !36 = !DILocation(line: 19, column: 7, scope: !33)
+// CHECK:STDOUT: !37 = distinct !DISubprogram(name: "Op", linkageName: "_COp.278d9a31079e7ff2:core.Destroy.Core", scope: null, file: !1, line: 19, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !38)
 // CHECK:STDOUT: !38 = !{!39}
 // CHECK:STDOUT: !39 = !DILocalVariable(arg: 1, scope: !37, type: !25)
-// CHECK:STDOUT: !40 = !DILocation(line: 22, column: 7, scope: !37)
-// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.f9d363db90f1ff8b:core.Destroy.Core", scope: null, file: !1, line: 22, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
+// CHECK:STDOUT: !40 = !DILocation(line: 19, column: 7, scope: !37)
+// CHECK:STDOUT: !41 = distinct !DISubprogram(name: "Op", linkageName: "_COp.f9d363db90f1ff8b:core.Destroy.Core", scope: null, file: !1, line: 19, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !42)
 // CHECK:STDOUT: !42 = !{!43}
 // CHECK:STDOUT: !43 = !DILocalVariable(arg: 1, scope: !41, type: !25)
-// CHECK:STDOUT: !44 = !DILocation(line: 22, column: 7, scope: !41)
-// CHECK:STDOUT: !45 = distinct !DISubprogram(name: "Op", linkageName: "_COp.db43fa38232c28dd:core.Destroy.Core", scope: null, file: !1, line: 22, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !46)
+// CHECK:STDOUT: !44 = !DILocation(line: 19, column: 7, scope: !41)
+// CHECK:STDOUT: !45 = distinct !DISubprogram(name: "Op", linkageName: "_COp.db43fa38232c28dd:core.Destroy.Core", scope: null, file: !1, line: 19, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !46)
 // CHECK:STDOUT: !46 = !{!47}
 // CHECK:STDOUT: !47 = !DILocalVariable(arg: 1, scope: !45, type: !25)
-// CHECK:STDOUT: !48 = !DILocation(line: 22, column: 18, scope: !45)
-// CHECK:STDOUT: !49 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0d5da2659ce22e5f:core.Destroy.Core", scope: null, file: !1, line: 22, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !50)
+// CHECK:STDOUT: !48 = !DILocation(line: 19, column: 18, scope: !45)
+// CHECK:STDOUT: !49 = distinct !DISubprogram(name: "Op", linkageName: "_COp.0d5da2659ce22e5f:core.Destroy.Core", scope: null, file: !1, line: 19, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !50)
 // CHECK:STDOUT: !50 = !{!51}
 // CHECK:STDOUT: !51 = !DILocalVariable(arg: 1, scope: !49, type: !25)
-// CHECK:STDOUT: !52 = !DILocation(line: 22, column: 18, scope: !49)
-// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "NewCursor", linkageName: "_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8", scope: null, file: !15, line: 16, type: !54, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !56)
+// CHECK:STDOUT: !52 = !DILocation(line: 19, column: 18, scope: !49)
+// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "NewCursor", linkageName: "_CNewCursor.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8", scope: null, file: !15, line: 19, type: !54, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !56)
 // CHECK:STDOUT: !54 = !DISubroutineType(types: !55)
 // CHECK:STDOUT: !55 = !{!18, !25}
 // CHECK:STDOUT: !56 = !{!57}
 // CHECK:STDOUT: !57 = !DILocalVariable(arg: 1, scope: !53, type: !25)
-// CHECK:STDOUT: !58 = !DILocation(line: 16, column: 43, scope: !53)
-// CHECK:STDOUT: !59 = !DILocation(line: 16, column: 36, scope: !53)
-// CHECK:STDOUT: !60 = distinct !DISubprogram(name: "Next", linkageName: "_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8", scope: null, file: !15, line: 17, type: !61, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !63)
+// CHECK:STDOUT: !58 = !DILocation(line: 19, column: 43, scope: !53)
+// CHECK:STDOUT: !59 = !DILocation(line: 19, column: 36, scope: !53)
+// CHECK:STDOUT: !60 = distinct !DISubprogram(name: "Next", linkageName: "_CNext.IntRange.9452f4c51951679b.Core:Iterate.Core.be1e879c1ad406d8", scope: null, file: !15, line: 20, type: !61, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !63)
 // CHECK:STDOUT: !61 = !DISubroutineType(types: !62)
 // CHECK:STDOUT: !62 = !{!25, !25, !25}
 // CHECK:STDOUT: !63 = !{!64, !65}
 // CHECK:STDOUT: !64 = !DILocalVariable(arg: 1, scope: !60, type: !25)
 // CHECK:STDOUT: !65 = !DILocalVariable(arg: 2, scope: !60, type: !25)
-// CHECK:STDOUT: !66 = !DILocation(line: 18, column: 7, scope: !60)
-// CHECK:STDOUT: !67 = !DILocation(line: 18, column: 27, scope: !60)
-// CHECK:STDOUT: !68 = !DILocation(line: 19, column: 19, scope: !60)
-// CHECK:STDOUT: !69 = !DILocation(line: 19, column: 11, scope: !60)
-// CHECK:STDOUT: !70 = !DILocation(line: 19, column: 10, scope: !60)
-// CHECK:STDOUT: !71 = !DILocation(line: 20, column: 9, scope: !60)
-// CHECK:STDOUT: !72 = !DILocation(line: 21, column: 38, scope: !60)
-// CHECK:STDOUT: !73 = !DILocation(line: 21, column: 16, scope: !60)
-// CHECK:STDOUT: !74 = !DILocation(line: 21, column: 9, scope: !60)
-// CHECK:STDOUT: !75 = !DILocation(line: 23, column: 16, scope: !60)
-// CHECK:STDOUT: !76 = !DILocation(line: 23, column: 9, scope: !60)
+// CHECK:STDOUT: !66 = !DILocation(line: 21, column: 7, scope: !60)
+// CHECK:STDOUT: !67 = !DILocation(line: 21, column: 27, scope: !60)
+// CHECK:STDOUT: !68 = !DILocation(line: 22, column: 19, scope: !60)
+// CHECK:STDOUT: !69 = !DILocation(line: 22, column: 11, scope: !60)
+// CHECK:STDOUT: !70 = !DILocation(line: 22, column: 10, scope: !60)
+// CHECK:STDOUT: !71 = !DILocation(line: 23, column: 9, scope: !60)
+// CHECK:STDOUT: !72 = !DILocation(line: 24, column: 38, scope: !60)
+// CHECK:STDOUT: !73 = !DILocation(line: 24, column: 16, scope: !60)
+// CHECK:STDOUT: !74 = !DILocation(line: 24, column: 9, scope: !60)
+// CHECK:STDOUT: !75 = !DILocation(line: 26, column: 16, scope: !60)
+// CHECK:STDOUT: !76 = !DILocation(line: 26, column: 9, scope: !60)
 // CHECK:STDOUT: !77 = distinct !DISubprogram(name: "HasValue", linkageName: "_CHasValue.Optional.Core.329ac87584bc77f7", scope: null, file: !78, line: 36, type: !79, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !81)
 // CHECK:STDOUT: !78 = !DIFile(filename: "{{.*}}/prelude/types/optional.carbon", directory: "")
 // CHECK:STDOUT: !79 = !DISubroutineType(types: !80)


### PR DESCRIPTION
As discussed in the 2026-06-14 toolchain open meeting, `Range`
is a better fit for the prelude than as a general library in
`Core`. This PR moves `Range` into the prelude, and updates
the build infrastructure and various tests to reflect that
change.