### PR TITLE
Give thunks weak_odr linkage.

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -347,11 +347,12 @@ auto FileContext::HandleReferencedSpecificFunction(
 auto FileContext::GetOrCreateLLVMFunction(
     const FunctionTypeInfo& function_type_info, SemIR::FunctionId function_id,
     SemIR::SpecificId specific_id) -> llvm::Function* {
+  const auto& function = sem_ir().functions().Get(function_id);
+
   // If this is a C++ function, tell Clang that we referenced it.
   // The global_ctor function can't be a C++ function (but doesn't have any
   // decl_id so it doesn't fall out naturally from the handling below)
   if (function_id != sem_ir().global_ctor_id()) {
-    const auto& function = sem_ir().functions().Get(function_id);
     if (const auto* clang_decl =
             sem_ir().clang_decls().Lookup(function.first_decl_id())) {
       if (clang_decl->is_imported) {
@@ -386,21 +387,8 @@ auto FileContext::GetOrCreateLLVMFunction(
                                      function_type_info.type);
   }
 
-  // TODO: For an imported inline function, consider generating an
-  // `available_externally` definition.
-  auto linkage = llvm::Function::ExternalLinkage;
-  if (function_id == sem_ir().global_ctor_id()) {
-    // The global constructor name would collide with global constructors for
-    // other files in the same package, so use an internal linkage symbol.
-    linkage = llvm::Function::InternalLinkage;
-  } else if (specific_id.has_value()) {
-    // Specific functions are allowed to be duplicated across files.
-    // TODO: CoreWitness should have the same behavior; see its use of
-    // WeakODRLinkage in BuildFunctionDefinition.
-    linkage = llvm::Function::LinkOnceODRLinkage;
-  }
-
-  auto* llvm_function = llvm::Function::Create(function_type_info.type, linkage,
+  auto* llvm_function = llvm::Function::Create(function_type_info.type,
+                                               llvm::Function::ExternalLinkage,
                                                mangled_name, llvm_module());
   CARBON_CHECK(llvm_function->getName() == mangled_name,
                "Mangled name collision: {0}", mangled_name);
@@ -550,13 +538,6 @@ auto FileContext::BuildFunctionBody(SemIR::FunctionId function_id,
                "Attempting to emit definition of inexact function: {0}",
                *function_info->llvm_function);
 
-  // TODO: Build CoreWitness functions when they're called instead of when
-  // they're defined. That should allow LinkOnceODRLinkage.
-  if (declaration_function.special_function_kind ==
-      SemIR::Function::SpecialFunctionKind::CoreWitness) {
-    function_info->llvm_function->setLinkage(llvm::Function::WeakODRLinkage);
-  }
-
   const auto& body_block_ids = definition_function.body_block_ids;
   CARBON_DCHECK(!body_block_ids.empty(),
                 "No function body blocks found during lowering.");
@@ -568,6 +549,26 @@ auto FileContext::BuildFunctionBody(SemIR::FunctionId function_id,
     // can deduplicate specifics from different files.
     AddLoweredSpecificForGeneric(declaration_function.generic_id, specific_id);
   }
+
+  // Set the linkage for the definition.
+  auto linkage = llvm::Function::ExternalLinkage;
+  if (function_id == sem_ir().global_ctor_id()) {
+    // The global constructor name would collide with global constructors for
+    // other files in the same package, so use an internal linkage symbol.
+    linkage = llvm::Function::InternalLinkage;
+  } else if (specific_id.has_value()) {
+    // Specific functions are emitted in each file they are referenced in.
+    linkage = llvm::Function::LinkOnceODRLinkage;
+  } else if (declaration_function.special_function_kind ==
+                 SemIR::Function::SpecialFunctionKind::CoreWitness ||
+             declaration_function.special_function_kind ==
+                 SemIR::Function::SpecialFunctionKind::Thunk) {
+    // TODO: Emit CoreWitness functions and thunks in files where they're called
+    // instead of in files where they're defined. That should allow
+    // LinkOnceODRLinkage.
+    linkage = llvm::Function::WeakODRLinkage;
+  }
+  function_info->llvm_function->setLinkage(linkage);
 
   // Set attributes on the function definition.
   {

--- a/toolchain/lower/testdata/class/static.carbon
+++ b/toolchain/lower/testdata/class/static.carbon
@@ -102,7 +102,7 @@ fn Run() -> i32 {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.C.Main"(ptr %self) #1 !dbg !13 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.C.Main"(ptr %self) #1 !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.807eb4f2d3ed7e54:core.Destroy.Core"(ptr %self), !dbg !19
 // CHECK:STDOUT:   ret void, !dbg !19

--- a/toolchain/lower/testdata/class/virtual.carbon
+++ b/toolchain/lower/testdata/class/virtual.carbon
@@ -232,7 +232,7 @@ fn Use() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_CFn:thunk:Intermediate.Classes:Derived.Classes"(ptr %self) #1 !dbg !15 {
+// CHECK:STDOUT: define weak_odr void @"_CFn:thunk:Intermediate.Classes:Derived.Classes"(ptr %self) #1 !dbg !15 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CFn.Derived.Classes(ptr %self), !dbg !18
 // CHECK:STDOUT:   ret void, !dbg !18
@@ -770,7 +770,7 @@ fn Use() {
 // CHECK:STDOUT: declare void @_CF.Derived.Main(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_CF:thunk:Base.Main:Derived.Main"(ptr %self) #0 !dbg !4 {
+// CHECK:STDOUT: define weak_odr void @"_CF:thunk:Base.Main:Derived.Main"(ptr %self) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CF.Derived.Main(ptr %self), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !10
@@ -1138,7 +1138,7 @@ fn Use() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_CF:thunk:Base.Main:Derived.Main"(ptr sret({}) %return, ptr %self, ptr %n) #1 !dbg !12 {
+// CHECK:STDOUT: define weak_odr void @"_CF:thunk:Base.Main:Derived.Main"(ptr sret({}) %return, ptr %self, ptr %n) #1 !dbg !12 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc17_52.2.temp = alloca {}, align 1, !dbg !16
 // CHECK:STDOUT:   %.5.temp = alloca {}, align 1, !dbg !17

--- a/toolchain/lower/testdata/impl/import_thunk.carbon
+++ b/toolchain/lower/testdata/impl/import_thunk.carbon
@@ -101,7 +101,7 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_CF:thunk:I.4b54445be9b10a0e.Main:61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !25 {
+// CHECK:STDOUT: define weak_odr void @"_CF:thunk:I.4b54445be9b10a0e.Main:61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc20_19.1.temp = alloca { i32 }, align 4, !dbg !28
 // CHECK:STDOUT:   %.4.temp = alloca { i32 }, align 4, !dbg !29
@@ -301,7 +301,7 @@ fn Test(a: A) -> C {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_CF:thunk:I.c81631f865470482.Main:X.Main:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !13 {
+// CHECK:STDOUT: define weak_odr void @"_CF:thunk:I.c81631f865470482.Main:X.Main:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !13 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc9_19.1.temp = alloca { i32 }, align 4, !dbg !16
 // CHECK:STDOUT:   %.4.temp = alloca { i32 }, align 4, !dbg !17

--- a/toolchain/lower/testdata/impl/thunk.carbon
+++ b/toolchain/lower/testdata/impl/thunk.carbon
@@ -105,7 +105,7 @@ fn CallCallGeneric(c: C(()), b: B) -> A {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_CF:thunk:I.4b54445be9b10a0e.Main:61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !25 {
+// CHECK:STDOUT: define weak_odr void @"_CF:thunk:I.4b54445be9b10a0e.Main:61ea2aba74ab3bf1:I.Main"(ptr sret({ i32 }) %return, ptr %a) #1 !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.loc20_19.1.temp = alloca { i32 }, align 4, !dbg !28
 // CHECK:STDOUT:   %.4.temp = alloca { i32 }, align 4, !dbg !29

--- a/toolchain/lower/testdata/interop/cpp/class/export/class.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/export/class.carbon
@@ -274,7 +274,7 @@ fn G() {
 // CHECK:STDOUT: declare void @_CCallC.Main(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #4 !dbg !19 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #4 !dbg !19 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.68011419f123494e:core.Destroy.Core"(ptr %self), !dbg !25
 // CHECK:STDOUT:   ret void, !dbg !25
@@ -307,7 +307,7 @@ fn G() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.B.Main"(ptr %self) #4 !dbg !45 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.B.Main"(ptr %self) #4 !dbg !45 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.6c3865e9cbd9f6de:core.Destroy.Core"(ptr %self), !dbg !48
 // CHECK:STDOUT:   ret void, !dbg !48
@@ -334,7 +334,7 @@ fn G() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.C.Main"(ptr %self) #4 !dbg !61 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.C.Main"(ptr %self) #4 !dbg !61 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.807eb4f2d3ed7e54:core.Destroy.Core"(ptr %self), !dbg !64
 // CHECK:STDOUT:   ret void, !dbg !64
@@ -477,7 +477,7 @@ fn G() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.C.Main"(ptr %self) #1 !dbg !20 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.C.Main"(ptr %self) #1 !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.807eb4f2d3ed7e54:core.Destroy.Core"(ptr %self), !dbg !26
 // CHECK:STDOUT:   ret void, !dbg !26

--- a/toolchain/lower/testdata/interop/cpp/class/export/method.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/export/method.carbon
@@ -117,7 +117,7 @@ fn CallCallF() { Cpp.CallF(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #5 !dbg !22 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #5 !dbg !22 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.68011419f123494e:core.Destroy.Core"(ptr %self), !dbg !25
 // CHECK:STDOUT:   ret void, !dbg !25
@@ -240,7 +240,7 @@ fn CallCallF() { Cpp.CallF(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #5 !dbg !25 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #5 !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.68011419f123494e:core.Destroy.Core"(ptr %self), !dbg !30
 // CHECK:STDOUT:   ret void, !dbg !30
@@ -355,7 +355,7 @@ fn CallCallF() { Cpp.CallF(); }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #3 !dbg !16 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #3 !dbg !16 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.68011419f123494e:core.Destroy.Core"(ptr %self), !dbg !22
 // CHECK:STDOUT:   ret void, !dbg !22

--- a/toolchain/lower/testdata/interop/cpp/class/import/alignment.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/alignment.carbon
@@ -84,7 +84,7 @@ fn Packed(n: i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.c846b89dd79c7366.Core:NaturallyAligned.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !25 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.c846b89dd79c7366.Core:NaturallyAligned.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !25 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN16NaturallyAlignedC1Ev.carbon_thunk.(ptr %return), !dbg !29
 // CHECK:STDOUT:   ret void, !dbg !29
@@ -114,7 +114,7 @@ fn Packed(n: i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.52e7708693d29223.Core:ExtraAlignment.Cpp"(ptr sret([16 x i8]) %return) #2 !dbg !39 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.52e7708693d29223.Core:ExtraAlignment.Cpp"(ptr sret([16 x i8]) %return) #2 !dbg !39 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN14ExtraAlignmentC1Ev.carbon_thunk.(ptr %return), !dbg !40
 // CHECK:STDOUT:   ret void, !dbg !40
@@ -144,7 +144,7 @@ fn Packed(n: i32) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.ca2b917a39954a06.Core:Packed.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !50 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.ca2b917a39954a06.Core:Packed.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !50 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN6PackedC1Ev.carbon_thunk.(ptr %return), !dbg !51
 // CHECK:STDOUT:   ret void, !dbg !51

--- a/toolchain/lower/testdata/interop/cpp/class/import/constructor.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/constructor.carbon
@@ -300,7 +300,7 @@ fn Four() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.dc3dd9c349162a91.Core:C.Cpp"(ptr sret([8 x i8]) %return) #2 !dbg !20 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.dc3dd9c349162a91.Core:C.Cpp"(ptr sret([8 x i8]) %return) #2 !dbg !20 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN1CC1Ev.carbon_thunk.(ptr %return), !dbg !25
 // CHECK:STDOUT:   ret void, !dbg !25
@@ -414,7 +414,7 @@ fn Four() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.48fb4c4d31b7d0bf.Core:ImplicitlyDefaultedDefault.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !23 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.48fb4c4d31b7d0bf.Core:ImplicitlyDefaultedDefault.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !23 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN26ImplicitlyDefaultedDefaultC1Ev.carbon_thunk.(ptr %return), !dbg !28
 // CHECK:STDOUT:   ret void, !dbg !28
@@ -431,7 +431,7 @@ fn Four() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.f7ca6602362234ee.Core:ExplicitlyDefaultedDefault.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !31 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.f7ca6602362234ee.Core:ExplicitlyDefaultedDefault.Cpp"(ptr sret([4 x i8]) %return) #2 !dbg !31 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN26ExplicitlyDefaultedDefaultC1Ev.carbon_thunk.(ptr %return), !dbg !32
 // CHECK:STDOUT:   ret void, !dbg !32
@@ -562,7 +562,7 @@ fn Four() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Copy.58fe21e3ef78b0d7.Core:Copy.Cpp"(ptr sret([4 x i8]) %return, ptr %self) #2 !dbg !23 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Copy.58fe21e3ef78b0d7.Core:Copy.Cpp"(ptr sret([4 x i8]) %return, ptr %self) #2 !dbg !23 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN4CopyC1ERKS_.carbon_thunk._(ptr %self, ptr %return), !dbg !27
 // CHECK:STDOUT:   ret void, !dbg !27

--- a/toolchain/lower/testdata/interop/cpp/class/import/destructor.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/destructor.carbon
@@ -1,0 +1,286 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/primitives.carbon
+// EXTRA-ARGS: --clang-arg=-std=c++20
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/interop/cpp/class/import/destructor.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/interop/cpp/class/import/destructor.carbon
+
+// --- call_destructor.carbon
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+inline Cpp '''
+struct Trivial {};
+struct Nontrivial {
+  ~Nontrivial();
+};
+struct Constexpr {
+  constexpr ~Constexpr() {}
+};
+''';
+
+fn Destroy() {
+  var _: Cpp.Trivial = {};
+  var _: Cpp.Nontrivial = {};
+  var _: Cpp.Constexpr = {};
+}
+
+interface Make {
+  fn Make() -> Self;
+}
+impl Cpp.Trivial as Make {
+  fn Make() -> Self { return Cpp.Trivial.Trivial(); }
+}
+impl Cpp.Nontrivial as Make {
+  fn Make() -> Self { return Cpp.Nontrivial.Nontrivial(); }
+}
+impl Cpp.Constexpr as Make {
+  fn Make() -> Self { return Cpp.Constexpr.Constexpr(); }
+}
+
+fn DestroyIndirectly(generic T: Core.Destroy & Make) {
+  var unused a: T = T.Make();
+}
+
+fn DestroyAIndirectly() {
+  DestroyIndirectly(Cpp.Trivial);
+  DestroyIndirectly(Cpp.Nontrivial);
+  DestroyIndirectly(Cpp.Constexpr);
+}
+
+// CHECK:STDOUT: ; ---
+// CHECK:STDOUT: ; ModuleID = 'call_destructor.carbon'
+// CHECK:STDOUT: source_filename = "call_destructor.carbon"
+// CHECK:STDOUT: target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+// CHECK:STDOUT: target triple = "x86_64-unknown-linux-gnu"
+// CHECK:STDOUT:
+// CHECK:STDOUT: $_ZN9ConstexprD2Ev = comdat any
+// CHECK:STDOUT:
+// CHECK:STDOUT: @Trivial.val.loc16_3 = internal constant {} zeroinitializer
+// CHECK:STDOUT: @Nontrivial.val.loc17_3 = internal constant {} zeroinitializer
+// CHECK:STDOUT: @Constexpr.val.loc18_3 = internal constant {} zeroinitializer
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CDestroy.Main() #0 !dbg !12 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %_.var.loc16 = alloca {}, align 1, !dbg !15
+// CHECK:STDOUT:   %_.var.loc17 = alloca {}, align 1, !dbg !16
+// CHECK:STDOUT:   %_.var.loc18 = alloca {}, align 1, !dbg !17
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc16), !dbg !15
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var.loc16, ptr align 1 @Trivial.val.loc16_3, i64 0, i1 false), !dbg !15
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc17), !dbg !16
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var.loc17, ptr align 1 @Nontrivial.val.loc17_3, i64 0, i1 false), !dbg !16
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %_.var.loc18), !dbg !17
+// CHECK:STDOUT:   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %_.var.loc18, ptr align 1 @Constexpr.val.loc18_3, i64 0, i1 false), !dbg !17
+// CHECK:STDOUT:   call void @_ZN9ConstexprD2Ev(ptr %_.var.loc18), !dbg !17
+// CHECK:STDOUT:   call void @_ZN10NontrivialD1Ev(ptr %_.var.loc17), !dbg !16
+// CHECK:STDOUT:   ret void, !dbg !18
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: mustprogress nounwind uwtable
+// CHECK:STDOUT: define linkonce_odr dso_local void @_ZN9ConstexprD2Ev(ptr noundef nonnull align 1 dereferenceable(1) %this) unnamed_addr #1 comdat align 2 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %this.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %this, ptr %this.addr, align 8, !tbaa !19
+// CHECK:STDOUT:   %this1 = load ptr, ptr %this.addr, align 8
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Destroy.74d6bfd440841f14.Core:Constexpr.Cpp"(ptr %self) #2 !dbg !22 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN9ConstexprD2Ev(ptr %self), !dbg !28
+// CHECK:STDOUT:   ret void, !dbg !28
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: declare void @_ZN10NontrivialD1Ev(ptr noundef nonnull align 1 dereferenceable(1)) unnamed_addr #3
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Destroy.470f41253d102356.Core:Trivial.Cpp"(ptr %self) #2 !dbg !29 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   ret void, !dbg !32
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @"_CMake.Trivial.Cpp:Make.Main"(ptr sret({}) %return) #0 !dbg !33 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN7TrivialC1Ev.carbon_thunk.(ptr %return), !dbg !36
+// CHECK:STDOUT:   ret void, !dbg !37
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN7TrivialC1Ev.carbon_thunk.(ptr noundef %return) #4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8, !tbaa !38
+// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8, !tbaa !38
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @"_CMake.Nontrivial.Cpp:Make.Main"(ptr sret({}) %return) #0 !dbg !40 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN10NontrivialC1Ev.carbon_thunk.(ptr %return), !dbg !41
+// CHECK:STDOUT:   ret void, !dbg !42
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN10NontrivialC1Ev.carbon_thunk.(ptr noundef %return) #4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8, !tbaa !43
+// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8, !tbaa !43
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @"_CMake.Constexpr.Cpp:Make.Main"(ptr sret({}) %return) #0 !dbg !45 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_ZN9ConstexprC1Ev.carbon_thunk.(ptr %return), !dbg !46
+// CHECK:STDOUT:   ret void, !dbg !47
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: alwaysinline mustprogress nounwind uwtable
+// CHECK:STDOUT: define internal void @_ZN9ConstexprC1Ev.carbon_thunk.(ptr noundef %return) #4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %return.addr = alloca ptr, align 8
+// CHECK:STDOUT:   store ptr %return, ptr %return.addr, align 8, !tbaa !19
+// CHECK:STDOUT:   %0 = load ptr, ptr %return.addr, align 8, !tbaa !19
+// CHECK:STDOUT:   ret void
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define void @_CDestroyAIndirectly.Main() #0 !dbg !48 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   call void @_CDestroyIndirectly.Main.e5fba025cd74a7f8(), !dbg !49
+// CHECK:STDOUT:   call void @_CDestroyIndirectly.Main.941e8170f59f4395(), !dbg !50
+// CHECK:STDOUT:   call void @_CDestroyIndirectly.Main.792f9aee5f4c6f04(), !dbg !51
+// CHECK:STDOUT:   ret void, !dbg !52
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.lifetime.start.p0(ptr captures(none)) #5
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+// CHECK:STDOUT: declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #5
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @_CDestroyIndirectly.Main.e5fba025cd74a7f8() #0 !dbg !53 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %a.var = alloca {}, align 1, !dbg !54
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !54
+// CHECK:STDOUT:   call void @"_CMake.Trivial.Cpp:Make.Main"(ptr %a.var), !dbg !55
+// CHECK:STDOUT:   call void @"_COp:thunk:Destroy.470f41253d102356.Core:Trivial.Cpp"(ptr %a.var), !dbg !54
+// CHECK:STDOUT:   ret void, !dbg !56
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @_CDestroyIndirectly.Main.941e8170f59f4395() #0 !dbg !57 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %a.var = alloca {}, align 1, !dbg !58
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !58
+// CHECK:STDOUT:   call void @"_CMake.Nontrivial.Cpp:Make.Main"(ptr %a.var), !dbg !59
+// CHECK:STDOUT:   call void @_ZN10NontrivialD1Ev(ptr %a.var), !dbg !58
+// CHECK:STDOUT:   ret void, !dbg !60
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; Function Attrs: nounwind
+// CHECK:STDOUT: define linkonce_odr void @_CDestroyIndirectly.Main.792f9aee5f4c6f04() #0 !dbg !61 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %a.var = alloca {}, align 1, !dbg !62
+// CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %a.var), !dbg !62
+// CHECK:STDOUT:   call void @"_CMake.Constexpr.Cpp:Make.Main"(ptr %a.var), !dbg !63
+// CHECK:STDOUT:   call void @"_COp:thunk:Destroy.74d6bfd440841f14.Core:Constexpr.Cpp"(ptr %a.var), !dbg !62
+// CHECK:STDOUT:   ret void, !dbg !64
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: ; uselistorder directives
+// CHECK:STDOUT: uselistorder ptr @_ZN9ConstexprD2Ev, { 1, 0 }
+// CHECK:STDOUT: uselistorder ptr @llvm.lifetime.start.p0, { 0, 1, 2, 5, 4, 3 }
+// CHECK:STDOUT: uselistorder ptr @llvm.memcpy.p0.p0.i64, { 2, 1, 0 }
+// CHECK:STDOUT:
+// CHECK:STDOUT: attributes #0 = { nounwind }
+// CHECK:STDOUT: attributes #1 = { mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #2 = { alwaysinline nounwind }
+// CHECK:STDOUT: attributes #3 = { nounwind "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #4 = { alwaysinline mustprogress nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+// CHECK:STDOUT: attributes #5 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.dbg.cu = !{!0}
+// CHECK:STDOUT: !llvm.module.flags = !{!2, !3, !4, !5, !6}
+// CHECK:STDOUT: !llvm.errno.tbaa = !{!7}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !1 = !DIFile(filename: "call_destructor.carbon", directory: "")
+// CHECK:STDOUT: !2 = !{i32 8, !"PIC Level", i32 2}
+// CHECK:STDOUT: !3 = !{i32 7, !"PIE Level", i32 2}
+// CHECK:STDOUT: !4 = !{i32 7, !"uwtable", i32 2}
+// CHECK:STDOUT: !5 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !6 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !7 = !{!8, !9, i64 0}
+// CHECK:STDOUT: !8 = !{!"__libc_errno", !9, i64 0}
+// CHECK:STDOUT: !9 = !{!"int", !10, i64 0}
+// CHECK:STDOUT: !10 = !{!"omnipotent char", !11, i64 0}
+// CHECK:STDOUT: !11 = !{!"Simple C++ TBAA"}
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "Destroy", linkageName: "_CDestroy.Main", scope: null, file: !1, line: 15, type: !13, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !13 = !DISubroutineType(types: !14)
+// CHECK:STDOUT: !14 = !{null}
+// CHECK:STDOUT: !15 = !DILocation(line: 16, column: 3, scope: !12)
+// CHECK:STDOUT: !16 = !DILocation(line: 17, column: 3, scope: !12)
+// CHECK:STDOUT: !17 = !DILocation(line: 18, column: 3, scope: !12)
+// CHECK:STDOUT: !18 = !DILocation(line: 15, column: 1, scope: !12)
+// CHECK:STDOUT: !19 = !{!20, !20, i64 0}
+// CHECK:STDOUT: !20 = !{!"p1 _ZTS9Constexpr", !21, i64 0}
+// CHECK:STDOUT: !21 = !{!"any pointer", !10, i64 0}
+// CHECK:STDOUT: !22 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:Destroy.74d6bfd440841f14.Core:Constexpr.Cpp", scope: null, file: !1, line: 11, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !26)
+// CHECK:STDOUT: !23 = !DISubroutineType(types: !24)
+// CHECK:STDOUT: !24 = !{null, !25}
+// CHECK:STDOUT: !25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+// CHECK:STDOUT: !26 = !{!27}
+// CHECK:STDOUT: !27 = !DILocalVariable(arg: 1, scope: !22, type: !25)
+// CHECK:STDOUT: !28 = !DILocation(line: 11, column: 13, scope: !22)
+// CHECK:STDOUT: !29 = distinct !DISubprogram(name: "Op", linkageName: "_COp:thunk:Destroy.470f41253d102356.Core:Trivial.Cpp", scope: null, file: !1, line: 6, type: !23, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !30)
+// CHECK:STDOUT: !30 = !{!31}
+// CHECK:STDOUT: !31 = !DILocalVariable(arg: 1, scope: !29, type: !25)
+// CHECK:STDOUT: !32 = !DILocation(line: 6, column: 8, scope: !29)
+// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "Make", linkageName: "_CMake.Trivial.Cpp:Make.Main", scope: null, file: !1, line: 25, type: !34, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !34 = !DISubroutineType(types: !35)
+// CHECK:STDOUT: !35 = !{!25}
+// CHECK:STDOUT: !36 = !DILocation(line: 25, column: 30, scope: !33)
+// CHECK:STDOUT: !37 = !DILocation(line: 25, column: 23, scope: !33)
+// CHECK:STDOUT: !38 = !{!39, !39, i64 0}
+// CHECK:STDOUT: !39 = !{!"p1 _ZTS7Trivial", !21, i64 0}
+// CHECK:STDOUT: !40 = distinct !DISubprogram(name: "Make", linkageName: "_CMake.Nontrivial.Cpp:Make.Main", scope: null, file: !1, line: 28, type: !34, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !41 = !DILocation(line: 28, column: 30, scope: !40)
+// CHECK:STDOUT: !42 = !DILocation(line: 28, column: 23, scope: !40)
+// CHECK:STDOUT: !43 = !{!44, !44, i64 0}
+// CHECK:STDOUT: !44 = !{!"p1 _ZTS10Nontrivial", !21, i64 0}
+// CHECK:STDOUT: !45 = distinct !DISubprogram(name: "Make", linkageName: "_CMake.Constexpr.Cpp:Make.Main", scope: null, file: !1, line: 31, type: !34, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !46 = !DILocation(line: 31, column: 30, scope: !45)
+// CHECK:STDOUT: !47 = !DILocation(line: 31, column: 23, scope: !45)
+// CHECK:STDOUT: !48 = distinct !DISubprogram(name: "DestroyAIndirectly", linkageName: "_CDestroyAIndirectly.Main", scope: null, file: !1, line: 38, type: !13, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !49 = !DILocation(line: 39, column: 3, scope: !48)
+// CHECK:STDOUT: !50 = !DILocation(line: 40, column: 3, scope: !48)
+// CHECK:STDOUT: !51 = !DILocation(line: 41, column: 3, scope: !48)
+// CHECK:STDOUT: !52 = !DILocation(line: 38, column: 1, scope: !48)
+// CHECK:STDOUT: !53 = distinct !DISubprogram(name: "DestroyIndirectly", linkageName: "_CDestroyIndirectly.Main.e5fba025cd74a7f8", scope: null, file: !1, line: 34, type: !13, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !54 = !DILocation(line: 35, column: 3, scope: !53)
+// CHECK:STDOUT: !55 = !DILocation(line: 35, column: 21, scope: !53)
+// CHECK:STDOUT: !56 = !DILocation(line: 34, column: 1, scope: !53)
+// CHECK:STDOUT: !57 = distinct !DISubprogram(name: "DestroyIndirectly", linkageName: "_CDestroyIndirectly.Main.941e8170f59f4395", scope: null, file: !1, line: 34, type: !13, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !58 = !DILocation(line: 35, column: 3, scope: !57)
+// CHECK:STDOUT: !59 = !DILocation(line: 35, column: 21, scope: !57)
+// CHECK:STDOUT: !60 = !DILocation(line: 34, column: 1, scope: !57)
+// CHECK:STDOUT: !61 = distinct !DISubprogram(name: "DestroyIndirectly", linkageName: "_CDestroyIndirectly.Main.792f9aee5f4c6f04", scope: null, file: !1, line: 34, type: !13, spFlags: DISPFlagDefinition, unit: !0)
+// CHECK:STDOUT: !62 = !DILocation(line: 35, column: 3, scope: !61)
+// CHECK:STDOUT: !63 = !DILocation(line: 35, column: 21, scope: !61)
+// CHECK:STDOUT: !64 = !DILocation(line: 34, column: 1, scope: !61)
+// CHECK:STDOUT:

--- a/toolchain/lower/testdata/interop/cpp/class/import/dynamic.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/import/dynamic.carbon
@@ -95,7 +95,7 @@ fn DoThing() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_Cfunc:thunk:Base.Cpp:Derived.Main"(ptr %self) #3 !dbg !26 {
+// CHECK:STDOUT: define weak_odr void @"_Cfunc:thunk:Base.Cpp:Derived.Main"(ptr %self) #3 !dbg !26 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_Cfunc.Derived.Main(ptr %self), !dbg !29
 // CHECK:STDOUT:   ret void, !dbg !29
@@ -129,7 +129,7 @@ fn DoThing() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.Derived.Main"(ptr %self) #3 !dbg !39 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.Derived.Main"(ptr %self) #3 !dbg !39 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.8185e3504351afa8:core.Destroy.Core"(ptr %self), !dbg !42
 // CHECK:STDOUT:   ret void, !dbg !42

--- a/toolchain/lower/testdata/interop/cpp/class/virtual_fn.carbon
+++ b/toolchain/lower/testdata/interop/cpp/class/virtual_fn.carbon
@@ -198,7 +198,7 @@ void delete_new_Base() {
 // CHECK:STDOUT: declare void @_CF.Final.Main(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_CF:thunk:A.Cpp:Final.Main"(ptr %self) #6 !dbg !23 {
+// CHECK:STDOUT: define weak_odr void @"_CF:thunk:A.Cpp:Final.Main"(ptr %self) #6 !dbg !23 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CF.Final.Main(ptr %self), !dbg !29
 // CHECK:STDOUT:   ret void, !dbg !29
@@ -207,14 +207,14 @@ void delete_new_Base() {
 // CHECK:STDOUT: declare void @_CF.Base.Main(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_CF:thunk:A.Cpp:Base.Main"(ptr %self) #6 !dbg !30 {
+// CHECK:STDOUT: define weak_odr void @"_CF:thunk:A.Cpp:Base.Main"(ptr %self) #6 !dbg !30 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_CF.Base.Main(ptr %self), !dbg !33
 // CHECK:STDOUT:   ret void, !dbg !33
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.Final.Main"(ptr %self) #6 !dbg !34 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.Final.Main"(ptr %self) #6 !dbg !34 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.6622c02ec7a967c3:core.Destroy.Core"(ptr %self), !dbg !37
 // CHECK:STDOUT:   ret void, !dbg !37
@@ -243,7 +243,7 @@ void delete_new_Base() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.Base.Main"(ptr %self) #6 !dbg !50 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.Base.Main"(ptr %self) #6 !dbg !50 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.a45b619846c20518:core.Destroy.Core"(ptr %self), !dbg !53
 // CHECK:STDOUT:   ret void, !dbg !53

--- a/toolchain/lower/testdata/interop/cpp/enum.carbon
+++ b/toolchain/lower/testdata/interop/cpp/enum.carbon
@@ -579,7 +579,7 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CEqual:thunk:EqWith.83b9626e83cf3dcc.Core:enclosed"(i16 %self, ptr %other) #2 !dbg !55 {
+// CHECK:STDOUT: define weak_odr i1 @"_CEqual:thunk:EqWith.83b9626e83cf3dcc.Core:enclosed"(i16 %self, ptr %other) #2 !dbg !55 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.4.temp = alloca i16, align 2, !dbg !59
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.4.temp), !dbg !59
@@ -590,7 +590,7 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CNotEqual:thunk:EqWith.83b9626e83cf3dcc.Core:enclosed"(i16 %self, ptr %other) #2 !dbg !60 {
+// CHECK:STDOUT: define weak_odr i1 @"_CNotEqual:thunk:EqWith.83b9626e83cf3dcc.Core:enclosed"(i16 %self, ptr %other) #2 !dbg !60 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.4.temp = alloca i16, align 2, !dbg !64
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.4.temp), !dbg !64
@@ -608,7 +608,7 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CEqual:thunk:EqWith.e8fe48de943d9652.Core:enclosed"(i32 %self, ptr %other) #2 !dbg !71 {
+// CHECK:STDOUT: define weak_odr i1 @"_CEqual:thunk:EqWith.e8fe48de943d9652.Core:enclosed"(i32 %self, ptr %other) #2 !dbg !71 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %__carbon_thunk.call = call i32 @_ZNK13ConvertToEnumcv2E2Ev.carbon_thunk._(ptr %other), !dbg !75
 // CHECK:STDOUT:   %Equal.call = icmp eq i32 %self, %__carbon_thunk.call, !dbg !75
@@ -616,7 +616,7 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CNotEqual:thunk:EqWith.e8fe48de943d9652.Core:enclosed"(i32 %self, ptr %other) #2 !dbg !76 {
+// CHECK:STDOUT: define weak_odr i1 @"_CNotEqual:thunk:EqWith.e8fe48de943d9652.Core:enclosed"(i32 %self, ptr %other) #2 !dbg !76 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %__carbon_thunk.call = call i32 @_ZNK13ConvertToEnumcv2E2Ev.carbon_thunk._(ptr %other), !dbg !80
 // CHECK:STDOUT:   %NotEqual.call = icmp ne i32 %self, %__carbon_thunk.call, !dbg !80
@@ -631,7 +631,7 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CEqual:thunk:EqWith.a294139a6615e163.Core:enclosed"(i16 %self, ptr %other) #2 !dbg !87 {
+// CHECK:STDOUT: define weak_odr i1 @"_CEqual:thunk:EqWith.a294139a6615e163.Core:enclosed"(i16 %self, ptr %other) #2 !dbg !87 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.4.temp = alloca i16, align 2, !dbg !91
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.4.temp), !dbg !91
@@ -642,7 +642,7 @@ fn CallCompareGeneric3(a: Cpp.C.E, b: Cpp.ConvertToEnum2) -> bool {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CNotEqual:thunk:EqWith.a294139a6615e163.Core:enclosed"(i16 %self, ptr %other) #2 !dbg !92 {
+// CHECK:STDOUT: define weak_odr i1 @"_CNotEqual:thunk:EqWith.a294139a6615e163.Core:enclosed"(i16 %self, ptr %other) #2 !dbg !92 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.4.temp = alloca i16, align 2, !dbg !96
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.4.temp), !dbg !96

--- a/toolchain/lower/testdata/interop/cpp/function/export/generic.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/export/generic.carbon
@@ -182,7 +182,7 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #5 !dbg !28 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #5 !dbg !28 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.68011419f123494e:core.Destroy.Core"(ptr %self), !dbg !31
 // CHECK:STDOUT:   ret void, !dbg !31
@@ -195,7 +195,7 @@ fn Run() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.B.Main"(ptr %self) #5 !dbg !36 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.B.Main"(ptr %self) #5 !dbg !36 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.6c3865e9cbd9f6de:core.Destroy.Core"(ptr %self), !dbg !39
 // CHECK:STDOUT:   ret void, !dbg !39

--- a/toolchain/lower/testdata/interop/cpp/function/import/parameters.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/import/parameters.carbon
@@ -393,7 +393,7 @@ fn PassValueExpr(y: Cpp.Y) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.eed9ddf3aaac414a.Core:X.Cpp"(ptr sret([12 x i8]) %return) #2 !dbg !24 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.eed9ddf3aaac414a.Core:X.Cpp"(ptr sret([12 x i8]) %return) #2 !dbg !24 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN1XC1Ev.carbon_thunk.(ptr %return), !dbg !29
 // CHECK:STDOUT:   ret void, !dbg !29

--- a/toolchain/lower/testdata/interop/cpp/issue7142.carbon
+++ b/toolchain/lower/testdata/interop/cpp/issue7142.carbon
@@ -64,7 +64,7 @@ void f() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #2 !dbg !21 {
+// CHECK:STDOUT: define weak_odr void @"_C__destroy_thunk:thunk.A.Main"(ptr %self) #2 !dbg !21 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.68011419f123494e:core.Destroy.Core"(ptr %self), !dbg !24
 // CHECK:STDOUT:   ret void, !dbg !24

--- a/toolchain/lower/testdata/interop/cpp/operators.carbon
+++ b/toolchain/lower/testdata/interop/cpp/operators.carbon
@@ -146,7 +146,7 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CEqual:thunk:EqWith.ffb401eeee8c4872.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !30 {
+// CHECK:STDOUT: define weak_odr i1 @"_CEqual:thunk:EqWith.ffb401eeee8c4872.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !30 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.6.temp = alloca i1, align 1, !dbg !36
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.6.temp), !dbg !36
@@ -156,7 +156,7 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CNotEqual:thunk:EqWith.ffb401eeee8c4872.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !37 {
+// CHECK:STDOUT: define weak_odr i1 @"_CNotEqual:thunk:EqWith.ffb401eeee8c4872.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !37 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.6.temp = alloca i1, align 1, !dbg !41
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.6.temp), !dbg !41
@@ -412,7 +412,7 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CLess:thunk:OrderedWith.92c0df05bd55f97a.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !30 {
+// CHECK:STDOUT: define weak_odr i1 @"_CLess:thunk:OrderedWith.92c0df05bd55f97a.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !30 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.6.temp = alloca i1, align 1, !dbg !36
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.6.temp), !dbg !36
@@ -422,7 +422,7 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CLessOrEquivalent:thunk:OrderedWith.92c0df05bd55f97a.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !37 {
+// CHECK:STDOUT: define weak_odr i1 @"_CLessOrEquivalent:thunk:OrderedWith.92c0df05bd55f97a.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !37 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.6.temp = alloca i1, align 1, !dbg !41
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.6.temp), !dbg !41
@@ -432,7 +432,7 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CGreater:thunk:OrderedWith.92c0df05bd55f97a.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !42 {
+// CHECK:STDOUT: define weak_odr i1 @"_CGreater:thunk:OrderedWith.92c0df05bd55f97a.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !42 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.6.temp = alloca i1, align 1, !dbg !46
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.6.temp), !dbg !46
@@ -442,7 +442,7 @@ fn Driver(x: Cpp.A, y: Cpp.A) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define i1 @"_CGreaterOrEquivalent:thunk:OrderedWith.92c0df05bd55f97a.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !47 {
+// CHECK:STDOUT: define weak_odr i1 @"_CGreaterOrEquivalent:thunk:OrderedWith.92c0df05bd55f97a.Core:Cpp"(ptr %self, ptr %other) #2 !dbg !47 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   %.6.temp = alloca i1, align 1, !dbg !51
 // CHECK:STDOUT:   call void @llvm.lifetime.start.p0(ptr %.6.temp), !dbg !51

--- a/toolchain/lower/testdata/interop/cpp/reference.carbon
+++ b/toolchain/lower/testdata/interop/cpp/reference.carbon
@@ -177,7 +177,7 @@ fn GetRefs() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.dc3dd9c349162a91.Core:C.Cpp"(ptr sret({}) %return) #2 !dbg !30 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.dc3dd9c349162a91.Core:C.Cpp"(ptr sret({}) %return) #2 !dbg !30 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN1CC1Ev.carbon_thunk.(ptr %return), !dbg !34
 // CHECK:STDOUT:   ret void, !dbg !34
@@ -368,7 +368,7 @@ fn GetRefs() {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Default.dc3dd9c349162a91.Core:C.Cpp"(ptr sret({}) %return) #2 !dbg !30 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Default.dc3dd9c349162a91.Core:C.Cpp"(ptr sret({}) %return) #2 !dbg !30 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN1CC1Ev.carbon_thunk.(ptr %return), !dbg !34
 // CHECK:STDOUT:   ret void, !dbg !34

--- a/toolchain/lower/testdata/interop/cpp/thunks.carbon
+++ b/toolchain/lower/testdata/interop/cpp/thunks.carbon
@@ -128,14 +128,14 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Copy.60e3c6e2415a2ad6.Core:NeedThunk.Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !24 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Copy.60e3c6e2415a2ad6.Core:NeedThunk.Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !24 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN9NeedThunkC1ERKS_.carbon_thunk._(ptr %self, ptr %return), !dbg !30
 // CHECK:STDOUT:   ret void, !dbg !30
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Destroy.092ad14c7174f642.Core:NeedThunk.Cpp"(ptr %self) #2 !dbg !31 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Destroy.092ad14c7174f642.Core:NeedThunk.Cpp"(ptr %self) #2 !dbg !31 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   ret void, !dbg !34
 // CHECK:STDOUT: }
@@ -232,7 +232,7 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Copy.c0735c73762b4d1c.Core:Box.Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !27 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Copy.c0735c73762b4d1c.Core:Box.Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !27 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN3BoxI1AEC1ERKS1_.carbon_thunk._(ptr %self, ptr %return), !dbg !33
 // CHECK:STDOUT:   ret void, !dbg !33
@@ -252,7 +252,7 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Copy.2c1dd62357f2b914.Core:Box.Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !36 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Copy.2c1dd62357f2b914.Core:Box.Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !36 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN3BoxI1BEC1ERKS1_.carbon_thunk._(ptr %self, ptr %return), !dbg !39
 // CHECK:STDOUT:   ret void, !dbg !39
@@ -368,7 +368,7 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Copy.9e522bb4dbf82e5c.Core:Collide.Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !27 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Copy.9e522bb4dbf82e5c.Core:Collide.Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !27 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN7CollideC1ERKS_.carbon_thunk._(ptr %self, ptr %return), !dbg !33
 // CHECK:STDOUT:   ret void, !dbg !33
@@ -388,7 +388,7 @@ fn Call(a: Cpp.Collide, b: Cpp.AnonCollide) {
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Copy.d1fe27f3241437fa.Core:Collide..Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !36 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Copy.d1fe27f3241437fa.Core:Collide..Cpp"(ptr sret([1 x i8]) %return, ptr %self) #2 !dbg !36 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @_ZN12_GLOBAL__N_17CollideC1ERKS0_.carbon_thunk._(ptr %self, ptr %return), !dbg !39
 // CHECK:STDOUT:   ret void, !dbg !39

--- a/toolchain/lower/testdata/var/destroy_control_flow.carbon
+++ b/toolchain/lower/testdata/var/destroy_control_flow.carbon
@@ -120,7 +120,7 @@ fn WhileContinue(cond: bool) {
 // CHECK:STDOUT: declare void @"_COp.Destructible.Main:Destroy.Core"(ptr)
 // CHECK:STDOUT:
 // CHECK:STDOUT: ; Function Attrs: alwaysinline nounwind
-// CHECK:STDOUT: define void @"_COp:thunk:Destroy.25364816f7046881.Core:Destructible.Main:Destroy.Core"(ptr %self) #0 !dbg !4 {
+// CHECK:STDOUT: define weak_odr void @"_COp:thunk:Destroy.25364816f7046881.Core:Destructible.Main:Destroy.Core"(ptr %self) #0 !dbg !4 {
 // CHECK:STDOUT: entry:
 // CHECK:STDOUT:   call void @"_COp.Destructible.Main:Destroy.Core"(ptr %self), !dbg !10
 // CHECK:STDOUT:   ret void, !dbg !10


### PR DESCRIPTION
We can end up emitting the same thunk from multiple compilations in some cases -- in particular, when the thunk is wrapping a function that is either synthesized by the compiler or imported from C++. When this happens, we will have multiple-definition link errors unless we allow redefinitions across multiple files.

It'd be nice to detect when we need to do this and when we don't, but that's a bit tricky to do in practice. Ideally, in fact, we would use a different strategy, and emit the thunks as discardable definitions in each compilation that *uses* them. But for now emitting them with weak_odr linkage seems like a good way to make progress.