### PR TITLE
move `carbon_prelude` to carbon_runtimes.bzl

### DIFF
--- a/bazel/carbon_rules/defs.bzl
+++ b/bazel/carbon_rules/defs.bzl
@@ -4,7 +4,6 @@
 
 """Provides rules for building Carbon files using the toolchain."""
 
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -206,42 +205,6 @@ def _carbon_library_impl(ctx):
 
     return [CarbonLibraryInfo(api = ctx.files.api[0], objs = depset(objs))]
 
-def _carbon_prelude_impl(ctx):
-    cc_toolchain = find_cpp_toolchain(ctx)
-
-    # TODO: find a less terrible way to figure this out
-    repo_root = str(cc_toolchain.compiler_executable)
-    repo_root = repo_root.removeprefix(cc_toolchain._crosstool_top_path + "/")
-
-    # The tool path seems to be relative to the toolchain _repository_ root, so
-    # it includes the `toolchain/install` suffix, which is why we remove it here.
-    repo_root = repo_root.removesuffix("toolchain/install/llvm/bin/clang++")
-
-    carbon_busybox = repo_root + cc_toolchain._tool_paths["carbon-busybox"]
-
-    srcs = [s for s in ctx.files.srcs if s.extension == "carbon"]
-    objs = []
-    for src in srcs:
-        out = ctx.actions.declare_file("_objs/{0}/{1}o".format(
-            ctx.label.name,
-            src.short_path.removeprefix(ctx.label.package).removesuffix(src.extension),
-        ))
-        objs.append(out)
-        srcs_reordered = [s for s in srcs if s != src] + [src]
-        ctx.actions.run(
-            outputs = [out],
-            inputs = depset(direct = srcs_reordered),
-            tools = depset(transitive = [cc_toolchain.all_files]),
-            executable = carbon_busybox,
-            arguments = ["compile", "--output=" + out.path, "--output-last-input-only"] +
-                        ["--no-prelude-import"] +
-                        [s.path for s in srcs_reordered] + ctx.attr.flags,
-            mnemonic = "CarbonPrelude",
-            progress_message = "Precompiling prelude file " + src.short_path,
-        )
-
-    return DefaultInfo(files = depset(objs))
-
 # We synthesize two sets of attributes from mirrored `select`s here
 # because we want to select on an internal property of these attributes
 # but that isn't `select`-able. Instead, we have both attributes and
@@ -368,19 +331,6 @@ _carbon_library_internal = rule(
         "_cc_toolchain": attr.label(default = "//toolchain/install:carbon_stage1_cc_toolchain"),
     },
     executable = False,
-    fragments = ["cpp"],
-)
-
-carbon_prelude = rule(
-    implementation = _carbon_prelude_impl,
-    attrs = {
-        "flags": attr.string_list(),
-        "srcs": attr.label_list(allow_files = [".carbon"]),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
-    },
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     fragments = ["cpp"],
 )
 

--- a/toolchain/install/BUILD
+++ b/toolchain/install/BUILD
@@ -34,7 +34,6 @@ load(
 load("@llvm-project//libcxx:libcxx_library.bzl", "libcxx_and_abi_copts")
 load("@llvm-project//libunwind:libunwind_library.bzl", "libunwind_copts")
 load("@rules_python//python:defs.bzl", "py_test")
-load("//bazel/carbon_rules:defs.bzl", "carbon_prelude")
 load("//bazel/cc_rules:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load(
     "//bazel/cc_toolchains:carbon_bootstrapping.bzl",
@@ -47,7 +46,7 @@ load(
     "//toolchain/base:runtimes_build_info.bzl",
     "generate_runtimes_build_vars",
 )
-load("//toolchain/runtimes:carbon_runtimes.bzl", "carbon_runtimes_config")
+load("//toolchain/runtimes:carbon_runtimes.bzl", "carbon_prelude", "carbon_runtimes_config")
 load("bazel/make_include_copts.bzl", "make_include_copts")
 load(
     "install_filegroups.bzl",

--- a/toolchain/runtimes/carbon_runtimes.bzl
+++ b/toolchain/runtimes/carbon_runtimes.bzl
@@ -16,6 +16,55 @@ dependency to be added.
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 
+def _carbon_prelude_impl(ctx):
+    cc_toolchain = find_cpp_toolchain(ctx)
+
+    # TODO: find a less terrible way to figure this out
+    repo_root = str(cc_toolchain.compiler_executable)
+    repo_root = repo_root.removeprefix(cc_toolchain._crosstool_top_path + "/")
+
+    # The tool path seems to be relative to the toolchain _repository_ root, so
+    # it includes the `toolchain/install` suffix, which is why we remove it here.
+    repo_root = repo_root.removesuffix("toolchain/install/llvm/bin/clang++")
+
+    carbon_busybox = repo_root + cc_toolchain._tool_paths["carbon-busybox"]
+
+    srcs = [s for s in ctx.files.srcs if s.extension == "carbon"]
+    objs = []
+    for src in srcs:
+        out = ctx.actions.declare_file("_objs/{0}/{1}o".format(
+            ctx.label.name,
+            src.short_path.removeprefix(ctx.label.package).removesuffix(src.extension),
+        ))
+        objs.append(out)
+        srcs_reordered = [s for s in srcs if s != src] + [src]
+        ctx.actions.run(
+            outputs = [out],
+            inputs = depset(direct = srcs_reordered),
+            tools = depset(transitive = [cc_toolchain.all_files]),
+            executable = carbon_busybox,
+            arguments = ["compile", "--output=" + out.path, "--output-last-input-only"] +
+                        ["--no-prelude-import"] +
+                        [s.path for s in srcs_reordered] + ctx.attr.flags,
+            mnemonic = "CarbonPrelude",
+            progress_message = "Precompiling prelude file " + src.short_path,
+        )
+
+    return DefaultInfo(files = depset(objs))
+
+carbon_prelude = rule(
+    implementation = _carbon_prelude_impl,
+    attrs = {
+        "flags": attr.string_list(),
+        "srcs": attr.label_list(allow_files = [".carbon"]),
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    fragments = ["cpp"],
+)
+
 def _build_crt_file(ctx, cc_toolchain, feature_configuration, crt_file, crt_copts):
     _, compilation_outputs = cc_common.compile(
         name = "{}.compile_{}".format(ctx.label.name, crt_file.basename),


### PR DESCRIPTION
The `carbon_prelude` macro was defined in bazel/carbon_rules/defs.bzl.
This file contains `carbon_library` and `carbon_binary` which are
mostly intended as example Bazel rules for building Carbon binaries.

The `carbon_prelude` macro, however, is used now to build the runtimes
for the Carbon toolchain. We move it to a more central location where
the rest of the runtimes are processed, in
toolchain/runtimes/carbon_runtimes.bzl.
