### PR TITLE
Avoid consuming a token after an invalid match_first opening

### DIFF
--- a/toolchain/parse/handle_match_first.cpp
+++ b/toolchain/parse/handle_match_first.cpp
@@ -26,7 +26,12 @@ auto HandleMatchFirst(Context& context) -> void {
 
 auto HandleMatchFirstFinish(Context& context) -> void {
   auto state = context.PopState();
-  context.AddNode(NodeKind::MatchFirst, context.Consume(), state.has_error);
+  if (auto closing_token = context.ConsumeIf(Lex::TokenKind::CloseCurlyBrace)) {
+    context.AddNode(NodeKind::MatchFirst, *closing_token, state.has_error);
+  } else {
+    // Recover from error by just moving on.
+    context.AddNode(NodeKind::MatchFirst, state.token, state.has_error);
+  }
 }
 
 }  // namespace Carbon::Parse

--- a/toolchain/parse/testdata/generics/impl/match_first.carbon
+++ b/toolchain/parse/testdata/generics/impl/match_first.carbon
@@ -20,6 +20,14 @@ match_first {}
 // CHECK:STDERR:
 match_first;
 
+// --- fail_eof.carbon
+
+match_first
+// CHECK:STDERR: fail_eof.carbon:[[@LINE+4]]:1: error: expected `{` after `match_first` [ExpectedCurlyBraceAfter]
+// CHECK:STDERR:
+// CHECK:STDERR: ^
+// CHECK:STDERR:
+
 // --- with_impls.carbon
 
 match_first {
@@ -47,7 +55,16 @@ impl forall [T: J] T as Interface {
 // CHECK:STDOUT:     {kind: 'FileStart', text: ''},
 // CHECK:STDOUT:         {kind: 'MatchFirstIntroducer', text: 'match_first'},
 // CHECK:STDOUT:       {kind: 'MatchFirstDefinitionStart', text: 'match_first', has_error: yes, subtree_size: 2},
-// CHECK:STDOUT:     {kind: 'MatchFirst', text: ';', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:     {kind: 'MatchFirst', text: 'match_first', has_error: yes, subtree_size: 3},
+// CHECK:STDOUT:     {kind: 'EmptyDecl', text: ';'},
+// CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
+// CHECK:STDOUT:   ]
+// CHECK:STDOUT: - filename: fail_eof.carbon
+// CHECK:STDOUT:   parse_tree: [
+// CHECK:STDOUT:     {kind: 'FileStart', text: ''},
+// CHECK:STDOUT:         {kind: 'MatchFirstIntroducer', text: 'match_first'},
+// CHECK:STDOUT:       {kind: 'MatchFirstDefinitionStart', text: 'match_first', has_error: yes, subtree_size: 2},
+// CHECK:STDOUT:     {kind: 'MatchFirst', text: 'match_first', has_error: yes, subtree_size: 3},
 // CHECK:STDOUT:     {kind: 'FileEnd', text: ''},
 // CHECK:STDOUT:   ]
 // CHECK:STDOUT: - filename: with_impls.carbon


### PR DESCRIPTION
If the `match_first` is not followed by `{` avoid consuming whatever comes after it. Recover by leaving whatever comes next alone. It could even be the `FileEnd` token, and then we would crash when we read off the end of the token stream looking for `FileEnd`.