### PR TITLE
Add location to clang classes created via reverse interop

### DIFF
--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -156,10 +156,11 @@ auto ExportClassToCpp(Context& context, SemIR::LocId loc_id,
 
   auto* decl_context =
       ExportNameScopeToCpp(context, loc_id, class_info.parent_scope_id);
-  // TODO: Provide a source location.
+  auto clang_loc =
+      GetCppLocation(context, SemIR::LocId(class_info.first_decl_id()));
   auto* record_decl = clang::CXXRecordDecl::Create(
-      context.ast_context(), clang::TagTypeKind::Class, decl_context,
-      clang::SourceLocation(), clang::SourceLocation(), identifier_info);
+      context.ast_context(), clang::TagTypeKind::Class, decl_context, clang_loc,
+      clang_loc, identifier_info);
   // If this is a member class, set its access.
   if (isa<clang::CXXRecordDecl>(decl_context)) {
     // TODO: Map Carbon access to C++ access.

--- a/toolchain/check/testdata/interop/cpp/class/export/base.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/export/base.carbon
@@ -62,10 +62,12 @@ import Cpp;
 class Final {}
 
 inline Cpp '''
-// CHECK:STDERR: fail_derive_from_final.carbon:[[@LINE+5]]:12: error: base 'Final' is marked 'final' [CppInteropParseError]
-// CHECK:STDERR:    13 | struct A : Carbon::Final {};
+// CHECK:STDERR: fail_derive_from_final.carbon:[[@LINE+7]]:12: error: base 'Final' is marked 'final' [CppInteropParseError]
+// CHECK:STDERR:    15 | struct A : Carbon::Final {};
 // CHECK:STDERR:       |            ^
-// CHECK:STDERR: note: 'Final' declared here [CppInteropParseNote]
+// CHECK:STDERR: fail_derive_from_final.carbon:[[@LINE-6]]:13: note: 'Final' declared here [CppInteropParseNote]
+// CHECK:STDERR:     5 | class Final {}
+// CHECK:STDERR:       |             ^
 // CHECK:STDERR:
 struct A : Carbon::Final {};
 ''';
@@ -91,10 +93,12 @@ abstract class Abstract {
 }
 
 inline Cpp '''
-// CHECK:STDERR: fail_abstract.carbon:[[@LINE+5]]:18: error: variable type 'Carbon::Abstract' is an abstract class [CppInteropParseError]
-// CHECK:STDERR:    26 | Carbon::Abstract x;
+// CHECK:STDERR: fail_abstract.carbon:[[@LINE+7]]:18: error: variable type 'Carbon::Abstract' is an abstract class [CppInteropParseError]
+// CHECK:STDERR:    28 | Carbon::Abstract x;
 // CHECK:STDERR:       |                  ^
-// CHECK:STDERR: note: unimplemented pure virtual method '~Abstract' in 'Abstract' [CppInteropParseNote]
+// CHECK:STDERR: fail_abstract.carbon:[[@LINE-8]]:25: note: unimplemented pure virtual method '~Abstract' in 'Abstract' [CppInteropParseNote]
+// CHECK:STDERR:    16 | abstract class Abstract {
+// CHECK:STDERR:       |                         ^
 // CHECK:STDERR:
 Carbon::Abstract x;
 ''';

--- a/toolchain/check/testdata/interop/cpp/class/export/class.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/export/class.carbon
@@ -66,9 +66,12 @@ import Cpp;
 class A;
 
 inline Cpp '''
-// CHECK:STDERR: fail_incomplete_concrete.carbon:[[@LINE+4]]:11: error: variable has incomplete type 'Carbon::A' [CppInteropParseError]
-// CHECK:STDERR:    16 | Carbon::A a;
+// CHECK:STDERR: fail_incomplete_concrete.carbon:[[@LINE+7]]:11: error: variable has incomplete type 'Carbon::A' [CppInteropParseError]
+// CHECK:STDERR:    19 | Carbon::A a;
 // CHECK:STDERR:       |           ^
+// CHECK:STDERR: fail_incomplete_concrete.carbon:[[@LINE-6]]:8: note: forward declaration of 'Carbon::A' [CppInteropParseNote]
+// CHECK:STDERR:     9 | class A;
+// CHECK:STDERR:       |        ^
 // CHECK:STDERR:
 Carbon::A a;
 ''';

--- a/toolchain/check/testdata/interop/cpp/primitive_types/array.carbon
+++ b/toolchain/check/testdata/interop/cpp/primitive_types/array.carbon
@@ -73,9 +73,12 @@ fn F() -> array(C, 5)*;
 
 inline Cpp '''
 void G() {
-  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+4]]:33: error: subscript of pointer to incomplete type 'Carbon::C' [CppInteropParseError]
-  // CHECK:STDERR:    19 |   Carbon::C *p = &(*Carbon::F())[0];
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE+7]]:33: error: subscript of pointer to incomplete type 'Carbon::C' [CppInteropParseError]
+  // CHECK:STDERR:    22 |   Carbon::C *p = &(*Carbon::F())[0];
   // CHECK:STDERR:       |                   ~~~~~~~~~~~~~~^
+  // CHECK:STDERR: fail_incomplete.carbon:[[@LINE-9]]:8: note: forward declaration of 'Carbon::C' [CppInteropParseNote]
+  // CHECK:STDERR:     9 | class C;
+  // CHECK:STDERR:       |        ^
   // CHECK:STDERR:
   Carbon::C *p = &(*Carbon::F())[0];
 }


### PR DESCRIPTION
The specific location's not ideal (rather than the open curly, or
semicolon for a declaration - the two locations should be the `class`
and then the class name), but the same as we do for functions for now &
enough to get by.

This specifically also fixes a crash I found due to dtors being
generated without a location (because implicitly created functions would
use the class's location), creating a function call without a debug
location, which fails the LLVM IR verifier.
