### PR TITLE
Filter binaries out of compilation database.

### DIFF
--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -59,16 +59,14 @@ _CPP_EXTENSIONS = {
 }
 
 
-def _is_cpp_source_or_header(path: str) -> bool:
+def _is_cpp_source_or_header(path: pathlib.Path) -> bool:
     """Returns True if path is a C/C++/Assembly source or header file."""
-    basename = path.rsplit("/", 1)[-1]
-    if "." in basename:
-        ext = basename.rsplit(".", 1)[-1]
-        return ext in _CPP_EXTENSIONS
+    if path.suffix:
+      return path.suffix in _CPP_EXTENSIONS
     # Extensionless files (e.g. C++ standard library headers like <vector>,
     # <string>, or CUDA/OpenMP wrappers) are headers only if located within an
     # include directory.
-    return "/include/" in path or path.startswith("include/")
+    return "include" in path.parts
 
 
 def _filter_compile_commands(

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -31,6 +31,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import argparse
 import json
 import os
+import pathlib
 import subprocess
 import sys
 from typing import Any, Dict
@@ -62,7 +63,7 @@ _CPP_EXTENSIONS = {
 def _is_cpp_source_or_header(path: pathlib.Path) -> bool:
     """Returns True if path is a C/C++/Assembly source or header file."""
     if path.suffix:
-      return path.suffix in _CPP_EXTENSIONS
+        return path.suffix in _CPP_EXTENSIONS
     # Extensionless files (e.g. C++ standard library headers like <vector>,
     # <string>, or CUDA/OpenMP wrappers) are headers only if located within an
     # include directory.
@@ -81,7 +82,7 @@ def _filter_compile_commands(
     filtered = [
         entry
         for entry in data
-        if _is_cpp_source_or_header(entry.get("file", ""))
+        if _is_cpp_source_or_header(pathlib.Path(entry.get("file", "")))
     ]
     removed_count = len(data) - len(filtered)
     if removed_count > 0:

--- a/scripts/create_compdb.py
+++ b/scripts/create_compdb.py
@@ -29,11 +29,71 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """
 
 import argparse
+import json
+import os
 import subprocess
 import sys
 from typing import Any, Dict
 
 import scripts_utils
+
+_CPP_EXTENSIONS = {
+    "c",
+    "cc",
+    "cpp",
+    "cxx",
+    "c++",
+    "C",
+    "h",
+    "hpp",
+    "hxx",
+    "h++",
+    "hh",
+    "H",
+    "inc",
+    "def",
+    "ipp",
+    "s",
+    "S",
+    "asm",
+}
+
+
+def _is_cpp_source_or_header(path: str) -> bool:
+    """Returns True if path is a C/C++/Assembly source or header file."""
+    basename = path.rsplit("/", 1)[-1]
+    if "." in basename:
+        ext = basename.rsplit(".", 1)[-1]
+        return ext in _CPP_EXTENSIONS
+    # Extensionless files (e.g. C++ standard library headers like <vector>,
+    # <string>, or CUDA/OpenMP wrappers) are headers only if located within an
+    # include directory.
+    return "/include/" in path or path.startswith("include/")
+
+
+def _filter_compile_commands(
+    compdb_path: str = "compile_commands.json",
+) -> None:
+    """Removes non-source/non-header entries from compile_commands.json."""
+    if not os.path.exists(compdb_path):
+        return
+    with open(compdb_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    filtered = [
+        entry
+        for entry in data
+        if _is_cpp_source_or_header(entry.get("file", ""))
+    ]
+    removed_count = len(data) - len(filtered)
+    if removed_count > 0:
+        print(
+            f"Filtered out {removed_count} non-source/non-header entries "
+            f"from {compdb_path}."
+        )
+        with open(compdb_path, "w", encoding="utf-8") as f:
+            json.dump(filtered, f, separators=(",", ":"))
+            f.write("\n")
 
 
 def _build_generated_files(
@@ -153,6 +213,8 @@ def main() -> None:
         ]
         + [f"--extra_aquery_arg={arg}" for arg in args.extra_bazel_flag]
     )
+
+    _filter_compile_commands()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since we started bootstrapping, our stage-1 toolchain binaries have been inputs to stage-2 compilations, and to the compilation database logic, they're indistinguishable from generated sources. This caused us to get compilation command lines for them, which clangd would try to index by parsing the binary, and would either run incredibly slowly or crash.

Filter out non-source files from the compilation database.

In passing, also emit the JSON dump without whitespace, which makes the database a bit smaller and faster for clangd to parse.

Assisted-by: Gemini via Antigravity