### PR TITLE
new_proposal.py fix for rumdl missing anchor from dangling ToC TODO entry

### DIFF
--- a/proposals/scripts/new_proposal.py
+++ b/proposals/scripts/new_proposal.py
@@ -114,6 +114,7 @@ def _fill_template(template_path: str, title: str, pr_num: int) -> str:
         r"\g<1>%d" % pr_num,
         content,
     )
+    content = re.sub(r"\n-   \[TODO: .*?\n", r"\n", content)
     content = re.sub(r"\n## TODO(?:.|\n)*?(\n## )", r"\1", content)
     return content
 


### PR DESCRIPTION
rumdl error broke the proposal script execution:
```
rumdl check..............................................................Failed
- hook id: rumdl
- exit code: 1

  proposals/p000003-test-proposal.md:15:5: [MD051] Link anchor '#todo-initial-proposal-setup' does not exist in document headings

  Issues: Found 1 issues in 1 file (11ms)
```
So update the script to remove the TODO entry in the ToC to match
removing the TODO section.
