### PR TITLE
Support exporting functions with generic return types to C++

### DIFF
--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -314,7 +314,8 @@ struct FunctionInfo {
                         clang::DeclContext* decl_context)
       : function_id(function_id),
         function(function),
-        decl_context(decl_context) {
+        decl_context(decl_context),
+        return_type_id(function.GetDeclaredReturnType(context.sem_ir())) {
     auto function_params =
         context.inst_blocks().Get(function.call_param_patterns_id);
     const auto& ranges = function.call_param_ranges;
@@ -366,6 +367,9 @@ struct FunctionInfo {
   // and whether the parameter is a reference.
   llvm::SmallVector<Param> explicit_params;
 
+  // Return type of the function.
+  SemIR::TypeId return_type_id;
+
   // For methods, the type of `self` and whether it is a reference. If
   // the function does not have a `self` parameter, this is `nullopt`.
   std::optional<Param> self_param;
@@ -406,8 +410,15 @@ static auto BuildFunctionInfo(Context& context, SemIR::LocId loc_id,
 }
 
 // Create a `clang::FunctionDecl` for the given Carbon function. This
-// can be used to call the Carbon function from C++. The Carbon
-// function's ABI must be compatible with C++.
+// can be used to call the Carbon function from C++.
+//
+// The Carbon function's ABI must be compatible with C++, unless it is a
+// generic function.
+//
+// For generic functions, the `clang::FunctionDecl` created here is only used
+// as a function template decl. Only specializations of this function
+// template decl are called directly, so the ABI of the function template
+// decl itself is irrelevant.
 //
 // The resulting decl is used to allow a generated C++ function to call
 // a generated Carbon function.
@@ -439,8 +450,15 @@ static auto BuildCppFunctionDeclForCarbonFn(Context& context,
     cpp_param_types.push_back(cpp_type);
   }
 
-  CARBON_CHECK(function.return_type_inst_id == SemIR::TypeInstId::None);
-  auto cpp_return_type = context.ast_context().VoidTy;
+  auto return_type_id = function.GetDeclaredReturnType(context.sem_ir());
+  clang::QualType cpp_return_type = context.ast_context().VoidTy;
+  if (return_type_id.has_value()) {
+    cpp_return_type = MapToCppType(context, return_type_id);
+    if (cpp_return_type.isNull()) {
+      context.TODO(loc_id, "failed to map Carbon return type to C++");
+      return nullptr;
+    }
+  }
 
   auto cpp_function_type = context.ast_context().getFunctionType(
       cpp_return_type, cpp_param_types,
@@ -533,9 +551,8 @@ static auto BuildCppToCarbonThunkFunctionType(Context& context,
   // Get the C++ return type (this corresponds to the return type of the
   // target Carbon function).
   clang::QualType cpp_return_type = context.ast_context().VoidTy;
-  auto return_type_id = target.function.GetDeclaredReturnType(context.sem_ir());
-  if (return_type_id != SemIR::TypeId::None) {
-    cpp_return_type = MapToCppType(context, return_type_id);
+  if (target.return_type_id != SemIR::TypeId::None) {
+    cpp_return_type = MapToCppType(context, target.return_type_id);
     if (cpp_return_type.isNull()) {
       context.TODO(loc_id, "failed to map Carbon return type to C++ type");
       return nullptr;
@@ -758,10 +775,8 @@ static auto BuildCarbonToCarbonThunk(Context& context, SemIR::LocId loc_id,
   for (const auto& param : target.explicit_params) {
     thunk_param_type_ids.push_back(param.type_id);
   }
-  auto callee_return_type_id =
-      target.function.GetDeclaredReturnType(context.sem_ir());
-  if (callee_return_type_id != SemIR::TypeId::None) {
-    thunk_param_type_ids.push_back(callee_return_type_id);
+  if (target.return_type_id != SemIR::TypeId::None) {
+    thunk_param_type_ids.push_back(target.return_type_id);
   }
 
   auto carbon_thunk_function_id =
@@ -921,16 +936,16 @@ auto ExportFunctionSpecializationToCpp(
         context.insts().Get(binding_const_inst_id).type_id()));
   }
 
-  // Create a specific, and use that to convert from parameters with
-  // symbolic types to concrete types.
+  // Create a specific, and use that to convert return type and
+  // parameters with symbolic types to concrete types.
   auto specific_id = MakeSpecific(context, loc_id, target.function.generic_id,
                                   specific_arg_ids);
+  target.return_type_id =
+      target.function.GetDeclaredReturnType(context.sem_ir(), specific_id);
   for (auto& param : target.explicit_params) {
     param.type_id =
         GetScrutineeTypeInSpecific(context, param.pattern_inst_id, specific_id);
   }
-
-  // TODO: handle generic return type.
 
   // Build the thunks. Mark the C++ thunk as a template specialization.
   auto* function_decl =

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -410,15 +410,8 @@ static auto BuildFunctionInfo(Context& context, SemIR::LocId loc_id,
 }
 
 // Create a `clang::FunctionDecl` for the given Carbon function. This
-// can be used to call the Carbon function from C++.
-//
-// The Carbon function's ABI must be compatible with C++, unless it is a
-// generic function.
-//
-// For generic functions, the `clang::FunctionDecl` created here is only used
-// as a function template decl. Only specializations of this function
-// template decl are called directly, so the ABI of the function template
-// decl itself is irrelevant.
+// can be used to call the Carbon function from C++. The Carbon
+// function's ABI must be compatible with C++.
 //
 // The resulting decl is used to allow a generated C++ function to call
 // a generated Carbon function.
@@ -429,6 +422,80 @@ static auto BuildCppFunctionDeclForCarbonFn(Context& context,
   auto clang_loc = GetCppLocation(context, loc_id);
 
   const SemIR::Function& function = context.functions().Get(function_id);
+  FunctionInfo callee(context, function_id, function, nullptr);
+
+  // Get parameters types.
+  llvm::SmallVector<clang::QualType> cpp_param_types;
+  if (callee.self_param) {
+    auto cpp_type = MapToCppThunkParamType(context, callee.self_param->type_id);
+    if (cpp_type.isNull()) {
+      context.TODO(loc_id, "failed to map Carbon self type to C++");
+      return nullptr;
+    }
+    cpp_param_types.push_back(cpp_type);
+  }
+  for (auto param : callee.explicit_params) {
+    auto cpp_type = MapToCppThunkParamType(context, param.type_id);
+    if (cpp_type.isNull()) {
+      context.TODO(loc_id, "failed to map Carbon type to C++");
+      return nullptr;
+    }
+    cpp_param_types.push_back(cpp_type);
+  }
+
+  CARBON_CHECK(function.return_type_inst_id == SemIR::TypeInstId::None);
+  auto cpp_return_type = context.ast_context().VoidTy;
+
+  auto cpp_function_type = context.ast_context().getFunctionType(
+      cpp_return_type, cpp_param_types,
+      clang::FunctionProtoType::ExtProtoInfo());
+
+  auto* identifier_info = GetClangIdentifierInfo(context, function.name_id);
+  CARBON_CHECK(identifier_info, "function with non-identifier name {0}",
+               function.name_id);
+
+  auto* tinfo = context.ast_context().getTrivialTypeSourceInfo(
+      cpp_function_type, clang_loc);
+  clang::FunctionDecl* function_decl = clang::FunctionDecl::Create(
+      context.ast_context(), context.ast_context().getTranslationUnitDecl(),
+      /*StartLoc=*/clang_loc, /*NLoc=*/clang_loc, identifier_info,
+      cpp_function_type, tinfo, clang::SC_Extern);
+
+  // Build parameter decls.
+  llvm::SmallVector<clang::ParmVarDecl*> param_var_decls;
+  for (auto [i, type] : llvm::enumerate(cpp_param_types)) {
+    auto* param_tinfo =
+        context.ast_context().getTrivialTypeSourceInfo(type, clang_loc);
+    clang::ParmVarDecl* param = clang::ParmVarDecl::Create(
+        context.ast_context(), function_decl, /*StartLoc=*/clang_loc,
+        /*IdLoc=*/clang_loc, /*Id=*/nullptr, type, param_tinfo, clang::SC_None,
+        /*DefArg=*/nullptr);
+    param_var_decls.push_back(param);
+  }
+  function_decl->setParams(param_var_decls);
+
+  // Mangle the function name and attach it to the `FunctionDecl`.
+  SemIR::Mangler m(context.sem_ir(), context.total_ir_count(),
+                   context.mangle_string_fingerprint());
+  std::string mangled_name = m.Mangle(function_id, SemIR::SpecificId::None);
+  function_decl->addAttr(
+      clang::AsmLabelAttr::Create(context.ast_context(), mangled_name));
+
+  return function_decl;
+}
+
+// Create a `clang::FunctionDecl` for the given generic Carbon function.
+//
+// The `clang::FunctionDecl` created here is only used as a function template
+// decl. Only specializations of this function template decl are called
+// directly, so the ABI of this function decl is irrelevant.
+static auto BuildCppFunctionDeclForGenericCarbonFn(
+    Context& context, SemIR::LocId loc_id, SemIR::FunctionId function_id)
+    -> clang::FunctionDecl* {
+  auto clang_loc = GetCppLocation(context, loc_id);
+
+  const SemIR::Function& function = context.functions().Get(function_id);
+  CARBON_CHECK(function.generic_id.has_value());
   FunctionInfo callee(context, function_id, function, nullptr);
 
   // Get parameters types.
@@ -1021,8 +1088,8 @@ static auto ExportGenericFunctionToCpp(Context& context, SemIR::LocId loc_id,
       /*RAngleLoc=*/clang_loc,
       /*RequiresClause=*/nullptr);
 
-  auto* function_decl =
-      BuildCppFunctionDeclForCarbonFn(context, loc_id, callee.function_id);
+  auto* function_decl = BuildCppFunctionDeclForGenericCarbonFn(
+      context, loc_id, callee.function_id);
   if (!function_decl) {
     return nullptr;
   }

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -458,9 +458,8 @@ static auto BuildCppFunctionDecl(Context& context,
 //
 // The resulting decl is used to allow a generated C++ function to call
 // a generated Carbon function.
-static auto BuildCppFunctionDeclForCarbonFn(Context& context,
-                                            SemIR::LocId loc_id,
-                                            SemIR::FunctionId function_id)
+static auto BuildCppFunctionDeclForNonGenericCarbonFn(
+    Context& context, SemIR::LocId loc_id, SemIR::FunctionId function_id)
     -> clang::FunctionDecl* {
   const SemIR::Function& function = context.functions().Get(function_id);
   CARBON_CHECK(!function.generic_id.has_value());
@@ -517,7 +516,7 @@ static auto BuildCppFunctionDeclForGenericCarbonFn(
   // Get parameters types.
   //
   // TODO: currently this matches the behavior of
-  // BuildCppFunctionDeclForCarbonFn, but for templates the ABI is
+  // BuildCppFunctionDeclForNonGenericCarbonFn, but for templates the ABI is
   // irrelevant, and the parameter should instead map to something that will
   // guide C++ template argument deduction into doing the right thing.
   llvm::SmallVector<clang::QualType> cpp_param_types;
@@ -885,7 +884,7 @@ static auto BuildCppToCarbonThunk(Context& context, SemIR::LocId loc_id,
       BuildCarbonToCarbonThunk(context, loc_id, target, extra_name);
 
   // Create a `clang::FunctionDecl` that can be used to call the Carbon thunk.
-  auto* carbon_function_decl = BuildCppFunctionDeclForCarbonFn(
+  auto* carbon_function_decl = BuildCppFunctionDeclForNonGenericCarbonFn(
       context, loc_id, carbon_thunk_function_id);
   if (!carbon_function_decl) {
     return;
@@ -1187,8 +1186,8 @@ auto ExportDestructorToCpp(Context& context, const SemIR::Class& class_info,
   // TODO: Once we support exporting specific classes, export the specific
   // destructor here rather than a generic one.
   auto thunk_function_id = BuildDestroyThunk(context, loc_id, class_info);
-  auto* cpp_function_decl =
-      BuildCppFunctionDeclForCarbonFn(context, loc_id, thunk_function_id);
+  auto* cpp_function_decl = BuildCppFunctionDeclForNonGenericCarbonFn(
+      context, loc_id, thunk_function_id);
   if (!cpp_function_decl) {
     return nullptr;
   }

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -555,13 +555,6 @@ static auto BuildCppFunctionDeclForGenericCarbonFn(
   }
   function_decl->setParams(param_var_decls);
 
-  // Mangle the function name and attach it to the `FunctionDecl`.
-  SemIR::Mangler m(context.sem_ir(), context.total_ir_count(),
-                   context.mangle_string_fingerprint());
-  std::string mangled_name = m.Mangle(function_id, SemIR::SpecificId::None);
-  function_decl->addAttr(
-      clang::AsmLabelAttr::Create(context.ast_context(), mangled_name));
-
   return function_decl;
 }
 

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -422,6 +422,7 @@ static auto BuildCppFunctionDeclForCarbonFn(Context& context,
   auto clang_loc = GetCppLocation(context, loc_id);
 
   const SemIR::Function& function = context.functions().Get(function_id);
+  CARBON_CHECK(!function.generic_id.has_value());
   FunctionInfo callee(context, function_id, function, nullptr);
 
   // Get parameters types.

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -409,6 +409,49 @@ static auto BuildFunctionInfo(Context& context, SemIR::LocId loc_id,
   return FunctionInfo(context, callee_function_id, callee, decl_context);
 }
 
+// Create a `clang::FunctionDecl` with the given parameter types and
+// return type.
+//
+// The function's name will match the one referenced by `function_name_id`,
+// and the function will be added to the given `decl_context`.
+static auto BuildCppFunctionDecl(Context& context,
+                                 clang::DeclContext* decl_context,
+                                 SemIR::LocId loc_id,
+                                 SemIR::NameId function_name_id,
+                                 clang::ArrayRef<clang::QualType> param_types,
+                                 clang::QualType return_type) {
+  auto clang_loc = GetCppLocation(context, loc_id);
+
+  auto cpp_function_type = context.ast_context().getFunctionType(
+      return_type, param_types, clang::FunctionProtoType::ExtProtoInfo());
+
+  auto* identifier_info = GetClangIdentifierInfo(context, function_name_id);
+  CARBON_CHECK(identifier_info, "function with non-identifier name {0}",
+               function_name_id);
+
+  auto* tinfo = context.ast_context().getTrivialTypeSourceInfo(
+      cpp_function_type, clang_loc);
+  clang::FunctionDecl* function_decl = clang::FunctionDecl::Create(
+      context.ast_context(), decl_context,
+      /*StartLoc=*/clang_loc, /*NLoc=*/clang_loc, identifier_info,
+      cpp_function_type, tinfo, clang::SC_Extern);
+
+  // Build parameter decls.
+  llvm::SmallVector<clang::ParmVarDecl*> param_var_decls;
+  for (auto [i, type] : llvm::enumerate(param_types)) {
+    auto* param_tinfo =
+        context.ast_context().getTrivialTypeSourceInfo(type, clang_loc);
+    clang::ParmVarDecl* param = clang::ParmVarDecl::Create(
+        context.ast_context(), function_decl, /*StartLoc=*/clang_loc,
+        /*IdLoc=*/clang_loc, /*Id=*/nullptr, type, param_tinfo, clang::SC_None,
+        /*DefArg=*/nullptr);
+    param_var_decls.push_back(param);
+  }
+  function_decl->setParams(param_var_decls);
+
+  return function_decl;
+}
+
 // Create a `clang::FunctionDecl` for the given Carbon function. This
 // can be used to call the Carbon function from C++. The Carbon
 // function's ABI must be compatible with C++.
@@ -419,8 +462,6 @@ static auto BuildCppFunctionDeclForCarbonFn(Context& context,
                                             SemIR::LocId loc_id,
                                             SemIR::FunctionId function_id)
     -> clang::FunctionDecl* {
-  auto clang_loc = GetCppLocation(context, loc_id);
-
   const SemIR::Function& function = context.functions().Get(function_id);
   CARBON_CHECK(!function.generic_id.has_value());
   FunctionInfo callee(context, function_id, function, nullptr);
@@ -447,33 +488,9 @@ static auto BuildCppFunctionDeclForCarbonFn(Context& context,
   CARBON_CHECK(function.return_type_inst_id == SemIR::TypeInstId::None);
   auto cpp_return_type = context.ast_context().VoidTy;
 
-  auto cpp_function_type = context.ast_context().getFunctionType(
-      cpp_return_type, cpp_param_types,
-      clang::FunctionProtoType::ExtProtoInfo());
-
-  auto* identifier_info = GetClangIdentifierInfo(context, function.name_id);
-  CARBON_CHECK(identifier_info, "function with non-identifier name {0}",
-               function.name_id);
-
-  auto* tinfo = context.ast_context().getTrivialTypeSourceInfo(
-      cpp_function_type, clang_loc);
-  clang::FunctionDecl* function_decl = clang::FunctionDecl::Create(
-      context.ast_context(), context.ast_context().getTranslationUnitDecl(),
-      /*StartLoc=*/clang_loc, /*NLoc=*/clang_loc, identifier_info,
-      cpp_function_type, tinfo, clang::SC_Extern);
-
-  // Build parameter decls.
-  llvm::SmallVector<clang::ParmVarDecl*> param_var_decls;
-  for (auto [i, type] : llvm::enumerate(cpp_param_types)) {
-    auto* param_tinfo =
-        context.ast_context().getTrivialTypeSourceInfo(type, clang_loc);
-    clang::ParmVarDecl* param = clang::ParmVarDecl::Create(
-        context.ast_context(), function_decl, /*StartLoc=*/clang_loc,
-        /*IdLoc=*/clang_loc, /*Id=*/nullptr, type, param_tinfo, clang::SC_None,
-        /*DefArg=*/nullptr);
-    param_var_decls.push_back(param);
-  }
-  function_decl->setParams(param_var_decls);
+  auto* function_decl = BuildCppFunctionDecl(
+      context, context.ast_context().getTranslationUnitDecl(), loc_id,
+      function.name_id, cpp_param_types, cpp_return_type);
 
   // Mangle the function name and attach it to the `FunctionDecl`.
   SemIR::Mangler m(context.sem_ir(), context.total_ir_count(),
@@ -493,8 +510,6 @@ static auto BuildCppFunctionDeclForCarbonFn(Context& context,
 static auto BuildCppFunctionDeclForGenericCarbonFn(
     Context& context, SemIR::LocId loc_id, SemIR::FunctionId function_id)
     -> clang::FunctionDecl* {
-  auto clang_loc = GetCppLocation(context, loc_id);
-
   const SemIR::Function& function = context.functions().Get(function_id);
   CARBON_CHECK(function.generic_id.has_value());
   FunctionInfo callee(context, function_id, function, nullptr);
@@ -533,37 +548,12 @@ static auto BuildCppFunctionDeclForGenericCarbonFn(
     }
   }
 
-  auto cpp_function_type = context.ast_context().getFunctionType(
-      cpp_return_type, cpp_param_types,
-      clang::FunctionProtoType::ExtProtoInfo());
-
-  auto* identifier_info = GetClangIdentifierInfo(context, function.name_id);
-  CARBON_CHECK(identifier_info, "function with non-identifier name {0}",
-               function.name_id);
-
-  auto* tinfo = context.ast_context().getTrivialTypeSourceInfo(
-      cpp_function_type, clang_loc);
-  clang::FunctionDecl* function_decl = clang::FunctionDecl::Create(
-      context.ast_context(),
-      // TODO: use the context corresponding to the Carbon generic function.
-      context.ast_context().getTranslationUnitDecl(),
-      /*StartLoc=*/clang_loc, /*NLoc=*/clang_loc, identifier_info,
-      cpp_function_type, tinfo, clang::SC_Extern);
-
-  // Build parameter decls.
-  llvm::SmallVector<clang::ParmVarDecl*> param_var_decls;
-  for (auto [i, type] : llvm::enumerate(cpp_param_types)) {
-    auto* param_tinfo =
-        context.ast_context().getTrivialTypeSourceInfo(type, clang_loc);
-    clang::ParmVarDecl* param = clang::ParmVarDecl::Create(
-        context.ast_context(), function_decl, /*StartLoc=*/clang_loc,
-        /*IdLoc=*/clang_loc, /*Id=*/nullptr, type, param_tinfo, clang::SC_None,
-        /*DefArg=*/nullptr);
-    param_var_decls.push_back(param);
-  }
-  function_decl->setParams(param_var_decls);
-
-  return function_decl;
+  return BuildCppFunctionDecl(context,
+                              // TODO: provide the decl context corresponding to
+                              // the Carbon generic function.
+                              context.ast_context().getTranslationUnitDecl(),
+                              loc_id, function.name_id, cpp_param_types,
+                              cpp_return_type);
 }
 
 // Returns whether the given Carbon parameter should be passed as a C++ const

--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -500,6 +500,11 @@ static auto BuildCppFunctionDeclForGenericCarbonFn(
   FunctionInfo callee(context, function_id, function, nullptr);
 
   // Get parameters types.
+  //
+  // TODO: currently this matches the behavior of
+  // BuildCppFunctionDeclForCarbonFn, but for templates the ABI is
+  // irrelevant, and the parameter should instead map to something that will
+  // guide C++ template argument deduction into doing the right thing.
   llvm::SmallVector<clang::QualType> cpp_param_types;
   if (callee.self_param) {
     auto cpp_type = MapToCppThunkParamType(context, callee.self_param->type_id);
@@ -539,7 +544,9 @@ static auto BuildCppFunctionDeclForGenericCarbonFn(
   auto* tinfo = context.ast_context().getTrivialTypeSourceInfo(
       cpp_function_type, clang_loc);
   clang::FunctionDecl* function_decl = clang::FunctionDecl::Create(
-      context.ast_context(), context.ast_context().getTranslationUnitDecl(),
+      context.ast_context(),
+      // TODO: use the context corresponding to the Carbon generic function.
+      context.ast_context().getTranslationUnitDecl(),
       /*StartLoc=*/clang_loc, /*NLoc=*/clang_loc, identifier_info,
       cpp_function_type, tinfo, clang::SC_Extern);
 

--- a/toolchain/check/testdata/interop/cpp/function/export/generic.carbon
+++ b/toolchain/check/testdata/interop/cpp/function/export/generic.carbon
@@ -16,30 +16,34 @@ import Cpp;
 
 //@dump-sem-ir-begin
 interface I {
-  fn Doit(self);
+  fn Doit(self) -> Self;
 }
 
 class A {
   impl as I {
-    fn Doit(unused self) {}
+    fn Doit(unused self) -> Self {
+      return {};
+    }
   }
 }
 class B {
   impl as I {
-    fn Doit(unused self) {}
+    fn Doit(unused self) -> Self {
+      return {};
+    }
   }
 }
 
-fn F[T: I](t: T) {
-  t.Doit();
+fn F[T: I](t: T) -> T {
+  return t.Doit();
 }
 
 inline Cpp '''
-void G() {
+Carbon::B G() {
   Carbon::A a;
   Carbon::B b;
   Carbon::F(a);
-  Carbon::F(b);
+  return Carbon::F(b);
 }
 ''';
 //@dump-sem-ir-end
@@ -142,6 +146,9 @@ void G() {
 // CHECK:STDOUT:   %pattern_type.c60: type = pattern_type %Self.as_type.c84 [symbolic]
 // CHECK:STDOUT:   %self.param_patt.a33: %pattern_type.c60 = value_param_pattern [symbolic]
 // CHECK:STDOUT:   %self.patt.696: %pattern_type.c60 = at_binding_pattern self, %self.param_patt.a33 [symbolic]
+// CHECK:STDOUT:   %.8fc: Core.Form = init_form %Self.as_type.c84 [symbolic]
+// CHECK:STDOUT:   %return.param_patt.434: %pattern_type.c60 = out_param_pattern [symbolic]
+// CHECK:STDOUT:   %return.patt.44a: %pattern_type.c60 = return_slot_pattern %return.param_patt.434, %Self.as_type.c84 [symbolic]
 // CHECK:STDOUT:   %I.WithSelf.Doit.type.26f: type = fn_type @I.WithSelf.Doit, @I.WithSelf(%Self.37e) [symbolic]
 // CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %I.WithSelf.Doit.11f: %I.WithSelf.Doit.type.26f = struct_value () [symbolic]
@@ -152,6 +159,9 @@ void G() {
 // CHECK:STDOUT:   %pattern_type.9ef: type = pattern_type %A [concrete]
 // CHECK:STDOUT:   %self.param_patt.04e: %pattern_type.9ef = value_param_pattern [concrete]
 // CHECK:STDOUT:   %self.patt.312: %pattern_type.9ef = at_binding_pattern self, %self.param_patt.04e [concrete]
+// CHECK:STDOUT:   %.cbf: Core.Form = init_form %A [concrete]
+// CHECK:STDOUT:   %return.param_patt.f0c: %pattern_type.9ef = out_param_pattern [concrete]
+// CHECK:STDOUT:   %return.patt.a6d: %pattern_type.9ef = return_slot_pattern %return.param_patt.f0c, %A [concrete]
 // CHECK:STDOUT:   %A.as.I.impl.Doit.type: type = fn_type @A.as.I.impl.Doit [concrete]
 // CHECK:STDOUT:   %A.as.I.impl.Doit: %A.as.I.impl.Doit.type = struct_value () [concrete]
 // CHECK:STDOUT:   %I.facet.64b: %I.type = facet_value %A, (%I.impl_witness.6ad) [concrete]
@@ -159,16 +169,22 @@ void G() {
 // CHECK:STDOUT:   %I.WithSelf.Doit.dab: %I.WithSelf.Doit.type.5b3 = struct_value () [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %empty_struct: %empty_struct_type = struct_value () [concrete]
+// CHECK:STDOUT:   %A.val: %A = struct_value () [concrete]
 // CHECK:STDOUT:   %B: type = class_type @B [concrete]
 // CHECK:STDOUT:   %I.impl_witness.5b8: <witness> = impl_witness @B.as.I.impl.%I.impl_witness_table [concrete]
 // CHECK:STDOUT:   %pattern_type.e39: type = pattern_type %B [concrete]
 // CHECK:STDOUT:   %self.param_patt.f1f: %pattern_type.e39 = value_param_pattern [concrete]
 // CHECK:STDOUT:   %self.patt.4eb: %pattern_type.e39 = at_binding_pattern self, %self.param_patt.f1f [concrete]
+// CHECK:STDOUT:   %.d83: Core.Form = init_form %B [concrete]
+// CHECK:STDOUT:   %return.param_patt.934: %pattern_type.e39 = out_param_pattern [concrete]
+// CHECK:STDOUT:   %return.patt.911: %pattern_type.e39 = return_slot_pattern %return.param_patt.934, %B [concrete]
 // CHECK:STDOUT:   %B.as.I.impl.Doit.type: type = fn_type @B.as.I.impl.Doit [concrete]
 // CHECK:STDOUT:   %B.as.I.impl.Doit: %B.as.I.impl.Doit.type = struct_value () [concrete]
 // CHECK:STDOUT:   %I.facet.9f8: %I.type = facet_value %B, (%I.impl_witness.5b8) [concrete]
 // CHECK:STDOUT:   %I.WithSelf.Doit.type.2ce: type = fn_type @I.WithSelf.Doit, @I.WithSelf(%I.facet.9f8) [concrete]
 // CHECK:STDOUT:   %I.WithSelf.Doit.450: %I.WithSelf.Doit.type.2ce = struct_value () [concrete]
+// CHECK:STDOUT:   %B.val: %B = struct_value () [concrete]
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
 // CHECK:STDOUT:   %.Self.frozen: %type = symbolic_binding .Self [symbolic_self]
 // CHECK:STDOUT:   %pattern_type.6cb: type = pattern_type %I.type [concrete]
@@ -178,6 +194,9 @@ void G() {
 // CHECK:STDOUT:   %pattern_type.b3a: type = pattern_type %T.as_type [symbolic]
 // CHECK:STDOUT:   %t.param_patt.5db: %pattern_type.b3a = value_param_pattern [symbolic]
 // CHECK:STDOUT:   %t.patt.030: %pattern_type.b3a = at_binding_pattern t, %t.param_patt.5db [symbolic]
+// CHECK:STDOUT:   %.0ce: Core.Form = init_form %T.as_type [symbolic]
+// CHECK:STDOUT:   %return.param_patt.b82: %pattern_type.b3a = out_param_pattern [symbolic]
+// CHECK:STDOUT:   %return.patt.2e6: %pattern_type.b3a = return_slot_pattern %return.param_patt.b82, %T.as_type [symbolic]
 // CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
 // CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
 // CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type [symbolic]
@@ -190,18 +209,18 @@ void G() {
 // CHECK:STDOUT:   %self.patt.300: %pattern_type.b3a = at_binding_pattern self, %self.param_patt.58e [symbolic]
 // CHECK:STDOUT:   %specific_impl_fn: <specific function> = specific_impl_function %impl.elem0, @I.WithSelf.Doit(%T) [symbolic]
 // CHECK:STDOUT:   %Destroy.type: type = facet_type <@Destroy> [concrete]
-// CHECK:STDOUT:   %Destroy.Op.type.1d8f74.2: type = fn_type @Destroy.Op.loc9_9.2 [concrete]
+// CHECK:STDOUT:   %Destroy.Op.type.1d8f74.2: type = fn_type @Destroy.Op.loc16_9.2 [concrete]
 // CHECK:STDOUT:   %Destroy.Op.1a2547.2: %Destroy.Op.type.1d8f74.2 = struct_value () [concrete]
 // CHECK:STDOUT:   %custom_witness.df9cc1.2: <witness> = custom_witness (%Destroy.Op.1a2547.2), @Destroy [concrete]
-// CHECK:STDOUT:   %Destroy.facet.6e5: %Destroy.type = facet_value %A, (%custom_witness.df9cc1.2) [concrete]
-// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.09e: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Destroy.facet.6e5) [concrete]
-// CHECK:STDOUT:   %.dca: type = fn_type_with_self_type %Destroy.WithSelf.Op.type.09e, %Destroy.facet.6e5 [concrete]
-// CHECK:STDOUT:   %Destroy.Op.type.1d8f74.3: type = fn_type @Destroy.Op.loc14 [concrete]
-// CHECK:STDOUT:   %Destroy.Op.1a2547.3: %Destroy.Op.type.1d8f74.3 = struct_value () [concrete]
-// CHECK:STDOUT:   %custom_witness.df9cc1.3: <witness> = custom_witness (%Destroy.Op.1a2547.3), @Destroy [concrete]
-// CHECK:STDOUT:   %Destroy.facet.f70: %Destroy.type = facet_value %B, (%custom_witness.df9cc1.3) [concrete]
+// CHECK:STDOUT:   %Destroy.facet.f70: %Destroy.type = facet_value %B, (%custom_witness.df9cc1.2) [concrete]
 // CHECK:STDOUT:   %Destroy.WithSelf.Op.type.cda: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Destroy.facet.f70) [concrete]
 // CHECK:STDOUT:   %.3d9: type = fn_type_with_self_type %Destroy.WithSelf.Op.type.cda, %Destroy.facet.f70 [concrete]
+// CHECK:STDOUT:   %Destroy.Op.type.1d8f74.3: type = fn_type @Destroy.Op.loc9 [concrete]
+// CHECK:STDOUT:   %Destroy.Op.1a2547.3: %Destroy.Op.type.1d8f74.3 = struct_value () [concrete]
+// CHECK:STDOUT:   %custom_witness.df9cc1.3: <witness> = custom_witness (%Destroy.Op.1a2547.3), @Destroy [concrete]
+// CHECK:STDOUT:   %Destroy.facet.6e5: %Destroy.type = facet_value %A, (%custom_witness.df9cc1.3) [concrete]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.09e: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Destroy.facet.6e5) [concrete]
+// CHECK:STDOUT:   %.dca: type = fn_type_with_self_type %Destroy.WithSelf.Op.type.09e, %Destroy.facet.6e5 [concrete]
 // CHECK:STDOUT:   %t.param_patt.169: %pattern_type.9ef = value_param_pattern [concrete]
 // CHECK:STDOUT:   %t.patt.ee8: %pattern_type.9ef = at_binding_pattern t, %t.param_patt.169 [concrete]
 // CHECK:STDOUT:   %F.specific_fn.f33: <specific function> = specific_function %F, @F(%I.facet.64b) [concrete]
@@ -223,29 +242,37 @@ void G() {
 // CHECK:STDOUT:   %A.decl: type = class_decl @A [concrete = constants.%A] {} {}
 // CHECK:STDOUT:   %B.decl: type = class_decl @B [concrete = constants.%B] {} {}
 // CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
-// CHECK:STDOUT:     %T.patt.loc20_7.1: %pattern_type.6cb = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_7.2 (constants.%T.patt)]
-// CHECK:STDOUT:     %t.param_patt.loc20_13.1: @F.%pattern_type (%pattern_type.b3a) = value_param_pattern [symbolic = %t.param_patt.loc20_13.2 (constants.%t.param_patt.5db)]
-// CHECK:STDOUT:     %t.patt.loc20_13.1: @F.%pattern_type (%pattern_type.b3a) = at_binding_pattern t, %t.param_patt.loc20_13.1 [symbolic = %t.patt.loc20_13.2 (constants.%t.patt.030)]
+// CHECK:STDOUT:     %T.patt.loc24_7.1: %pattern_type.6cb = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc24_7.2 (constants.%T.patt)]
+// CHECK:STDOUT:     %t.param_patt.loc24_13.1: @F.%pattern_type (%pattern_type.b3a) = value_param_pattern [symbolic = %t.param_patt.loc24_13.2 (constants.%t.param_patt.5db)]
+// CHECK:STDOUT:     %t.patt.loc24_13.1: @F.%pattern_type (%pattern_type.b3a) = at_binding_pattern t, %t.param_patt.loc24_13.1 [symbolic = %t.patt.loc24_13.2 (constants.%t.patt.030)]
+// CHECK:STDOUT:     %return.param_patt.loc24_21.1: @F.%pattern_type (%pattern_type.b3a) = out_param_pattern [symbolic = %return.param_patt.loc24_21.2 (constants.%return.param_patt.b82)]
+// CHECK:STDOUT:     %return.patt.loc24_18.1: @F.%pattern_type (%pattern_type.b3a) = return_slot_pattern %return.param_patt.loc24_21.1, %.loc24_21.3 [symbolic = %return.patt.loc24_18.2 (constants.%return.patt.2e6)]
 // CHECK:STDOUT:   } {
-// CHECK:STDOUT:     %.loc20_9: type = splice_block %I.ref [concrete = constants.%I.type] {
+// CHECK:STDOUT:     %T.ref.loc24_21: %I.type = name_ref T, %T.loc24_7.2 [symbolic = %T.loc24_7.1 (constants.%T)]
+// CHECK:STDOUT:     %T.as_type.loc24_21: type = facet_access_type %T.ref.loc24_21 [symbolic = %T.as_type.loc24_15.1 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc24_21.3: type = converted %T.ref.loc24_21, %T.as_type.loc24_21 [symbolic = %T.as_type.loc24_15.1 (constants.%T.as_type)]
+// CHECK:STDOUT:     %.loc24_21.4: Core.Form = init_form %.loc24_21.3 [symbolic = %.loc24_21.2 (constants.%.0ce)]
+// CHECK:STDOUT:     %.loc24_9: type = splice_block %I.ref [concrete = constants.%I.type] {
 // CHECK:STDOUT:       %.Self.frozen: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.frozen]
 // CHECK:STDOUT:       %I.ref: type = name_ref I, file.%I.decl [concrete = constants.%I.type]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %T.loc20_7.2: %I.type = symbolic_binding T, 0 [symbolic = %T.loc20_7.1 (constants.%T)]
-// CHECK:STDOUT:     %t.param: @F.%T.as_type.loc20_15.1 (%T.as_type) = value_param call_param0
-// CHECK:STDOUT:     %.loc20_15.1: type = splice_block %.loc20_15.2 [symbolic = %T.as_type.loc20_15.1 (constants.%T.as_type)] {
-// CHECK:STDOUT:       %T.ref: %I.type = name_ref T, %T.loc20_7.2 [symbolic = %T.loc20_7.1 (constants.%T)]
-// CHECK:STDOUT:       %T.as_type.loc20_15.2: type = facet_access_type %T.ref [symbolic = %T.as_type.loc20_15.1 (constants.%T.as_type)]
-// CHECK:STDOUT:       %.loc20_15.2: type = converted %T.ref, %T.as_type.loc20_15.2 [symbolic = %T.as_type.loc20_15.1 (constants.%T.as_type)]
+// CHECK:STDOUT:     %T.loc24_7.2: %I.type = symbolic_binding T, 0 [symbolic = %T.loc24_7.1 (constants.%T)]
+// CHECK:STDOUT:     %t.param: @F.%T.as_type.loc24_15.1 (%T.as_type) = value_param call_param0
+// CHECK:STDOUT:     %.loc24_15.1: type = splice_block %.loc24_15.2 [symbolic = %T.as_type.loc24_15.1 (constants.%T.as_type)] {
+// CHECK:STDOUT:       %T.ref.loc24_15: %I.type = name_ref T, %T.loc24_7.2 [symbolic = %T.loc24_7.1 (constants.%T)]
+// CHECK:STDOUT:       %T.as_type.loc24_15.2: type = facet_access_type %T.ref.loc24_15 [symbolic = %T.as_type.loc24_15.1 (constants.%T.as_type)]
+// CHECK:STDOUT:       %.loc24_15.2: type = converted %T.ref.loc24_15, %T.as_type.loc24_15.2 [symbolic = %T.as_type.loc24_15.1 (constants.%T.as_type)]
 // CHECK:STDOUT:     }
-// CHECK:STDOUT:     %t: @F.%T.as_type.loc20_15.1 (%T.as_type) = wrapper_binding t, %t.param
+// CHECK:STDOUT:     %t: @F.%T.as_type.loc24_15.1 (%T.as_type) = wrapper_binding t, %t.param
+// CHECK:STDOUT:     %return.param: ref @F.%T.as_type.loc24_15.1 (%T.as_type) = out_param call_param1
+// CHECK:STDOUT:     %return: ref @F.%T.as_type.loc24_15.1 (%T.as_type) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
-// CHECK:STDOUT:   %I.facet.loc20_18.1: %I.type = facet_value %A.decl, (constants.%I.impl_witness.6ad) [concrete = constants.%I.facet.64b]
-// CHECK:STDOUT:   %.loc20_18.1: %I.type = converted %A.decl, %I.facet.loc20_18.1 [concrete = constants.%I.facet.64b]
-// CHECK:STDOUT:   %I.facet.loc20_18.2: %I.type = facet_value %B.decl, (constants.%I.impl_witness.5b8) [concrete = constants.%I.facet.9f8]
-// CHECK:STDOUT:   %.loc20_18.2: %I.type = converted %B.decl, %I.facet.loc20_18.2 [concrete = constants.%I.facet.9f8]
-// CHECK:STDOUT:   inline_cpp "void G() {\n  Carbon::A a;\n  Carbon::B b;\n  Carbon::F(a);\n  Carbon::F(b);\n}\n"
+// CHECK:STDOUT:   %I.facet.loc24_23.1: %I.type = facet_value %A.decl, (constants.%I.impl_witness.6ad) [concrete = constants.%I.facet.64b]
+// CHECK:STDOUT:   %.loc24_23.1: %I.type = converted %A.decl, %I.facet.loc24_23.1 [concrete = constants.%I.facet.64b]
+// CHECK:STDOUT:   %I.facet.loc24_23.2: %I.type = facet_value %B.decl, (constants.%I.impl_witness.5b8) [concrete = constants.%I.facet.9f8]
+// CHECK:STDOUT:   %.loc24_23.2: %I.type = converted %B.decl, %I.facet.loc24_23.2 [concrete = constants.%I.facet.9f8]
+// CHECK:STDOUT:   inline_cpp "Carbon::B G() {\n  Carbon::A a;\n  Carbon::B b;\n  Carbon::F(a);\n  return Carbon::F(b);\n}\n"
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: interface @I {
@@ -256,14 +283,22 @@ void G() {
 // CHECK:STDOUT:   %I.WithSelf.Doit.decl: @I.WithSelf.%I.WithSelf.Doit.type (%I.WithSelf.Doit.type.26f) = fn_decl @I.WithSelf.Doit [symbolic = @I.WithSelf.%I.WithSelf.Doit (constants.%I.WithSelf.Doit.11f)] {
 // CHECK:STDOUT:     %self.param_patt.loc6_11.1: @I.WithSelf.Doit.%pattern_type (%pattern_type.c60) = value_param_pattern [symbolic = %self.param_patt.loc6_11.2 (constants.%self.param_patt.a33)]
 // CHECK:STDOUT:     %self.patt.loc6_11.1: @I.WithSelf.Doit.%pattern_type (%pattern_type.c60) = at_binding_pattern self, %self.param_patt.loc6_11.1 [symbolic = %self.patt.loc6_11.2 (constants.%self.patt.696)]
+// CHECK:STDOUT:     %return.param_patt.loc6_20.1: @I.WithSelf.Doit.%pattern_type (%pattern_type.c60) = out_param_pattern [symbolic = %return.param_patt.loc6_20.2 (constants.%return.param_patt.434)]
+// CHECK:STDOUT:     %return.patt.loc6_17.1: @I.WithSelf.Doit.%pattern_type (%pattern_type.c60) = return_slot_pattern %return.param_patt.loc6_20.1, %.loc6_20.2 [symbolic = %return.patt.loc6_17.2 (constants.%return.patt.44a)]
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Self.ref.loc6_20: %I.type = name_ref Self, @I.%Self [symbolic = %Self (constants.%Self.37e)]
+// CHECK:STDOUT:     %Self.as_type.loc6_20: type = facet_access_type %Self.ref.loc6_20 [symbolic = %Self.as_type.loc6_11.1 (constants.%Self.as_type.c84)]
+// CHECK:STDOUT:     %.loc6_20.2: type = converted %Self.ref.loc6_20, %Self.as_type.loc6_20 [symbolic = %Self.as_type.loc6_11.1 (constants.%Self.as_type.c84)]
+// CHECK:STDOUT:     %.loc6_20.3: Core.Form = init_form %.loc6_20.2 [symbolic = %.loc6_20.1 (constants.%.8fc)]
 // CHECK:STDOUT:     %self.param: @I.WithSelf.Doit.%Self.as_type.loc6_11.1 (%Self.as_type.c84) = value_param call_param0
 // CHECK:STDOUT:     %.loc6_11.1: type = splice_block %.loc6_11.2 [symbolic = %Self.as_type.loc6_11.1 (constants.%Self.as_type.c84)] {
-// CHECK:STDOUT:       %Self.ref: %I.type = name_ref Self, @I.%Self [symbolic = %Self (constants.%Self.37e)]
-// CHECK:STDOUT:       %Self.as_type.loc6_11.2: type = facet_access_type %Self.ref [symbolic = %Self.as_type.loc6_11.1 (constants.%Self.as_type.c84)]
-// CHECK:STDOUT:       %.loc6_11.2: type = converted %Self.ref, %Self.as_type.loc6_11.2 [symbolic = %Self.as_type.loc6_11.1 (constants.%Self.as_type.c84)]
+// CHECK:STDOUT:       %Self.ref.loc6_11: %I.type = name_ref Self, @I.%Self [symbolic = %Self (constants.%Self.37e)]
+// CHECK:STDOUT:       %Self.as_type.loc6_11.2: type = facet_access_type %Self.ref.loc6_11 [symbolic = %Self.as_type.loc6_11.1 (constants.%Self.as_type.c84)]
+// CHECK:STDOUT:       %.loc6_11.2: type = converted %Self.ref.loc6_11, %Self.as_type.loc6_11.2 [symbolic = %Self.as_type.loc6_11.1 (constants.%Self.as_type.c84)]
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:     %self: @I.WithSelf.Doit.%Self.as_type.loc6_11.1 (%Self.as_type.c84) = wrapper_binding self, %self.param
+// CHECK:STDOUT:     %return.param: ref @I.WithSelf.Doit.%Self.as_type.loc6_11.1 (%Self.as_type.c84) = out_param call_param1
+// CHECK:STDOUT:     %return: ref @I.WithSelf.Doit.%Self.as_type.loc6_11.1 (%Self.as_type.c84) = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %assoc0: %I.assoc_type = assoc_entity element0, %I.WithSelf.Doit.decl [concrete = constants.%assoc0.628]
 // CHECK:STDOUT:
@@ -279,10 +314,16 @@ void G() {
 // CHECK:STDOUT:   %A.as.I.impl.Doit.decl: %A.as.I.impl.Doit.type = fn_decl @A.as.I.impl.Doit [concrete = constants.%A.as.I.impl.Doit] {
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.9ef = value_param_pattern [concrete = constants.%self.param_patt.04e]
 // CHECK:STDOUT:     %self.patt: %pattern_type.9ef = at_binding_pattern self, %self.param_patt [concrete = constants.%self.patt.312]
+// CHECK:STDOUT:     %return.param_patt: %pattern_type.9ef = out_param_pattern [concrete = constants.%return.param_patt.f0c]
+// CHECK:STDOUT:     %return.patt: %pattern_type.9ef = return_slot_pattern %return.param_patt, %Self.ref.loc11_29 [concrete = constants.%return.patt.a6d]
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Self.ref.loc11_29: type = name_ref Self, constants.%A [concrete = constants.%A]
+// CHECK:STDOUT:     %.loc11: Core.Form = init_form %Self.ref.loc11_29 [concrete = constants.%.cbf]
 // CHECK:STDOUT:     %self.param: %A = value_param call_param0
-// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%A [concrete = constants.%A]
+// CHECK:STDOUT:     %Self.ref.loc11_20: type = name_ref Self, constants.%A [concrete = constants.%A]
 // CHECK:STDOUT:     %self: %A = wrapper_binding self, %self.param
+// CHECK:STDOUT:     %return.param: ref %A = out_param call_param1
+// CHECK:STDOUT:     %return: ref %A = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (%A.as.I.impl.Doit.decl), @A.as.I.impl [concrete]
 // CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness %I.impl_witness_table [concrete = constants.%I.impl_witness.6ad]
@@ -297,10 +338,16 @@ void G() {
 // CHECK:STDOUT:   %B.as.I.impl.Doit.decl: %B.as.I.impl.Doit.type = fn_decl @B.as.I.impl.Doit [concrete = constants.%B.as.I.impl.Doit] {
 // CHECK:STDOUT:     %self.param_patt: %pattern_type.e39 = value_param_pattern [concrete = constants.%self.param_patt.f1f]
 // CHECK:STDOUT:     %self.patt: %pattern_type.e39 = at_binding_pattern self, %self.param_patt [concrete = constants.%self.patt.4eb]
+// CHECK:STDOUT:     %return.param_patt: %pattern_type.e39 = out_param_pattern [concrete = constants.%return.param_patt.934]
+// CHECK:STDOUT:     %return.patt: %pattern_type.e39 = return_slot_pattern %return.param_patt, %Self.ref.loc18_29 [concrete = constants.%return.patt.911]
 // CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %Self.ref.loc18_29: type = name_ref Self, constants.%B [concrete = constants.%B]
+// CHECK:STDOUT:     %.loc18: Core.Form = init_form %Self.ref.loc18_29 [concrete = constants.%.d83]
 // CHECK:STDOUT:     %self.param: %B = value_param call_param0
-// CHECK:STDOUT:     %Self.ref: type = name_ref Self, constants.%B [concrete = constants.%B]
+// CHECK:STDOUT:     %Self.ref.loc18_20: type = name_ref Self, constants.%B [concrete = constants.%B]
 // CHECK:STDOUT:     %self: %B = wrapper_binding self, %self.param
+// CHECK:STDOUT:     %return.param: ref %B = out_param call_param1
+// CHECK:STDOUT:     %return: ref %B = return_slot %return.param
 // CHECK:STDOUT:   }
 // CHECK:STDOUT:   %I.impl_witness_table = impl_witness_table (%B.as.I.impl.Doit.decl), @B.as.I.impl [concrete]
 // CHECK:STDOUT:   %I.impl_witness: <witness> = impl_witness %I.impl_witness_table [concrete = constants.%I.impl_witness.5b8]
@@ -343,102 +390,119 @@ void G() {
 // CHECK:STDOUT:   %pattern_type: type = pattern_type %Self.as_type.loc6_11.1 [symbolic = %pattern_type (constants.%pattern_type.c60)]
 // CHECK:STDOUT:   %self.param_patt.loc6_11.2: @I.WithSelf.Doit.%pattern_type (%pattern_type.c60) = value_param_pattern [symbolic = %self.param_patt.loc6_11.2 (constants.%self.param_patt.a33)]
 // CHECK:STDOUT:   %self.patt.loc6_11.2: @I.WithSelf.Doit.%pattern_type (%pattern_type.c60) = at_binding_pattern self, %self.param_patt.loc6_11.2 [symbolic = %self.patt.loc6_11.2 (constants.%self.patt.696)]
+// CHECK:STDOUT:   %.loc6_20.1: Core.Form = init_form %Self.as_type.loc6_11.1 [symbolic = %.loc6_20.1 (constants.%.8fc)]
+// CHECK:STDOUT:   %return.param_patt.loc6_20.2: @I.WithSelf.Doit.%pattern_type (%pattern_type.c60) = out_param_pattern [symbolic = %return.param_patt.loc6_20.2 (constants.%return.param_patt.434)]
+// CHECK:STDOUT:   %return.patt.loc6_17.2: @I.WithSelf.Doit.%pattern_type (%pattern_type.c60) = return_slot_pattern %return.param_patt.loc6_20.2, %Self.as_type.loc6_11.1 [symbolic = %return.patt.loc6_17.2 (constants.%return.patt.44a)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%self.param: @I.WithSelf.Doit.%Self.as_type.loc6_11.1 (%Self.as_type.c84));
+// CHECK:STDOUT:   fn(%self.param: @I.WithSelf.Doit.%Self.as_type.loc6_11.1 (%Self.as_type.c84)) -> out %return.param: @I.WithSelf.Doit.%Self.as_type.loc6_11.1 (%Self.as_type.c84);
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @A.as.I.impl.Doit(%self.param: %A) {
+// CHECK:STDOUT: fn @A.as.I.impl.Doit(%self.param: %A) -> out %return.param: %A {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   return
+// CHECK:STDOUT:   %.loc12_15.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:   %.loc12_15.2: init %A to %return.param = class_init () [concrete = constants.%A.val]
+// CHECK:STDOUT:   %.loc12_16: init %A = converted %.loc12_15.1, %.loc12_15.2 [concrete = constants.%A.val]
+// CHECK:STDOUT:   return %.loc12_16 to %return.param
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @B.as.I.impl.Doit(%self.param: %B) {
+// CHECK:STDOUT: fn @B.as.I.impl.Doit(%self.param: %B) -> out %return.param: %B {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   return
+// CHECK:STDOUT:   %.loc19_15.1: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:   %.loc19_15.2: init %B to %return.param = class_init () [concrete = constants.%B.val]
+// CHECK:STDOUT:   %.loc19_16: init %B = converted %.loc19_15.1, %.loc19_15.2 [concrete = constants.%B.val]
+// CHECK:STDOUT:   return %.loc19_16 to %return.param
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: generic fn @F(%T.loc20_7.2: %I.type) {
-// CHECK:STDOUT:   %T.patt.loc20_7.2: %pattern_type.6cb = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc20_7.2 (constants.%T.patt)]
-// CHECK:STDOUT:   %T.loc20_7.1: %I.type = symbolic_binding T, 0 [symbolic = %T.loc20_7.1 (constants.%T)]
-// CHECK:STDOUT:   %T.as_type.loc20_15.1: type = facet_access_type %T.loc20_7.1 [symbolic = %T.as_type.loc20_15.1 (constants.%T.as_type)]
-// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc20_15.1 [symbolic = %pattern_type (constants.%pattern_type.b3a)]
-// CHECK:STDOUT:   %t.param_patt.loc20_13.2: @F.%pattern_type (%pattern_type.b3a) = value_param_pattern [symbolic = %t.param_patt.loc20_13.2 (constants.%t.param_patt.5db)]
-// CHECK:STDOUT:   %t.patt.loc20_13.2: @F.%pattern_type (%pattern_type.b3a) = at_binding_pattern t, %t.param_patt.loc20_13.2 [symbolic = %t.patt.loc20_13.2 (constants.%t.patt.030)]
+// CHECK:STDOUT: generic fn @F(%T.loc24_7.2: %I.type) {
+// CHECK:STDOUT:   %T.patt.loc24_7.2: %pattern_type.6cb = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc24_7.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %T.loc24_7.1: %I.type = symbolic_binding T, 0 [symbolic = %T.loc24_7.1 (constants.%T)]
+// CHECK:STDOUT:   %T.as_type.loc24_15.1: type = facet_access_type %T.loc24_7.1 [symbolic = %T.as_type.loc24_15.1 (constants.%T.as_type)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %T.as_type.loc24_15.1 [symbolic = %pattern_type (constants.%pattern_type.b3a)]
+// CHECK:STDOUT:   %t.param_patt.loc24_13.2: @F.%pattern_type (%pattern_type.b3a) = value_param_pattern [symbolic = %t.param_patt.loc24_13.2 (constants.%t.param_patt.5db)]
+// CHECK:STDOUT:   %t.patt.loc24_13.2: @F.%pattern_type (%pattern_type.b3a) = at_binding_pattern t, %t.param_patt.loc24_13.2 [symbolic = %t.patt.loc24_13.2 (constants.%t.patt.030)]
+// CHECK:STDOUT:   %.loc24_21.2: Core.Form = init_form %T.as_type.loc24_15.1 [symbolic = %.loc24_21.2 (constants.%.0ce)]
+// CHECK:STDOUT:   %return.param_patt.loc24_21.2: @F.%pattern_type (%pattern_type.b3a) = out_param_pattern [symbolic = %return.param_patt.loc24_21.2 (constants.%return.param_patt.b82)]
+// CHECK:STDOUT:   %return.patt.loc24_18.2: @F.%pattern_type (%pattern_type.b3a) = return_slot_pattern %return.param_patt.loc24_21.2, %T.as_type.loc24_15.1 [symbolic = %return.patt.loc24_18.2 (constants.%return.patt.2e6)]
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
-// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc20_15.1 [symbolic = %require_complete (constants.%require_complete)]
-// CHECK:STDOUT:   %I.WithSelf.Doit.type: type = fn_type @I.WithSelf.Doit, @I.WithSelf(%T.loc20_7.1) [symbolic = %I.WithSelf.Doit.type (constants.%I.WithSelf.Doit.type.860)]
-// CHECK:STDOUT:   %.loc21_4: type = fn_type_with_self_type %I.WithSelf.Doit.type, %T.loc20_7.1 [symbolic = %.loc21_4 (constants.%.8a9)]
-// CHECK:STDOUT:   %I.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc20_7.1, @I [symbolic = %I.lookup_impl_witness (constants.%I.lookup_impl_witness)]
-// CHECK:STDOUT:   %impl.elem0.loc21_4.2: @F.%.loc21_4 (%.8a9) = impl_witness_access %I.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc21_4.2 (constants.%impl.elem0)]
-// CHECK:STDOUT:   %specific_impl_fn.loc21_4.2: <specific function> = specific_impl_function %impl.elem0.loc21_4.2, @I.WithSelf.Doit(%T.loc20_7.1) [symbolic = %specific_impl_fn.loc21_4.2 (constants.%specific_impl_fn)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %T.as_type.loc24_15.1 [symbolic = %require_complete (constants.%require_complete)]
+// CHECK:STDOUT:   %I.WithSelf.Doit.type: type = fn_type @I.WithSelf.Doit, @I.WithSelf(%T.loc24_7.1) [symbolic = %I.WithSelf.Doit.type (constants.%I.WithSelf.Doit.type.860)]
+// CHECK:STDOUT:   %.loc25_11: type = fn_type_with_self_type %I.WithSelf.Doit.type, %T.loc24_7.1 [symbolic = %.loc25_11 (constants.%.8a9)]
+// CHECK:STDOUT:   %I.lookup_impl_witness: <witness> = lookup_impl_witness %T.loc24_7.1, @I [symbolic = %I.lookup_impl_witness (constants.%I.lookup_impl_witness)]
+// CHECK:STDOUT:   %impl.elem0.loc25_11.2: @F.%.loc25_11 (%.8a9) = impl_witness_access %I.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc25_11.2 (constants.%impl.elem0)]
+// CHECK:STDOUT:   %specific_impl_fn.loc25_11.2: <specific function> = specific_impl_function %impl.elem0.loc25_11.2, @I.WithSelf.Doit(%T.loc24_7.1) [symbolic = %specific_impl_fn.loc25_11.2 (constants.%specific_impl_fn)]
 // CHECK:STDOUT:
-// CHECK:STDOUT:   fn(%t.param: @F.%T.as_type.loc20_15.1 (%T.as_type)) {
+// CHECK:STDOUT:   fn(%t.param: @F.%T.as_type.loc24_15.1 (%T.as_type)) -> out %return.param: @F.%T.as_type.loc24_15.1 (%T.as_type) {
 // CHECK:STDOUT:   !entry:
-// CHECK:STDOUT:     %t.ref: @F.%T.as_type.loc20_15.1 (%T.as_type) = name_ref t, %t
+// CHECK:STDOUT:     %t.ref: @F.%T.as_type.loc24_15.1 (%T.as_type) = name_ref t, %t
 // CHECK:STDOUT:     %Doit.ref: %I.assoc_type = name_ref Doit, @I.WithSelf.%assoc0 [concrete = constants.%assoc0.628]
-// CHECK:STDOUT:     %impl.elem0.loc21_4.1: @F.%.loc21_4 (%.8a9) = impl_witness_access constants.%I.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc21_4.2 (constants.%impl.elem0)]
-// CHECK:STDOUT:     %bound_method.loc21_4: <bound method> = bound_method %t.ref, %impl.elem0.loc21_4.1
-// CHECK:STDOUT:     %.loc21_10.1: %I.type = converted constants.%T.as_type, constants.%T [symbolic = %T.loc20_7.1 (constants.%T)]
-// CHECK:STDOUT:     %.loc21_10.2: %I.type = converted constants.%T.as_type, constants.%T [symbolic = %T.loc20_7.1 (constants.%T)]
-// CHECK:STDOUT:     %specific_impl_fn.loc21_4.1: <specific function> = specific_impl_function %impl.elem0.loc21_4.1, @I.WithSelf.Doit(constants.%T) [symbolic = %specific_impl_fn.loc21_4.2 (constants.%specific_impl_fn)]
-// CHECK:STDOUT:     %bound_method.loc21_10: <bound method> = bound_method %t.ref, %specific_impl_fn.loc21_4.1
-// CHECK:STDOUT:     %I.WithSelf.Doit.call: init %empty_tuple.type = call %bound_method.loc21_10(%t.ref)
-// CHECK:STDOUT:     return
+// CHECK:STDOUT:     %impl.elem0.loc25_11.1: @F.%.loc25_11 (%.8a9) = impl_witness_access constants.%I.lookup_impl_witness, element0 [symbolic = %impl.elem0.loc25_11.2 (constants.%impl.elem0)]
+// CHECK:STDOUT:     %bound_method.loc25_11: <bound method> = bound_method %t.ref, %impl.elem0.loc25_11.1
+// CHECK:STDOUT:     %.loc25_17.1: %I.type = converted constants.%T.as_type, constants.%T [symbolic = %T.loc24_7.1 (constants.%T)]
+// CHECK:STDOUT:     %.loc25_17.2: %I.type = converted constants.%T.as_type, constants.%T [symbolic = %T.loc24_7.1 (constants.%T)]
+// CHECK:STDOUT:     %specific_impl_fn.loc25_11.1: <specific function> = specific_impl_function %impl.elem0.loc25_11.1, @I.WithSelf.Doit(constants.%T) [symbolic = %specific_impl_fn.loc25_11.2 (constants.%specific_impl_fn)]
+// CHECK:STDOUT:     %bound_method.loc25_17: <bound method> = bound_method %t.ref, %specific_impl_fn.loc25_11.1
+// CHECK:STDOUT:     %.loc24_21.1: ref @F.%T.as_type.loc24_15.1 (%T.as_type) = splice_block %return.param {}
+// CHECK:STDOUT:     %I.WithSelf.Doit.call: init @F.%T.as_type.loc24_15.1 (%T.as_type) to %.loc24_21.1 = call %bound_method.loc25_17(%t.ref)
+// CHECK:STDOUT:     return %I.WithSelf.Doit.call to %return.param
 // CHECK:STDOUT:   }
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @A.__destroy_thunk(%self.param: ref %A) {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %impl.elem0: %.dca = impl_witness_access constants.%custom_witness.df9cc1.2, element0 [concrete = constants.%Destroy.Op.1a2547.2]
-// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %self.param, %impl.elem0
-// CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %bound_method(%self.param)
-// CHECK:STDOUT:   return
-// CHECK:STDOUT: }
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc9_9.1(%self.param: ref %empty_struct_type) = "no_op";
-// CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc9_9.2(%self.param: ref %A) {
-// CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: fn @B.__destroy_thunk(%self.param: ref %B) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %impl.elem0: %.3d9 = impl_witness_access constants.%custom_witness.df9cc1.3, element0 [concrete = constants.%Destroy.Op.1a2547.3]
+// CHECK:STDOUT:   %impl.elem0: %.3d9 = impl_witness_access constants.%custom_witness.df9cc1.2, element0 [concrete = constants.%Destroy.Op.1a2547.2]
 // CHECK:STDOUT:   %bound_method: <bound method> = bound_method %self.param, %impl.elem0
 // CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %bound_method(%self.param)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @Destroy.Op.loc14(%self.param: ref %B) {
+// CHECK:STDOUT: fn @Destroy.Op.loc16_9.1(%self.param: ref %empty_struct_type) = "no_op";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Destroy.Op.loc16_9.2(%self.param: ref %B) {
 // CHECK:STDOUT: !entry:
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F__carbon_thunkinst64000035(%_.param: ref %A) {
+// CHECK:STDOUT: fn @A.__destroy_thunk(%self.param: ref %A) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F__carbon_thunkinst64000035.ref: %F.type = name_ref F__carbon_thunkinst64000035, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %I.facet.loc20_18.1: %I.type = facet_value constants.%A, (constants.%I.impl_witness.6ad) [concrete = constants.%I.facet.64b]
-// CHECK:STDOUT:   %.loc20_18.1: %I.type = converted constants.%A, %I.facet.loc20_18.1 [concrete = constants.%I.facet.64b]
-// CHECK:STDOUT:   %I.facet.loc20_18.2: %I.type = facet_value constants.%A, (constants.%I.impl_witness.6ad) [concrete = constants.%I.facet.64b]
-// CHECK:STDOUT:   %.loc20_18.2: %I.type = converted constants.%A, %I.facet.loc20_18.2 [concrete = constants.%I.facet.64b]
-// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F__carbon_thunkinst64000035.ref, @F(constants.%I.facet.64b) [concrete = constants.%F.specific_fn.f33]
-// CHECK:STDOUT:   %.loc20_18.3: %A = acquire_value %_.param
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn(%.loc20_18.3)
+// CHECK:STDOUT:   %impl.elem0: %.dca = impl_witness_access constants.%custom_witness.df9cc1.3, element0 [concrete = constants.%Destroy.Op.1a2547.3]
+// CHECK:STDOUT:   %bound_method: <bound method> = bound_method %self.param, %impl.elem0
+// CHECK:STDOUT:   %Destroy.Op.call: init %empty_tuple.type = call %bound_method(%self.param)
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: fn @F__carbon_thunkinst64000050(%_.param: ref %B) {
+// CHECK:STDOUT: fn @Destroy.Op.loc9(%self.param: ref %A) {
 // CHECK:STDOUT: !entry:
-// CHECK:STDOUT:   %F__carbon_thunkinst64000050.ref: %F.type = name_ref F__carbon_thunkinst64000050, file.%F.decl [concrete = constants.%F]
-// CHECK:STDOUT:   %I.facet.loc20_18.1: %I.type = facet_value constants.%B, (constants.%I.impl_witness.5b8) [concrete = constants.%I.facet.9f8]
-// CHECK:STDOUT:   %.loc20_18.1: %I.type = converted constants.%B, %I.facet.loc20_18.1 [concrete = constants.%I.facet.9f8]
-// CHECK:STDOUT:   %I.facet.loc20_18.2: %I.type = facet_value constants.%B, (constants.%I.impl_witness.5b8) [concrete = constants.%I.facet.9f8]
-// CHECK:STDOUT:   %.loc20_18.2: %I.type = converted constants.%B, %I.facet.loc20_18.2 [concrete = constants.%I.facet.9f8]
-// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F__carbon_thunkinst64000050.ref, @F(constants.%I.facet.9f8) [concrete = constants.%F.specific_fn.db2]
-// CHECK:STDOUT:   %.loc20_18.3: %B = acquire_value %_.param
-// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn(%.loc20_18.3)
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F__carbon_thunkinst64000043(%_.param.loc24_23.1: ref %A, %_.param.loc24_23.2: ref %A) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %F__carbon_thunkinst64000043.ref: %F.type = name_ref F__carbon_thunkinst64000043, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:   %I.facet.loc24_23.1: %I.type = facet_value constants.%A, (constants.%I.impl_witness.6ad) [concrete = constants.%I.facet.64b]
+// CHECK:STDOUT:   %.loc24_23.1: %I.type = converted constants.%A, %I.facet.loc24_23.1 [concrete = constants.%I.facet.64b]
+// CHECK:STDOUT:   %I.facet.loc24_23.2: %I.type = facet_value constants.%A, (constants.%I.impl_witness.6ad) [concrete = constants.%I.facet.64b]
+// CHECK:STDOUT:   %.loc24_23.2: %I.type = converted constants.%A, %I.facet.loc24_23.2 [concrete = constants.%I.facet.64b]
+// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F__carbon_thunkinst64000043.ref, @F(constants.%I.facet.64b) [concrete = constants.%F.specific_fn.f33]
+// CHECK:STDOUT:   %.loc24_23.3: ref %A = splice_block %_.param.loc24_23.2 {}
+// CHECK:STDOUT:   %.loc24_23.4: %A = acquire_value %_.param.loc24_23.1
+// CHECK:STDOUT:   %F.call: init %A to %.loc24_23.3 = call %F.specific_fn(%.loc24_23.4)
+// CHECK:STDOUT:   assign %_.param.loc24_23.2, %F.call
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @F__carbon_thunkinst6400006C(%_.param.loc24_23.1: ref %B, %_.param.loc24_23.2: ref %B) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %F__carbon_thunkinst6400006C.ref: %F.type = name_ref F__carbon_thunkinst6400006C, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:   %I.facet.loc24_23.1: %I.type = facet_value constants.%B, (constants.%I.impl_witness.5b8) [concrete = constants.%I.facet.9f8]
+// CHECK:STDOUT:   %.loc24_23.1: %I.type = converted constants.%B, %I.facet.loc24_23.1 [concrete = constants.%I.facet.9f8]
+// CHECK:STDOUT:   %I.facet.loc24_23.2: %I.type = facet_value constants.%B, (constants.%I.impl_witness.5b8) [concrete = constants.%I.facet.9f8]
+// CHECK:STDOUT:   %.loc24_23.2: %I.type = converted constants.%B, %I.facet.loc24_23.2 [concrete = constants.%I.facet.9f8]
+// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F__carbon_thunkinst6400006C.ref, @F(constants.%I.facet.9f8) [concrete = constants.%F.specific_fn.db2]
+// CHECK:STDOUT:   %.loc24_23.3: ref %B = splice_block %_.param.loc24_23.2 {}
+// CHECK:STDOUT:   %.loc24_23.4: %B = acquire_value %_.param.loc24_23.1
+// CHECK:STDOUT:   %F.call: init %B to %.loc24_23.3 = call %F.specific_fn(%.loc24_23.4)
+// CHECK:STDOUT:   assign %_.param.loc24_23.2, %F.call
 // CHECK:STDOUT:   return
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -455,6 +519,9 @@ void G() {
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.c60
 // CHECK:STDOUT:   %self.param_patt.loc6_11.2 => constants.%self.param_patt.a33
 // CHECK:STDOUT:   %self.patt.loc6_11.2 => constants.%self.patt.696
+// CHECK:STDOUT:   %.loc6_20.1 => constants.%.8fc
+// CHECK:STDOUT:   %return.param_patt.loc6_20.2 => constants.%return.param_patt.434
+// CHECK:STDOUT:   %return.patt.loc6_17.2 => constants.%return.patt.44a
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I.WithSelf(constants.%I.facet.64b) {
@@ -470,6 +537,9 @@ void G() {
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.9ef
 // CHECK:STDOUT:   %self.param_patt.loc6_11.2 => constants.%self.param_patt.04e
 // CHECK:STDOUT:   %self.patt.loc6_11.2 => constants.%self.patt.312
+// CHECK:STDOUT:   %.loc6_20.1 => constants.%.cbf
+// CHECK:STDOUT:   %return.param_patt.loc6_20.2 => constants.%return.param_patt.f0c
+// CHECK:STDOUT:   %return.patt.loc6_17.2 => constants.%return.patt.a6d
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I.WithSelf(constants.%I.facet.9f8) {
@@ -485,15 +555,21 @@ void G() {
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.e39
 // CHECK:STDOUT:   %self.param_patt.loc6_11.2 => constants.%self.param_patt.f1f
 // CHECK:STDOUT:   %self.patt.loc6_11.2 => constants.%self.patt.4eb
+// CHECK:STDOUT:   %.loc6_20.1 => constants.%.d83
+// CHECK:STDOUT:   %return.param_patt.loc6_20.2 => constants.%return.param_patt.934
+// CHECK:STDOUT:   %return.patt.loc6_17.2 => constants.%return.patt.911
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%T) {
-// CHECK:STDOUT:   %T.patt.loc20_7.2 => constants.%T.patt
-// CHECK:STDOUT:   %T.loc20_7.1 => constants.%T
-// CHECK:STDOUT:   %T.as_type.loc20_15.1 => constants.%T.as_type
+// CHECK:STDOUT:   %T.patt.loc24_7.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc24_7.1 => constants.%T
+// CHECK:STDOUT:   %T.as_type.loc24_15.1 => constants.%T.as_type
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.b3a
-// CHECK:STDOUT:   %t.param_patt.loc20_13.2 => constants.%t.param_patt.5db
-// CHECK:STDOUT:   %t.patt.loc20_13.2 => constants.%t.patt.030
+// CHECK:STDOUT:   %t.param_patt.loc24_13.2 => constants.%t.param_patt.5db
+// CHECK:STDOUT:   %t.patt.loc24_13.2 => constants.%t.patt.030
+// CHECK:STDOUT:   %.loc24_21.2 => constants.%.0ce
+// CHECK:STDOUT:   %return.param_patt.loc24_21.2 => constants.%return.param_patt.b82
+// CHECK:STDOUT:   %return.patt.loc24_18.2 => constants.%return.patt.2e6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @I.WithSelf(constants.%T) {
@@ -509,57 +585,72 @@ void G() {
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.b3a
 // CHECK:STDOUT:   %self.param_patt.loc6_11.2 => constants.%self.param_patt.58e
 // CHECK:STDOUT:   %self.patt.loc6_11.2 => constants.%self.patt.300
+// CHECK:STDOUT:   %.loc6_20.1 => constants.%.0ce
+// CHECK:STDOUT:   %return.param_patt.loc6_20.2 => constants.%return.param_patt.b82
+// CHECK:STDOUT:   %return.patt.loc6_17.2 => constants.%return.patt.2e6
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(file.%.loc20_18.1) {
-// CHECK:STDOUT:   %T.patt.loc20_7.2 => constants.%T.patt
-// CHECK:STDOUT:   %T.loc20_7.1 => constants.%I.facet.64b
-// CHECK:STDOUT:   %T.as_type.loc20_15.1 => constants.%A
+// CHECK:STDOUT: specific @F(file.%.loc24_23.1) {
+// CHECK:STDOUT:   %T.patt.loc24_7.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc24_7.1 => constants.%I.facet.64b
+// CHECK:STDOUT:   %T.as_type.loc24_15.1 => constants.%A
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.9ef
-// CHECK:STDOUT:   %t.param_patt.loc20_13.2 => constants.%t.param_patt.169
-// CHECK:STDOUT:   %t.patt.loc20_13.2 => constants.%t.patt.ee8
+// CHECK:STDOUT:   %t.param_patt.loc24_13.2 => constants.%t.param_patt.169
+// CHECK:STDOUT:   %t.patt.loc24_13.2 => constants.%t.patt.ee8
+// CHECK:STDOUT:   %.loc24_21.2 => constants.%.cbf
+// CHECK:STDOUT:   %return.param_patt.loc24_21.2 => constants.%return.param_patt.f0c
+// CHECK:STDOUT:   %return.patt.loc24_18.2 => constants.%return.patt.a6d
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%I.facet.64b) {
-// CHECK:STDOUT:   %T.patt.loc20_7.2 => constants.%T.patt
-// CHECK:STDOUT:   %T.loc20_7.1 => constants.%I.facet.64b
-// CHECK:STDOUT:   %T.as_type.loc20_15.1 => constants.%A
+// CHECK:STDOUT:   %T.patt.loc24_7.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc24_7.1 => constants.%I.facet.64b
+// CHECK:STDOUT:   %T.as_type.loc24_15.1 => constants.%A
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.9ef
-// CHECK:STDOUT:   %t.param_patt.loc20_13.2 => constants.%t.param_patt.169
-// CHECK:STDOUT:   %t.patt.loc20_13.2 => constants.%t.patt.ee8
+// CHECK:STDOUT:   %t.param_patt.loc24_13.2 => constants.%t.param_patt.169
+// CHECK:STDOUT:   %t.patt.loc24_13.2 => constants.%t.patt.ee8
+// CHECK:STDOUT:   %.loc24_21.2 => constants.%.cbf
+// CHECK:STDOUT:   %return.param_patt.loc24_21.2 => constants.%return.param_patt.f0c
+// CHECK:STDOUT:   %return.patt.loc24_18.2 => constants.%return.patt.a6d
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type
 // CHECK:STDOUT:   %I.WithSelf.Doit.type => constants.%I.WithSelf.Doit.type.5b3
-// CHECK:STDOUT:   %.loc21_4 => constants.%.660
+// CHECK:STDOUT:   %.loc25_11 => constants.%.660
 // CHECK:STDOUT:   %I.lookup_impl_witness => constants.%I.impl_witness.6ad
-// CHECK:STDOUT:   %impl.elem0.loc21_4.2 => constants.%A.as.I.impl.Doit
-// CHECK:STDOUT:   %specific_impl_fn.loc21_4.2 => constants.%A.as.I.impl.Doit
+// CHECK:STDOUT:   %impl.elem0.loc25_11.2 => constants.%A.as.I.impl.Doit
+// CHECK:STDOUT:   %specific_impl_fn.loc25_11.2 => constants.%A.as.I.impl.Doit
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: specific @F(file.%.loc20_18.2) {
-// CHECK:STDOUT:   %T.patt.loc20_7.2 => constants.%T.patt
-// CHECK:STDOUT:   %T.loc20_7.1 => constants.%I.facet.9f8
-// CHECK:STDOUT:   %T.as_type.loc20_15.1 => constants.%B
+// CHECK:STDOUT: specific @F(file.%.loc24_23.2) {
+// CHECK:STDOUT:   %T.patt.loc24_7.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc24_7.1 => constants.%I.facet.9f8
+// CHECK:STDOUT:   %T.as_type.loc24_15.1 => constants.%B
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.e39
-// CHECK:STDOUT:   %t.param_patt.loc20_13.2 => constants.%t.param_patt.267
-// CHECK:STDOUT:   %t.patt.loc20_13.2 => constants.%t.patt.062
+// CHECK:STDOUT:   %t.param_patt.loc24_13.2 => constants.%t.param_patt.267
+// CHECK:STDOUT:   %t.patt.loc24_13.2 => constants.%t.patt.062
+// CHECK:STDOUT:   %.loc24_21.2 => constants.%.d83
+// CHECK:STDOUT:   %return.param_patt.loc24_21.2 => constants.%return.param_patt.934
+// CHECK:STDOUT:   %return.patt.loc24_18.2 => constants.%return.patt.911
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: specific @F(constants.%I.facet.9f8) {
-// CHECK:STDOUT:   %T.patt.loc20_7.2 => constants.%T.patt
-// CHECK:STDOUT:   %T.loc20_7.1 => constants.%I.facet.9f8
-// CHECK:STDOUT:   %T.as_type.loc20_15.1 => constants.%B
+// CHECK:STDOUT:   %T.patt.loc24_7.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc24_7.1 => constants.%I.facet.9f8
+// CHECK:STDOUT:   %T.as_type.loc24_15.1 => constants.%B
 // CHECK:STDOUT:   %pattern_type => constants.%pattern_type.e39
-// CHECK:STDOUT:   %t.param_patt.loc20_13.2 => constants.%t.param_patt.267
-// CHECK:STDOUT:   %t.patt.loc20_13.2 => constants.%t.patt.062
+// CHECK:STDOUT:   %t.param_patt.loc24_13.2 => constants.%t.param_patt.267
+// CHECK:STDOUT:   %t.patt.loc24_13.2 => constants.%t.patt.062
+// CHECK:STDOUT:   %.loc24_21.2 => constants.%.d83
+// CHECK:STDOUT:   %return.param_patt.loc24_21.2 => constants.%return.param_patt.934
+// CHECK:STDOUT:   %return.patt.loc24_18.2 => constants.%return.patt.911
 // CHECK:STDOUT:
 // CHECK:STDOUT: !definition:
 // CHECK:STDOUT:   %require_complete => constants.%complete_type
 // CHECK:STDOUT:   %I.WithSelf.Doit.type => constants.%I.WithSelf.Doit.type.2ce
-// CHECK:STDOUT:   %.loc21_4 => constants.%.545
+// CHECK:STDOUT:   %.loc25_11 => constants.%.545
 // CHECK:STDOUT:   %I.lookup_impl_witness => constants.%I.impl_witness.5b8
-// CHECK:STDOUT:   %impl.elem0.loc21_4.2 => constants.%B.as.I.impl.Doit
-// CHECK:STDOUT:   %specific_impl_fn.loc21_4.2 => constants.%B.as.I.impl.Doit
+// CHECK:STDOUT:   %impl.elem0.loc25_11.2 => constants.%B.as.I.impl.Doit
+// CHECK:STDOUT:   %specific_impl_fn.loc25_11.2 => constants.%B.as.I.impl.Doit
 // CHECK:STDOUT: }
 // CHECK:STDOUT:


### PR DESCRIPTION
Add a `return_type_id` field to `FunctionInfo` in `toolchain/check/cpp/export.cpp`. As with the `explicit_params` field, `ExportFunctionSpecializationToCpp` updates this to the return type in the specific.

Refactored `BuildCppFunctionDeclForCarbonFn` into `BuildCppFunctionDeclForNonGenericCarbonFn` and `BuildCppFunctionDeclForGenericCarbonFn`, with `BuildCppFunctionDecl` containing shared code.

The `generic_type_impls_interface.carbon` test is updated to include a generic return type.