### PR TITLE
CHECK that the self is a symbolic type when looking for a Destroy and its type is a facet

### DIFF
--- a/toolchain/check/custom_witness.cpp
+++ b/toolchain/check/custom_witness.cpp
@@ -185,6 +185,7 @@ static auto CanDestroyType(
     // The value's type is a facet (whose type is a facet type). We don't
     // provide a custom witness for symbolic values of type facet. The witness
     // will be found from impl lookup.
+    CARBON_CHECK(query_self_const_id.is_symbolic());
     return DestroyFormat::NoDestroy;
   }
 


### PR DESCRIPTION
As a follow up to #7546 (and see the discussion there), verify our assumptions that you can't have an object of type facet where the facet is not symbolic, and then need to find a Destroy witness for the object.