### PR TITLE
Update member access design doc to reflect proposal #3720: Member binding operators

### DIFF
--- a/docs/design/expressions/member_access.md
+++ b/docs/design/expressions/member_access.md
@@ -312,7 +312,8 @@ class C(N: i32) {
 }
 
 fn F() {
-  // Requires `C(-1)` to be complete, which requires `A(-1)` to be complete, which requires `B(array(i32, -1))` to be complete.
+  // Requires `C(-1)` to be complete, which requires `A(-1)` to be
+  // complete, which requires `B(array(i32, -1))` to be complete.
   var c: C(-1);
 }
 ```
@@ -1034,10 +1035,10 @@ steps of member access (like `impl` lookup and instance binding) by rewriting
 compound member access expressions into calls to methods on user-implementable
 interfaces.
 
-This does not change how typical member access is written or read in Carbon code. Under the hood, for a compound member access
-expression `x.(y)` where `x` has type `T` and `y` has type `U`, the compiler
-rewrites the expression into a call to an interface method on one of three
-interfaces:
+This does not change how typical member access is written or read in Carbon
+code. Under the hood, for a compound member access expression `x.(y)` where `x`
+has type `T` and `y` has type `U`, the compiler rewrites the expression into a
+call to an interface method on one of three interfaces:
 
 ```carbon
 // An interface to identify the result type of member binding.
@@ -1079,7 +1080,8 @@ by how they rewrite into the `x.(y)` form using these two rules:
         the `T.(`\_\_\_`)` form.
 -   `x->y` and `x->(y)` are interpreted as `(*x).y` and `(*x).(y)` respectively.
 
-These interfaces may be used as constraints, allowing a generic function to perform binding.
+These interfaces may be used as constraints, allowing a generic function to
+perform binding.
 
 ```carbon
 fn CallsMethodWithValueBinding
@@ -1089,7 +1091,8 @@ fn CallsMethodWithValueBinding
 }
 ```
 
-This generic function may be called with the name of any method that is callable on `x` with no arguments, as in:
+This generic function may be called with the name of any method that is
+callable on `x` with no arguments, as in:
 
 ```carbon
 interface I {
@@ -1133,12 +1136,15 @@ let x: C = {};
 x.F();
 ```
 
--   The member `C.F` has a unique, empty type which is unnamed, but we will refer to as `__TypeOf_C_F`.
--   An adapter type is generated to adapt `C`, which we will refer to as `__Binding_C_F`.
--   `__TypeOf_C_F` implements `BindToValue(C)` and `BindToRef(C)` with `Op` returning
+-   The member `C.F` has a unique, empty type which is unnamed, but we will
+    refer to as `__TypeOf_C_F`.
+-   An adapter type is generated to adapt `C`, which we will refer to as
     `__Binding_C_F`.
--   The implementation of the member binding interfaces allow implicit conversions, to support
-    calling a method from a base type on an object of a derived type. See
+-   `__TypeOf_C_F` implements `BindToValue(C)` and `BindToRef(C)` with `Op`
+    returning `__Binding_C_F`.
+-   The implementation of the member binding interfaces allow implicit
+    conversions, to support calling a method from a base type on an object of a
+    derived type. See
     ["Inheritance and other implicit conversions" in proposal #3720](/proposals/p003720-member-binding-operators.md#inheritance-and-other-implicit-conversions).
 -   `__Binding_C_F` implements the `Call(())` interface, which maps to the
     actual method implementation body:
@@ -1155,8 +1161,8 @@ impl __Binding_C_F as Call(()) with .Result = i32 {
 Note that the implementation of the `Call` operator needs to use a compiler
 intrinsic to avoid recursive application of these same rules.
 
-The result is that the expression `x.F` is a bound method value of type `__Binding_C_F`
-(adapting `x`) that can be called like a function.
+The result is that the expression `x.F` is a bound method value of type
+`__Binding_C_F` (adapting `x`) that can be called like a function.
 
 #### Fields
 
@@ -1171,7 +1177,8 @@ var x: C = {.m = 7};
 x.m = 42;
 ```
 
--   The member `C.m` has an unnamed unique type which we will call `__TypeOf_C_m`.
+-   The member `C.m` has an unnamed unique type which we will call
+    `__TypeOf_C_m`.
 -   `__TypeOf_C_m` implements `BindToValue(C)` with `.Result = i32`, returning
     the value of `m` by way of a compiler intrinsic:
 
@@ -1202,7 +1209,8 @@ Tuple types and struct types have their fields implemented in the same way.
 
 #### Non-instance members
 
-Classes may also have non-instance members. This includes non-instance member functions and static member variables, as in:
+Classes may also have non-instance members. This includes non-instance member
+functions and static member variables, as in:
 
 ```carbon
 class C {
@@ -1216,14 +1224,14 @@ C.s = 3;
 
 Non-instance members use `BindToType` when accessed on a type facet:
 
--   For `fn NonInstance()` in class `C`, its type `__TypeOf_C_NonInstance` implements
-    `BindToType(C)` with `.Result = __TypeBinding_C_NonInstance`.
+-   For `fn NonInstance()` in class `C`, its type `__TypeOf_C_NonInstance`
+    implements `BindToType(C)` with `.Result = __TypeBinding_C_NonInstance`.
 -   To support calling directly on a type facet, `__TypeOf_C_NonInstance` also
     implements `Call(())` directly (supporting `C.NonInstance()`).
 -   To support calling on value/reference instances `x.NonInstance()`,
-    `__TypeOf_C_NonInstance` implements `BindToValue(C)` and `BindToRef(C)` returning
-    a bound adapter whose `Call` implementation ignores its `self` argument,
-    effectively discarding the evaluated instance `x`.
+    `__TypeOf_C_NonInstance` implements `BindToValue(C)` and `BindToRef(C)`
+    returning a bound adapter whose `Call` implementation ignores its `self`
+    argument, effectively discarding the evaluated instance `x`.
 
 #### Interface members and `impl` lookup
 
@@ -1241,11 +1249,12 @@ class C {
 }
 ```
 
--   The `I.F` member has an unnamed unique type, which we will refer to a `__TypeOf_I_F`.
--   `__TypeOf_I_F` implements `BindToValue(T)` for all types `T impls I` returning
-    `__Binding_I_F(T)` (which adapts `T`).
--   The actual implementation of `I` for `T` is resolved during generic matching
-    when `Call.Op` is called on the adapter:
+-   The `I.F` member has an unnamed unique type, which we will refer to a
+    `__TypeOf_I_F`.
+-   `__TypeOf_I_F` implements `BindToValue(T)` for all types `T impls I`
+    returning `__Binding_I_F(T)` (which adapts `T`).
+-   The actual implementation of `I` for `T` is resolved during generic
+    matching when `Call.Op` is called on the adapter:
 
     ```carbon
     impl forall [T: I] __TypeOf_I_F as BindToValue(T) {
@@ -1264,13 +1273,20 @@ class C {
     }
     ```
 
--   The type of an interface method taking `ref self` would also implement `BindToRef(T)`.
--   In all cases, the type of an interface member would implement `BindToType(T)` for all types `T impls I`. The result would depend on the specifics of the member, but generally would be a value of a unique empty type associated with the specific interface member, parameterized by `T`. This value could then be bound to an instance of `T` in a succeeding operation.
+-   The type of an interface method taking `ref self` would also implement
+    `BindToRef(T)`.
+-   In all cases, the type of an interface member would implement
+    `BindToType(T)` for all types `T impls I`. The result would depend on the
+    specifics of the member, but generally would be a value of a unique empty
+    type associated with the specific interface member, parameterized by `T`.
+    This value could then be bound to an instance of `T` in a succeeding
+    operation.
 
 ### Member binding restrictions
 
-The restrictions that only certain compound member accesses are valid are naturally enforced by whether the
-member's type implements the required `BindToValue`, `BindToRef`, or `BindToType` interfaces.
+The restrictions that only certain compound member accesses are valid are
+naturally enforced by whether the member's type implements the required
+`BindToValue`, `BindToRef`, or `BindToType` interfaces.
 
 ```carbon
 class C {
@@ -1285,10 +1301,12 @@ v.(C.(C.F))();
 ```
 
 `v.(v.F)` fails because the bound method
-adapter does not implement member binding interfaces, following the rules of [instance binding](#instance-binding).
+adapter does not implement member binding interfaces, following the rules of
+[instance binding](#instance-binding).
 
-However, `C.(C.F)` is an allowed [vacuous member access](#vacuous-member-access),
-so `__TypeOf_C_F` needs to implement `BindToType(C)` in addition to `BindToValue(C)` and `BindToRef(C)`.
+However, `C.(C.F)` is an allowed
+[vacuous member access](#vacuous-member-access), so `__TypeOf_C_F` needs to
+implement `BindToType(C)` in addition to `BindToValue(C)` and `BindToRef(C)`.
 
 ## Precedence and associativity
 

--- a/docs/design/expressions/member_access.md
+++ b/docs/design/expressions/member_access.md
@@ -25,7 +25,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [`impl` lookup for compound member access](#impl-lookup-for-compound-member-access)
 -   [Instance binding](#instance-binding)
 -   [Non-instance members](#non-instance-members)
--   [Vacuous member access](#vacuous-member-access)
+-   [Restrictions on compound member access](#restrictions-on-compound-member-access)
 -   [Member binding interfaces](#member-binding-interfaces)
     -   [Compiler implementation of binding interfaces](#compiler-implementation-of-binding-interfaces)
         -   [Methods](#methods)
@@ -958,38 +958,74 @@ fn CallStaticMethod(c: C) {
 }
 ```
 
-## Vacuous member access
+## Restrictions on compound member access
 
-A compound member access expression where the first operand is not used for
-`impl` lookup or instance binding is valid, even though the first operand is
-redundant.
+Compound member access is rewritten to use
+[member binding interfaces](#member-binding-interfaces). The
+[compiler provides](#compiler-implementation-of-binding-interfaces)
+automatic implementations of these interfaces subject to these restrictions:
 
-Instead, tools such as linters can highlight such code as suspicious on a
-best-effort basis, particularly when the issue is contained in a single
-expression. Such tools may still allow code that performs the same operation
-across multiple statements, as in:
+-   If the first operand is a type, then the second operand must be a member of
+    an interface, triggering [`impl` lookup](#impl-lookup).
 
-```carbon
-class C {
-  fn NonInstance();
-}
+    ```carbon
+    interface I {
+      fn F();
+    }
+    class C {
+      impl as I;
+      fn G();
+    }
+    // ✅ Valid
+    C.(I.F)();
 
-let M:! auto = C.NonInstance;
+    // ❌ Error: `C.G` is not an interface member.
+    C.(C.G)();
+    ```
 
-let v: C = {};
-// ✅ Allowed, even though `v.` is not used.
-v.(M)();
-```
+-   Otherwise, the first operand must be used in some way: a compound member
+    access must result in `impl` lookup, instance binding, or both. We say the
+    member access must be "non-vacuous." Note: simple member access doesn't
+    have the same restrictions, since the first operand is always used for
+    lookup.
 
-> **Note:** Earlier wording restricted vacuous member access by making
-> expressions such as `v.(C.NonInstance)` invalid because the `v.`
-> portion is redundant. That rule was removed by proposal
+-   As an exception, if the second operand names a function, we allow vacuous
+    compound member access. Instead, tools such as linters can highlight such
+    code as suspicious on a best-effort basis, particularly when the issue is
+    contained in a single expression. Such tools may still allow code that
+    performs the same operation across multiple statements, as in:
+
+    ```carbon
+    class C {
+      fn NonInstance();
+    }
+
+    let M:! auto = C.NonInstance;
+
+    let v: C = {};
+    // ✅ Allowed, even though `v.` is not used.
+    v.(M)();
+    ```
+
+-   The compiler-provided binding implementations never produce a result that
+    has a compiler-provided binding implementation.
+
+    ```carbon
+    // `v.(M)` is the result of binding, so applying `v.` again is invalid
+    // ❌ v.(v.(M))();
+    ```
+
+> **Note:** The exception allowing vacuous compound member access with
+> functions was added by proposal
 > [#3720: Member binding operators](/proposals/p003720-member-binding-operators.md#details).
-
-In the case where `M` is an overloaded name, it could be an instance member in some
-cases and a non-instance member in others, depending on the arguments passed.
-This is another reason to delegate this to linters analyzing a whole expression
-on a best-effort basis, rather than a strict rule just about member binding.
+> Previously expressions such as `v.(C.NonInstance)` were invalid because the
+> `v.` portion was considered redundant.
+>
+> Beyond the issue of restricting operations spread across multiple expressions,
+> there was also a concern when `M` is an overloaded name, since it could be an
+> instance member in some cases and a non-instance member in others, depending
+> on the arguments passed. This was another reason to delegate this to linters
+> analyzing a whole expression on a best-effort basis.
 
 ```carbon
 interface Printable {
@@ -1017,14 +1053,23 @@ impl i32 as Factory;
 
 // ✅ OK, member `Make` of interface `Factory`.
 alias X1 = Factory.Make;
-// ⚠️ Suspicious (linter warning), but valid: compound access without impl
-// lookup or instance binding.
+
+// ❌ Invalid. Since `Factory.Make` is an interface member, we perform
+// `impl` lookup and `Factory` is not a type that implements `Factory`.
 alias X2 = Factory.(Factory.Make);
+
 // ✅ OK, member `Make` of `impl i32 as Factory`.
 alias X3 = (i32 as Factory).Make;
+
 // ⚠️ Suspicious (linter warning), but valid: compound access without impl
 // lookup or instance binding.
 alias X4 = i32.((i32 as Factory).Make);
+
+// ⚠️ Suspicious (linter warning), but valid: same as `X4`.
+alias X5 = i64.((i32 as Factory).Make);
+
+// ❌ Invalid: binding something that has already been bound.
+alias X6 = i32.(i32.((i32 as Factory).Make));
 ```
 
 ## Member binding interfaces
@@ -1228,10 +1273,11 @@ Non-instance members use `BindToType` when accessed on a type facet:
     implements `BindToType(C)` with `.Result = __TypeBinding_C_NonInstance`.
 -   To support calling directly on a type facet, `__TypeOf_C_NonInstance` also
     implements `Call(())` directly (supporting `C.NonInstance()`).
--   To support calling on value/reference instances `x.NonInstance()`,
-    `__TypeOf_C_NonInstance` implements `BindToValue(C)` and `BindToRef(C)`
-    returning a bound adapter whose `Call` implementation ignores its `self`
-    argument, effectively discarding the evaluated instance `x`.
+-   To support calling on value/reference instances `x.NonInstance()`, for
+    function members `NonInstance`, `__TypeOf_C_NonInstance` implements
+    `BindToValue(C)` and `BindToRef(C)` returning a bound adapter whose `Call`
+    implementation ignores its `self` argument, effectively discarding the
+    evaluated instance `x`.
 
 #### Interface members and `impl` lookup
 
@@ -1291,22 +1337,30 @@ naturally enforced by whether the member's type implements the required
 ```carbon
 class C {
   fn F(self);
+  fn G();
 }
 
 let v: C = {};
 // ❌ Invalid, instance binding to something already bound.
 v.(v.F)();
-// ✅ Allowed, even though `C.(C.F)` is redundant.
-v.(C.(C.F))();
+// ✅ Allowed, even though `C.G` is non-instance.
+v.(C.G)();
+// ❌ Invalid, accessing a non-interface-member of type.
+C.(C.G)();
 ```
 
-`v.(v.F)` fails because the bound method
-adapter does not implement member binding interfaces, following the rules of
-[instance binding](#instance-binding).
+In this example:
 
-However, `C.(C.F)` is an allowed
-[vacuous member access](#vacuous-member-access), so `__TypeOf_C_F` needs to
-implement `BindToType(C)` in addition to `BindToValue(C)` and `BindToRef(C)`.
+-   `v.(v.F)` fails because the bound method adapter does not implement member
+    binding interfaces, since it already bound, following the rules of
+    [instance binding](#instance-binding) and
+    [compound member access](#restrictions-on-compound-member-access).
+-   `v.(C.G)` is an allowed
+    [vacuous member access](#restrictions-on-compound-member-access), so
+    `__TypeOf_C_F` needs to implement `BindToType(C)` in addition to
+    `BindToValue(C)` and `BindToRef(C)`.
+-   `C.(C.G)` is not valid, so the type of `C.G` does not implement
+    `BindToType(C)`.
 
 ## Precedence and associativity
 

--- a/docs/design/expressions/member_access.md
+++ b/docs/design/expressions/member_access.md
@@ -25,7 +25,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     -   [`impl` lookup for compound member access](#impl-lookup-for-compound-member-access)
 -   [Instance binding](#instance-binding)
 -   [Non-instance members](#non-instance-members)
--   [Non-vacuous member access restriction](#non-vacuous-member-access-restriction)
+-   [Vacuous member access](#vacuous-member-access)
+-   [Member binding interfaces](#member-binding-interfaces)
+    -   [Compiler implementation of binding interfaces](#compiler-implementation-of-binding-interfaces)
+        -   [Methods](#methods)
+        -   [Fields](#fields)
+        -   [Non-instance members](#non-instance-members-1)
+        -   [Interface members and `impl` lookup](#interface-members-and-impl-lookup)
+    -   [Member binding restrictions](#member-binding-restrictions)
 -   [Precedence and associativity](#precedence-and-associativity)
 -   [Alternatives considered](#alternatives-considered)
 -   [References](#references)
@@ -33,13 +40,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 <!-- tocstop -->
 
 ## Overview
-
-> **TODO:** >
-> [#3720: Member binding operators](/proposals/p003720-member-binding-operators.md)
-> introduces an additional "member binding" step, redefines simple member access
-> in terms of compound member access, and defines compound member access in
-> terms of calls to user-implementable interface methods. This document must be
-> updated to reflect those changes.
 
 A _qualified name_ is a [word](../lexical_conventions/words.md) that is preceded
 by a period or a rightward arrow. The name is found within a contextually
@@ -128,6 +128,10 @@ A member access expression is processed using the following steps:
 -   If [instance binding is not performed](#non-instance-members), the result is
     `M`.
 
+Under the hood, these steps are implemented by rewriting member access
+expressions into calls to methods of user-implementable
+[member binding interfaces](#member-binding-interfaces).
+
 ## Member resolution
 
 The process of _member resolution_ determines which member `M` a member access
@@ -162,7 +166,7 @@ member with that name.
 An expression that names a package or namespace can only be used as the first
 operand of a member access or as the target of an `alias` declaration.
 
-```
+```carbon
 namespace MyNamespace;
 fn MyNamespace.MyFunction() {}
 
@@ -332,7 +336,7 @@ _integer-literal_ is required to exactly match one of those names, and the
 result of member resolution is an instance member that refers to the
 corresponding element of the tuple.
 
-```
+```carbon
 // ✅ `a == 42`.
 let a: i32 = (41, 42, 43).1;
 // ❌ Error: no tuple element named `0x1`.
@@ -353,7 +357,7 @@ be a non-negative template constant that is less than the number of tuple
 elements, and the result is an instance member that refers to the corresponding
 positional element of the tuple.
 
-```
+```carbon
 // ✅ `d == 43`.
 let d: i32 = (41, 42, 43).(1 + 1);
 // ✅ `e == 2`.
@@ -410,7 +414,7 @@ of the facet `T` of facet type `C`.
 
 For example:
 
-```
+```carbon
 interface Printable {
   fn Print(self);
 }
@@ -953,14 +957,40 @@ fn CallStaticMethod(c: C) {
 }
 ```
 
-## Non-vacuous member access restriction
+## Vacuous member access
 
-The first operand of a member access expression must be used in some way: a
-compound member access must result in `impl` lookup, instance binding, or both.
-In a simple member access, this always holds, because the first operand is
-always used for lookup.
+A compound member access expression where the first operand is not used for
+`impl` lookup or instance binding is valid, even though the first operand is
+redundant.
 
+Instead, tools such as linters can highlight such code as suspicious on a
+best-effort basis, particularly when the issue is contained in a single
+expression. Such tools may still allow code that performs the same operation
+across multiple statements, as in:
+
+```carbon
+class C {
+  fn NonInstance();
+}
+
+let M:! auto = C.NonInstance;
+
+let v: C = {};
+// ✅ Allowed, even though `v.` is not used.
+v.(M)();
 ```
+
+> **Note:** Earlier wording restricted vacuous member access by making
+> expressions such as `v.(C.NonInstance)` invalid because the `v.`
+> portion is redundant. That rule was removed by proposal
+> [#3720: Member binding operators](/proposals/p003720-member-binding-operators.md#details).
+
+In the case where `M` is an overloaded name, it could be an instance member in some
+cases and a non-instance member in others, depending on the arguments passed.
+This is another reason to delegate this to linters analyzing a whole expression
+on a best-effort basis, rather than a strict rule just about member binding.
+
+```carbon
 interface Printable {
   fn Print(self);
 }
@@ -986,19 +1016,285 @@ impl i32 as Factory;
 
 // ✅ OK, member `Make` of interface `Factory`.
 alias X1 = Factory.Make;
-// ❌ Error, compound access without impl lookup or instance binding.
+// ⚠️ Suspicious (linter warning), but valid: compound access without impl
+// lookup or instance binding.
 alias X2 = Factory.(Factory.Make);
 // ✅ OK, member `Make` of `impl i32 as Factory`.
 alias X3 = (i32 as Factory).Make;
-// ❌ Error, compound access without impl lookup or instance binding.
+// ⚠️ Suspicious (linter warning), but valid: compound access without impl
+// lookup or instance binding.
 alias X4 = i32.((i32 as Factory).Make);
 ```
+
+## Member binding interfaces
+
+To support advanced customization, such as user-defined properties, custom smart
+pointers, and pointer-to-member conversions, Carbon implements the conceptual
+steps of member access (like `impl` lookup and instance binding) by rewriting
+compound member access expressions into calls to methods on user-implementable
+interfaces.
+
+This does not change how typical member access is written or read in Carbon code. Under the hood, for a compound member access
+expression `x.(y)` where `x` has type `T` and `y` has type `U`, the compiler
+rewrites the expression into a call to an interface method on one of three
+interfaces:
+
+```carbon
+// An interface to identify the result type of member binding.
+// Both `BindToValue` and `BindToRef` extend this to ensure they produce the
+// same type regardless of expression category.
+interface Bind(T: type) {
+  let Result: type;
+}
+
+// Used when `x` is a value expression.
+// `x.(y)` is rewritten to: `y.((U as BindToValue(T)).Op)(x)`
+interface BindToValue(T: type) {
+  extend Bind(T);
+  fn Op(self, x: T) -> Result;
+}
+
+// Used when `x` is a reference expression.
+// `x.(y)` is rewritten to: `y.((U as BindToRef(T)).Op)(ref x)`
+interface BindToRef(T: type) {
+  extend Bind(T);
+  fn Op(self, ref p: T) -> ref Result;
+}
+
+// Used when `x` is a type or facet value.
+// `x.(y)` is rewritten to: `y.((U as BindToType(x)).Op)()`
+interface BindToType(T: type) {
+  let Result: type;
+  fn Op(self) -> Result;
+}
+```
+
+The other member access operators -- `x.y`, `x->y`, and `x->(y)` -- are defined
+by how they rewrite into the `x.(y)` form using these two rules:
+
+-   `x.y` is interpreted using the [member resolution rules](#member-resolution).
+    For example, `x.y` is treated as `x.(T.y)` for non-type values `x` with type
+    `T`.
+    -   Simple member access of a facet `T`, as in `T.y`, is not rewritten into
+        the `T.(`\_\_\_`)` form.
+-   `x->y` and `x->(y)` are interpreted as `(*x).y` and `(*x).(y)` respectively.
+
+These interfaces may be used as constraints, allowing a generic function to perform binding.
+
+```carbon
+fn CallsMethodWithValueBinding
+    [T: type, U: BindToValue(T) where .Result impls Call(())](x: T, y: U) {
+  // Equivalent to: y.Op(x)();
+  x.(y)();
+}
+```
+
+This generic function may be called with the name of any method that is callable on `x` with no arguments, as in:
+
+```carbon
+interface I {
+  fn F(self);
+}
+
+class C {
+  fn G(self);
+  impl as I {
+    fn F(self);
+  }
+}
+
+let x: C = {};
+// Calls `x.G()`.
+CallsMethodWithValueBinding(x, C.G);
+
+// Calls `x.(I.F)()`.
+CallsMethodWithValueBinding(x, I.F);
+
+// ❌ Invalid, `x.G` doesn't implement `BindToValue(C)`,
+// since methods may only be bound to an instance once.
+CallsMethodWithValueBinding(x, x.G);
+```
+
+### Compiler implementation of binding interfaces
+
+The compiler automatically provides implementations of these interfaces for the
+types associated with class, interface, and built-in type members.
+
+#### Methods
+
+Consider a method `F` in class `C`:
+
+```carbon
+class C {
+  fn F(self) -> i32;
+}
+
+let x: C = {};
+x.F();
+```
+
+-   The member `C.F` has a unique, empty type which is unnamed, but we will refer to as `__TypeOf_C_F`.
+-   An adapter type is generated to adapt `C`, which we will refer to as `__Binding_C_F`.
+-   `__TypeOf_C_F` implements `BindToValue(C)` and `BindToRef(C)` with `Op` returning
+    `__Binding_C_F`.
+-   The implementation of the member binding interfaces allow implicit conversions, to support
+    calling a method from a base type on an object of a derived type. See
+    ["Inheritance and other implicit conversions" in proposal #3720](/proposals/p003720-member-binding-operators.md#inheritance-and-other-implicit-conversions).
+-   `__Binding_C_F` implements the `Call(())` interface, which maps to the
+    actual method implementation body:
+
+```carbon
+impl __Binding_C_F as Call(()) with .Result = i32 {
+  fn Op(self) -> i32 {
+    return inlined_method_call_compiler_intrinsic(
+        <function body C.F>, self as C, ());
+  }
+}
+```
+
+Note that the implementation of the `Call` operator needs to use a compiler
+intrinsic to avoid recursive application of these same rules.
+
+The result is that the expression `x.F` is a bound method value of type `__Binding_C_F`
+(adapting `x`) that can be called like a function.
+
+#### Fields
+
+For a field `var m: i32` in class `C`:
+
+```carbon
+class C {
+  var m: i32;
+}
+
+var x: C = {.m = 7};
+x.m = 42;
+```
+
+-   The member `C.m` has an unnamed unique type which we will call `__TypeOf_C_m`.
+-   `__TypeOf_C_m` implements `BindToValue(C)` with `.Result = i32`, returning
+    the value of `m` by way of a compiler intrinsic:
+
+    ```carbon
+    impl __TypeOf_C_m as BindToValue(C) where .Result = i32 {
+      fn Op(self, x: C) -> i32 {
+        return value_compiler_intrinsic(x, __OffsetOf_C_m, i32);
+      }
+    }
+    ```
+
+-   `__TypeOf_C_m` implements `BindToRef(C)` with `.Result = i32`, returning a
+    reference to `m` by way of a compiler offset intrinsic:
+
+    ```carbon
+    impl __TypeOf_C_m as BindToRef(C) where .Result = i32 {
+      fn Op(self, ref p: C) -> ref i32 {
+        return offset_compiler_intrinsic(ref p, __OffsetOf_C_m, i32);
+      }
+    }
+    ```
+
+This ensures that if `x` is a reference expression of type `C`, then `x.m`
+(rewritten using `BindToRef`) evaluates to a reference
+expression referring to the subobject `m` inside `x.m`.
+
+Tuple types and struct types have their fields implemented in the same way.
+
+#### Non-instance members
+
+Classes may also have non-instance members. This includes non-instance member functions and static member variables, as in:
+
+```carbon
+class C {
+  fn NonInstance();
+  static var s: i32 = 0;
+}
+
+C.NonInstance();
+C.s = 3;
+```
+
+Non-instance members use `BindToType` when accessed on a type facet:
+
+-   For `fn NonInstance()` in class `C`, its type `__TypeOf_C_NonInstance` implements
+    `BindToType(C)` with `.Result = __TypeBinding_C_NonInstance`.
+-   To support calling directly on a type facet, `__TypeOf_C_NonInstance` also
+    implements `Call(())` directly (supporting `C.NonInstance()`).
+-   To support calling on value/reference instances `x.NonInstance()`,
+    `__TypeOf_C_NonInstance` implements `BindToValue(C)` and `BindToRef(C)` returning
+    a bound adapter whose `Call` implementation ignores its `self` argument,
+    effectively discarding the evaluated instance `x`.
+
+#### Interface members and `impl` lookup
+
+For members of an interface, such as `F` in
+
+```carbon
+interface I {
+  fn F(self);
+}
+
+class C {
+  impl as I {
+    fn F(self);
+  }
+}
+```
+
+-   The `I.F` member has an unnamed unique type, which we will refer to a `__TypeOf_I_F`.
+-   `__TypeOf_I_F` implements `BindToValue(T)` for all types `T impls I` returning
+    `__Binding_I_F(T)` (which adapts `T`).
+-   The actual implementation of `I` for `T` is resolved during generic matching
+    when `Call.Op` is called on the adapter:
+
+    ```carbon
+    impl forall [T: I] __TypeOf_I_F as BindToValue(T) {
+      where .Result = __Binding_I_F(T);
+      fn Op(self, x: T) -> __Binding_I_F(T) {
+        return x as __Binding_I_F(T);
+      }
+    }
+
+    // If C implements I:
+    impl __Binding_I_F(C) as Call(()) where .Result = () {
+      fn Op(self) {
+        inlined_method_call_compiler_intrinsic(
+            <function body (C as I).F>, self as C, ());
+      }
+    }
+    ```
+
+-   The type of an interface method taking `ref self` would also implement `BindToRef(T)`.
+-   In all cases, the type of an interface member would implement `BindToType(T)` for all types `T impls I`. The result would depend on the specifics of the member, but generally would be a value of a unique empty type associated with the specific interface member, parameterized by `T`. This value could then be bound to an instance of `T` in a succeeding operation.
+
+### Member binding restrictions
+
+The restrictions that only certain compound member accesses are valid are naturally enforced by whether the
+member's type implements the required `BindToValue`, `BindToRef`, or `BindToType` interfaces.
+
+```carbon
+class C {
+  fn F(self);
+}
+
+let v: C = {};
+// ❌ Invalid, instance binding to something already bound.
+v.(v.F)();
+// ✅ Allowed, even though `C.(C.F)` is redundant.
+v.(C.(C.F))();
+```
+
+`v.(v.F)` fails because the bound method
+adapter does not implement member binding interfaces, following the rules of [instance binding](#instance-binding).
+
+However, `C.(C.F)` is an allowed [vacuous member access](#vacuous-member-access),
+so `__TypeOf_C_F` needs to implement `BindToType(C)` in addition to `BindToValue(C)` and `BindToRef(C)`.
 
 ## Precedence and associativity
 
 Member access expressions associate left-to-right:
 
-```
+```carbon
 class A {
   class B {
     fn F();
@@ -1024,7 +1320,7 @@ expressions (literals, unqualified names, and expressions in parentheses, as in
 [C++](https://cppreference.com/cpp/language/expressions#Primary_expressions)),
 and higher precedence than all other expression forms.
 
-```
+```carbon
 // ✅ OK, `*` has lower precedence than `.`. Same as `(A.B)*`.
 var p: A.B*;
 // ✅ OK, `1 + (X.Y)` not `(1 + X).Y`.
@@ -1036,6 +1332,14 @@ var n: i32 = 1 + X.Y;
 -   [Separate syntax for static versus dynamic access, such as `::` versus `.`](/proposals/p000989-member-access-expressions.md#separate-syntax-for-static-versus-dynamic-access)
 -   [Use a different lookup rule for names in templates](/proposals/p000989-member-access-expressions.md#use-a-different-lookup-rule-in-templates)
 -   [Meaning of `Type.Interface`](/proposals/p000989-member-access-expressions.md#meaning-of-typeinterface)
+-   [Non-vacuous member access restriction](/proposals/p003720-member-binding-operators.md#proposal)
+-   [Swap the member binding interface parameters](/proposals/p003720-member-binding-operators.md#swap-the-member-binding-interface-parameters)
+-   [Member binding to references produces a value that wraps a pointer](/proposals/p003720-member-binding-operators.md#member-binding-to-references-produces-a-value-that-wraps-a-pointer)
+-   [Separate interface for compile-time member binding instead of type member binding](/proposals/p003720-member-binding-operators.md#separate-interface-for-compile-time-member-binding-instead-of-type-member-binding)
+-   [Non-instance members are idempotent under member binding](/proposals/p003720-member-binding-operators.md#non-instance-members-are-idempotent-under-member-binding)
+-   [Separate `Result` types for `BindToValue` and `BindToRef`](/proposals/p003720-member-binding-operators.md#separate-result-types-for-bindtovalue-and-bindtoref)
+-   [`BindToValue` is a subtype of `BindToRef`](/proposals/p003720-member-binding-operators.md#bindtovalue-is-a-subtype-of-bindtoref)
+-   [Directly rewrite all calls to interface member functions to method call intrinsics](/proposals/p003720-member-binding-operators.md#directly-rewrite-all-calls-to-interface-member-functions-to-method-call-intrinsics)
 
 ## References
 
@@ -1046,5 +1350,7 @@ var n: i32 = 1 + X.Y;
     [#2360: Types are values of type `type`](https://github.com/carbon-language/carbon-lang/pull/2360)
 -   Proposal
     [#2550: Simplified package declaration for the `Main` package](https://github.com/carbon-language/carbon-lang/pull/2550)
+-   Proposal
+    [#3720: Member binding operators](https://github.com/carbon-language/carbon-lang/pull/3720)
 -   Proposal
     [#6395: Type completeness in extend](https://github.com/carbon-language/carbon-lang/pull/6395)

--- a/docs/design/expressions/member_access.md
+++ b/docs/design/expressions/member_access.md
@@ -12,6 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 -   [Overview](#overview)
 -   [Member resolution](#member-resolution)
+-   [Member access operations](#member-access-operations)
     -   [Package and namespace members](#package-and-namespace-members)
     -   [Types, extended types, and facets](#types-extended-types-and-facets)
         -   [`extend`](#extend)
@@ -114,19 +115,17 @@ and semantics can be found in the [pointers](/docs/design/values.md#pointers)
 design. The rest of this document describes the semantics using `.` alone for
 simplicity.
 
-A member access expression is processed using the following steps:
+A member access expression is processed using some of the following operations:
 
--   First, the member name to the right of the `.` is
-    [resolved](#member-resolution) to a specific member entity, called `M` in
-    this document.
--   Then, if necessary, [`impl` lookup](#impl-lookup) is performed to map from a
-    member of an interface to a member of the relevant `impl`, potentially
-    updating `M`.
--   Then, if necessary, [instance binding](#instance-binding) is performed to
-    locate the member subobject corresponding to a field name or to build a
+-   For simple member access, qualified name lookup is performed. Here, the
+    member name to the right of `.` is looked up either in the value of the
+    expression to the left of the `.` or in its type.
+-   In some cases, this is followed by [`impl` lookup](#impl-lookup). This
+    maps from a member of an interface to a member of the relevant `impl`.
+-   Lastly in some cases, [instance binding](#instance-binding) is performed
+    to locate the member subobject corresponding to a field name or to build a
     bound method object, producing the result of the member access expression.
--   If [instance binding is not performed](#non-instance-members), the result is
-    `M`.
+    -   [Otherwise](#non-instance-members) the result is the member itself.
 
 Under the hood, these steps are implemented by rewriting member access
 expressions into calls to methods of user-implementable
@@ -134,27 +133,54 @@ expressions into calls to methods of user-implementable
 
 ## Member resolution
 
-The process of _member resolution_ determines which member `M` a member access
-expression is referring to.
+FIXME: Remove references to this section.
 
-For a simple member access, if the first operand is a type, extended type,
-facet, package, or namespace, a search for the member name is performed in the
-first operand. Otherwise, a search for the member name is performed in the type
-of the first operand. In either case, the search must succeed. In the latter
-case, if the result is an instance member, then
-[instance binding](#instance-binding) is performed on the first operand.
+## Member access operations
 
-A search for a name within an extended type searches for the name in its
-[type component](/docs/design/values.md#extended-types). Note that this means
-that the extended type of an expression never affects simple member access into
-that expression, except through its type component.
+The operations used to resolve a member access expression depend on the kind of
+entities involved and whether it is a simple or compound member access.
 
-For a compound member access, the second operand is evaluated as a compile-time
-constant to determine the member being accessed. The evaluation is required to
-succeed and to result in a member of a type, interface, or non-type facet, or a
-value of an integer or integer literal type. If the result is an instance
-member, then [instance binding](#instance-binding) is always performed on the
-first operand.
+For a simple member access `a.b`:
+
+-   If `a` is a namespace, package, type, extended type, or facet, a search for
+    the member name `b` is performed in `a`, called _qualified member name lookup_.
+    -   A search for a name within an extended type searches for the name in
+        its [type component](/docs/design/values.md#extended-types). Note that
+        this means that the extended type of an expression never affects simple
+        member access into that expression, except through its type component.
+    -   If `a` is a facet, the result is the member of the witness identified
+        by `b`.
+    -   Otherwise, if `a` is a type, then perform _type binding_.
+        -   When `b` is an interface member, this does
+            [`impl` lookup](#impl-lookup) to find the implementation of `b`
+            for the type `a`.
+-   Otherwise when `a` is any other kind of value, `b` is looked up in the
+    _type_ of `a` to get a result `M`. `a.b` is rewritten to compound member
+    access `a.(M)`.
+
+A compound member access `a.(M)`, either written directly in the source or as
+the result of a rewritten simple member access, performs _type binding_ if `a`
+is a type, or _member binding_ otherwise:
+
+-   If `M` is an interface member, [`impl` lookup](#impl-lookup) will be performed map from `M` to the corresponding member of the `impl` of that interface for the type
+
+If `a` is not a facet, then
+
+-   If `a` is a type, then _type binding_ is performed.
+    -   If `b` is an interface member, type binding will cause
+-   The second operand is evaluated as a compile-time constant to determine the
+    member being accessed. The evaluation is required to succeed.
+    -   If the result is a member of a type, interface, or non-type facet, or a
+        value of an integer or integer literal type, then the behavior is as
+        defined below.
+    -   The behavior for other cases is determined by [member binding interfaces](#member-binding-interfaces).
+-   If `M` names a member of an interface, then [`impl` lookup](#impl-lookup)
+    is performed.
+-   [Instance binding](#instance-binding) is performed on the first operand.
+
+    This
+will perform [`impl` lookup](#impl-lookup) and then
+[instance binding](#instance-binding) when those are applicable.
 
 ### Package and namespace members
 
@@ -324,7 +350,7 @@ enclosing scope is not complete. This seems reasonable as all names available
 inside the enclosing interface or named constraint are already available or
 would conflict with the ones that are.
 
-> **Alternative considered:** >
+> **Alternative considered:**
 > [Not requiring the target scope to be complete immediately](/proposals/p006395-type-completeness-in-extend.md#alternatives-considered).
 
 ### Tuple indexing
@@ -373,8 +399,10 @@ let n: i32 = p->(e);
 ### Values
 
 If the first operand is not a type, extended type, facet, package, or namespace,
-it does not have member names, and a search is performed into the type of the
-first operand instead.
+it does not have member names. Simple member access `x.y` is rewritten to
+compound member access `x.(T.y)`, where `T` is the type of `x`. A search for `y`
+is performed in `T` (performing [`impl` lookup](#impl-lookup) if `y` is an
+interface member), and the resulting member is bound to `x`.
 
 ```carbon
 interface Printable {
@@ -630,6 +658,10 @@ For a simple member access `a.b` where `b` names a member of an interface `I`:
     -   More generally, if the member was found in something the type extends,
         such as a facet type or mixin, `T` is the type that was initially
         searched, not what it extended.
+-   If `a` is a value, `a.b` is rewritten to `a.(typeof(a)::b)`. Qualified lookup
+    in `typeof(a)` performs `impl` lookup for `typeof(a) as I`, replacing `b`
+    with the corresponding member of `impl typeof(a) as I`. The compound access
+    then binds `a` directly to that member.
 -   Otherwise, `impl` lookup is not performed.
 
 The appropriate `impl T as I` implementation is located. The program is invalid
@@ -921,17 +953,26 @@ doesn't attempt to perform instance binding on `T`, in contrast to `T.(I.M)`.
 
 ## Non-instance members
 
-If instance binding is not performed, the result is the member `M` determined by
-member resolution and `impl` lookup. Evaluating the member access expression
-evaluates the first argument and discards the result.
+When qualified name lookup into a type `C` resolves to a non-instance member `M`
+(such as a static method, static variable, or nested type), the result of `C.M`
+is `M`.
 
-An expression that names an instance member, but for which instance binding is
-not performed, can only be used as the second operand of a compound member
-access or as the target of an `alias` declaration.
+When accessing a non-instance member through an instance `c.M`, the expression
+is rewritten to compound member access `c.(C.M)`:
+
+-   **Non-instance functions**: The compiler provides a binding implementation
+    for non-instance member functions that evaluates the receiver `c`, discards
+    the resulting value, and returns a callable function object.
+-   **Member types and static variables**: Member types and static variables
+    cannot be bound to an instance. Consequently, accessing them through an
+    instance (for example, `c.NestedType` or `c.StaticVar`) is invalid and results in a
+    compile-time error. They must be accessed through the enclosing type (for example,
+    `C.NestedType` or `C.StaticVar`).
 
 ```carbon
 class C {
   fn StaticMethod();
+  static var StaticVar: i32;
   var field: i32;
   class Nested {}
 }
@@ -939,22 +980,25 @@ fn CallStaticMethod(c: C) {
   // ✅ OK, calls `C.StaticMethod`.
   C.StaticMethod();
 
-  // ✅ OK, evaluates expression `c`, discards the result, then
-  // calls `C.StaticMethod`.
+  // ✅ OK, rewrites to `c.(C.StaticMethod)()`. Evaluates `c`,
+  // discards the result, and calls `C.StaticMethod`.
   c.StaticMethod();
 
-  // ❌ Error: name of instance member `C.field` can only be used in
-  // a member access or alias.
+  // ❌ Error: `C.field` is an instance member and cannot be accessed
+  // on type `C` without an instance.
   C.field = 1;
-  // ✅ OK, instance binding is performed by outer member access,
-  // same as `c.field = 1;`
+  // ✅ OK, instance binding binds `field` to `c`.
   c.(C.field) = 1;
 
-  // ✅ OK (also OK with `template`)
+  // ✅ OK, member type accessed on type `C`.
   let generic G: type = C.Nested;
-  // ❌ Error: value of `generic` binding is not compile-time because it
-  // refers to local variable `c`.
-  let generic U: type = c.Nested;
+  // ❌ Error: member types cannot be accessed through an instance `c`.
+  var y: c.Nested;
+
+  // ✅ OK, static variable accessed on type `C`.
+  C.StaticVar = 1;
+  // ❌ Error: static variables cannot be accessed through an instance `c`.
+  c.StaticVar = 1;
 }
 ```
 
@@ -1118,11 +1162,11 @@ interface BindToType(T: type) {
 The other member access operators -- `x.y`, `x->y`, and `x->(y)` -- are defined
 by how they rewrite into the `x.(y)` form using these two rules:
 
--   `x.y` is interpreted using the [member resolution rules](#member-resolution).
-    For example, `x.y` is treated as `x.(T.y)` for non-type values `x` with type
-    `T`.
-    -   Simple member access of a facet `T`, as in `T.y`, is not rewritten into
-        the `T.(`\_\_\_`)` form.
+-   `x.y` is interpreted using the [member resolution rules](#member-resolution):
+    -   If `x` has member names (a namespace, package, type, or facet), `x.y` is
+        resolved by way of qualified name lookup of `y` in `x`.
+    -   Otherwise, `x.y` is rewritten to `x.(M)` where `M` is the result of
+        qualified name lookup of `y` in `typeof(x)`.
 -   `x->y` and `x->(y)` are interpreted as `(*x).y` and `(*x).(y)` respectively.
 
 These interfaces may be used as constraints, allowing a generic function to
@@ -1255,29 +1299,30 @@ Tuple types and struct types have their fields implemented in the same way.
 #### Non-instance members
 
 Classes may also have non-instance members. This includes non-instance member
-functions and static member variables, as in:
+functions, static member variables, and nested types, as in:
 
 ```carbon
 class C {
   fn NonInstance();
   static var s: i32 = 0;
+  class Nested {}
 }
 
 C.NonInstance();
 C.s = 3;
+var n: C.Nested = {};
 ```
 
-Non-instance members use `BindToType` when accessed on a type facet:
-
 -   For `fn NonInstance()` in class `C`, its type `__TypeOf_C_NonInstance`
-    implements `BindToType(C)` with `.Result = __TypeBinding_C_NonInstance`.
--   To support calling directly on a type facet, `__TypeOf_C_NonInstance` also
     implements `Call(())` directly (supporting `C.NonInstance()`).
--   To support calling on value/reference instances `x.NonInstance()`, for
-    function members `NonInstance`, `__TypeOf_C_NonInstance` implements
-    `BindToValue(C)` and `BindToRef(C)` returning a bound adapter whose `Call`
-    implementation ignores its `self` argument, effectively discarding the
-    evaluated instance `x`.
+-   To support calling on value and reference instances (such as `x.NonInstance()`),
+    `__TypeOf_C_NonInstance` implements `BindToValue(C)` and `BindToRef(C)`
+    returning a bound adapter whose `Call` implementation ignores its receiver
+    argument, discarding the evaluated instance `x`.
+-   Types (like `C.Nested`) and static variables (like `C.s`) do not implement
+    `BindToValue(C)` or `BindToRef(C)`. As a result, compound member access
+    `x.(C.Nested)` and simple member access `x.Nested` (as well as `x.s`) fail to
+    compile because no matching binding implementation exists.
 
 #### Interface members and `impl` lookup
 
@@ -1314,7 +1359,13 @@ class C {
     impl __Binding_I_F(C) as Call(()) where .Result = () {
       fn Op(self) {
         inlined_method_call_compiler_intrinsic(
-            <function body (C as I).F>, self as C, ());
+    ```
+
+    ```
+    <function body (C as I).F>, self as C, ());
+    ```
+
+    ```
       }
     }
     ```
@@ -1352,15 +1403,15 @@ C.(C.G)();
 In this example:
 
 -   `v.(v.F)` fails because the bound method adapter does not implement member
-    binding interfaces, since it already bound, following the rules of
+    binding interfaces, since it is already bound, following the rules of
     [instance binding](#instance-binding) and
     [compound member access](#restrictions-on-compound-member-access).
 -   `v.(C.G)` is an allowed
-    [vacuous member access](#restrictions-on-compound-member-access), so
-    `__TypeOf_C_F` needs to implement `BindToType(C)` in addition to
-    `BindToValue(C)` and `BindToRef(C)`.
--   `C.(C.G)` is not valid, so the type of `C.G` does not implement
-    `BindToType(C)`.
+    [vacuous member access](#restrictions-on-compound-member-access), where
+    `__TypeOf_C_G` implements `BindToValue(C)` and `BindToRef(C)` (evaluating
+    and discarding `v`).
+-   `C.(C.G)` is not valid because `C.G` is not an interface member, so the type
+    of `C.G` does not implement `BindToType(C)`.
 
 ## Precedence and associativity
 

--- a/proposals/p003720-member-binding-operators.md
+++ b/proposals/p003720-member-binding-operators.md
@@ -877,7 +877,7 @@ requirements. If necessary, we can in the future introduce a specific construct
 just for C++ interop that invokes the C++ arrow operator, such as
 `CppArrowOperator(x)`, that returns a pointer.
 
-**Context:** This was discuseed in
+**Context:** This was discussed in
 [2024-02-29 open discussion](https://docs.google.com/document/d/1s3mMCupmuSpWOFJGnvjoElcBIe2aoaysTIdyczvKX84/edit?resourcekey=0-G095Wc3sR6pW1hLJbGgE0g&tab=t.0#heading=h.5vj8ohrvqjqh)
 and in
 [a comment on this proposal](https://github.com/carbon-language/carbon-lang/pull/3720/files#r1507917882).


### PR DESCRIPTION
The new content reflects the new syntax for function declarations (with #7016 that puts `self` in `(`...`)` and no use of `:!` due to #7254 ) and updates the `BindToRef` interface to reflect introduction of `ref` in #5434 .

See [#generics-and-templates](https://discord.com/channels/655572317891461132/941071822756143115/1540063686201311342) and [discussion on 2026-08-24](https://docs.google.com/document/d/1mjllGO3ZCL4qGt9uJHUtcxKoHAGEY7Y999ie4EtBWB8/edit?tab=t.3ot8c9eu3e1h#heading=h.bpukwg8e3446) for clarifications on the ambiguous points from #3720.

Assisted-by: Gemini via Antigravity
