### PR TITLE
Export abstract methods as pure virtual

### DIFF
--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -791,7 +791,10 @@ static auto BuildCppToCarbonThunkDecl(Context& context, SemIR::LocId loc_id,
             SemIR::Function::VirtualModifier::None &&
         target.function.virtual_modifier !=
             SemIR::Function::VirtualModifier::Override);
-    // TODO: Call setIsPureVirtual if VirtualModifier::Abstract is present.
+    if (target.function.virtual_modifier ==
+        SemIR::Function::VirtualModifier::Abstract) {
+      cast<clang::CXXMethodDecl>(thunk_function_decl)->setIsPureVirtual(true);
+    }
   } else {
     thunk_function_decl = clang::FunctionDecl::Create(
         ast_context, target.decl_context, clang_loc, name_info, thunk_qual_type,

--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -544,6 +544,11 @@ auto CarbonExternalASTSource::CompleteType(clang::TagDecl* tag_decl) -> void {
                method_decl,
                MakeVirtualFunctionSignature(*context_, method_decl)),
            .inst_id = function.first_decl_id()});
+      // An abstract function has no definition, so it doesn't need a thunk.
+      if (function.virtual_modifier ==
+          SemIR::Function::VirtualModifier::Abstract) {
+        continue;
+      }
       pending_virtual_functions.push_back(
           {.loc_id = SemIR::LocId(vtable_entry_id),
            .function_id = callee_function.function_id,

--- a/toolchain/check/testdata/interop/cpp/class/export/base.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/export/base.carbon
@@ -145,6 +145,65 @@ class Derived : public Carbon::Abstract {
 };
 ''';
 
+// --- fail_abstract_method.carbon
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+inline Cpp '''
+struct VirtualDestructor {
+  virtual ~VirtualDestructor() {}
+};
+''';
+
+// CHECK:STDERR: fail_abstract_method.carbon:[[@LINE+4]]:1: error: cannot access member of interface `Core.Destroy` in type `Abstract` that does not implement that interface [MissingImplInMemberAccess]
+// CHECK:STDERR: abstract class Abstract {
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+abstract class Abstract {
+  extend base: Cpp.VirtualDestructor;
+  abstract fn F(self);
+}
+
+inline Cpp '''
+// CHECK:STDERR: fail_abstract_method.carbon:[[@LINE+7]]:18: error: variable type 'Carbon::Abstract' is an abstract class [CppInteropParseError]
+// CHECK:STDERR:    28 | Carbon::Abstract x;
+// CHECK:STDERR:       |                  ^
+// CHECK:STDERR: fail_abstract_method.carbon:[[@LINE-7]]:22: note: unimplemented pure virtual method 'F' in 'Abstract' [CppInteropParseNote]
+// CHECK:STDERR:    17 |   abstract fn F(self);
+// CHECK:STDERR:       |                      ^
+// CHECK:STDERR:
+Carbon::Abstract x;
+''';
+
+// --- fail_todo_abstract_method_overridden_in_cpp.carbon
+library "[[@TEST_NAME]]";
+
+import Cpp;
+
+inline Cpp '''
+struct VirtualDestructor {
+  virtual ~VirtualDestructor() {}
+};
+''';
+
+// CHECK:STDERR: fail_todo_abstract_method_overridden_in_cpp.carbon:[[@LINE+4]]:1: error: cannot access member of interface `Core.Destroy` in type `Abstract` that does not implement that interface [MissingImplInMemberAccess]
+// CHECK:STDERR: abstract class Abstract {
+// CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK:STDERR:
+abstract class Abstract {
+  extend base: Cpp.VirtualDestructor;
+  abstract fn F(ref self);
+}
+
+// A C++ class that overrides the abstract method can be instantiated.
+inline Cpp '''
+struct Derived : Carbon::Abstract {
+  void F() & override {}
+};
+Derived d;
+''';
+
 // --- override_virtual_dtor.carbon
 library "[[@TEST_NAME]]";
 

--- a/toolchain/check/testdata/interop/cpp/class/export/base.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/export/base.carbon
@@ -150,27 +150,20 @@ library "[[@TEST_NAME]]";
 
 import Cpp;
 
-inline Cpp '''
-struct VirtualDestructor {
-  virtual ~VirtualDestructor() {}
-};
-''';
-
 // CHECK:STDERR: fail_abstract_method.carbon:[[@LINE+4]]:1: error: cannot access member of interface `Core.Destroy` in type `Abstract` that does not implement that interface [MissingImplInMemberAccess]
 // CHECK:STDERR: abstract class Abstract {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 abstract class Abstract {
-  extend base: Cpp.VirtualDestructor;
   abstract fn F(self);
 }
 
 inline Cpp '''
 // CHECK:STDERR: fail_abstract_method.carbon:[[@LINE+7]]:18: error: variable type 'Carbon::Abstract' is an abstract class [CppInteropParseError]
-// CHECK:STDERR:    28 | Carbon::Abstract x;
+// CHECK:STDERR:    21 | Carbon::Abstract x;
 // CHECK:STDERR:       |                  ^
 // CHECK:STDERR: fail_abstract_method.carbon:[[@LINE-7]]:22: note: unimplemented pure virtual method 'F' in 'Abstract' [CppInteropParseNote]
-// CHECK:STDERR:    17 |   abstract fn F(self);
+// CHECK:STDERR:    10 |   abstract fn F(self);
 // CHECK:STDERR:       |                      ^
 // CHECK:STDERR:
 Carbon::Abstract x;
@@ -181,18 +174,11 @@ library "[[@TEST_NAME]]";
 
 import Cpp;
 
-inline Cpp '''
-struct VirtualDestructor {
-  virtual ~VirtualDestructor() {}
-};
-''';
-
 // CHECK:STDERR: fail_todo_abstract_method_overridden_in_cpp.carbon:[[@LINE+4]]:1: error: cannot access member of interface `Core.Destroy` in type `Abstract` that does not implement that interface [MissingImplInMemberAccess]
 // CHECK:STDERR: abstract class Abstract {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
 abstract class Abstract {
-  extend base: Cpp.VirtualDestructor;
   abstract fn F(ref self);
 }
 

--- a/toolchain/check/testdata/interop/cpp/class/export/base.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/export/base.carbon
@@ -145,12 +145,15 @@ class Derived : public Carbon::Abstract {
 };
 ''';
 
-// --- fail_abstract_method.carbon
+// --- fail_variable_with_abstract_method.carbon
 library "[[@TEST_NAME]]";
 
 import Cpp;
 
-// CHECK:STDERR: fail_abstract_method.carbon:[[@LINE+4]]:1: error: cannot access member of interface `Core.Destroy` in type `Abstract` that does not implement that interface [MissingImplInMemberAccess]
+// TODO: We should support generating a base subobject destructor for an
+// abstract class, even though we refuse to generate a complete object
+// destructor.
+// CHECK:STDERR: fail_variable_with_abstract_method.carbon:[[@LINE+4]]:1: error: cannot access member of interface `Core.Destroy` in type `Abstract` that does not implement that interface [MissingImplInMemberAccess]
 // CHECK:STDERR: abstract class Abstract {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~
 // CHECK:STDERR:
@@ -159,11 +162,11 @@ abstract class Abstract {
 }
 
 inline Cpp '''
-// CHECK:STDERR: fail_abstract_method.carbon:[[@LINE+7]]:18: error: variable type 'Carbon::Abstract' is an abstract class [CppInteropParseError]
-// CHECK:STDERR:    21 | Carbon::Abstract x;
+// CHECK:STDERR: fail_variable_with_abstract_method.carbon:[[@LINE+7]]:18: error: variable type 'Carbon::Abstract' is an abstract class [CppInteropParseError]
+// CHECK:STDERR:    24 | Carbon::Abstract x;
 // CHECK:STDERR:       |                  ^
-// CHECK:STDERR: fail_abstract_method.carbon:[[@LINE-7]]:22: note: unimplemented pure virtual method 'F' in 'Abstract' [CppInteropParseNote]
-// CHECK:STDERR:    10 |   abstract fn F(self);
+// CHECK:STDERR: fail_variable_with_abstract_method.carbon:[[@LINE-7]]:22: note: unimplemented pure virtual method 'F' in 'Abstract' [CppInteropParseNote]
+// CHECK:STDERR:    13 |   abstract fn F(self);
 // CHECK:STDERR:       |                      ^
 // CHECK:STDERR:
 Carbon::Abstract x;
@@ -174,6 +177,9 @@ library "[[@TEST_NAME]]";
 
 import Cpp;
 
+// TODO: We should support generating a base subobject destructor for an
+// abstract class, even though we refuse to generate a complete object
+// destructor.
 // CHECK:STDERR: fail_todo_abstract_method_overridden_in_cpp.carbon:[[@LINE+4]]:1: error: cannot access member of interface `Core.Destroy` in type `Abstract` that does not implement that interface [MissingImplInMemberAccess]
 // CHECK:STDERR: abstract class Abstract {
 // CHECK:STDERR: ^~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`abstract fn` was exported to C++ as a plain virtual function rather than a pure virtual one, so the class wasn't abstract and could be instantiated from C++.

Abstract functions no longer get a thunk since there is no definition to call. The tests are prefixed with `fail_` since an abstract class still errors on `Core.Destroy` regardless.