### PR TITLE
Take specific into account in CalculateCppFieldOffsets

### DIFF
--- a/toolchain/check/cpp/export.cpp
+++ b/toolchain/check/cpp/export.cpp
@@ -273,8 +273,8 @@ static auto CreateInvalidFieldDecl(Context& context,
 auto ExportAllFieldsToCpp(Context& context, SemIR::Class& class_info) -> void {
   const auto& class_scope = context.name_scopes().Get(class_info.scope_id);
 
-  for (const auto& struct_field :
-       class_info.GetStructTypeFields(context.sem_ir())) {
+  for (const auto& struct_field : class_info.GetStructTypeFields(
+           context.sem_ir(), SemIR::SpecificId::None)) {
     auto class_field = LookupClassFieldByStructField(context.sem_ir(),
                                                      class_scope, struct_field);
     if (!class_field) {

--- a/toolchain/sem_ir/class.cpp
+++ b/toolchain/sem_ir/class.cpp
@@ -52,7 +52,8 @@ auto Class::GetObjectRepr(const File& file, SpecificId specific_id) const
           .object_repr_type_inst_id);
 }
 
-auto Class::GetStructTypeFields(const File& sem_ir) const
+auto Class::GetStructTypeFields(const File& sem_ir,
+                                SpecificId specific_id) const
     -> llvm::ArrayRef<SemIR::StructTypeField> {
   if (adapt_id.has_value()) {
     // The representation of an adapter won't necessarily be a
@@ -61,7 +62,7 @@ auto Class::GetStructTypeFields(const File& sem_ir) const
     return {};
   }
 
-  auto object_repr_type_id = GetObjectRepr(sem_ir, SemIR::SpecificId::None);
+  auto object_repr_type_id = GetObjectRepr(sem_ir, specific_id);
   if (object_repr_type_id == SemIR::ErrorInst::TypeId) {
     return {};
   }

--- a/toolchain/sem_ir/class.h
+++ b/toolchain/sem_ir/class.h
@@ -139,7 +139,7 @@ struct Class : public EntityWithParamsBase,
   auto GetObjectRepr(const File& file, SpecificId specific_id) const -> TypeId;
 
   // Get the `StructTypeField`s from a class's object repr.
-  auto GetStructTypeFields(const File& sem_ir) const
+  auto GetStructTypeFields(const File& sem_ir, SpecificId specific_id) const
       -> llvm::ArrayRef<SemIR::StructTypeField>;
 };
 

--- a/toolchain/sem_ir/read_only_ast_source.cpp
+++ b/toolchain/sem_ir/read_only_ast_source.cpp
@@ -18,7 +18,8 @@ static auto CalculateCppFieldOffsets(
   const auto& class_scope = sem_ir.name_scopes().Get(class_info.scope_id);
 
   auto class_layout = SemIR::ObjectLayout::Empty();
-  for (const auto& struct_field : class_info.GetStructTypeFields(sem_ir)) {
+  for (const auto& struct_field :
+       class_info.GetStructTypeFields(sem_ir, SemIR::SpecificId::None)) {
     auto field_type_id =
         sem_ir.types().GetTypeIdForTypeInstId(struct_field.type_inst_id);
     auto field_layout =

--- a/toolchain/sem_ir/read_only_ast_source.cpp
+++ b/toolchain/sem_ir/read_only_ast_source.cpp
@@ -12,14 +12,14 @@ char ReadOnlyASTSource::id;
 //
 // Returns true on success, false if any error occurs.
 static auto CalculateCppFieldOffsets(
-    const File& sem_ir, SemIR::ClassId class_id,
+    const File& sem_ir, ClassType class_type,
     llvm::DenseMap<const clang::FieldDecl*, uint64_t>& field_offsets) -> bool {
-  auto class_info = sem_ir.classes().Get(class_id);
+  auto class_info = sem_ir.classes().Get(class_type.class_id);
   const auto& class_scope = sem_ir.name_scopes().Get(class_info.scope_id);
 
   auto class_layout = SemIR::ObjectLayout::Empty();
   for (const auto& struct_field :
-       class_info.GetStructTypeFields(sem_ir, SemIR::SpecificId::None)) {
+       class_info.GetStructTypeFields(sem_ir, class_type.specific_id)) {
     auto field_type_id =
         sem_ir.types().GetTypeIdForTypeInstId(struct_field.type_inst_id);
     auto field_layout =
@@ -31,8 +31,8 @@ static auto CalculateCppFieldOffsets(
     auto class_field =
         LookupClassFieldByStructField(sem_ir, class_scope, struct_field);
     if (class_field) {
-      const auto* clang_decl =
-          sem_ir.clang_decls().Lookup(class_field->inst_id);
+      const auto* clang_decl = sem_ir.clang_decls().Lookup(
+          class_field->inst_id, class_type.specific_id);
       if (!clang_decl) {
         return false;
       }
@@ -68,7 +68,7 @@ auto ReadOnlyASTSource::layoutRecordType(
   alignment = layout.alignment.bits();
 
   // Fill in `field_offsets`.
-  CalculateCppFieldOffsets(sem_ir_, class_type.class_id, field_offsets);
+  CalculateCppFieldOffsets(sem_ir_, class_type, field_offsets);
 
   // Add offset for base class, if any.
   if (const auto* class_decl = dyn_cast<clang::CXXRecordDecl>(record_decl);


### PR DESCRIPTION
Add a `SpecificID` arg to `Class::GetStructTypeFields`, and use that in `CalculateCppFieldOffsets`. Also include the specific in the `clang_decls` lookup. This has no immediate effect since no specific class fields are being exported yet, but will be useful for exporting generic classes.