### PR TITLE
Implement a terminal rendering library in common/terminal

### DIFF
--- a/.codespell_ignore
+++ b/.codespell_ignore
@@ -17,6 +17,7 @@ groupt
 indext
 inout
 isELF
+iterm
 parameteras
 pullrequest
 rightt

--- a/common/filesystem.cpp
+++ b/common/filesystem.cpp
@@ -103,15 +103,8 @@ auto Internal::FileRefBase::ReadFileToString()
 auto Internal::FileRefBase::WriteFileFromString(llvm::StringRef str)
     -> ErrorOr<Success, FdError> {
   CARBON_RETURN_IF_ERROR(SeekFromBeginning(0));
-  auto bytes = llvm::ArrayRef<std::byte>(
-      reinterpret_cast<const std::byte*>(str.data()), str.size());
-  while (!bytes.empty()) {
-    auto write_result = WriteFromBuffer(bytes);
-    if (!write_result.ok()) {
-      return std::move(write_result).error();
-    }
-    bytes = *write_result;
-  }
+  CARBON_RETURN_IF_ERROR(WriteCompleteBuffer(llvm::ArrayRef<std::byte>(
+      reinterpret_cast<const std::byte*>(str.data()), str.size())));
   CARBON_RETURN_IF_ERROR(Truncate(str.size()));
   return Success();
 }

--- a/common/filesystem.h
+++ b/common/filesystem.h
@@ -219,6 +219,24 @@ namespace Internal {
 class FileRefBase;
 }  // namespace Internal
 
+// Convenience type defs for the three access combinations.
+using ReadFileRef = FileRef<OpenAccess::ReadOnly>;
+using WriteFileRef = FileRef<OpenAccess::WriteOnly>;
+using ReadWriteFileRef = FileRef<OpenAccess::ReadWrite>;
+
+// Returns constant references to the standard streams the process is started
+// with.
+//
+// The returned references are non-owning: the process shares these descriptors
+// with whatever started it, closing them is never correct, and unrelated code
+// throughout the process may be reading or writing the same descriptor.
+//
+// Their descriptor numbers are fixed by the platform rather than discovered at
+// runtime, so these are constant expressions.
+consteval auto Stdin() -> ReadFileRef;
+consteval auto Stdout() -> WriteFileRef;
+consteval auto Stderr() -> WriteFileRef;
+
 // Returns a constant `Dir` object that models the open current working
 // directory.
 //
@@ -348,7 +366,13 @@ class Internal::FileRefBase {
   FileRefBase() = default;
 
   // Returns true if this refers to a valid open file, and false otherwise.
-  auto is_valid() const -> bool { return fd_ != -1; }
+  constexpr auto is_valid() const -> bool { return fd_ != -1; }
+
+  // Non-portable API only available on Unix-like systems. Returns the
+  // underlying file descriptor, for the platform calls this type doesn't wrap,
+  // such as `isatty` and `ioctl`. The descriptor remains owned by whatever owns
+  // this file.
+  constexpr auto unix_fd() const -> int { return fd_; }
 
   // Reads the file status.
   //
@@ -405,6 +429,24 @@ class Internal::FileRefBase {
   auto WriteFromBuffer(llvm::ArrayRef<std::byte> buffer)
       -> ErrorOr<llvm::ArrayRef<std::byte>, FdError>;
 
+  // Writes the complete contents of the provided buffer.
+  //
+  // Unlike `WriteFromBuffer`, this doesn't return until every byte has been
+  // written or an error occurs. It repeats `WriteFromBuffer` over whatever is
+  // left, so each write is issued for as much of the buffer as remains and the
+  // whole is written in as few writes as the file allows. Anything else writing
+  // to the same file can only interleave between those writes, which leaves no
+  // room to interleave at all when the file accepts the buffer in one write.
+  //
+  // On an error, an unspecified prefix of the buffer has already been written
+  // and can't be un-written. How much isn't reported; a caller that needs to
+  // know should drive `WriteFromBuffer` itself.
+  //
+  // This method retries `EINTR` on Unix-like systems and returns other errors
+  // to the caller.
+  auto WriteCompleteBuffer(llvm::ArrayRef<std::byte> buffer)
+      -> ErrorOr<Success, FdError>;
+
   // Returns an LLVM `raw_fd_ostream` that writes to this file.
   //
   // Note that this doesn't expose any write errors here, those will surface
@@ -458,7 +500,7 @@ class Internal::FileRefBase {
                Duration poll_interval = {}) -> ErrorOr<FileLock, FdError>;
 
  protected:
-  explicit FileRefBase(int fd) : fd_(fd) {}
+  explicit constexpr FileRefBase(int fd) : fd_(fd) {}
 
   // Note: this should only be used or made part of the public API by subclasses
   // that provide *ownership* of the open file. It is implemented here to
@@ -536,6 +578,9 @@ class FileRef : public Internal::FileRefBase {
   auto WriteFromBuffer(llvm::ArrayRef<std::byte> buffer)
       -> ErrorOr<llvm::ArrayRef<std::byte>, FdError>
     requires Writeable;
+  auto WriteCompleteBuffer(llvm::ArrayRef<std::byte> buffer)
+      -> ErrorOr<Success, FdError>
+    requires Writeable;
   auto WriteStream() -> llvm::raw_fd_ostream
     requires Writeable;
   auto ReadFileToString() -> ErrorOr<std::string, FdError>
@@ -546,15 +591,13 @@ class FileRef : public Internal::FileRefBase {
  protected:
   friend File<A>;
   friend DirRef;
+  friend consteval auto Stdin() -> ReadFileRef;
+  friend consteval auto Stdout() -> WriteFileRef;
+  friend consteval auto Stderr() -> WriteFileRef;
 
   // Other constructors from the base are also available, but remain protected.
   using FileRefBase::FileRefBase;
 };
-
-// Convenience type defs for the three access combinations.
-using ReadFileRef = FileRef<OpenAccess::ReadOnly>;
-using WriteFileRef = FileRef<OpenAccess::WriteOnly>;
-using ReadWriteFileRef = FileRef<OpenAccess::ReadWrite>;
 
 // An owning handle to an open file.
 //
@@ -1320,6 +1363,10 @@ inline auto DurationToTimespec(Duration d) -> timespec {
 
 }  // namespace Internal
 
+consteval auto Stdin() -> ReadFileRef { return ReadFileRef(STDIN_FILENO); }
+consteval auto Stdout() -> WriteFileRef { return WriteFileRef(STDOUT_FILENO); }
+consteval auto Stderr() -> WriteFileRef { return WriteFileRef(STDERR_FILENO); }
+
 consteval auto Cwd() -> Dir { return Dir(AT_FDCWD); }
 
 inline auto FileLock::Destroy() -> void {
@@ -1431,6 +1478,14 @@ inline auto Internal::FileRefBase::WriteFromBuffer(
   }
 }
 
+inline auto Internal::FileRefBase::WriteCompleteBuffer(
+    llvm::ArrayRef<std::byte> buffer) -> ErrorOr<Success, FdError> {
+  while (!buffer.empty()) {
+    CARBON_ASSIGN_OR_RETURN(buffer, WriteFromBuffer(buffer));
+  }
+  return Success();
+}
+
 inline auto Internal::FileRefBase::WriteStream() -> llvm::raw_fd_ostream {
   return llvm::raw_fd_ostream(fd_, /*shouldClose=*/false);
 }
@@ -1493,6 +1548,14 @@ auto FileRef<A>::WriteFromBuffer(llvm::ArrayRef<std::byte> buffer)
   requires Writeable
 {
   return FileRefBase::WriteFromBuffer(buffer);
+}
+
+template <OpenAccess A>
+auto FileRef<A>::WriteCompleteBuffer(llvm::ArrayRef<std::byte> buffer)
+    -> ErrorOr<Success, FdError>
+  requires Writeable
+{
+  return FileRefBase::WriteCompleteBuffer(buffer);
 }
 
 template <OpenAccess A>

--- a/common/filesystem_test.cpp
+++ b/common/filesystem_test.cpp
@@ -411,6 +411,58 @@ TEST_F(FilesystemTest, WriteStream) {
   EXPECT_THAT(dir_.ReadFileToString("test"), IsSuccess(Eq(content_str)));
 }
 
+TEST_F(FilesystemTest, WriteCompleteBuffer) {
+  std::string content_str = "0123456789";
+  auto bytes = llvm::ArrayRef<std::byte>(
+      reinterpret_cast<const std::byte*>(content_str.data()),
+      content_str.size());
+
+  auto write = dir_.OpenWriteOnly("test", CreationOptions::CreateNew);
+  ASSERT_THAT(write, IsSuccess(_));
+  EXPECT_THAT(write->WriteCompleteBuffer(bytes), IsSuccess(_));
+  // Writing appends rather than replacing, unlike `WriteFileFromString`.
+  EXPECT_THAT(write->WriteCompleteBuffer(bytes), IsSuccess(_));
+  // An empty buffer is a no-op rather than an error.
+  EXPECT_THAT(write->WriteCompleteBuffer(llvm::ArrayRef<std::byte>()),
+              IsSuccess(_));
+  (*std::move(write)).Close().Check();
+
+  EXPECT_THAT(dir_.ReadFileToString("test"),
+              IsSuccess(Eq(content_str + content_str)));
+}
+
+TEST_F(FilesystemTest, StandardStreams) {
+  // The standard streams name descriptors the process already has, so these
+  // are constants and never open or close anything.
+  static_assert(Stdin().unix_fd() == STDIN_FILENO);
+  static_assert(Stdout().unix_fd() == STDOUT_FILENO);
+  static_assert(Stderr().unix_fd() == STDERR_FILENO);
+  EXPECT_TRUE(Stderr().is_valid());
+
+  // Writing through one reaches the descriptor. Tests run with stdout captured,
+  // so this uses a pipe put in its place for the duration.
+  int fds[2];
+  ASSERT_EQ(pipe(fds), 0);
+  int saved = dup(STDOUT_FILENO);
+  ASSERT_GE(saved, 0);
+  ASSERT_GE(dup2(fds[1], STDOUT_FILENO), 0);
+
+  llvm::StringRef message = "through stdout";
+  auto result = Stdout().WriteCompleteBuffer(llvm::ArrayRef<std::byte>(
+      reinterpret_cast<const std::byte*>(message.data()), message.size()));
+
+  ASSERT_GE(dup2(saved, STDOUT_FILENO), 0);
+  ASSERT_EQ(close(saved), 0);
+  ASSERT_EQ(close(fds[1]), 0);
+  EXPECT_THAT(result, IsSuccess(_));
+
+  char buffer[64];
+  ssize_t n = read(fds[0], buffer, sizeof(buffer));
+  ASSERT_EQ(close(fds[0]), 0);
+  ASSERT_GT(n, 0);
+  EXPECT_EQ(llvm::StringRef(buffer, n), message);
+}
+
 TEST_F(FilesystemTest, Rename) {
   // Rename a file within a directory.
   ASSERT_THAT(dir_.WriteFileFromString("file1", "content1"), IsSuccess(_));

--- a/common/terminal/BUILD
+++ b/common/terminal/BUILD
@@ -76,6 +76,7 @@ cc_test(
         "//common:raw_string_ostream",
         "//testing/base:gtest_main",
         "@googletest//:gtest",
+        "@llvm-project//llvm:Support",
     ],
 )
 
@@ -147,7 +148,23 @@ cc_test(
     srcs = ["buffer_test.cpp"],
     deps = [
         ":buffer",
+        ":metrics",
         "//common:filesystem",
+        "//testing/base:gtest_main",
+        "@googletest//:gtest",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "pressure_test",
+    size = "small",
+    srcs = ["pressure_test.cpp"],
+    deps = [
+        ":buffer",
+        ":capabilities",
+        ":metrics",
+        ":style",
         "//testing/base:gtest_main",
         "@googletest//:gtest",
         "@llvm-project//llvm:Support",

--- a/common/terminal/BUILD
+++ b/common/terminal/BUILD
@@ -103,12 +103,36 @@ cc_test(
 )
 
 cc_library(
+    name = "metrics",
+    srcs = ["metrics.cpp"],
+    hdrs = ["metrics.h"],
+    deps = [
+        ":capabilities",
+        "//common:check",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "metrics_test",
+    size = "small",
+    srcs = ["metrics_test.cpp"],
+    deps = [
+        ":metrics",
+        "//testing/base:gtest_main",
+        "@googletest//:gtest",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "buffer",
     srcs = ["buffer.cpp"],
     hdrs = ["buffer.h"],
     deps = [
         ":capabilities",
         ":color",
+        ":metrics",
         ":output_buffer_ref",
         ":style",
         "//common:check",

--- a/common/terminal/BUILD
+++ b/common/terminal/BUILD
@@ -1,0 +1,154 @@
+# Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+# Exceptions. See /LICENSE for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Terminal rendering: what the attached terminal can do, and how to draw styled
+# text for it. Used for diagnostic rendering and for command line output.
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//bazel/cc_rules:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "output_buffer_ref",
+    hdrs = ["output_buffer_ref.h"],
+    deps = ["@llvm-project//llvm:Support"],
+)
+
+cc_test(
+    name = "output_buffer_ref_test",
+    size = "small",
+    srcs = ["output_buffer_ref_test.cpp"],
+    deps = [
+        ":output_buffer_ref",
+        "//testing/base:gtest_main",
+        "@googletest//:gtest",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "color",
+    srcs = ["color.cpp"],
+    hdrs = ["color.h"],
+    deps = [
+        ":output_buffer_ref",
+        "//common:check",
+        "//common:ostream",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "color_test",
+    size = "small",
+    srcs = ["color_test.cpp"],
+    deps = [
+        ":color",
+        "//common:ostream",
+        "//testing/base:gtest_main",
+        "@googletest//:gtest",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "style",
+    srcs = ["style.cpp"],
+    hdrs = ["style.h"],
+    deps = [
+        ":color",
+        ":output_buffer_ref",
+        "//common:check",
+        "//common:ostream",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "style_test",
+    size = "small",
+    srcs = ["style_test.cpp"],
+    deps = [
+        ":style",
+        "//common:ostream",
+        "//common:raw_string_ostream",
+        "//testing/base:gtest_main",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "capabilities",
+    srcs = ["capabilities.cpp"],
+    hdrs = ["capabilities.h"],
+    deps = [
+        ":color",
+        "//common:filesystem",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "capabilities_test",
+    size = "small",
+    srcs = ["capabilities_test.cpp"],
+    deps = [
+        ":capabilities",
+        "//common:filesystem",
+        "//testing/base:gtest_main",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "buffer",
+    srcs = ["buffer.cpp"],
+    hdrs = ["buffer.h"],
+    deps = [
+        ":capabilities",
+        ":color",
+        ":output_buffer_ref",
+        ":style",
+        "//common:check",
+        "//common:filesystem",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_test(
+    name = "buffer_test",
+    size = "small",
+    srcs = ["buffer_test.cpp"],
+    deps = [
+        ":buffer",
+        "//common:filesystem",
+        "//testing/base:gtest_main",
+        "@googletest//:gtest",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_binary(
+    name = "terminal_benchmark",
+    testonly = 1,
+    srcs = ["terminal_benchmark.cpp"],
+    deps = [
+        ":buffer",
+        ":capabilities",
+        ":color",
+        ":style",
+        "//testing/base:benchmark_main",
+        "@abseil-cpp//absl/random",
+        "@google_benchmark//:benchmark",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+sh_test(
+    name = "terminal_benchmark_test",
+    size = "small",
+    srcs = [":terminal_benchmark"],
+    args = ["--benchmark_dry_run"],
+)

--- a/common/terminal/buffer.cpp
+++ b/common/terminal/buffer.cpp
@@ -450,28 +450,15 @@ auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
     text = text.drop_front(word.size());
 
     // Move a word that doesn't fit down to the next row. If it doesn't fit
-    // there either, the loop below breaks it as it draws it.
+    // there either it overhangs rather than being broken, and the buffer grows
+    // to hold it.
     if (cur_x > x && cur_x + MeasureWidth(word) > limit) {
       cur_x = x;
       ++cur_y;
     }
 
     while (!word.empty()) {
-      char32_t symbol = TakeSymbol(word);
-      // Combining marks have no width and must stay with the symbol they
-      // follow, so they never trigger a break.
-      int width = SymbolWidth(symbol);
-      // A symbol too wide for the whole wrap region has no row that could hold
-      // it, and drawing it anyway would run past the region into whatever is
-      // laid out beside it.
-      if (width > max_width) {
-        continue;
-      }
-      if (width > 0 && cur_x > x && cur_x + width > limit) {
-        cur_x = x;
-        ++cur_y;
-      }
-      cur_x = DrawSymbol(cur_x, cur_y, symbol, style).x;
+      cur_x = DrawSymbol(cur_x, cur_y, TakeSymbol(word), style).x;
     }
   }
 

--- a/common/terminal/buffer.cpp
+++ b/common/terminal/buffer.cpp
@@ -290,8 +290,11 @@ auto Buffer::WalkWrappedText(int x, int y, int max_width, llvm::StringRef text,
 
   int cur_x = x;
   int cur_y = y;
-  int limit = x + max_width;
 
+  // What a row has room for is decided from the columns it has used rather
+  // than from a column computed once from `max_width`, so that a width no row
+  // reaches works like any other instead of overflowing the column it names.
+  //
   // Splitting on bytes is safe because every character text can break at is
   // ASCII, and UTF-8 never encodes anything else using an ASCII byte. Only the
   // runs that get drawn are decoded.
@@ -311,7 +314,7 @@ auto Buffer::WalkWrappedText(int x, int y, int max_width, llvm::StringRef text,
       // never drawn, so CRLF line endings break exactly once.
       if (cur_x > x) {
         for (char space : spaces) {
-          if (space == '\r' || cur_x >= limit) {
+          if (space == '\r' || cur_x - x >= max_width) {
             continue;
           }
           cur_x = place(cur_x, cur_y, U' ');
@@ -327,7 +330,7 @@ auto Buffer::WalkWrappedText(int x, int y, int max_width, llvm::StringRef text,
     // Move a word that doesn't fit down to the next row. If it doesn't fit
     // there either it overhangs rather than being broken, and the buffer grows
     // to hold it.
-    if (cur_x > x && cur_x + metrics_.Width(word) > limit) {
+    if (cur_x > x && cur_x - x + metrics_.Width(word) > max_width) {
       cur_x = x;
       ++cur_y;
     }

--- a/common/terminal/buffer.cpp
+++ b/common/terminal/buffer.cpp
@@ -87,7 +87,7 @@ auto Buffer::EnsureRow(int y) -> void {
   cells_.resize(static_cast<size_t>(y + 1) * width_);
 }
 
-auto Buffer::EnsureWidth(int x) -> void {
+auto Buffer::EnsureColumn(int x) -> void {
   CARBON_CHECK(x >= 0 && x < MaxColumns, "Column {0} is outside [0, {1}).", x,
                MaxColumns);
   if (x < width_) {
@@ -197,7 +197,7 @@ auto Buffer::PlaceCodePoint(int x, int y, char32_t code_point,
     return x + width;
   }
 
-  EnsureWidth(x + width - 1);
+  EnsureColumn(x + width - 1);
   EnsureRow(y);
   ClearCells(x, y, width);
 
@@ -223,7 +223,7 @@ auto Buffer::DrawLine(int x, int y, uint8_t directions, const Style& style)
     -> void {
   CARBON_DCHECK(directions <= LineDirections,
                 "Direction bits {0} name no glyph.", directions);
-  EnsureWidth(x);
+  EnsureColumn(x);
   EnsureRow(y);
 
   uint8_t existing = CellAt(x, y).lines;
@@ -296,10 +296,14 @@ auto Buffer::DrawBox(int x, int y, int box_width, int box_height,
 }
 
 template <typename PlaceFn>
-auto Buffer::WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
-    -> DrawEnd {
-  CheckOrigin(x, y);
+auto Buffer::WalkText(int x, int y, int margin, llvm::StringRef text,
+                      PlaceFn place) const -> DrawEnd {
   CheckTextSize(text);
+  CARBON_CHECK(
+      margin >= 0 && margin <= x && x < columns_ && y >= 0 && y < MaxRows,
+      "Text at ({0}, {1}) with a margin of {2} is outside the {3} "
+      "columns and {4} rows a buffer covers, or left of its margin.",
+      x, y, margin, columns_, MaxRows);
 
   int cur_x = x;
   int cur_y = y;
@@ -307,16 +311,16 @@ auto Buffer::WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
   while (!text.empty()) {
     char32_t code_point = metrics_.TakeCodePoint(text);
     if (code_point == '\n') {
-      cur_x = x;
+      cur_x = margin;
       ++cur_y;
       continue;
     }
     if (code_point == '\r') {
-      cur_x = x;
+      cur_x = margin;
       continue;
     }
     if (code_point == '\t') {
-      int stop = NextTabStop(cur_x, x, tab_width_);
+      int stop = NextTabStop(cur_x, margin, tab_width_);
       for (; cur_x < stop; ++cur_x) {
         place(cur_x, cur_y, U' ');
       }
@@ -329,31 +333,46 @@ auto Buffer::WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
   return {.x = cur_x, .y = cur_y};
 }
 
-auto Buffer::DrawText(int x, int y, llvm::StringRef text, const Style& style)
-    -> DrawEnd {
-  return WalkText(x, y, text, [&](int cur_x, int cur_y, char32_t code_point) {
-    return PlaceCodePoint(cur_x, cur_y, code_point, style);
-  });
+auto Buffer::DrawText(int x, int y, int margin, llvm::StringRef text,
+                      const Style& style) -> DrawEnd {
+  return WalkText(x, y, margin, text,
+                  [&](int cur_x, int cur_y, char32_t code_point) {
+                    return PlaceCodePoint(cur_x, cur_y, code_point, style);
+                  });
 }
 
-auto Buffer::MeasureText(int x, int y, llvm::StringRef text) const -> DrawEnd {
-  return WalkText(x, y, text,
+auto Buffer::MeasureText(int x, int y, int margin, llvm::StringRef text) const
+    -> DrawEnd {
+  return WalkText(x, y, margin, text,
                   [&](int cur_x, int /*cur_y*/, char32_t code_point) {
                     return cur_x + metrics_.CodePointWidth(code_point);
                   });
+}
+
+// Returns whether wrapped text can be broken at `c`.
+//
+// This is the one definition of where wrapping may introduce a break, so that
+// measuring what text wraps into and drawing it wrapped agree about it.
+// Carriage returns count so that a CRLF ending is whitespace rather than part
+// of the word before it; what becomes of the `\r` is then up to the drawing.
+static constexpr auto IsWrapBreak(char c) -> bool {
+  return c == ' ' || c == '\t' || c == '\r';
 }
 
 template <typename PlaceFn>
 auto Buffer::WalkWrappedText(int x, int y, int margin, int max_width,
                              llvm::StringRef text, PlaceFn place) const
     -> DrawEnd {
-  CheckOrigin(x, y);
   CheckTextSize(text);
-  CARBON_CHECK(margin >= 0 && margin <= x && max_width > 0 &&
-                   x - margin < max_width && margin <= columns_ - max_width,
-               "A block of {0} columns at {1} holding text from {2} does not "
-               "fit the {3} columns a buffer covers.",
-               max_width, margin, x, columns_);
+  // The block runs from the margin to `margin + max_width`, lies within the
+  // buffer, and holds the column the text starts in, which is every bound on
+  // the three of them read in one order.
+  CARBON_CHECK(llvm::is_sorted(std::array{0, margin, x, x + 1,
+                                          margin + max_width, columns_}) &&
+                   y >= 0 && y < MaxRows,
+               "A block of {0} columns at {1} holding text from ({2}, {3}) "
+               "does not fit the {4} columns and {5} rows a buffer covers.",
+               max_width, margin, x, y, columns_, MaxRows);
 
   // The column a row runs out of room at. The block lies within the buffer's
   // width, so this is a column like any other rather than a sum that has to be
@@ -362,12 +381,6 @@ auto Buffer::WalkWrappedText(int x, int y, int margin, int max_width,
 
   int cur_x = x;
   int cur_y = y;
-  // Whether the row being written was started by wrapping, rather than by the
-  // text itself. Spaces are dropped at the start of a wrapped row and kept at
-  // the start of one the text asked for, which is the difference between
-  // indentation the caller wrote and indentation an accident of width would
-  // otherwise introduce.
-  bool wrapped_row = false;
 
   // Splitting on bytes is safe because every character text can break at is
   // ASCII, and UTF-8 never encodes anything else using an ASCII byte. Only
@@ -377,27 +390,38 @@ auto Buffer::WalkWrappedText(int x, int y, int margin, int max_width,
       text = text.drop_front();
       cur_x = margin;
       ++cur_y;
-      wrapped_row = false;
       continue;
     }
 
     if (IsWrapBreak(text.front())) {
       llvm::StringRef breaks = text.take_while(IsWrapBreak);
       text = text.drop_front(breaks.size());
-      if (cur_x > margin || !wrapped_row) {
-        for (char c : breaks) {
-          if (c == '\r') {
-            continue;
-          }
-          // Whitespace stops at the block's edge, leaving the word after it to
-          // wrap.
-          int next = std::min(
-              c == '\t' ? NextTabStop(cur_x, margin, tab_width_) : cur_x + 1,
-              limit);
-          while (cur_x < next) {
-            cur_x = place(cur_x, cur_y, U' ');
-          }
+      for (char c : breaks) {
+        if (c == '\r') {
+          continue;
         }
+        // Whitespace stops at the block's edge, leaving the word after it to
+        // wrap.
+        int next = std::min(
+            c == '\t' ? NextTabStop(cur_x, margin, tab_width_) : cur_x + 1,
+            limit);
+        while (cur_x < next) {
+          cur_x = place(cur_x, cur_y, U' ');
+        }
+      }
+
+      // A combining mark renders into the column before it, so one following
+      // whitespace belongs to that whitespace and goes with it. Left to begin
+      // the next word, it would move to another row whenever that word wrapped
+      // and attach to whatever preceded it there.
+      while (!text.empty()) {
+        llvm::StringRef rest = text;
+        char32_t code_point = metrics_.TakeCodePoint(rest);
+        if (metrics_.CodePointWidth(code_point) != 0) {
+          break;
+        }
+        text = rest;
+        cur_x = place(cur_x, cur_y, code_point);
       }
       continue;
     }
@@ -407,11 +431,12 @@ auto Buffer::WalkWrappedText(int x, int y, int margin, int max_width,
     text = text.drop_front(word.size());
 
     // Move a word that doesn't fit down to the next row, which minimizes the
-    // overhang when it doesn't fit there either.
+    // overhang when it doesn't fit there either. The word is drawn into the row
+    // this starts before anything else can reach it, so a wrapped row begins at
+    // the margin rather than with the whitespace the wrap came after.
     if (cur_x > margin && cur_x + metrics_.Width(word) > limit) {
       cur_x = margin;
       ++cur_y;
-      wrapped_row = true;
     }
 
     while (!word.empty()) {
@@ -438,6 +463,17 @@ auto Buffer::MeasureWrappedText(int x, int y, int margin, int max_width,
                          [&](int cur_x, int /*cur_y*/, char32_t code_point) {
                            return cur_x + metrics_.CodePointWidth(code_point);
                          });
+}
+
+auto Buffer::MeasureWrapWidth(llvm::StringRef text) const -> int {
+  int width = 0;
+  while (!text.empty()) {
+    llvm::StringRef word =
+        text.take_until([](char c) { return c == '\n' || IsWrapBreak(c); });
+    width = std::max(width, metrics_.Width(word));
+    text = text.drop_front(std::max<size_t>(word.size(), 1));
+  }
+  return width;
 }
 
 auto Buffer::LastVisibleColumn(int y, ColorMode mode) const -> int {

--- a/common/terminal/buffer.cpp
+++ b/common/terminal/buffer.cpp
@@ -4,9 +4,13 @@
 
 #include "common/terminal/buffer.h"
 
+#include <algorithm>
 #include <array>
+#include <utility>
 
 #include "common/check.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Unicode.h"
@@ -188,6 +192,35 @@ auto Buffer::EnsureRow(int y) -> void {
   cells_.resize(static_cast<size_t>(y + 1) * width_);
 }
 
+auto Buffer::EnsureWidth(int x) -> void {
+  if (x < width_) {
+    return;
+  }
+  // Growing by halves rather than to exactly what was asked keeps a row drawn
+  // one symbol at a time from reflowing on every symbol.
+  int width = std::max(x + 1, width_ + width_ / 2);
+
+  // Rows are stored back to back, so every row but the first moves.
+  int rows = height();
+  llvm::SmallVector<Cell, 0> widened(static_cast<size_t>(rows) * width);
+  for (int y : llvm::seq(rows)) {
+    llvm::copy(llvm::ArrayRef(cells_).slice(
+                   static_cast<size_t>(y) * width_, width_),
+               widened.begin() + static_cast<size_t>(y) * width);
+  }
+  cells_ = std::move(widened);
+
+  // The marks are keyed by cell index, which is where the row moved it to.
+  llvm::DenseMap<int, std::string> moved;
+  moved.reserve(combining_marks_.size());
+  for (auto& [index, marks] : combining_marks_) {
+    moved.insert({index / width_ * width + index % width_, std::move(marks)});
+  }
+  combining_marks_ = std::move(moved);
+
+  width_ = width;
+}
+
 auto Buffer::ClearCells(int x, int y, int width) -> void {
   // A cleared range must not leave half of a double-width symbol behind, so it
   // extends over either half that crosses its edges.
@@ -207,10 +240,8 @@ auto Buffer::ClearCells(int x, int y, int width) -> void {
 }
 
 auto Buffer::AttachCombiningMark(int x, int y, char32_t symbol) -> void {
-  // Marks render into the column before them, so there must be one, it must be
-  // in the buffer, and it must already have been drawn. Text walks past the
-  // right edge rather than stopping there, so `x` can be well beyond it, in
-  // which case the base was clipped and its marks go with it.
+  // Marks render into the column before them, so there must be one and it must
+  // already have been drawn.
   if (x <= 0 || x > width_ || y < 0 || y >= height()) {
     return;
   }
@@ -231,7 +262,8 @@ auto Buffer::AttachCombiningMark(int x, int y, char32_t symbol) -> void {
 auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
     -> int {
   if (charset_ == Charset::Ascii) {
-    if (x >= 0 && x < width_ && y >= 0) {
+    if (x >= 0 && y >= 0) {
+      EnsureWidth(x);
       EnsureRow(y);
       CellAt(x, y) = {
           .symbol = IsPrintableAscii(symbol) ? symbol : AsciiReplacement,
@@ -250,12 +282,13 @@ auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
     width = 1;
   }
 
-  // Out of bounds, or a double-width symbol that would straddle the right
-  // edge; splitting one would leave the terminal rendering half a character.
-  if (x < 0 || y < 0 || x + width > width_) {
+  if (x < 0 || y < 0) {
     return width;
   }
 
+  // A double-width symbol needs both its columns, since splitting one would
+  // leave the terminal rendering half a character.
+  EnsureWidth(x + width - 1);
   EnsureRow(y);
   ClearCells(x, y, width);
 
@@ -272,10 +305,11 @@ auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
 
 auto Buffer::DrawLine(int x, int y, uint8_t directions, const Style& style)
     -> void {
-  if (x < 0 || x >= width_ || y < 0) {
+  if (x < 0 || y < 0) {
     return;
   }
   CARBON_DCHECK(directions < Utf8LineGlyphs.size());
+  EnsureWidth(x);
   EnsureRow(y);
 
   uint8_t existing = CellAt(x, y).lines;

--- a/common/terminal/buffer.cpp
+++ b/common/terminal/buffer.cpp
@@ -1,0 +1,508 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/buffer.h"
+
+#include <array>
+
+#include "common/check.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/ConvertUTF.h"
+#include "llvm/Support/Unicode.h"
+
+namespace Carbon::Terminal {
+
+// Stands in for a byte an ASCII terminal has no dependable rendering for.
+static constexpr char32_t AsciiReplacement = U'?';
+
+// Stands in for anything a UTF-8 terminal has no rendering for: invalid UTF-8,
+// control characters, and unassigned code points.
+static constexpr char32_t Utf8Replacement = U'�';
+
+// Columns between tab stops, measured from where the text began rather than
+// from the left edge of the buffer.
+static constexpr int TabWidth = 8;
+
+// The most bytes of combining marks kept on one cell. Text stacking more than
+// this is either adversarial or already illegible, and keeping all of it would
+// let one input character produce unbounded output.
+static constexpr size_t MaxCombiningBytes = 32;
+
+// The most bytes one code point encodes to in UTF-8.
+static constexpr size_t MaxUtf8Bytes = 4;
+
+// Returns whether an ASCII terminal renders `symbol` as itself, in one column.
+static auto IsPrintableAscii(char32_t symbol) -> bool {
+  return symbol >= 0x20 && symbol < 0x7f;
+}
+
+// Encodes `symbol` as UTF-8 into `storage`, returning the bytes written.
+//
+// Code points with no valid encoding, including surrogates and anything past
+// U+10FFFF, become the replacement character.
+static auto EncodeUtf8(char32_t symbol, std::array<char, MaxUtf8Bytes>& storage)
+    -> llvm::StringRef {
+  // Most of what gets rendered is ASCII, and encoding it is a single byte.
+  if (symbol < 0x80) {
+    storage[0] = static_cast<char>(symbol);
+    return llvm::StringRef(storage.data(), 1);
+  }
+
+  // Surrogates have no encoding of their own, and nothing past the last code
+  // point has one at all.
+  if (symbol > 0x10ffff || (symbol >= 0xd800 && symbol < 0xe000)) {
+    symbol = Utf8Replacement;
+  }
+
+  // Spelled out rather than handed to a general converter, which walks a range
+  // and checks bounds this already knows. Box-drawing characters go through
+  // here for every cell of every line drawn.
+  auto trailing = [symbol](int shift) {
+    return static_cast<char>(0x80 | ((symbol >> shift) & 0x3f));
+  };
+  if (symbol < 0x800) {
+    storage[0] = static_cast<char>(0xc0 | (symbol >> 6));
+    storage[1] = trailing(0);
+    return llvm::StringRef(storage.data(), 2);
+  }
+  if (symbol < 0x10000) {
+    storage[0] = static_cast<char>(0xe0 | (symbol >> 12));
+    storage[1] = trailing(6);
+    storage[2] = trailing(0);
+    return llvm::StringRef(storage.data(), 3);
+  }
+  storage[0] = static_cast<char>(0xf0 | (symbol >> 18));
+  storage[1] = trailing(12);
+  storage[2] = trailing(6);
+  storage[3] = trailing(0);
+  return llvm::StringRef(storage.data(), 4);
+}
+
+// Returns the columns `symbol` occupies on a UTF-8 terminal: zero for a
+// combining mark, one or two for a symbol with a glyph of its own, and a
+// negative value when there is no printable rendering for it.
+static auto Utf8SymbolWidth(char32_t symbol) -> int {
+  // Printable ASCII is one column, and is most of what gets measured. The
+  // general path parses a UTF-8 sequence and searches several code point
+  // range tables, which is far more than this needs.
+  if (IsPrintableAscii(symbol)) {
+    return 1;
+  }
+
+  std::array<char, MaxUtf8Bytes> storage;
+  return llvm::sys::unicode::columnWidthUTF8(EncodeUtf8(symbol, storage));
+}
+
+// Removes the first UTF-8 sequence from `text` and returns the code point it
+// encodes.
+//
+// A byte that doesn't start a valid sequence yields the replacement character
+// and is consumed on its own, so decoding resynchronizes at the next byte
+// rather than discarding the rest of the text.
+static auto TakeUtf8Symbol(llvm::StringRef& text) -> char32_t {
+  const auto* begin = reinterpret_cast<const llvm::UTF8*>(text.data());
+  const auto* pos = begin;
+  llvm::UTF32 symbol = 0;
+  if (llvm::convertUTF8Sequence(&pos, begin + text.size(), &symbol,
+                                llvm::strictConversion) != llvm::conversionOK) {
+    text = text.drop_front(1);
+    return Utf8Replacement;
+  }
+  text = text.drop_front(pos - begin);
+  return symbol;
+}
+
+// Glyphs for every combination of line directions, indexed by the direction
+// bits. Index zero never comes up, as a cell with no directions holds no line.
+static constexpr std::array<char32_t, 16> Utf8LineGlyphs = {
+    U' ',  // (none)
+    U'─',  // left
+    U'─',  // right
+    U'─',  // left, right
+    U'│',  // up
+    U'╯',  // left, up
+    U'╰',  // right, up
+    U'┴',  // left, right, up
+    U'│',  // down
+    U'╮',  // left, down
+    U'╭',  // right, down
+    U'┬',  // left, right, down
+    U'│',  // up, down
+    U'┤',  // left, up, down
+    U'├',  // right, up, down
+    U'┼',  // left, right, up, down
+};
+
+// The ASCII stand-ins, which can only distinguish horizontal, vertical, and
+// everything else.
+static constexpr std::array<char32_t, 16> AsciiLineGlyphs = {
+    U' ', U'-', U'-', U'-', U'|', U'+', U'+', U'+',
+    U'|', U'+', U'+', U'+', U'|', U'+', U'+', U'+',
+};
+
+Buffer::Buffer(int width, Charset charset) : width_(width), charset_(charset) {
+  CARBON_CHECK(width > 0, "Buffer width must be positive, but was {0}.", width);
+}
+
+auto Buffer::TakeSymbol(llvm::StringRef& text) const -> char32_t {
+  CARBON_DCHECK(!text.empty());
+  if (charset_ == Charset::Ascii) {
+    auto byte = static_cast<unsigned char>(text.front());
+    text = text.drop_front();
+    return byte;
+  }
+  return TakeUtf8Symbol(text);
+}
+
+auto Buffer::SymbolWidth(char32_t symbol) const -> int {
+  if (charset_ == Charset::Ascii) {
+    return 1;
+  }
+  int width = Utf8SymbolWidth(symbol);
+  // A symbol with no rendering is drawn as the replacement character, which
+  // takes one column.
+  return width < 0 ? 1 : width;
+}
+
+auto Buffer::MeasureWidth(llvm::StringRef text) const -> int {
+  if (charset_ == Charset::Ascii) {
+    return static_cast<int>(text.size());
+  }
+
+  int width = 0;
+  while (!text.empty()) {
+    width += SymbolWidth(TakeUtf8Symbol(text));
+  }
+  return width;
+}
+
+auto Buffer::height() const -> int {
+  return static_cast<int>(cells_.size()) / width_;
+}
+
+auto Buffer::EnsureRow(int y) -> void {
+  if (y < height()) {
+    return;
+  }
+  cells_.resize(static_cast<size_t>(y + 1) * width_);
+}
+
+auto Buffer::ClearCells(int x, int y, int width) -> void {
+  // A cleared range must not leave half of a double-width symbol behind, so it
+  // extends over either half that crosses its edges.
+  int begin = x;
+  if (begin > 0 && CellAt(begin, y).is_continuation) {
+    --begin;
+  }
+  int end = x + width;
+  if (end < width_ && CellAt(end, y).is_continuation) {
+    ++end;
+  }
+
+  for (int i = begin; i < end; ++i) {
+    CellAt(i, y) = Cell();
+    combining_marks_.erase(CellIndex(i, y));
+  }
+}
+
+auto Buffer::AttachCombiningMark(int x, int y, char32_t symbol) -> void {
+  // Marks render into the column before them, so there must be one, it must be
+  // in the buffer, and it must already have been drawn. Text walks past the
+  // right edge rather than stopping there, so `x` can be well beyond it, in
+  // which case the base was clipped and its marks go with it.
+  if (x <= 0 || x > width_ || y < 0 || y >= height()) {
+    return;
+  }
+  int base = x - 1;
+  if (CellAt(base, y).is_continuation) {
+    --base;
+  }
+
+  std::array<char, MaxUtf8Bytes> storage;
+  llvm::StringRef encoded = EncodeUtf8(symbol, storage);
+  std::string& marks = combining_marks_[CellIndex(base, y)];
+  if (marks.size() + encoded.size() > MaxCombiningBytes) {
+    return;
+  }
+  marks.append(encoded.data(), encoded.size());
+}
+
+auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
+    -> int {
+  if (charset_ == Charset::Ascii) {
+    if (x >= 0 && x < width_ && y >= 0) {
+      EnsureRow(y);
+      CellAt(x, y) = {
+          .symbol = IsPrintableAscii(symbol) ? symbol : AsciiReplacement,
+          .style = style};
+    }
+    return 1;
+  }
+
+  int width = Utf8SymbolWidth(symbol);
+  if (width == 0) {
+    AttachCombiningMark(x, y, symbol);
+    return 0;
+  }
+  if (width < 0) {
+    symbol = Utf8Replacement;
+    width = 1;
+  }
+
+  // Out of bounds, or a double-width symbol that would straddle the right
+  // edge; splitting one would leave the terminal rendering half a character.
+  if (x < 0 || y < 0 || x + width > width_) {
+    return width;
+  }
+
+  EnsureRow(y);
+  ClearCells(x, y, width);
+
+  Cell& cell = CellAt(x, y);
+  cell.symbol = symbol;
+  cell.style = style;
+  for (int i = 1; i < width; ++i) {
+    Cell& continuation = CellAt(x + i, y);
+    continuation.style = style;
+    continuation.is_continuation = true;
+  }
+  return width;
+}
+
+auto Buffer::DrawLine(int x, int y, uint8_t directions, const Style& style)
+    -> void {
+  if (x < 0 || x >= width_ || y < 0) {
+    return;
+  }
+  CARBON_DCHECK(directions < Utf8LineGlyphs.size());
+  EnsureRow(y);
+
+  uint8_t existing = CellAt(x, y).lines;
+  if (existing == 0) {
+    // Whatever is here isn't a line. Clearing also removes either half of a
+    // double-width symbol the cell was part of.
+    ClearCells(x, y, 1);
+  }
+
+  Cell& cell = CellAt(x, y);
+  cell.lines = existing | directions;
+  cell.symbol = charset_ == Charset::Utf8 ? Utf8LineGlyphs[cell.lines]
+                                          : AsciiLineGlyphs[cell.lines];
+  cell.style = style;
+}
+
+auto Buffer::DrawHorizontalLine(int x, int y, int length, const Style& style)
+    -> void {
+  for (int i = 0; i < length; ++i) {
+    // The ends of a line only connect inward, so a line meeting another at its
+    // end forms a corner rather than a crossing. A one-cell line has no inward
+    // direction and is drawn as a bare horizontal segment.
+    uint8_t directions =
+        length == 1 ? LineLeft | LineRight
+                    : (i > 0 ? LineLeft : 0) | (i + 1 < length ? LineRight : 0);
+    DrawLine(x + i, y, directions, style);
+  }
+}
+
+auto Buffer::DrawVerticalLine(int x, int y, int length, const Style& style)
+    -> void {
+  for (int i = 0; i < length; ++i) {
+    uint8_t directions =
+        length == 1 ? LineUp | LineDown
+                    : (i > 0 ? LineUp : 0) | (i + 1 < length ? LineDown : 0);
+    DrawLine(x, y + i, directions, style);
+  }
+}
+
+auto Buffer::DrawBox(int x, int y, int box_width, int box_height,
+                     const Style& style) -> void {
+  if (box_width <= 0 || box_height <= 0) {
+    return;
+  }
+  // A box with no interior is just the one line that bounds it.
+  if (box_width == 1) {
+    DrawVerticalLine(x, y, box_height, style);
+    return;
+  }
+  if (box_height == 1) {
+    DrawHorizontalLine(x, y, box_width, style);
+    return;
+  }
+
+  DrawHorizontalLine(x, y, box_width, style);
+  DrawHorizontalLine(x, y + box_height - 1, box_width, style);
+  DrawVerticalLine(x, y, box_height, style);
+  DrawVerticalLine(x + box_width - 1, y, box_height, style);
+}
+
+auto Buffer::DrawText(int x, int y, llvm::StringRef text, const Style& style)
+    -> int {
+  int cur_x = x;
+  int cur_y = y;
+
+  while (!text.empty()) {
+    char32_t symbol = TakeSymbol(text);
+    if (symbol == '\n') {
+      cur_x = x;
+      ++cur_y;
+      continue;
+    }
+    if (symbol == '\r') {
+      cur_x = x;
+      continue;
+    }
+    if (symbol == '\t') {
+      int stop = x + ((cur_x - x) / TabWidth + 1) * TabWidth;
+      for (; cur_x < stop; ++cur_x) {
+        DrawSymbol(cur_x, cur_y, ' ', style);
+      }
+      continue;
+    }
+
+    cur_x += DrawSymbol(cur_x, cur_y, symbol, style);
+  }
+
+  return cur_y - y + 1;
+}
+
+// Returns whether `c` is a character wrapped text can be broken at. Carriage
+// returns count, so that a CRLF ending breaks only on its newline.
+static auto IsBreakSpace(char c) -> bool {
+  return c == ' ' || c == '\t' || c == '\r';
+}
+
+auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
+                             const Style& style) -> int {
+  if (max_width <= 0) {
+    return 0;
+  }
+
+  int cur_x = x;
+  int cur_y = y;
+  int limit = x + max_width;
+
+  // Splitting on bytes is safe because every character text can break at is
+  // ASCII, and UTF-8 never encodes anything else using an ASCII byte. Only the
+  // runs that get drawn are decoded.
+  while (!text.empty()) {
+    if (text.front() == '\n') {
+      text = text.drop_front();
+      cur_x = x;
+      ++cur_y;
+      continue;
+    }
+
+    if (IsBreakSpace(text.front())) {
+      llvm::StringRef spaces = text.take_while(IsBreakSpace);
+      text = text.drop_front(spaces.size());
+      // Spaces are dropped wherever they would begin a row, which is what
+      // keeps wrapped text aligned with where it started. Carriage returns are
+      // never drawn, so CRLF line endings break exactly once.
+      if (cur_x > x) {
+        for (char space : spaces) {
+          if (space == '\r' || cur_x >= limit) {
+            continue;
+          }
+          cur_x += DrawSymbol(cur_x, cur_y, ' ', style);
+        }
+      }
+      continue;
+    }
+
+    llvm::StringRef word =
+        text.take_until([](char c) { return c == '\n' || IsBreakSpace(c); });
+    text = text.drop_front(word.size());
+
+    // Move a word that doesn't fit down to the next row. If it doesn't fit
+    // there either, the loop below breaks it as it draws it.
+    if (cur_x > x && cur_x + MeasureWidth(word) > limit) {
+      cur_x = x;
+      ++cur_y;
+    }
+
+    while (!word.empty()) {
+      char32_t symbol = TakeSymbol(word);
+      // Combining marks have no width and must stay with the symbol they
+      // follow, so they never trigger a break.
+      int width = SymbolWidth(symbol);
+      // A symbol too wide for the whole wrap region has no row that could hold
+      // it, and drawing it anyway would run past the region into whatever is
+      // laid out beside it.
+      if (width > max_width) {
+        continue;
+      }
+      if (width > 0 && cur_x > x && cur_x + width > limit) {
+        cur_x = x;
+        ++cur_y;
+      }
+      cur_x += DrawSymbol(cur_x, cur_y, symbol, style);
+    }
+  }
+
+  return cur_y - y + 1;
+}
+
+auto Buffer::LastVisibleColumn(int y, ColorMode mode) const -> int {
+  // A style only paints a blank cell if it is rendered at all, so with color
+  // off a blank cell is padding whatever style it carries.
+  bool styles_render = mode != ColorMode::NoColor;
+  for (int x = width_ - 1; x >= 0; --x) {
+    const Cell& cell = CellAt(x, y);
+    if (cell.is_continuation || cell.symbol != ' ' ||
+        (styles_render && cell.style.IsVisibleOnBlank()) ||
+        (!combining_marks_.empty() &&
+         combining_marks_.contains(CellIndex(x, y)))) {
+      return x;
+    }
+  }
+  return -1;
+}
+
+auto Buffer::Render(OutputBufferRef out, ColorMode mode) const -> void {
+  std::array<char, MaxUtf8Bytes> storage;
+
+  // The style a terminal starts a row in, and the one each row leaves it in.
+  const Style default_style;
+
+  for (int y = 0, rows = height(); y < rows; ++y) {
+    // Cells outlive this loop, so the active style is tracked by pointing at
+    // one rather than copying a whole style per cell.
+    const Style* active = &default_style;
+    int last = LastVisibleColumn(y, mode);
+    for (int x = 0; x <= last; ++x) {
+      const Cell& cell = CellAt(x, y);
+      if (cell.is_continuation) {
+        continue;
+      }
+
+      active->AppendTransitionTo(out, cell.style, mode);
+      active = &cell.style;
+      out.Append(EncodeUtf8(cell.symbol, storage));
+
+      // Almost nothing has combining marks, so the lookup is worth skipping
+      // outright rather than doing it for every cell on the screen.
+      if (!combining_marks_.empty()) {
+        auto marks = combining_marks_.find(CellIndex(x, y));
+        if (marks != combining_marks_.end()) {
+          out.Append(marks->second);
+        }
+      }
+    }
+
+    active->AppendTransitionTo(out, default_style, mode);
+    out.Append("\n");
+  }
+}
+
+auto Buffer::WriteTo(Filesystem::WriteFileRef file, ColorMode mode) const
+    -> ErrorOr<Success, Filesystem::FdError> {
+  // Sized for the few short lines a diagnostic renders to. A full screen with
+  // color runs well past it and allocates once.
+  llvm::SmallString<1024> bytes;
+  Render(bytes, mode);
+  return file.WriteCompleteBuffer(llvm::ArrayRef<std::byte>(
+      reinterpret_cast<const std::byte*>(bytes.data()), bytes.size()));
+}
+
+}  // namespace Carbon::Terminal

--- a/common/terminal/buffer.cpp
+++ b/common/terminal/buffer.cpp
@@ -260,7 +260,7 @@ auto Buffer::AttachCombiningMark(int x, int y, char32_t symbol) -> void {
 }
 
 auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
-    -> int {
+    -> DrawEnd {
   if (charset_ == Charset::Ascii) {
     if (x >= 0 && y >= 0) {
       EnsureWidth(x);
@@ -269,13 +269,13 @@ auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
           .symbol = IsPrintableAscii(symbol) ? symbol : AsciiReplacement,
           .style = style};
     }
-    return 1;
+    return {.x = x + 1, .y = y};
   }
 
   int width = Utf8SymbolWidth(symbol);
   if (width == 0) {
     AttachCombiningMark(x, y, symbol);
-    return 0;
+    return {.x = x, .y = y};
   }
   if (width < 0) {
     symbol = Utf8Replacement;
@@ -283,7 +283,7 @@ auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
   }
 
   if (x < 0 || y < 0) {
-    return width;
+    return {.x = x + width, .y = y};
   }
 
   // A double-width symbol needs both its columns, since splitting one would
@@ -300,7 +300,7 @@ auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
     continuation.style = style;
     continuation.is_continuation = true;
   }
-  return width;
+  return {.x = x + width, .y = y};
 }
 
 auto Buffer::DrawLine(int x, int y, uint8_t directions, const Style& style)
@@ -327,7 +327,7 @@ auto Buffer::DrawLine(int x, int y, uint8_t directions, const Style& style)
 }
 
 auto Buffer::DrawHorizontalLine(int x, int y, int length, const Style& style)
-    -> void {
+    -> DrawEnd {
   for (int i = 0; i < length; ++i) {
     // The ends of a line only connect inward, so a line meeting another at its
     // end forms a corner rather than a crossing. A one-cell line has no inward
@@ -337,41 +337,42 @@ auto Buffer::DrawHorizontalLine(int x, int y, int length, const Style& style)
                     : (i > 0 ? LineLeft : 0) | (i + 1 < length ? LineRight : 0);
     DrawLine(x + i, y, directions, style);
   }
+  return {.x = x + std::max(length, 0), .y = y};
 }
 
 auto Buffer::DrawVerticalLine(int x, int y, int length, const Style& style)
-    -> void {
+    -> DrawEnd {
   for (int i = 0; i < length; ++i) {
     uint8_t directions =
         length == 1 ? LineUp | LineDown
                     : (i > 0 ? LineUp : 0) | (i + 1 < length ? LineDown : 0);
     DrawLine(x, y + i, directions, style);
   }
+  return {.x = x, .y = y + std::max(length, 0)};
 }
 
 auto Buffer::DrawBox(int x, int y, int box_width, int box_height,
-                     const Style& style) -> void {
+                     const Style& style) -> DrawEnd {
   if (box_width <= 0 || box_height <= 0) {
-    return;
+    return {.x = x, .y = y};
   }
   // A box with no interior is just the one line that bounds it.
   if (box_width == 1) {
-    DrawVerticalLine(x, y, box_height, style);
-    return;
+    return DrawVerticalLine(x, y, box_height, style);
   }
   if (box_height == 1) {
-    DrawHorizontalLine(x, y, box_width, style);
-    return;
+    return DrawHorizontalLine(x, y, box_width, style);
   }
 
   DrawHorizontalLine(x, y, box_width, style);
   DrawHorizontalLine(x, y + box_height - 1, box_width, style);
   DrawVerticalLine(x, y, box_height, style);
   DrawVerticalLine(x + box_width - 1, y, box_height, style);
+  return {.x = x + box_width, .y = y + box_height};
 }
 
 auto Buffer::DrawText(int x, int y, llvm::StringRef text, const Style& style)
-    -> int {
+    -> DrawEnd {
   int cur_x = x;
   int cur_y = y;
 
@@ -394,10 +395,10 @@ auto Buffer::DrawText(int x, int y, llvm::StringRef text, const Style& style)
       continue;
     }
 
-    cur_x += DrawSymbol(cur_x, cur_y, symbol, style);
+    cur_x = DrawSymbol(cur_x, cur_y, symbol, style).x;
   }
 
-  return cur_y - y + 1;
+  return {.x = cur_x, .y = cur_y};
 }
 
 // Returns whether `c` is a character wrapped text can be broken at. Carriage
@@ -407,9 +408,9 @@ static auto IsBreakSpace(char c) -> bool {
 }
 
 auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
-                             const Style& style) -> int {
+                             const Style& style) -> DrawEnd {
   if (max_width <= 0) {
-    return 0;
+    return {.x = x, .y = y};
   }
 
   int cur_x = x;
@@ -438,7 +439,7 @@ auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
           if (space == '\r' || cur_x >= limit) {
             continue;
           }
-          cur_x += DrawSymbol(cur_x, cur_y, ' ', style);
+          cur_x = DrawSymbol(cur_x, cur_y, ' ', style).x;
         }
       }
       continue;
@@ -470,11 +471,11 @@ auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
         cur_x = x;
         ++cur_y;
       }
-      cur_x += DrawSymbol(cur_x, cur_y, symbol, style);
+      cur_x = DrawSymbol(cur_x, cur_y, symbol, style).x;
     }
   }
 
-  return cur_y - y + 1;
+  return {.x = cur_x, .y = cur_y};
 }
 
 auto Buffer::LastVisibleColumn(int y, ColorMode mode) const -> int {

--- a/common/terminal/buffer.cpp
+++ b/common/terminal/buffer.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <utility>
 
 #include "common/check.h"
@@ -17,27 +18,23 @@
 
 namespace Carbon::Terminal {
 
-// Columns between tab stops, measured from where the text began rather than
-// from the left edge of the buffer.
-static constexpr int TabWidth = 8;
-
 // The most bytes of combining marks kept on one cell. Text stacking more than
 // this is either adversarial or already illegible, and keeping all of it would
-// let one input character produce unbounded output.
+// let a single column of output carry unbounded bytes.
 static constexpr size_t MaxCombiningBytes = 32;
 
 // Glyphs for every combination of line directions, indexed by the direction
-// bits. Index zero never comes up, as a cell with no directions holds no line.
+// bits.
 static constexpr std::array<char32_t, 16> Utf8LineGlyphs = {
-    U' ',  // (none)
-    U'─',  // left
-    U'─',  // right
+    U'·',  // (none): a line between one center and itself, which is a point
+    U'╴',  // left
+    U'╶',  // right
     U'─',  // left, right
-    U'│',  // up
+    U'╵',  // up
     U'╯',  // left, up
     U'╰',  // right, up
     U'┴',  // left, right, up
-    U'│',  // down
+    U'╷',  // down
     U'╮',  // left, down
     U'╭',  // right, down
     U'┬',  // left, right, down
@@ -50,12 +47,29 @@ static constexpr std::array<char32_t, 16> Utf8LineGlyphs = {
 // The ASCII stand-ins, which can only distinguish horizontal, vertical, and
 // everything else.
 static constexpr std::array<char32_t, 16> AsciiLineGlyphs = {
-    U' ', U'-', U'-', U'-', U'|', U'+', U'+', U'+',
+    U'+', U'-', U'-', U'-', U'|', U'+', U'+', U'+',
     U'|', U'+', U'+', U'+', U'|', U'+', U'+', U'+',
 };
 
-Buffer::Buffer(int width, Charset charset) : width_(width), metrics_(charset) {
-  CARBON_CHECK(width > 0, "Buffer width must be positive, but was {0}.", width);
+// Returns the next tab stop after `x` on a line whose stops are `tab_width`
+// columns apart counting from `origin`, which `x` must not be left of.
+static auto NextTabStop(int x, int origin, int tab_width) -> int {
+  CARBON_DCHECK(x >= origin, "Column {0} is left of the origin {1}.", x,
+                origin);
+  return origin + ((x - origin) / tab_width + 1) * tab_width;
+}
+
+Buffer::Buffer(int columns, Charset charset, int tab_width)
+    : columns_(columns),
+      width_(columns),
+      tab_width_(tab_width),
+      metrics_(charset) {
+  CARBON_CHECK(columns > 0 && columns <= MaxColumns,
+               "Buffer width must be in [1, {0}], but was {1}.", MaxColumns,
+               columns);
+  CARBON_CHECK(tab_width > 0 && tab_width <= MaxTabWidth,
+               "Tab width must be in [1, {0}], but was {1}.", MaxTabWidth,
+               tab_width);
 }
 
 auto Buffer::height() const -> int {
@@ -63,44 +77,60 @@ auto Buffer::height() const -> int {
 }
 
 auto Buffer::EnsureRow(int y) -> void {
+  CARBON_CHECK(y >= 0 && y < MaxRows, "Row {0} is outside [0, {1}).", y,
+               MaxRows);
   if (y < height()) {
     return;
   }
+  // Rows are added at the end and nothing already in the grid moves, so this
+  // asks for exactly the rows wanted and lets the vector amortize the growing.
   cells_.resize(static_cast<size_t>(y + 1) * width_);
 }
 
 auto Buffer::EnsureWidth(int x) -> void {
+  CARBON_CHECK(x >= 0 && x < MaxColumns, "Column {0} is outside [0, {1}).", x,
+               MaxColumns);
   if (x < width_) {
     return;
   }
-  // Growing by halves rather than to exactly what was asked keeps a row drawn
-  // one symbol at a time from reflowing on every symbol.
-  int width = std::max(x + 1, width_ + width_ / 2);
+  // Widening moves every row, so it grows by halves rather than to exactly what
+  // was asked: a row drawn one code point at a time would otherwise copy the
+  // whole grid on every one of them. Growth stops at the bound, which is what
+  // holds the product of the two dimensions inside what a cell index can
+  // represent.
+  int width = std::min(std::max(x + 1, width_ + width_ / 2), MaxColumns);
 
-  // Rows are stored back to back, so every row but the first moves.
   int rows = height();
-  llvm::SmallVector<Cell, 0> widened(static_cast<size_t>(rows) * width);
+  llvm::SmallVector<Cell, 0> new_cells(static_cast<size_t>(rows) * width);
   for (int y : llvm::seq(rows)) {
     llvm::copy(
         llvm::ArrayRef(cells_).slice(static_cast<size_t>(y) * width_, width_),
-        widened.begin() + static_cast<size_t>(y) * width);
+        new_cells.begin() + static_cast<size_t>(y) * width);
   }
-  cells_ = std::move(widened);
+  cells_ = std::move(new_cells);
 
-  // The marks are keyed by cell index, which is where the row moved it to.
-  llvm::DenseMap<int, std::string> moved;
-  moved.reserve(combining_marks_.size());
+  // A mark's key is a cell index, which depends on the width, so each is
+  // recomputed for the new one.
+  llvm::DenseMap<int, std::string> new_combining_marks;
+  new_combining_marks.reserve(combining_marks_.size());
   for (auto& [index, marks] : combining_marks_) {
-    moved.insert({index / width_ * width + index % width_, std::move(marks)});
+    new_combining_marks.insert(
+        {index / width_ * width + index % width_, std::move(marks)});
   }
-  combining_marks_ = std::move(moved);
+  combining_marks_ = std::move(new_combining_marks);
 
   width_ = width;
 }
 
 auto Buffer::ClearCells(int x, int y, int width) -> void {
-  // A cleared range must not leave half of a double-width symbol behind, so it
-  // extends over either half that crosses its edges.
+  CARBON_CHECK(
+      x >= 0 && width >= 0 && x + width <= width_ && y >= 0 && y < height(),
+      "Clearing [{0}, {1}) of row {2} reaches outside the {3}x{4} cells the "
+      "buffer holds.",
+      x, x + width, y, width_, height());
+
+  // A cleared range must not leave half of a double-width character behind, so
+  // it extends over either half that crosses its edges.
   int begin = x;
   if (begin > 0 && CellAt(begin, y).is_continuation) {
     --begin;
@@ -116,19 +146,21 @@ auto Buffer::ClearCells(int x, int y, int width) -> void {
   }
 }
 
-auto Buffer::AttachCombiningMark(int x, int y, char32_t symbol) -> void {
-  // Marks render into the column before them, so there must be one and it must
-  // already have been drawn.
+auto Buffer::AttachCombiningMark(int x, int y, char32_t code_point) -> void {
+  // A mark has nowhere to go when no cell precedes it, so it is dropped.
   if (x <= 0 || x > width_ || y < 0 || y >= height()) {
     return;
   }
+  // The left half of a double-width character is never itself a continuation,
+  // so stepping back from one always lands on a real character.
   int base = x - 1;
   if (CellAt(base, y).is_continuation) {
     --base;
   }
+  CARBON_CHECK(base >= 0, "A continuation cell at column zero has no base.");
 
   Utf8Storage storage;
-  llvm::StringRef encoded = EncodeUtf8(symbol, storage);
+  llvm::StringRef encoded = EncodeUtf8(code_point, storage);
   std::string& marks = combining_marks_[CellIndex(base, y)];
   if (marks.size() + encoded.size() > MaxCombiningBytes) {
     return;
@@ -136,100 +168,126 @@ auto Buffer::AttachCombiningMark(int x, int y, char32_t symbol) -> void {
   marks.append(encoded.data(), encoded.size());
 }
 
-auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
-    -> DrawEnd {
-  // A combining mark takes no column of its own, and renders into the one
-  // before it instead.
-  int width = metrics_.SymbolWidth(symbol);
+auto Buffer::DrawCodePoint(int x, int y, char32_t code_point,
+                           const Style& style) -> DrawEnd {
+  CheckOrigin(x, y);
+  return {.x = PlaceCodePoint(x, y, code_point, style), .y = y};
+}
+
+auto Buffer::PlaceCodePoint(int x, int y, char32_t code_point,
+                            const Style& style) -> int {
+  CARBON_DCHECK(x >= 0 && y >= 0,
+                "Placing at ({0}, {1}), which no walk should reach.", x, y);
+
+  int width = metrics_.CodePointWidth(code_point);
   if (width == 0) {
-    AttachCombiningMark(x, y, symbol);
-    return {.x = x, .y = y};
+    AttachCombiningMark(x, y, code_point);
+    return x;
   }
-  symbol = metrics_.RenderedSymbol(symbol);
+  code_point = metrics_.RenderedCodePoint(code_point);
 
-  if (x < 0 || y < 0) {
-    return {.x = x + width, .y = y};
+  // Both bounds are reached by what the text holds rather than by where the
+  // caller aimed -- a word overhanging the target width, or newlines running
+  // past the rows a grid can index -- so past either one nothing is drawn and
+  // the column still advances, which is what keeps measuring and drawing
+  // answering the same thing. A double-width character needs both its columns,
+  // so one that would only half fit is past the edge like any other: splitting
+  // it would leave the terminal rendering half a character.
+  if (y >= MaxRows || x > MaxColumns - width) {
+    return x + width;
   }
 
-  // A double-width symbol needs both its columns, since splitting one would
-  // leave the terminal rendering half a character.
   EnsureWidth(x + width - 1);
   EnsureRow(y);
   ClearCells(x, y, width);
 
   Cell& cell = CellAt(x, y);
-  cell.symbol = symbol;
+  cell.code_point = code_point;
   cell.style = style;
-  for (int i = 1; i < width; ++i) {
-    Cell& continuation = CellAt(x + i, y);
+  // Nothing is wider than two columns, so the second is the only continuation
+  // there can be.
+  if (width > 1) {
+    Cell& continuation = CellAt(x + 1, y);
     continuation.style = style;
     continuation.is_continuation = true;
   }
-  return {.x = x + width, .y = y};
+  return x + width;
+}
+
+// Returns the glyphs a cell's directions are read from.
+static auto LineGlyphs(Charset charset) -> const std::array<char32_t, 16>& {
+  return charset == Charset::Utf8 ? Utf8LineGlyphs : AsciiLineGlyphs;
 }
 
 auto Buffer::DrawLine(int x, int y, uint8_t directions, const Style& style)
     -> void {
-  if (x < 0 || y < 0) {
-    return;
-  }
-  CARBON_DCHECK(directions < Utf8LineGlyphs.size());
+  CARBON_DCHECK(directions <= LineDirections,
+                "Direction bits {0} name no glyph.", directions);
   EnsureWidth(x);
   EnsureRow(y);
 
   uint8_t existing = CellAt(x, y).lines;
   if (existing == 0) {
     // Whatever is here isn't a line. Clearing also removes either half of a
-    // double-width symbol the cell was part of.
+    // double-width character the cell was part of.
     ClearCells(x, y, 1);
   }
 
   Cell& cell = CellAt(x, y);
-  cell.lines = existing | directions;
-  cell.symbol = metrics_.charset() == Charset::Utf8
-                    ? Utf8LineGlyphs[cell.lines]
-                    : AsciiLineGlyphs[cell.lines];
+  cell.lines = existing | directions | LineCell;
+  cell.code_point = LineGlyphs(metrics_.charset())[cell.lines & LineDirections];
   cell.style = style;
 }
 
-auto Buffer::DrawHorizontalLine(int x, int y, int length, const Style& style)
-    -> DrawEnd {
-  for (int i = 0; i < length; ++i) {
-    // The ends of a line only connect inward, so a line meeting another at its
-    // end forms a corner rather than a crossing. A one-cell line has no inward
-    // direction and is drawn as a bare horizontal segment.
-    uint8_t directions =
-        length == 1 ? LineLeft | LineRight
-                    : (i > 0 ? LineLeft : 0) | (i + 1 < length ? LineRight : 0);
-    DrawLine(x + i, y, directions, style);
-  }
-  return {.x = x + std::max(length, 0), .y = y};
+// Checks that a line of `length` starting at `position` stays within `limit`,
+// which is the width for a horizontal line and `MaxRows` for a vertical one.
+//
+// Unlike text, a line has no reason to reach outside what it is being drawn
+// into: nothing about it is unbreakable, and a layout that put one there
+// computed the wrong extent.
+static auto CheckLineFits(int position, int length, int limit) -> void {
+  CARBON_CHECK(length >= 0 && position <= limit - length,
+               "A line of {0} at {1} runs outside the {2} available to it.",
+               length, position, limit);
 }
 
-auto Buffer::DrawVerticalLine(int x, int y, int length, const Style& style)
-    -> DrawEnd {
-  for (int i = 0; i < length; ++i) {
+auto Buffer::DrawHorizontalLine(int x, int y, int length, const Style& style,
+                                LineEnd start, LineEnd end) -> DrawEnd {
+  CheckOrigin(x, y);
+  CheckLineFits(x, length, columns_);
+  for (int i : llvm::seq(length)) {
+    // A cell in the middle of the line is entered from one side and left by the
+    // other. An end cell is only left towards the rest of the line, unless that
+    // end runs out through the cell's own side.
     uint8_t directions =
-        length == 1 ? LineUp | LineDown
-                    : (i > 0 ? LineUp : 0) | (i + 1 < length ? LineDown : 0);
+        (i > 0 || start == LineEnd::Edge ? LineLeft : 0) |
+        (i + 1 < length || end == LineEnd::Edge ? LineRight : 0);
+    DrawLine(x + i, y, directions, style);
+  }
+  return {.x = x + length, .y = y};
+}
+
+auto Buffer::DrawVerticalLine(int x, int y, int length, const Style& style,
+                              LineEnd start, LineEnd end) -> DrawEnd {
+  CheckOrigin(x, y);
+  CheckLineFits(y, length, MaxRows);
+  for (int i : llvm::seq(length)) {
+    uint8_t directions =
+        (i > 0 || start == LineEnd::Edge ? LineUp : 0) |
+        (i + 1 < length || end == LineEnd::Edge ? LineDown : 0);
     DrawLine(x, y + i, directions, style);
   }
-  return {.x = x, .y = y + std::max(length, 0)};
+  return {.x = x, .y = y + length};
 }
 
 auto Buffer::DrawBox(int x, int y, int box_width, int box_height,
                      const Style& style) -> DrawEnd {
-  if (box_width <= 0 || box_height <= 0) {
+  CheckOrigin(x, y);
+  CheckLineFits(x, box_width, columns_);
+  CheckLineFits(y, box_height, MaxRows);
+  if (box_width == 0 || box_height == 0) {
     return {.x = x, .y = y};
   }
-  // A box with no interior is just the one line that bounds it.
-  if (box_width == 1) {
-    return DrawVerticalLine(x, y, box_height, style);
-  }
-  if (box_height == 1) {
-    return DrawHorizontalLine(x, y, box_width, style);
-  }
-
   DrawHorizontalLine(x, y, box_width, style);
   DrawHorizontalLine(x, y + box_height - 1, box_width, style);
   DrawVerticalLine(x, y, box_height, style);
@@ -240,29 +298,32 @@ auto Buffer::DrawBox(int x, int y, int box_width, int box_height,
 template <typename PlaceFn>
 auto Buffer::WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
     -> DrawEnd {
+  CheckOrigin(x, y);
+  CheckTextSize(text);
+
   int cur_x = x;
   int cur_y = y;
 
   while (!text.empty()) {
-    char32_t symbol = metrics_.TakeSymbol(text);
-    if (symbol == '\n') {
+    char32_t code_point = metrics_.TakeCodePoint(text);
+    if (code_point == '\n') {
       cur_x = x;
       ++cur_y;
       continue;
     }
-    if (symbol == '\r') {
+    if (code_point == '\r') {
       cur_x = x;
       continue;
     }
-    if (symbol == '\t') {
-      int stop = x + ((cur_x - x) / TabWidth + 1) * TabWidth;
+    if (code_point == '\t') {
+      int stop = NextTabStop(cur_x, x, tab_width_);
       for (; cur_x < stop; ++cur_x) {
         place(cur_x, cur_y, U' ');
       }
       continue;
     }
 
-    cur_x = place(cur_x, cur_y, symbol);
+    cur_x = place(cur_x, cur_y, code_point);
   }
 
   return {.x = cur_x, .y = cur_y};
@@ -270,54 +331,72 @@ auto Buffer::WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
 
 auto Buffer::DrawText(int x, int y, llvm::StringRef text, const Style& style)
     -> DrawEnd {
-  return WalkText(x, y, text, [&](int cur_x, int cur_y, char32_t symbol) {
-    return DrawSymbol(cur_x, cur_y, symbol, style).x;
+  return WalkText(x, y, text, [&](int cur_x, int cur_y, char32_t code_point) {
+    return PlaceCodePoint(cur_x, cur_y, code_point, style);
   });
 }
 
 auto Buffer::MeasureText(int x, int y, llvm::StringRef text) const -> DrawEnd {
-  return WalkText(x, y, text, [&](int cur_x, int /*cur_y*/, char32_t symbol) {
-    return cur_x + metrics_.SymbolWidth(symbol);
-  });
+  return WalkText(x, y, text,
+                  [&](int cur_x, int /*cur_y*/, char32_t code_point) {
+                    return cur_x + metrics_.CodePointWidth(code_point);
+                  });
 }
 
 template <typename PlaceFn>
-auto Buffer::WalkWrappedText(int x, int y, int max_width, llvm::StringRef text,
-                             PlaceFn place) const -> DrawEnd {
-  if (max_width <= 0) {
-    return {.x = x, .y = y};
-  }
+auto Buffer::WalkWrappedText(int x, int y, int margin, int max_width,
+                             llvm::StringRef text, PlaceFn place) const
+    -> DrawEnd {
+  CheckOrigin(x, y);
+  CheckTextSize(text);
+  CARBON_CHECK(margin >= 0 && margin <= x && max_width > 0 &&
+                   x - margin < max_width && margin <= columns_ - max_width,
+               "A block of {0} columns at {1} holding text from {2} does not "
+               "fit the {3} columns a buffer covers.",
+               max_width, margin, x, columns_);
+
+  // The column a row runs out of room at. The block lies within the buffer's
+  // width, so this is a column like any other rather than a sum that has to be
+  // kept from overflowing.
+  int limit = margin + max_width;
 
   int cur_x = x;
   int cur_y = y;
+  // Whether the row being written was started by wrapping, rather than by the
+  // text itself. Spaces are dropped at the start of a wrapped row and kept at
+  // the start of one the text asked for, which is the difference between
+  // indentation the caller wrote and indentation an accident of width would
+  // otherwise introduce.
+  bool wrapped_row = false;
 
-  // What a row has room for is decided from the columns it has used rather
-  // than from a column computed once from `max_width`, so that a width no row
-  // reaches works like any other instead of overflowing the column it names.
-  //
   // Splitting on bytes is safe because every character text can break at is
-  // ASCII, and UTF-8 never encodes anything else using an ASCII byte. Only the
-  // runs that get drawn are decoded.
+  // ASCII, and UTF-8 never encodes anything else using an ASCII byte. Only
+  // words are decoded; whitespace is handled a byte at a time.
   while (!text.empty()) {
     if (text.front() == '\n') {
       text = text.drop_front();
-      cur_x = x;
+      cur_x = margin;
       ++cur_y;
+      wrapped_row = false;
       continue;
     }
 
     if (IsWrapBreak(text.front())) {
-      llvm::StringRef spaces = text.take_while(IsWrapBreak);
-      text = text.drop_front(spaces.size());
-      // Spaces are dropped wherever they would begin a row, which is what
-      // keeps wrapped text aligned with where it started. Carriage returns are
-      // never drawn, so CRLF line endings break exactly once.
-      if (cur_x > x) {
-        for (char space : spaces) {
-          if (space == '\r' || cur_x - x >= max_width) {
+      llvm::StringRef breaks = text.take_while(IsWrapBreak);
+      text = text.drop_front(breaks.size());
+      if (cur_x > margin || !wrapped_row) {
+        for (char c : breaks) {
+          if (c == '\r') {
             continue;
           }
-          cur_x = place(cur_x, cur_y, U' ');
+          // Whitespace stops at the block's edge, leaving the word after it to
+          // wrap.
+          int next = std::min(
+              c == '\t' ? NextTabStop(cur_x, margin, tab_width_) : cur_x + 1,
+              limit);
+          while (cur_x < next) {
+            cur_x = place(cur_x, cur_y, U' ');
+          }
         }
       }
       continue;
@@ -327,35 +406,37 @@ auto Buffer::WalkWrappedText(int x, int y, int max_width, llvm::StringRef text,
         text.take_until([](char c) { return c == '\n' || IsWrapBreak(c); });
     text = text.drop_front(word.size());
 
-    // Move a word that doesn't fit down to the next row. If it doesn't fit
-    // there either it overhangs rather than being broken, and the buffer grows
-    // to hold it.
-    if (cur_x > x && cur_x - x + metrics_.Width(word) > max_width) {
-      cur_x = x;
+    // Move a word that doesn't fit down to the next row, which minimizes the
+    // overhang when it doesn't fit there either.
+    if (cur_x > margin && cur_x + metrics_.Width(word) > limit) {
+      cur_x = margin;
       ++cur_y;
+      wrapped_row = true;
     }
 
     while (!word.empty()) {
-      cur_x = place(cur_x, cur_y, metrics_.TakeSymbol(word));
+      cur_x = place(cur_x, cur_y, metrics_.TakeCodePoint(word));
     }
   }
 
   return {.x = cur_x, .y = cur_y};
 }
 
-auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
-                             const Style& style) -> DrawEnd {
-  return WalkWrappedText(x, y, max_width, text,
-                         [&](int cur_x, int cur_y, char32_t symbol) {
-                           return DrawSymbol(cur_x, cur_y, symbol, style).x;
+auto Buffer::DrawWrappedText(int x, int y, int margin, int max_width,
+                             llvm::StringRef text, const Style& style)
+    -> DrawEnd {
+  return WalkWrappedText(x, y, margin, max_width, text,
+                         [&](int cur_x, int cur_y, char32_t code_point) {
+                           return PlaceCodePoint(cur_x, cur_y, code_point,
+                                                 style);
                          });
 }
 
-auto Buffer::MeasureWrappedText(int x, int y, int max_width,
+auto Buffer::MeasureWrappedText(int x, int y, int margin, int max_width,
                                 llvm::StringRef text) const -> DrawEnd {
-  return WalkWrappedText(x, y, max_width, text,
-                         [&](int cur_x, int /*cur_y*/, char32_t symbol) {
-                           return cur_x + metrics_.SymbolWidth(symbol);
+  return WalkWrappedText(x, y, margin, max_width, text,
+                         [&](int cur_x, int /*cur_y*/, char32_t code_point) {
+                           return cur_x + metrics_.CodePointWidth(code_point);
                          });
 }
 
@@ -365,7 +446,7 @@ auto Buffer::LastVisibleColumn(int y, ColorMode mode) const -> int {
   bool styles_render = mode != ColorMode::NoColor;
   for (int x = width_ - 1; x >= 0; --x) {
     const Cell& cell = CellAt(x, y);
-    if (cell.is_continuation || cell.symbol != ' ' ||
+    if (cell.is_continuation || cell.code_point != ' ' ||
         (styles_render && cell.style.IsVisibleOnBlank()) ||
         (!combining_marks_.empty() &&
          combining_marks_.contains(CellIndex(x, y)))) {
@@ -378,13 +459,17 @@ auto Buffer::LastVisibleColumn(int y, ColorMode mode) const -> int {
 auto Buffer::Render(OutputBufferRef out, ColorMode mode) const -> void {
   Utf8Storage storage;
 
-  // The style a terminal starts a row in, and the one each row leaves it in.
+  // The style a terminal starts in, and the one it is left in.
   const Style default_style;
 
-  for (int y = 0, rows = height(); y < rows; ++y) {
-    // Cells outlive this loop, so the active style is tracked by pointing at
-    // one rather than copying a whole style per cell.
-    const Style* active = &default_style;
+  // Cells outlive this loop, so the active style is tracked by pointing at one
+  // rather than copying a whole style per cell. It carries across rows: a style
+  // is usually still in use on the row below, and turning it off and back on
+  // costs a reset and a fresh start for nothing.
+  const Style* active = &default_style;
+
+  int rows = height();
+  for (int y = 0; y < rows; ++y) {
     int last = LastVisibleColumn(y, mode);
     for (int x = 0; x <= last; ++x) {
       const Cell& cell = CellAt(x, y);
@@ -394,7 +479,7 @@ auto Buffer::Render(OutputBufferRef out, ColorMode mode) const -> void {
 
       active->AppendTransitionTo(out, cell.style, mode);
       active = &cell.style;
-      out.Append(EncodeUtf8(cell.symbol, storage));
+      out.Append(EncodeUtf8(cell.code_point, storage));
 
       // Almost nothing has combining marks, so the lookup is worth skipping
       // outright rather than doing it for every cell on the screen.
@@ -406,7 +491,16 @@ auto Buffer::Render(OutputBufferRef out, ColorMode mode) const -> void {
       }
     }
 
-    active->AppendTransitionTo(out, default_style, mode);
+    // A style is turned off before the newline in two cases. On the last row,
+    // so that nothing is left set for whatever is printed after this and the
+    // escape that turns it off still falls inside the rendering. And whenever
+    // it paints where there is no glyph, because a terminal fills the rest of
+    // the row with the background it is in when the row ends, so leaving one
+    // set would paint a stripe out to the right edge that nothing asked for.
+    if (y + 1 == rows || active->IsVisibleOnBlank()) {
+      active->AppendTransitionTo(out, default_style, mode);
+      active = &default_style;
+    }
     out.Append("\n");
   }
 }

--- a/common/terminal/buffer.cpp
+++ b/common/terminal/buffer.cpp
@@ -17,13 +17,6 @@
 
 namespace Carbon::Terminal {
 
-// Stands in for a byte an ASCII terminal has no dependable rendering for.
-static constexpr char32_t AsciiReplacement = U'?';
-
-// Stands in for anything a UTF-8 terminal has no rendering for: invalid UTF-8,
-// control characters, and unassigned code points.
-static constexpr char32_t Utf8Replacement = U'�';
-
 // Columns between tab stops, measured from where the text began rather than
 // from the left edge of the buffer.
 static constexpr int TabWidth = 8;
@@ -32,90 +25,6 @@ static constexpr int TabWidth = 8;
 // this is either adversarial or already illegible, and keeping all of it would
 // let one input character produce unbounded output.
 static constexpr size_t MaxCombiningBytes = 32;
-
-// The most bytes one code point encodes to in UTF-8.
-static constexpr size_t MaxUtf8Bytes = 4;
-
-// Returns whether an ASCII terminal renders `symbol` as itself, in one column.
-static auto IsPrintableAscii(char32_t symbol) -> bool {
-  return symbol >= 0x20 && symbol < 0x7f;
-}
-
-// Encodes `symbol` as UTF-8 into `storage`, returning the bytes written.
-//
-// Code points with no valid encoding, including surrogates and anything past
-// U+10FFFF, become the replacement character.
-static auto EncodeUtf8(char32_t symbol, std::array<char, MaxUtf8Bytes>& storage)
-    -> llvm::StringRef {
-  // Most of what gets rendered is ASCII, and encoding it is a single byte.
-  if (symbol < 0x80) {
-    storage[0] = static_cast<char>(symbol);
-    return llvm::StringRef(storage.data(), 1);
-  }
-
-  // Surrogates have no encoding of their own, and nothing past the last code
-  // point has one at all.
-  if (symbol > 0x10ffff || (symbol >= 0xd800 && symbol < 0xe000)) {
-    symbol = Utf8Replacement;
-  }
-
-  // Spelled out rather than handed to a general converter, which walks a range
-  // and checks bounds this already knows. Box-drawing characters go through
-  // here for every cell of every line drawn.
-  auto trailing = [symbol](int shift) {
-    return static_cast<char>(0x80 | ((symbol >> shift) & 0x3f));
-  };
-  if (symbol < 0x800) {
-    storage[0] = static_cast<char>(0xc0 | (symbol >> 6));
-    storage[1] = trailing(0);
-    return llvm::StringRef(storage.data(), 2);
-  }
-  if (symbol < 0x10000) {
-    storage[0] = static_cast<char>(0xe0 | (symbol >> 12));
-    storage[1] = trailing(6);
-    storage[2] = trailing(0);
-    return llvm::StringRef(storage.data(), 3);
-  }
-  storage[0] = static_cast<char>(0xf0 | (symbol >> 18));
-  storage[1] = trailing(12);
-  storage[2] = trailing(6);
-  storage[3] = trailing(0);
-  return llvm::StringRef(storage.data(), 4);
-}
-
-// Returns the columns `symbol` occupies on a UTF-8 terminal: zero for a
-// combining mark, one or two for a symbol with a glyph of its own, and a
-// negative value when there is no printable rendering for it.
-static auto Utf8SymbolWidth(char32_t symbol) -> int {
-  // Printable ASCII is one column, and is most of what gets measured. The
-  // general path parses a UTF-8 sequence and searches several code point
-  // range tables, which is far more than this needs.
-  if (IsPrintableAscii(symbol)) {
-    return 1;
-  }
-
-  std::array<char, MaxUtf8Bytes> storage;
-  return llvm::sys::unicode::columnWidthUTF8(EncodeUtf8(symbol, storage));
-}
-
-// Removes the first UTF-8 sequence from `text` and returns the code point it
-// encodes.
-//
-// A byte that doesn't start a valid sequence yields the replacement character
-// and is consumed on its own, so decoding resynchronizes at the next byte
-// rather than discarding the rest of the text.
-static auto TakeUtf8Symbol(llvm::StringRef& text) -> char32_t {
-  const auto* begin = reinterpret_cast<const llvm::UTF8*>(text.data());
-  const auto* pos = begin;
-  llvm::UTF32 symbol = 0;
-  if (llvm::convertUTF8Sequence(&pos, begin + text.size(), &symbol,
-                                llvm::strictConversion) != llvm::conversionOK) {
-    text = text.drop_front(1);
-    return Utf8Replacement;
-  }
-  text = text.drop_front(pos - begin);
-  return symbol;
-}
 
 // Glyphs for every combination of line directions, indexed by the direction
 // bits. Index zero never comes up, as a cell with no directions holds no line.
@@ -145,40 +54,8 @@ static constexpr std::array<char32_t, 16> AsciiLineGlyphs = {
     U'|', U'+', U'+', U'+', U'|', U'+', U'+', U'+',
 };
 
-Buffer::Buffer(int width, Charset charset) : width_(width), charset_(charset) {
+Buffer::Buffer(int width, Charset charset) : width_(width), metrics_(charset) {
   CARBON_CHECK(width > 0, "Buffer width must be positive, but was {0}.", width);
-}
-
-auto Buffer::TakeSymbol(llvm::StringRef& text) const -> char32_t {
-  CARBON_DCHECK(!text.empty());
-  if (charset_ == Charset::Ascii) {
-    auto byte = static_cast<unsigned char>(text.front());
-    text = text.drop_front();
-    return byte;
-  }
-  return TakeUtf8Symbol(text);
-}
-
-auto Buffer::SymbolWidth(char32_t symbol) const -> int {
-  if (charset_ == Charset::Ascii) {
-    return 1;
-  }
-  int width = Utf8SymbolWidth(symbol);
-  // A symbol with no rendering is drawn as the replacement character, which
-  // takes one column.
-  return width < 0 ? 1 : width;
-}
-
-auto Buffer::MeasureWidth(llvm::StringRef text) const -> int {
-  if (charset_ == Charset::Ascii) {
-    return static_cast<int>(text.size());
-  }
-
-  int width = 0;
-  while (!text.empty()) {
-    width += SymbolWidth(TakeUtf8Symbol(text));
-  }
-  return width;
 }
 
 auto Buffer::height() const -> int {
@@ -204,9 +81,9 @@ auto Buffer::EnsureWidth(int x) -> void {
   int rows = height();
   llvm::SmallVector<Cell, 0> widened(static_cast<size_t>(rows) * width);
   for (int y : llvm::seq(rows)) {
-    llvm::copy(llvm::ArrayRef(cells_).slice(
-                   static_cast<size_t>(y) * width_, width_),
-               widened.begin() + static_cast<size_t>(y) * width);
+    llvm::copy(
+        llvm::ArrayRef(cells_).slice(static_cast<size_t>(y) * width_, width_),
+        widened.begin() + static_cast<size_t>(y) * width);
   }
   cells_ = std::move(widened);
 
@@ -250,7 +127,7 @@ auto Buffer::AttachCombiningMark(int x, int y, char32_t symbol) -> void {
     --base;
   }
 
-  std::array<char, MaxUtf8Bytes> storage;
+  Utf8Storage storage;
   llvm::StringRef encoded = EncodeUtf8(symbol, storage);
   std::string& marks = combining_marks_[CellIndex(base, y)];
   if (marks.size() + encoded.size() > MaxCombiningBytes) {
@@ -261,26 +138,14 @@ auto Buffer::AttachCombiningMark(int x, int y, char32_t symbol) -> void {
 
 auto Buffer::DrawSymbol(int x, int y, char32_t symbol, const Style& style)
     -> DrawEnd {
-  if (charset_ == Charset::Ascii) {
-    if (x >= 0 && y >= 0) {
-      EnsureWidth(x);
-      EnsureRow(y);
-      CellAt(x, y) = {
-          .symbol = IsPrintableAscii(symbol) ? symbol : AsciiReplacement,
-          .style = style};
-    }
-    return {.x = x + 1, .y = y};
-  }
-
-  int width = Utf8SymbolWidth(symbol);
+  // A combining mark takes no column of its own, and renders into the one
+  // before it instead.
+  int width = metrics_.SymbolWidth(symbol);
   if (width == 0) {
     AttachCombiningMark(x, y, symbol);
     return {.x = x, .y = y};
   }
-  if (width < 0) {
-    symbol = Utf8Replacement;
-    width = 1;
-  }
+  symbol = metrics_.RenderedSymbol(symbol);
 
   if (x < 0 || y < 0) {
     return {.x = x + width, .y = y};
@@ -321,8 +186,9 @@ auto Buffer::DrawLine(int x, int y, uint8_t directions, const Style& style)
 
   Cell& cell = CellAt(x, y);
   cell.lines = existing | directions;
-  cell.symbol = charset_ == Charset::Utf8 ? Utf8LineGlyphs[cell.lines]
-                                          : AsciiLineGlyphs[cell.lines];
+  cell.symbol = metrics_.charset() == Charset::Utf8
+                    ? Utf8LineGlyphs[cell.lines]
+                    : AsciiLineGlyphs[cell.lines];
   cell.style = style;
 }
 
@@ -371,13 +237,14 @@ auto Buffer::DrawBox(int x, int y, int box_width, int box_height,
   return {.x = x + box_width, .y = y + box_height};
 }
 
-auto Buffer::DrawText(int x, int y, llvm::StringRef text, const Style& style)
+template <typename PlaceFn>
+auto Buffer::WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
     -> DrawEnd {
   int cur_x = x;
   int cur_y = y;
 
   while (!text.empty()) {
-    char32_t symbol = TakeSymbol(text);
+    char32_t symbol = metrics_.TakeSymbol(text);
     if (symbol == '\n') {
       cur_x = x;
       ++cur_y;
@@ -390,25 +257,33 @@ auto Buffer::DrawText(int x, int y, llvm::StringRef text, const Style& style)
     if (symbol == '\t') {
       int stop = x + ((cur_x - x) / TabWidth + 1) * TabWidth;
       for (; cur_x < stop; ++cur_x) {
-        DrawSymbol(cur_x, cur_y, ' ', style);
+        place(cur_x, cur_y, U' ');
       }
       continue;
     }
 
-    cur_x = DrawSymbol(cur_x, cur_y, symbol, style).x;
+    cur_x = place(cur_x, cur_y, symbol);
   }
 
   return {.x = cur_x, .y = cur_y};
 }
 
-// Returns whether `c` is a character wrapped text can be broken at. Carriage
-// returns count, so that a CRLF ending breaks only on its newline.
-static auto IsBreakSpace(char c) -> bool {
-  return c == ' ' || c == '\t' || c == '\r';
+auto Buffer::DrawText(int x, int y, llvm::StringRef text, const Style& style)
+    -> DrawEnd {
+  return WalkText(x, y, text, [&](int cur_x, int cur_y, char32_t symbol) {
+    return DrawSymbol(cur_x, cur_y, symbol, style).x;
+  });
 }
 
-auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
-                             const Style& style) -> DrawEnd {
+auto Buffer::MeasureText(int x, int y, llvm::StringRef text) const -> DrawEnd {
+  return WalkText(x, y, text, [&](int cur_x, int /*cur_y*/, char32_t symbol) {
+    return cur_x + metrics_.SymbolWidth(symbol);
+  });
+}
+
+template <typename PlaceFn>
+auto Buffer::WalkWrappedText(int x, int y, int max_width, llvm::StringRef text,
+                             PlaceFn place) const -> DrawEnd {
   if (max_width <= 0) {
     return {.x = x, .y = y};
   }
@@ -428,8 +303,8 @@ auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
       continue;
     }
 
-    if (IsBreakSpace(text.front())) {
-      llvm::StringRef spaces = text.take_while(IsBreakSpace);
+    if (IsWrapBreak(text.front())) {
+      llvm::StringRef spaces = text.take_while(IsWrapBreak);
       text = text.drop_front(spaces.size());
       // Spaces are dropped wherever they would begin a row, which is what
       // keeps wrapped text aligned with where it started. Carriage returns are
@@ -439,30 +314,46 @@ auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
           if (space == '\r' || cur_x >= limit) {
             continue;
           }
-          cur_x = DrawSymbol(cur_x, cur_y, ' ', style).x;
+          cur_x = place(cur_x, cur_y, U' ');
         }
       }
       continue;
     }
 
     llvm::StringRef word =
-        text.take_until([](char c) { return c == '\n' || IsBreakSpace(c); });
+        text.take_until([](char c) { return c == '\n' || IsWrapBreak(c); });
     text = text.drop_front(word.size());
 
     // Move a word that doesn't fit down to the next row. If it doesn't fit
     // there either it overhangs rather than being broken, and the buffer grows
     // to hold it.
-    if (cur_x > x && cur_x + MeasureWidth(word) > limit) {
+    if (cur_x > x && cur_x + metrics_.Width(word) > limit) {
       cur_x = x;
       ++cur_y;
     }
 
     while (!word.empty()) {
-      cur_x = DrawSymbol(cur_x, cur_y, TakeSymbol(word), style).x;
+      cur_x = place(cur_x, cur_y, metrics_.TakeSymbol(word));
     }
   }
 
   return {.x = cur_x, .y = cur_y};
+}
+
+auto Buffer::DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
+                             const Style& style) -> DrawEnd {
+  return WalkWrappedText(x, y, max_width, text,
+                         [&](int cur_x, int cur_y, char32_t symbol) {
+                           return DrawSymbol(cur_x, cur_y, symbol, style).x;
+                         });
+}
+
+auto Buffer::MeasureWrappedText(int x, int y, int max_width,
+                                llvm::StringRef text) const -> DrawEnd {
+  return WalkWrappedText(x, y, max_width, text,
+                         [&](int cur_x, int /*cur_y*/, char32_t symbol) {
+                           return cur_x + metrics_.SymbolWidth(symbol);
+                         });
 }
 
 auto Buffer::LastVisibleColumn(int y, ColorMode mode) const -> int {
@@ -482,7 +373,7 @@ auto Buffer::LastVisibleColumn(int y, ColorMode mode) const -> int {
 }
 
 auto Buffer::Render(OutputBufferRef out, ColorMode mode) const -> void {
-  std::array<char, MaxUtf8Bytes> storage;
+  Utf8Storage storage;
 
   // The style a terminal starts a row in, and the one each row leaves it in.
   const Style default_style;

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -5,9 +5,11 @@
 #ifndef CARBON_COMMON_TERMINAL_BUFFER_H_
 #define CARBON_COMMON_TERMINAL_BUFFER_H_
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 
+#include "common/check.h"
 #include "common/filesystem.h"
 #include "common/terminal/capabilities.h"
 #include "common/terminal/color.h"
@@ -20,6 +22,31 @@
 
 namespace Carbon::Terminal {
 
+// Where a line stops within the cell at one of its ends.
+//
+// A line runs between points, and in a grid of cells the two points it can
+// name are a cell's center and a cell's outer edge. Which one an end is decides
+// what a line meeting it there becomes: a line ending at a center and another
+// leaving that center form a corner, while a line running out through an edge
+// carries on past whatever meets it, which is a tee.
+//
+// This is the distinction a vector graphics stroke draws between a butt cap and
+// a square cap, where the square cap extends the stroke by half its width past
+// the endpoint. Half a stroke here is half a cell.
+//
+// Unicode has a glyph for a line reaching only the middle of its cell (U+2574
+// through U+2577), so a `Center` end is drawn as one and the reader sees where
+// the line really stops rather than having to infer it from the junctions. With
+// `Charset::Ascii` there is nothing to draw half a line with, so both ends fill
+// their cell and only the junctions around them say which was which.
+enum class LineEnd : int8_t {
+  // The line stops at the center of its end cell. Lines meeting there corner.
+  Center,
+  // The line runs out through the outer edge of its end cell, joining whatever
+  // is beyond it. Lines meeting there tee.
+  Edge,
+};
+
 // A grid of styled cells staged for rendering to a terminal.
 //
 // Coordinates are 0-based with (0, 0) at the top left, `x` counting terminal
@@ -28,6 +55,21 @@ namespace Carbon::Terminal {
 // A buffer renders once, top to bottom, the way a compiler writes diagnostics.
 // There is no cursor addressing and nothing is ever redrawn, so a rendered
 // buffer is just as valid in a file or a pipe as on a terminal.
+//
+// Every row is a line, ended by a newline of its own, so nothing is left for
+// the terminal to break. A break introduced to fit a width is an ordinary
+// newline like any other, which is what lets wrapped text carry an indent or
+// sit in a column beside a gutter: a terminal wrapping a row of its own accord
+// continues at column zero, under the gutter rather than beside it. It also
+// means text copied out of the output holds the lines that were displayed.
+//
+// The cost is that such a break is in whatever a reader copies, so wrapping
+// never puts one inside a word. A path or a URL stays whole and overhangs the
+// width when it doesn't fit, which is what keeps it selectable in one piece and
+// clickable where a terminal recognizes one. Wrapping only adds breaks as well:
+// the newlines already in a caller's text are kept as they are. A row is a row
+// once something is drawn into it, so a break the text ends with closes its
+// last line rather than opening an empty one after it.
 //
 // Staging into a grid lets layout position content directly, rather than
 // interleaving text, padding, and escape sequences as it goes. That separation
@@ -52,16 +94,78 @@ namespace Carbon::Terminal {
 //   precomposed form, so this comes up in ordinary input. Anything with no
 //   printable rendering, including invalid UTF-8, becomes U+FFFD.
 //
-// A buffer grows to hold whatever is drawn into it, in both directions.
-// Nothing is clipped, so a caller never has to work out how wide its output
-// will be before it starts producing it -- a measuring pass that mirrors the
-// drawing pass, and that is wrong whenever the two disagree about a string.
-// What to draw is still the caller's to decide: a terminal's width bounds how
-// much source a snippet shows, not how much the grid can hold.
+// A buffer is `columns()` wide, and that width is the whole point of it: it is
+// what wrapping fits text into, and it comes from the terminal where one was
+// measured and from `DefaultColumns` where none was. Rows are the direction
+// there is no bound in -- a buffer grows downward to whatever is drawn into it,
+// up to `MaxRows` -- so laying out is a question of how many rows something
+// takes, never of how wide the grid will turn out to be.
+//
+// Coordinates are the caller's to get right. Drawing a line outside the width,
+// or starting text outside it, is a programming error and is checked: a caller
+// deciding where to put something already knows the width, since it is what
+// decided the layout, and a drawing that lands outside it is a bug in that
+// layout rather than something to silently clip. Origins are checked against
+// `MaxRows` the same way, though text that runs off the bottom on its own
+// newlines is clipped rather than checked, as an overhang is.
+//
+// A row can still end up wider than `columns()`. Text that starts inside the
+// width may run off the right of it: a quoted source line longer than the room
+// left, a double-width character in the last column, and above all a word
+// wrapping cannot break, which is moved to a row of its own and then overhangs
+// it. Breaking that word is the alternative, and it costs a reader the ability
+// to copy or click it. So `width()` can exceed `columns()`, while nothing is
+// ever drawn left of the origin or beyond `MaxColumns`.
+//
+// A combining mark renders into the cell before it, so one with no cell before
+// it -- at column zero, or on a row nothing has been drawn on -- has nowhere to
+// go and is dropped. That is data rather than a coordinate, which is why it is
+// dropped rather than checked: source files contain such text.
+//
+// TODO: None of this handles bidirectional text. A right-to-left run reorders
+// on screen, so the column a character occupies stops following from the
+// characters before it, which is the assumption every position here rests on:
+// that drawing advances left to right by the width of what was drawn. Getting
+// this right needs the reordering to happen before anything is placed, which
+// makes it a question about where the boundary between a client's layout and
+// this buffer should sit -- whether the buffer takes runs that are already in
+// visual order, or takes logical order and reorders as it draws, and what it
+// then means for a caller to name a column at all. Marking a span and drawing a
+// line under it are the hard cases, since a logically contiguous span need not
+// be contiguous on screen. Worth settling before anything depends on the
+// current answer, which is that text is assumed to be left-to-right throughout.
 class Buffer {
  public:
-  // Where a drawing ended: the row it ended on, and the column after its last
-  // symbol on that row.
+  // The bounds a buffer exists within.
+  //
+  // These are far past anything a terminal displays, and exist so that a cell
+  // index stays representable rather than to ration anything. `columns()` and
+  // every row drawn into are checked against them, so a caller cannot reach
+  // outside them by asking. What can reach `MaxColumns` without being asked for
+  // is a word overhanging the target width, and that alone is clipped rather
+  // than checked, since how far it overhangs is a fact about the text.
+  static constexpr int MaxColumns = 1 << 14;
+  static constexpr int MaxRows = 1 << 16;
+
+  // The most bytes of text one operation draws or measures.
+  //
+  // The column advances by the width of what was drawn whether or not a cell
+  // was written, so without this a long enough run would carry it past what an
+  // `int` holds and come back negative. Far more text than any terminal shows,
+  // and a caller with this much has built it rather than read it off a line.
+  static constexpr int MaxTextBytes = 1 << 24;
+
+  // The widest tab stops a buffer draws to.
+  //
+  // Far past any terminal, and small enough that even text made entirely of
+  // tabs measures into a column an `int` holds: a tab is the one character
+  // that occupies more columns than it does bytes, so this is what bounds
+  // `MaxTextBytes` of them.
+  static constexpr int MaxTabWidth = 64;
+
+  // Where a drawing ended: for text, the row it ended on and the column after
+  // its last code point there; for a line or a box, the cell past the end of
+  // what it drew.
   //
   // Everything that draws returns one, so that a caller placing something
   // after a drawing advances from this rather than measuring the same text a
@@ -74,24 +178,42 @@ class Buffer {
     friend auto operator==(DrawEnd lhs, DrawEnd rhs) -> bool = default;
   };
 
-  // Constructs an empty buffer holding `charset`.
-  explicit Buffer(Charset charset) : Buffer(1, charset) {}
+  // Constructs an empty buffer holding `charset`, laying out for
+  // `DefaultColumns`.
+  explicit Buffer(Charset charset) : Buffer(DefaultColumns, charset) {}
 
-  // Constructs an empty buffer starting `width` columns wide, which must be
-  // positive. The width is a starting size rather than a bound; it grows to
-  // fit. Passing one saves the regrowing, and passing none costs only that.
-  Buffer(int width, Charset charset);
+  // Constructs an empty buffer `columns` wide, which must be in
+  // [1, `MaxColumns`], and whose tabs advance to stops `tab_width` columns
+  // apart.
+  //
+  // The width is what everything drawn into the buffer is laid out for and
+  // checked against, not a starting size. The grid holds it from the start, so
+  // a row is only ever reallocated for something that overhangs it.
+  Buffer(int columns, Charset charset, int tab_width = DefaultTabWidth);
 
-  // Constructs an empty buffer holding `capabilities`'s charset, starting at
-  // its width when there is one to start from.
+  // Constructs an empty buffer holding `capabilities`'s charset and tab stops,
+  // laying out for its width, or for `DefaultColumns` where it has none.
+  //
+  // Both numbers are clamped rather than checked. They describe a terminal
+  // rather than coming from a caller -- `columns` by way of `COLUMNS`, which
+  // anyone can export as anything -- so a value a grid cannot hold is bad input
+  // rather than a mistake, and the nearest usable one lays out no worse than
+  // the fallback would.
   explicit Buffer(const Capabilities& capabilities)
-      : Buffer(capabilities.columns.value_or(1), capabilities.charset) {}
+      : Buffer(std::clamp(capabilities.columns.value_or(DefaultColumns), 1,
+                          MaxColumns),
+               capabilities.charset,
+               std::clamp(capabilities.tab_width, 1, MaxTabWidth)) {}
 
-  // Returns the columns the buffer currently holds, which is at least as many
-  // as anything drawn into it occupies.
+  // Returns the width everything drawn into the buffer is laid out for.
+  auto columns() const -> int { return columns_; }
+
+  // Returns the columns the grid currently holds: `columns()` until something
+  // overhangs it, and at least enough to hold the overhang after that.
   auto width() const -> int { return width_; }
 
-  // Returns the number of rows drawn into so far.
+  // Returns the number of rows the grid holds, which is one past the last row
+  // drawn into.
   auto height() const -> int;
 
   auto charset() const -> Charset { return metrics_.charset(); }
@@ -99,39 +221,49 @@ class Buffer {
   // Returns how text is measured for this buffer's charset.
   //
   // The buffer lays its cells out with this, so a caller deciding where to put
-  // something asks the same thing the drawing will. Most such questions are
-  // about text rather than about a drawing -- how wide a word is, where to cut
-  // a line -- and want this rather than a buffer.
+  // something asks the same thing the drawing will.
   auto metrics() const -> Metrics { return metrics_; }
 
   // Returns where `DrawText` would end for these arguments, without drawing.
   //
   // Measuring and drawing walk the text with the same code, differing only in
   // whether they write a cell, so a layout decision made from this can't
-  // disagree with what drawing then does. Measurement written separately would
-  // have to agree about every string, and the ones it is most likely to get
-  // wrong -- a tab, a newline, a double-width character -- are the ones whose
-  // being wrong is hardest to see.
+  // disagree with what drawing then does.
   //
-  // This is for text that a tab or a newline makes positional. Text without
-  // either is as wide wherever it is drawn, and `Metrics::Width` answers for
-  // it without a buffer to draw into.
+  // This is for text that a tab, a newline, or a carriage return makes
+  // positional. Text with none of them is as wide wherever it is drawn, and
+  // `Metrics::Width` answers for it without a buffer to draw into.
   auto MeasureText(int x, int y, llvm::StringRef text) const -> DrawEnd;
 
   // Returns where `DrawWrappedText` would end for these arguments, without
   // drawing.
-  auto MeasureWrappedText(int x, int y, int max_width,
+  //
+  // The block and the origin are checked as drawing checks them, so measuring
+  // answers only for arguments drawing would accept.
+  auto MeasureWrappedText(int x, int y, int margin, int max_width,
                           llvm::StringRef text) const -> DrawEnd;
 
-  // Draws `symbol` at (x, y), growing the buffer as needed to reach it.
+  // Draws `code_point` at (x, y), which must be inside `columns()` and
+  // `MaxRows`, adding rows as needed to reach it.
   //
   // Returns the column after it, which is `x` again for a combining mark since
-  // one renders into the column before it. A symbol before the buffer's origin
-  // still reports the columns it would have taken, so that text walking a row
-  // stays in step.
-  auto DrawSymbol(int x, int y, char32_t symbol, const Style& style) -> DrawEnd;
+  // one renders into the column before it. A double-width character starting in
+  // the last column is drawn rather than refused, and takes the column after
+  // it: half a character is not something a terminal can render, so the choice
+  // is between the whole of it and none, and this is the same overhang wrapping
+  // allows a word that fits no row.
+  auto DrawCodePoint(int x, int y, char32_t code_point, const Style& style)
+      -> DrawEnd;
 
-  // Draws a horizontal line of `length` columns starting at (x, y).
+  // Draws a horizontal line across `length` columns starting at (x, y).
+  //
+  // By default the line runs between the centers of its first and last cells,
+  // which is what a line connecting two things is: `DrawBox` draws its four
+  // sides this way, and each pair meets at a corner. `LineEnd::Edge` instead
+  // runs that end out through the side of its cell, which is what a line
+  // bounding `length` whole columns of something is, and what makes a line
+  // meeting it there a tee. A line of one column between two centers is a
+  // point, and is drawn as one.
   //
   // Lines join wherever they overlap: a cell records which directions lines
   // leave it in, and its glyph follows from those bits alone, so crossings,
@@ -143,60 +275,106 @@ class Buffer {
   //
   // A cell's style is whatever was drawn there last, so crossing lines of
   // different styles do depend on order.
-  auto DrawHorizontalLine(int x, int y, int length, const Style& style)
-      -> DrawEnd;
+  auto DrawHorizontalLine(int x, int y, int length, const Style& style,
+                          LineEnd start = LineEnd::Center,
+                          LineEnd end = LineEnd::Center) -> DrawEnd;
 
-  // Draws a vertical line of `length` rows starting at (x, y). Returns the row
-  // after it, in the column it ran down.
-  auto DrawVerticalLine(int x, int y, int length, const Style& style)
-      -> DrawEnd;
+  // Draws a vertical line down `length` rows starting at (x, y), with the same
+  // meaning for its ends. Returns the row after it, in the column it ran down.
+  auto DrawVerticalLine(int x, int y, int length, const Style& style,
+                        LineEnd start = LineEnd::Center,
+                        LineEnd end = LineEnd::Center) -> DrawEnd;
 
-  // Draws the outline of a box with its top-left corner at (x, y). Its corners
-  // come out of the four sides meeting. A box with no interior is the single
-  // line that bounds it, and one with no extent draws nothing.
+  // Draws the outline of a box with its top-left corner at (x, y).
+  //
+  // Each side runs between the centers of the cells it ends in, so the four
+  // corners come out of the sides meeting there. A box with no interior is
+  // then the single line that bounds it, and one with no extent in either
+  // direction is a point, without either being a case of its own.
   auto DrawBox(int x, int y, int box_width, int box_height, const Style& style)
       -> DrawEnd;
 
-  // Draws `text` starting at (x, y).
+  // Draws `text` starting at (x, y), which must be inside `columns()`.
+  //
+  // Nothing here wraps, so text with no newline in it runs off the right of the
+  // width when it is longer than the room left, exactly as an overhanging word
+  // does. That is what this is for: a source line is quoted as it was written,
+  // and deciding how much of one to show is the caller's, made against
+  // `columns()` before the quoting starts.
   //
   // Newlines return to column `x` on the next row, carriage returns to column
-  // `x` on the same row, and tabs advance to the next eight-column stop
-  // measured from `x`. Returns where it ended, which for text with a newline
-  // in it is on a later row than it started.
+  // `x` on the same row, and tabs advance to the next tab stop, with stops
+  // measured from `x` so that a quoted source line keeps the tab alignment it
+  // had in the file wherever the quote is placed. Returns where it ended, which
+  // for text with a newline in it is on a later row than it started.
   auto DrawText(int x, int y, llvm::StringRef text, const Style& style)
       -> DrawEnd;
 
-  // Draws `text` starting at (x, y), wrapping it within `max_width` columns.
+  // Draws `text` starting at (x, y), into the block of `max_width` columns
+  // beginning at `margin`.
   //
-  // Wrapping breaks at ASCII spaces and tabs, and only there. A word too long
-  // for a row of its own is moved down to one and then overhangs it: breaking
-  // a path or a type name costs a reader more than the overhang does, and the
-  // buffer grows to hold what overhangs. Spaces are dropped wherever they
-  // would begin a row, including at the start of the text, so wrapped text
-  // stays aligned to `x`.
+  // The block must lie within `columns()` and `x` within the block, so
+  // `0 <= margin <= x < margin + max_width <= columns()`. A block is a division
+  // of the width rather than something that can exceed it: what a caller wants
+  // when it has nothing to divide is `max_width` of `columns() - margin`, the
+  // whole of what is left.
   //
-  // Newlines break the line as they do in `DrawText`, and carriage returns are
-  // dropped so that CRLF endings break exactly once. Tabs are break
-  // opportunities that render as a single space rather than advancing to a tab
-  // stop, unlike in `DrawText`, because a tab stop is measured from the start
-  // of a line and wrapped text has no fixed one.
+  // The block is what the text wraps within, and (x, y) is only where this run
+  // of it starts: rows after the first begin at `margin`, and how much room a
+  // row has is measured from there. A block whose spans are styled differently
+  // is drawn as one call per span, each starting where the last ended and all
+  // naming the same margin and width. Passing `x` as the margin draws a block
+  // in one call.
   //
-  // Any positive `max_width` works, however large, and one no row can reach
-  // wraps nothing. That is what a caller with no width to fit passes, rather
-  // than there being a second way to draw for having none.
+  // Wrapping breaks at ASCII spaces, tabs, and carriage returns, and only
+  // there. A word here is whatever lies between two of them, so a URL is one
+  // word, and one too long for a row of its own is moved down to one and then
+  // overhangs it rather than being broken.
   //
-  // Returns where it ended, which is (x, y) when `max_width` isn't positive,
-  // in which case nothing is drawn.
-  auto DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
-                       const Style& style) -> DrawEnd;
+  // Spaces that would begin a wrapped row are dropped, so a row the width
+  // happened to break stays aligned to the margin; spaces the text opens with,
+  // or that follow a newline in it, are kept, since those are indentation the
+  // caller wrote.
+  //
+  // Newlines are breaks the caller already made, and are kept as they are:
+  // wrapping only adds breaks to the text it is given. They break the line as a
+  // wrap does, continuing at `margin` on the next row, and carriage returns are
+  // dropped so that CRLF endings break exactly once.
+  //
+  // A tab is both a break opportunity and a jump to the next tab stop, with
+  // stops measured from `margin` rather than from `x`. The margin is the one
+  // column every row of the block begins at, so the stops are the same on each
+  // of them and a tabbed column stays a column however the text wraps; stops
+  // from `x` would move with the span that happened to be drawn first. A tab
+  // that would reach past the block stops at its edge, like the spaces do,
+  // leaving the word after it to wrap.
+  //
+  // `DrawText` is the way to draw text that should not wrap at all, and differs
+  // in more than that: it keeps every space, counts tab stops from `x` since it
+  // has no block to count them from, and returns to column `x` on a carriage
+  // return rather than dropping it.
+  //
+  // Returns where it ended.
+  //
+  // TODO: There is no mode that reflows, treating the newlines in `text` as
+  // breaks to be chosen again rather than kept. Text that arrives wrapped to
+  // some other width keeps that wrapping, which is wrong for it wherever that
+  // width isn't the one it is being drawn into. Add one when there is a caller
+  // with such text, since which breaks a reflow may discard -- every newline,
+  // or only those a previous wrapping introduced -- is a question about where
+  // that text came from.
+  auto DrawWrappedText(int x, int y, int margin, int max_width,
+                       llvm::StringRef text, const Style& style) -> DrawEnd;
 
   // Renders the grid, appending the bytes that draw it to `out`.
   //
   // Each row ends in a newline, with trailing blank cells dropped so output
-  // carries no invisible padding, and with any style turned off so it can't
-  // bleed into whatever is printed next. Color is chosen here rather than at
-  // construction because it affects only how cells are serialized, while the
-  // charset decides how content is laid out into them.
+  // carries no invisible padding. The rendering ends with the style turned off
+  // so nothing bleeds into what is printed next, and a style that paints blank
+  // cells is turned off at each row's end so a background does not run to the
+  // right edge. Color is chosen here rather than at construction because it
+  // affects only how cells are serialized, while the charset decides how
+  // content is laid out into them.
   auto Render(OutputBufferRef out, ColorMode mode) const -> void;
 
   // Renders the grid and writes it to `file`.
@@ -210,30 +388,45 @@ class Buffer {
       -> ErrorOr<Success, Filesystem::FdError>;
 
  private:
-  // The directions in which drawn lines leave a cell. A cell's glyph is a
-  // function of these bits alone.
+  // The directions in which drawn lines leave a cell, and whether the cell
+  // holds line art at all. A cell's glyph is a function of the directions
+  // alone.
   enum LineDirection : uint8_t {
     LineLeft = 1 << 0,
     LineRight = 1 << 1,
     LineUp = 1 << 2,
     LineDown = 1 << 3,
+    LineDirections = 0xf,
+    // Set on every cell line drawing writes. A cell can hold line art and no
+    // directions -- a line between one center and itself is a point -- and
+    // without this such a cell would be indistinguishable from one holding
+    // text, so nothing drawn later would join it.
+    LineCell = 1 << 4,
   };
 
   struct Cell {
     // The code point rendered here. For a cell with `lines` set, this is
     // derived from those bits and the charset.
-    char32_t symbol = ' ';
+    char32_t code_point = ' ';
 
     Style style;
 
-    // Which directions drawn lines leave this cell in, or zero for a cell
-    // holding text.
+    // Which directions drawn lines leave this cell in, with `LineCell` set,
+    // or zero for a cell holding text.
     uint8_t lines = 0;
 
-    // Whether this cell is the right half of a double-width symbol, and so
+    // Whether this cell is the right half of a double-width character, and so
     // renders nothing of its own.
     bool is_continuation = false;
   };
+
+  // Checks that `text` is short enough to measure without overflowing a column.
+  static auto CheckTextSize(llvm::StringRef text) -> void {
+    CARBON_CHECK(text.size() <= MaxTextBytes,
+                 "Laying out {0} bytes of text is past the {1} one operation "
+                 "handles.",
+                 text.size(), MaxTextBytes);
+  }
 
   auto CellIndex(int x, int y) const -> int { return y * width_ + x; }
   auto CellAt(int x, int y) -> Cell& { return cells_[CellIndex(x, y)]; }
@@ -241,30 +434,48 @@ class Buffer {
     return cells_[CellIndex(x, y)];
   }
 
+  // Checks that (x, y) is somewhere a drawing may start.
+  auto CheckOrigin(int x, int y) const -> void {
+    CARBON_CHECK(
+        x >= 0 && x < columns_ && y >= 0 && y < MaxRows,
+        "Drawing at ({0}, {1}) is outside the {2} columns and {3} rows "
+        "a buffer covers.",
+        x, y, columns_, MaxRows);
+  }
+
+  // Places `code_point` at (x, y) without checking it against the target width
+  // or `MaxRows`, which text reaches on its own by overhanging or by carrying
+  // newlines. Past either, nothing is drawn and the column still advances. The
+  // coordinates must be non-negative, which follows from the origin the walk
+  // was checked at.
+  auto PlaceCodePoint(int x, int y, char32_t code_point, const Style& style)
+      -> int;
+
   // The walks behind the text operations, over which drawing and measuring are
-  // the same code. `place` is called with each symbol and where it goes, and
-  // returns the column after it: `DrawSymbol` when drawing, and the width alone
-  // when measuring.
+  // the same code. `place` is called with each code point and where it goes,
+  // and returns the column after it: `PlaceCodePoint` when drawing, and the
+  // width alone when measuring.
   template <typename PlaceFn>
   auto WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
       -> DrawEnd;
   template <typename PlaceFn>
-  auto WalkWrappedText(int x, int y, int max_width, llvm::StringRef text,
-                       PlaceFn place) const -> DrawEnd;
+  auto WalkWrappedText(int x, int y, int margin, int max_width,
+                       llvm::StringRef text, PlaceFn place) const -> DrawEnd;
 
   // Adds rows until row `y` exists.
   auto EnsureRow(int y) -> void;
 
-  // Widens the buffer until column `x` exists, reflowing the rows it already
-  // holds, which are stored back to back.
+  // Widens the grid until column `x` exists, reflowing the rows it already
+  // holds, which are stored back to back. Only something overhanging the target
+  // width reaches past it, so this runs for nothing else.
   auto EnsureWidth(int x) -> void;
 
   // Resets the cells in row `y` spanning columns [x, x + width), along with
-  // either half of a double-width symbol that straddles the range's edges.
+  // either half of a double-width character that straddles the range's edges.
   auto ClearCells(int x, int y, int width) -> void;
 
-  // Appends `symbol` to the marks rendered with the cell before column `x`.
-  auto AttachCombiningMark(int x, int y, char32_t symbol) -> void;
+  // Appends `code_point` to the marks rendered with the cell before column `x`.
+  auto AttachCombiningMark(int x, int y, char32_t code_point) -> void;
 
   // Adds `directions` to the lines through (x, y) and updates its glyph.
   auto DrawLine(int x, int y, uint8_t directions, const Style& style) -> void;
@@ -273,7 +484,12 @@ class Buffer {
   // -1 when the row renders nothing.
   auto LastVisibleColumn(int y, ColorMode mode) const -> int;
 
+  // The width laid out for, and the width the grid holds. They differ only
+  // where something overhung the first.
+  int columns_;
   int width_;
+
+  int tab_width_;
   Metrics metrics_;
 
   llvm::SmallVector<Cell, 0> cells_;

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -132,8 +132,7 @@ enum class LineEnd : int8_t {
 // visual order, or takes logical order and reorders as it draws, and what it
 // then means for a caller to name a column at all. Marking a span and drawing a
 // line under it are the hard cases, since a logically contiguous span need not
-// be contiguous on screen. Worth settling before anything depends on the
-// current answer, which is that text is assumed to be left-to-right throughout.
+// be contiguous on screen.
 class Buffer {
  public:
   // The bounds a buffer exists within.

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -82,10 +82,10 @@ class Buffer {
   // fit. Passing one saves the regrowing, and passing none costs only that.
   Buffer(int width, Charset charset);
 
-  // Constructs an empty buffer starting at `capabilities`'s width and holding
-  // its charset.
+  // Constructs an empty buffer holding `capabilities`'s charset, starting at
+  // its width when there is one to start from.
   explicit Buffer(const Capabilities& capabilities)
-      : Buffer(capabilities.columns, capabilities.charset) {}
+      : Buffer(capabilities.columns.value_or(1), capabilities.charset) {}
 
   // Returns the columns the buffer currently holds, which is at least as many
   // as anything drawn into it occupies.
@@ -180,6 +180,10 @@ class Buffer {
   // opportunities that render as a single space rather than advancing to a tab
   // stop, unlike in `DrawText`, because a tab stop is measured from the start
   // of a line and wrapped text has no fixed one.
+  //
+  // Any positive `max_width` works, however large, and one no row can reach
+  // wraps nothing. That is what a caller with no width to fit passes, rather
+  // than there being a second way to draw for having none.
   //
   // Returns where it ended, which is (x, y) when `max_width` isn't positive,
   // in which case nothing is drawn.

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -11,6 +11,7 @@
 #include "common/filesystem.h"
 #include "common/terminal/capabilities.h"
 #include "common/terminal/color.h"
+#include "common/terminal/metrics.h"
 #include "common/terminal/output_buffer_ref.h"
 #include "common/terminal/style.h"
 #include "llvm/ADT/DenseMap.h"
@@ -22,10 +23,7 @@ namespace Carbon::Terminal {
 // A grid of styled cells staged for rendering to a terminal.
 //
 // Coordinates are 0-based with (0, 0) at the top left, `x` counting terminal
-// columns and `y` counting rows. Width is fixed at construction to match the
-// terminal, and drawing past it clips. Height grows to fit whatever is drawn,
-// so layout code doesn't need to know how tall its output is before producing
-// it.
+// columns and `y` counting rows.
 //
 // A buffer renders once, top to bottom, the way a compiler writes diagnostics.
 // There is no cursor addressing and nothing is ever redrawn, so a rendered
@@ -53,6 +51,7 @@ namespace Carbon::Terminal {
 //   form C, which still spells out marks for characters that have no
 //   precomposed form, so this comes up in ordinary input. Anything with no
 //   printable rendering, including invalid UTF-8, becomes U+FFFD.
+//
 // A buffer grows to hold whatever is drawn into it, in both directions.
 // Nothing is clipped, so a caller never has to work out how wide its output
 // will be before it starts producing it -- a measuring pass that mirrors the
@@ -66,10 +65,8 @@ class Buffer {
   //
   // Everything that draws returns one, so that a caller placing something
   // after a drawing advances from this rather than measuring the same text a
-  // second time. Measuring and drawing would otherwise have to agree about
-  // every string, and where they don't -- a tab or a newline, which
-  // `MeasureWidth` counts as one column and drawing interprets -- the caller
-  // is silently wrong.
+  // second time. The `Measure` operations return one too, and answer for text
+  // that hasn't been drawn yet what drawing it would answer.
   struct DrawEnd {
     int x;
     int y;
@@ -97,13 +94,34 @@ class Buffer {
   // Returns the number of rows drawn into so far.
   auto height() const -> int;
 
-  auto charset() const -> Charset { return charset_; }
+  auto charset() const -> Charset { return metrics_.charset(); }
 
-  // Returns the columns `text` occupies, measured as text rather than as
-  // something drawn: newlines and tabs count as one column each, where drawing
-  // interprets both. Use the `DrawEnd` a drawing returns to find out where it
-  // actually went; this is for laying out what hasn't been drawn yet.
-  auto MeasureWidth(llvm::StringRef text) const -> int;
+  // Returns how text is measured for this buffer's charset.
+  //
+  // The buffer lays its cells out with this, so a caller deciding where to put
+  // something asks the same thing the drawing will. Most such questions are
+  // about text rather than about a drawing -- how wide a word is, where to cut
+  // a line -- and want this rather than a buffer.
+  auto metrics() const -> Metrics { return metrics_; }
+
+  // Returns where `DrawText` would end for these arguments, without drawing.
+  //
+  // Measuring and drawing walk the text with the same code, differing only in
+  // whether they write a cell, so a layout decision made from this can't
+  // disagree with what drawing then does. Measurement written separately would
+  // have to agree about every string, and the ones it is most likely to get
+  // wrong -- a tab, a newline, a double-width character -- are the ones whose
+  // being wrong is hardest to see.
+  //
+  // This is for text that a tab or a newline makes positional. Text without
+  // either is as wide wherever it is drawn, and `Metrics::Width` answers for
+  // it without a buffer to draw into.
+  auto MeasureText(int x, int y, llvm::StringRef text) const -> DrawEnd;
+
+  // Returns where `DrawWrappedText` would end for these arguments, without
+  // drawing.
+  auto MeasureWrappedText(int x, int y, int max_width,
+                          llvm::StringRef text) const -> DrawEnd;
 
   // Draws `symbol` at (x, y), growing the buffer as needed to reach it.
   //
@@ -219,14 +237,16 @@ class Buffer {
     return cells_[CellIndex(x, y)];
   }
 
-  // Removes the next symbol from `text`, which must not be empty, and returns
-  // it: one byte under `Charset::Ascii`, and one decoded code point under
-  // `Charset::Utf8`.
-  auto TakeSymbol(llvm::StringRef& text) const -> char32_t;
-
-  // Returns the columns `symbol` occupies once drawn, which is what
-  // `DrawSymbol` returns for it.
-  auto SymbolWidth(char32_t symbol) const -> int;
+  // The walks behind the text operations, over which drawing and measuring are
+  // the same code. `place` is called with each symbol and where it goes, and
+  // returns the column after it: `DrawSymbol` when drawing, and the width alone
+  // when measuring.
+  template <typename PlaceFn>
+  auto WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
+      -> DrawEnd;
+  template <typename PlaceFn>
+  auto WalkWrappedText(int x, int y, int max_width, llvm::StringRef text,
+                       PlaceFn place) const -> DrawEnd;
 
   // Adds rows until row `y` exists.
   auto EnsureRow(int y) -> void;
@@ -250,7 +270,7 @@ class Buffer {
   auto LastVisibleColumn(int y, ColorMode mode) const -> int;
 
   int width_;
-  Charset charset_;
+  Metrics metrics_;
 
   llvm::SmallVector<Cell, 0> cells_;
 

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -1,0 +1,226 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_TERMINAL_BUFFER_H_
+#define CARBON_COMMON_TERMINAL_BUFFER_H_
+
+#include <cstdint>
+#include <string>
+
+#include "common/filesystem.h"
+#include "common/terminal/capabilities.h"
+#include "common/terminal/color.h"
+#include "common/terminal/output_buffer_ref.h"
+#include "common/terminal/style.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace Carbon::Terminal {
+
+// A grid of styled cells staged for rendering to a terminal.
+//
+// Coordinates are 0-based with (0, 0) at the top left, `x` counting terminal
+// columns and `y` counting rows. Width is fixed at construction to match the
+// terminal, and drawing past it clips. Height grows to fit whatever is drawn,
+// so layout code doesn't need to know how tall its output is before producing
+// it.
+//
+// A buffer renders once, top to bottom, the way a compiler writes diagnostics.
+// There is no cursor addressing and nothing is ever redrawn, so a rendered
+// buffer is just as valid in a file or a pipe as on a terminal.
+//
+// Staging into a grid lets layout position content directly, rather than
+// interleaving text, padding, and escape sequences as it goes. That separation
+// is what makes the two hard parts tractable: escape sequences are minimized
+// once, in `Render`, and the drawing APIs reason about columns on screen rather
+// than bytes in a stream.
+//
+// Which bytes make up a column depends on the charset, and the buffer handles
+// that rather than leaving it to callers, because getting it wrong misaligns
+// everything downstream of it:
+//
+// - Under `Charset::Ascii` no UTF-8 processing happens at all. Every byte is
+//   one column, exactly as a terminal decoding some single-byte encoding will
+//   treat it, and bytes outside printable ASCII are replaced with `?` because
+//   there is no telling what such a terminal would draw for them.
+// - Under `Charset::Utf8` bytes are decoded as UTF-8. Double-width characters
+//   occupy both of the columns they will really take, and drawing over either
+//   column erases the whole character instead of leaving half of one behind.
+//   Combining marks render into the column before them, so a base character
+//   and its marks stay in one cell. Carbon source is in Unicode normalization
+//   form C, which still spells out marks for characters that have no
+//   precomposed form, so this comes up in ordinary input. Anything with no
+//   printable rendering, including invalid UTF-8, becomes U+FFFD.
+class Buffer {
+ public:
+  // Constructs an empty buffer `width` columns wide, which must be positive.
+  Buffer(int width, Charset charset);
+
+  // Constructs an empty buffer sized and encoded for `capabilities`.
+  explicit Buffer(const Capabilities& capabilities)
+      : Buffer(capabilities.columns, capabilities.charset) {}
+
+  auto width() const -> int { return width_; }
+
+  // Returns the number of rows drawn into so far.
+  auto height() const -> int;
+
+  auto charset() const -> Charset { return charset_; }
+
+  // Returns the columns `text` occupies when drawn into this buffer.
+  //
+  // Newlines and tabs are not interpreted; they count as one column each, the
+  // same as any other character with no rendering of its own.
+  auto MeasureWidth(llvm::StringRef text) const -> int;
+
+  // Draws `symbol` at (x, y), adding rows as needed to reach `y`.
+  //
+  // Returns the columns it occupies, which is what a caller walking across a
+  // row should advance by. That is zero only for a combining mark, and is
+  // otherwise the symbol's width whether or not it was actually drawn, so that
+  // clipping a symbol doesn't shift what comes after it.
+  auto DrawSymbol(int x, int y, char32_t symbol, const Style& style) -> int;
+
+  // Draws a horizontal line of `length` columns starting at (x, y).
+  //
+  // Lines join wherever they overlap: a cell records which directions lines
+  // leave it in, and its glyph follows from those bits alone, so crossings,
+  // corners, and tees all appear without being asked for and whatever order
+  // the lines were drawn in. This is the only way to produce a junction, and
+  // it suffices because a junction in real line art always has the lines that
+  // imply it running through it. Only line drawing records directions, so text
+  // containing `-` or `+` is never redrawn as line art.
+  //
+  // A cell's style is whatever was drawn there last, so crossing lines of
+  // different styles do depend on order.
+  auto DrawHorizontalLine(int x, int y, int length, const Style& style) -> void;
+
+  // Draws a vertical line of `length` rows starting at (x, y).
+  auto DrawVerticalLine(int x, int y, int length, const Style& style) -> void;
+
+  // Draws the outline of a box with its top-left corner at (x, y). Its corners
+  // come out of the four sides meeting. A box with no interior is the single
+  // line that bounds it, and one with no extent draws nothing.
+  auto DrawBox(int x, int y, int box_width, int box_height, const Style& style)
+      -> void;
+
+  // Draws `text` starting at (x, y).
+  //
+  // Newlines return to column `x` on the next row, carriage returns to column
+  // `x` on the same row, and tabs advance to the next eight-column stop
+  // measured from `x`. Returns the number of rows spanned, counting the row
+  // the text ends on.
+  auto DrawText(int x, int y, llvm::StringRef text, const Style& style) -> int;
+
+  // Draws `text` starting at (x, y), wrapping it within `max_width` columns.
+  //
+  // Wrapping breaks at ASCII spaces and tabs. A word too long for a row of its
+  // own is moved down and then broken as it is drawn, and a symbol wider than
+  // `max_width` is dropped, since no row could hold it. Spaces are dropped
+  // wherever they would begin a row, including at the start of the text, so
+  // wrapped text stays aligned to `x`.
+  //
+  // Newlines break the line as they do in `DrawText`, and carriage returns are
+  // dropped so that CRLF endings break exactly once. Tabs are break
+  // opportunities that render as a single space rather than advancing to a tab
+  // stop, unlike in `DrawText`, because a tab stop is measured from the start
+  // of a line and wrapped text has no fixed one.
+  //
+  // Returns the number of rows spanned, or zero when `max_width` isn't
+  // positive, in which case nothing is drawn.
+  auto DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
+                       const Style& style) -> int;
+
+  // Renders the grid, appending the bytes that draw it to `out`.
+  //
+  // Each row ends in a newline, with trailing blank cells dropped so output
+  // carries no invisible padding, and with any style turned off so it can't
+  // bleed into whatever is printed next. Color is chosen here rather than at
+  // construction because it affects only how cells are serialized, while the
+  // charset decides how content is laid out into them.
+  auto Render(OutputBufferRef out, ColorMode mode) const -> void;
+
+  // Renders the grid and writes it to `file`.
+  //
+  // The whole grid goes out in one `write` where the destination accepts it,
+  // which is what gives the output whatever atomicity the descriptor offers
+  // against other writers: a terminal or a pipe interleaves at write
+  // boundaries, so one call per rendered buffer is the most that can be had
+  // without a lock.
+  auto WriteTo(Filesystem::WriteFileRef file, ColorMode mode) const
+      -> ErrorOr<Success, Filesystem::FdError>;
+
+ private:
+  // The directions in which drawn lines leave a cell. A cell's glyph is a
+  // function of these bits alone.
+  enum LineDirection : uint8_t {
+    LineLeft = 1 << 0,
+    LineRight = 1 << 1,
+    LineUp = 1 << 2,
+    LineDown = 1 << 3,
+  };
+
+  struct Cell {
+    // The code point rendered here. For a cell with `lines` set, this is
+    // derived from those bits and the charset.
+    char32_t symbol = ' ';
+
+    Style style;
+
+    // Which directions drawn lines leave this cell in, or zero for a cell
+    // holding text.
+    uint8_t lines = 0;
+
+    // Whether this cell is the right half of a double-width symbol, and so
+    // renders nothing of its own.
+    bool is_continuation = false;
+  };
+
+  auto CellIndex(int x, int y) const -> int { return y * width_ + x; }
+  auto CellAt(int x, int y) -> Cell& { return cells_[CellIndex(x, y)]; }
+  auto CellAt(int x, int y) const -> const Cell& {
+    return cells_[CellIndex(x, y)];
+  }
+
+  // Removes the next symbol from `text`, which must not be empty, and returns
+  // it: one byte under `Charset::Ascii`, and one decoded code point under
+  // `Charset::Utf8`.
+  auto TakeSymbol(llvm::StringRef& text) const -> char32_t;
+
+  // Returns the columns `symbol` occupies once drawn, which is what
+  // `DrawSymbol` returns for it.
+  auto SymbolWidth(char32_t symbol) const -> int;
+
+  // Adds rows until row `y` exists.
+  auto EnsureRow(int y) -> void;
+
+  // Resets the cells in row `y` spanning columns [x, x + width), along with
+  // either half of a double-width symbol that straddles the range's edges.
+  auto ClearCells(int x, int y, int width) -> void;
+
+  // Appends `symbol` to the marks rendered with the cell before column `x`.
+  auto AttachCombiningMark(int x, int y, char32_t symbol) -> void;
+
+  // Adds `directions` to the lines through (x, y) and updates its glyph.
+  auto DrawLine(int x, int y, uint8_t directions, const Style& style) -> void;
+
+  // Returns the last column in row `y` that renders anything under `mode`, or
+  // -1 when the row renders nothing.
+  auto LastVisibleColumn(int y, ColorMode mode) const -> int;
+
+  int width_;
+  Charset charset_;
+
+  llvm::SmallVector<Cell, 0> cells_;
+
+  // Combining marks, as UTF-8, for the few cells that have any, keyed by cell
+  // index. Kept out of `Cell` so that the common case of no marks costs
+  // nothing per cell. Always empty under `Charset::Ascii`.
+  llvm::DenseMap<int, std::string> combining_marks_;
+};
+
+}  // namespace Carbon::Terminal
+
+#endif  // CARBON_COMMON_TERMINAL_BUFFER_H_

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -150,11 +150,12 @@ class Buffer {
 
   // Draws `text` starting at (x, y), wrapping it within `max_width` columns.
   //
-  // Wrapping breaks at ASCII spaces and tabs. A word too long for a row of its
-  // own is moved down and then broken as it is drawn, and a symbol wider than
-  // `max_width` is dropped, since no row could hold it. Spaces are dropped
-  // wherever they would begin a row, including at the start of the text, so
-  // wrapped text stays aligned to `x`.
+  // Wrapping breaks at ASCII spaces and tabs, and only there. A word too long
+  // for a row of its own is moved down to one and then overhangs it: breaking
+  // a path or a type name costs a reader more than the overhang does, and the
+  // buffer grows to hold what overhangs. Spaces are dropped wherever they
+  // would begin a row, including at the start of the text, so wrapped text
+  // stays aligned to `x`.
   //
   // Newlines break the line as they do in `DrawText`, and carriage returns are
   // dropped so that CRLF endings break exactly once. Tabs are break

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -53,15 +53,29 @@ namespace Carbon::Terminal {
 //   form C, which still spells out marks for characters that have no
 //   precomposed form, so this comes up in ordinary input. Anything with no
 //   printable rendering, including invalid UTF-8, becomes U+FFFD.
+// A buffer grows to hold whatever is drawn into it, in both directions.
+// Nothing is clipped, so a caller never has to work out how wide its output
+// will be before it starts producing it -- a measuring pass that mirrors the
+// drawing pass, and that is wrong whenever the two disagree about a string.
+// What to draw is still the caller's to decide: a terminal's width bounds how
+// much source a snippet shows, not how much the grid can hold.
 class Buffer {
  public:
-  // Constructs an empty buffer `width` columns wide, which must be positive.
+  // Constructs an empty buffer holding `charset`.
+  explicit Buffer(Charset charset) : Buffer(1, charset) {}
+
+  // Constructs an empty buffer starting `width` columns wide, which must be
+  // positive. The width is a starting size rather than a bound; it grows to
+  // fit. Passing one saves the regrowing, and passing none costs only that.
   Buffer(int width, Charset charset);
 
-  // Constructs an empty buffer sized and encoded for `capabilities`.
+  // Constructs an empty buffer starting at `capabilities`'s width and holding
+  // its charset.
   explicit Buffer(const Capabilities& capabilities)
       : Buffer(capabilities.columns, capabilities.charset) {}
 
+  // Returns the columns the buffer currently holds, which is at least as many
+  // as anything drawn into it occupies.
   auto width() const -> int { return width_; }
 
   // Returns the number of rows drawn into so far.
@@ -195,6 +209,10 @@ class Buffer {
 
   // Adds rows until row `y` exists.
   auto EnsureRow(int y) -> void;
+
+  // Widens the buffer until column `x` exists, reflowing the rows it already
+  // holds, which are stored back to back.
+  auto EnsureWidth(int x) -> void;
 
   // Resets the cells in row `y` spanning columns [x, x + width), along with
   // either half of a double-width symbol that straddles the range's edges.

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -61,6 +61,22 @@ namespace Carbon::Terminal {
 // much source a snippet shows, not how much the grid can hold.
 class Buffer {
  public:
+  // Where a drawing ended: the row it ended on, and the column after its last
+  // symbol on that row.
+  //
+  // Everything that draws returns one, so that a caller placing something
+  // after a drawing advances from this rather than measuring the same text a
+  // second time. Measuring and drawing would otherwise have to agree about
+  // every string, and where they don't -- a tab or a newline, which
+  // `MeasureWidth` counts as one column and drawing interprets -- the caller
+  // is silently wrong.
+  struct DrawEnd {
+    int x;
+    int y;
+
+    friend auto operator==(DrawEnd lhs, DrawEnd rhs) -> bool = default;
+  };
+
   // Constructs an empty buffer holding `charset`.
   explicit Buffer(Charset charset) : Buffer(1, charset) {}
 
@@ -83,19 +99,19 @@ class Buffer {
 
   auto charset() const -> Charset { return charset_; }
 
-  // Returns the columns `text` occupies when drawn into this buffer.
-  //
-  // Newlines and tabs are not interpreted; they count as one column each, the
-  // same as any other character with no rendering of its own.
+  // Returns the columns `text` occupies, measured as text rather than as
+  // something drawn: newlines and tabs count as one column each, where drawing
+  // interprets both. Use the `DrawEnd` a drawing returns to find out where it
+  // actually went; this is for laying out what hasn't been drawn yet.
   auto MeasureWidth(llvm::StringRef text) const -> int;
 
-  // Draws `symbol` at (x, y), adding rows as needed to reach `y`.
+  // Draws `symbol` at (x, y), growing the buffer as needed to reach it.
   //
-  // Returns the columns it occupies, which is what a caller walking across a
-  // row should advance by. That is zero only for a combining mark, and is
-  // otherwise the symbol's width whether or not it was actually drawn, so that
-  // clipping a symbol doesn't shift what comes after it.
-  auto DrawSymbol(int x, int y, char32_t symbol, const Style& style) -> int;
+  // Returns the column after it, which is `x` again for a combining mark since
+  // one renders into the column before it. A symbol before the buffer's origin
+  // still reports the columns it would have taken, so that text walking a row
+  // stays in step.
+  auto DrawSymbol(int x, int y, char32_t symbol, const Style& style) -> DrawEnd;
 
   // Draws a horizontal line of `length` columns starting at (x, y).
   //
@@ -109,24 +125,28 @@ class Buffer {
   //
   // A cell's style is whatever was drawn there last, so crossing lines of
   // different styles do depend on order.
-  auto DrawHorizontalLine(int x, int y, int length, const Style& style) -> void;
+  auto DrawHorizontalLine(int x, int y, int length, const Style& style)
+      -> DrawEnd;
 
-  // Draws a vertical line of `length` rows starting at (x, y).
-  auto DrawVerticalLine(int x, int y, int length, const Style& style) -> void;
+  // Draws a vertical line of `length` rows starting at (x, y). Returns the row
+  // after it, in the column it ran down.
+  auto DrawVerticalLine(int x, int y, int length, const Style& style)
+      -> DrawEnd;
 
   // Draws the outline of a box with its top-left corner at (x, y). Its corners
   // come out of the four sides meeting. A box with no interior is the single
   // line that bounds it, and one with no extent draws nothing.
   auto DrawBox(int x, int y, int box_width, int box_height, const Style& style)
-      -> void;
+      -> DrawEnd;
 
   // Draws `text` starting at (x, y).
   //
   // Newlines return to column `x` on the next row, carriage returns to column
   // `x` on the same row, and tabs advance to the next eight-column stop
-  // measured from `x`. Returns the number of rows spanned, counting the row
-  // the text ends on.
-  auto DrawText(int x, int y, llvm::StringRef text, const Style& style) -> int;
+  // measured from `x`. Returns where it ended, which for text with a newline
+  // in it is on a later row than it started.
+  auto DrawText(int x, int y, llvm::StringRef text, const Style& style)
+      -> DrawEnd;
 
   // Draws `text` starting at (x, y), wrapping it within `max_width` columns.
   //
@@ -142,10 +162,10 @@ class Buffer {
   // stop, unlike in `DrawText`, because a tab stop is measured from the start
   // of a line and wrapped text has no fixed one.
   //
-  // Returns the number of rows spanned, or zero when `max_width` isn't
-  // positive, in which case nothing is drawn.
+  // Returns where it ended, which is (x, y) when `max_width` isn't positive,
+  // in which case nothing is drawn.
   auto DrawWrappedText(int x, int y, int max_width, llvm::StringRef text,
-                       const Style& style) -> int;
+                       const Style& style) -> DrawEnd;
 
   // Renders the grid, appending the bytes that draw it to `out`.
   //

--- a/common/terminal/buffer.h
+++ b/common/terminal/buffer.h
@@ -232,7 +232,14 @@ class Buffer {
   // This is for text that a tab, a newline, or a carriage return makes
   // positional. Text with none of them is as wide wherever it is drawn, and
   // `Metrics::Width` answers for it without a buffer to draw into.
-  auto MeasureText(int x, int y, llvm::StringRef text) const -> DrawEnd;
+  auto MeasureText(int x, int y, int margin, llvm::StringRef text) const
+      -> DrawEnd;
+
+  // Returns where the `DrawText` taking no margin would end, which draws `text`
+  // as text of its own beginning at (x, y).
+  auto MeasureText(int x, int y, llvm::StringRef text) const -> DrawEnd {
+    return MeasureText(x, y, x, text);
+  }
 
   // Returns where `DrawWrappedText` would end for these arguments, without
   // drawing.
@@ -241,6 +248,13 @@ class Buffer {
   // answers only for arguments drawing would accept.
   auto MeasureWrappedText(int x, int y, int margin, int max_width,
                           llvm::StringRef text) const -> DrawEnd;
+
+  // Returns the fewest columns `text` wraps into without overhanging them,
+  // which is the width of its widest word since wrapping never breaks one.
+  //
+  // Wrapping into fewer columns still draws everything; the excess overhangs.
+  // So this is a layout preference rather than a minimum.
+  auto MeasureWrapWidth(llvm::StringRef text) const -> int;
 
   // Draws `code_point` at (x, y), which must be inside `columns()` and
   // `MaxRows`, adding rows as needed to reach it.
@@ -293,7 +307,8 @@ class Buffer {
   auto DrawBox(int x, int y, int box_width, int box_height, const Style& style)
       -> DrawEnd;
 
-  // Draws `text` starting at (x, y), which must be inside `columns()`.
+  // Draws `text` starting at (x, y), which must be inside `columns()`, as part
+  // of text whose left edge is `margin`.
   //
   // Nothing here wraps, so text with no newline in it runs off the right of the
   // width when it is longer than the room left, exactly as an overhanging word
@@ -301,13 +316,27 @@ class Buffer {
   // and deciding how much of one to show is the caller's, made against
   // `columns()` before the quoting starts.
   //
-  // Newlines return to column `x` on the next row, carriage returns to column
-  // `x` on the same row, and tabs advance to the next tab stop, with stops
-  // measured from `x` so that a quoted source line keeps the tab alignment it
-  // had in the file wherever the quote is placed. Returns where it ended, which
-  // for text with a newline in it is on a later row than it started.
+  // Newlines return to column `margin` on the next row, carriage returns to
+  // column `margin` on the same row, and tabs advance to the next tab stop,
+  // with stops measured from `margin` so that a quoted source line keeps the
+  // tab alignment it had in the file wherever the quote is placed. Returns
+  // where it ended, which for text with a newline in it is on a later row than
+  // it started.
+  //
+  // The margin is what lets text with newlines in it be drawn as differently
+  // styled spans, each starting where the last ended and all naming the same
+  // margin, the way `DrawWrappedText` does for a block: a newline in the middle
+  // of such a run returns to the text's own left edge rather than to wherever
+  // the span it fell in happened to start.
+  auto DrawText(int x, int y, int margin, llvm::StringRef text,
+                const Style& style) -> DrawEnd;
+
+  // Draws `text` as text of its own beginning at (x, y), which is then both
+  // where it starts and the margin its later rows return to.
   auto DrawText(int x, int y, llvm::StringRef text, const Style& style)
-      -> DrawEnd;
+      -> DrawEnd {
+    return DrawText(x, y, x, text, style);
+  }
 
   // Draws `text` starting at (x, y), into the block of `max_width` columns
   // beginning at `margin`.
@@ -330,10 +359,11 @@ class Buffer {
   // word, and one too long for a row of its own is moved down to one and then
   // overhangs it rather than being broken.
   //
-  // Spaces that would begin a wrapped row are dropped, so a row the width
-  // happened to break stays aligned to the margin; spaces the text opens with,
-  // or that follow a newline in it, are kept, since those are indentation the
-  // caller wrote.
+  // Whitespace stops at the block's edge rather than running past it, so the
+  // spaces between two words stay on the row the first of them ended and the
+  // row the second wraps onto begins at the margin. Spaces the text opens with,
+  // or that follow a newline in it, are kept as they are, since those are
+  // indentation the caller wrote.
   //
   // Newlines are breaks the caller already made, and are kept as they are:
   // wrapping only adds breaks to the text it is given. They break the line as a
@@ -349,9 +379,8 @@ class Buffer {
   // leaving the word after it to wrap.
   //
   // `DrawText` is the way to draw text that should not wrap at all, and differs
-  // in more than that: it keeps every space, counts tab stops from `x` since it
-  // has no block to count them from, and returns to column `x` on a carriage
-  // return rather than dropping it.
+  // in more than that: it keeps every space, and returns to the margin on a
+  // carriage return rather than dropping it.
   //
   // Returns where it ended.
   //
@@ -395,7 +424,7 @@ class Buffer {
     LineRight = 1 << 1,
     LineUp = 1 << 2,
     LineDown = 1 << 3,
-    LineDirections = 0xf,
+    LineDirections = 0b1111,
     // Set on every cell line drawing writes. A cell can hold line art and no
     // directions -- a line between one center and itself is a point -- and
     // without this such a cell would be indistinguishable from one holding
@@ -434,6 +463,10 @@ class Buffer {
   }
 
   // Checks that (x, y) is somewhere a drawing may start.
+  //
+  // The text walks check this themselves, together with the bounds particular
+  // to each: they are inlined into every text operation, and one check there
+  // costs measurably less than two.
   auto CheckOrigin(int x, int y) const -> void {
     CARBON_CHECK(
         x >= 0 && x < columns_ && y >= 0 && y < MaxRows,
@@ -455,8 +488,8 @@ class Buffer {
   // and returns the column after it: `PlaceCodePoint` when drawing, and the
   // width alone when measuring.
   template <typename PlaceFn>
-  auto WalkText(int x, int y, llvm::StringRef text, PlaceFn place) const
-      -> DrawEnd;
+  auto WalkText(int x, int y, int margin, llvm::StringRef text,
+                PlaceFn place) const -> DrawEnd;
   template <typename PlaceFn>
   auto WalkWrappedText(int x, int y, int margin, int max_width,
                        llvm::StringRef text, PlaceFn place) const -> DrawEnd;
@@ -467,7 +500,7 @@ class Buffer {
   // Widens the grid until column `x` exists, reflowing the rows it already
   // holds, which are stored back to back. Only something overhanging the target
   // width reaches past it, so this runs for nothing else.
-  auto EnsureWidth(int x) -> void;
+  auto EnsureColumn(int x) -> void;
 
   // Resets the cells in row `y` spanning columns [x, x + width), along with
   // either half of a double-width character that straddles the range's edges.

--- a/common/terminal/buffer_test.cpp
+++ b/common/terminal/buffer_test.cpp
@@ -6,6 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <optional>
+
 #include "common/filesystem.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -472,6 +475,17 @@ TEST(BufferTest, WrappedTextLineBreaks) {
   EXPECT_EQ(Render(degenerate), "");
 }
 
+TEST(BufferTest, WrappedTextWithNoWidthToFit) {
+  // A caller with no width to fit passes one no row reaches, which has to wrap
+  // nothing rather than overflow the column it would name.
+  Buffer buffer(10, Charset::Ascii);
+  llvm::StringRef text = "several words that would otherwise wrap";
+  EXPECT_EQ(buffer.DrawWrappedText(3, 0, std::numeric_limits<int>::max(), text,
+                                   Style()),
+            DrawEnd(3 + static_cast<int>(text.size()), 0));
+  EXPECT_EQ(Render(buffer), "   several words that would otherwise wrap\n");
+}
+
 TEST(BufferTest, WrappedTextKeepsSymbolsWiderThanTheRegion) {
   // No row in a one-column region could hold a double-width symbol. Drawing it
   // anyway overruns the region, which is what keeping the text costs here.
@@ -613,6 +627,13 @@ TEST(BufferTest, BuiltFromCapabilities) {
   EXPECT_EQ(buffer.charset(), Charset::Utf8);
   buffer.DrawHorizontalLine(0, 0, 5, Style());
   EXPECT_EQ(Render(buffer, capabilities.color_mode), "─────\n");
+
+  // With no width to start from, the buffer starts at nothing and grows, which
+  // is what it would have done past any starting width anyway.
+  capabilities.columns = std::nullopt;
+  Buffer grown(capabilities);
+  grown.DrawHorizontalLine(0, 0, 5, Style());
+  EXPECT_EQ(Render(grown, capabilities.color_mode), "─────\n");
 }
 
 TEST(BufferTest, CombiningMarkPastTheWidthItStartedWith) {

--- a/common/terminal/buffer_test.cpp
+++ b/common/terminal/buffer_test.cpp
@@ -1,0 +1,608 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/buffer.h"
+
+#include <gtest/gtest.h>
+
+#include "common/filesystem.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace Carbon::Terminal {
+namespace {
+
+// "e" followed by U+0301 COMBINING ACUTE ACCENT. Spelled out because the
+// precomposed U+00E9 is a single code point and wouldn't exercise marks at all.
+constexpr char32_t CombiningAcute = 0x0301;
+constexpr llvm::StringLiteral AcuteE = "e\xcc\x81";
+
+auto Render(const Buffer& buffer, ColorMode mode = ColorMode::NoColor)
+    -> std::string {
+  llvm::SmallString<256> out;
+  buffer.Render(out, mode);
+  return std::string(out);
+}
+
+TEST(BufferTest, Empty) {
+  Buffer buffer(10, Charset::Ascii);
+  EXPECT_EQ(buffer.width(), 10);
+  EXPECT_EQ(buffer.height(), 0);
+  EXPECT_EQ(Render(buffer), "");
+}
+
+TEST(BufferTest, GrowsToFitWhatIsDrawn) {
+  Buffer buffer(4, Charset::Ascii);
+  EXPECT_EQ(buffer.DrawSymbol(0, 2, 'x', Style()), 1);
+  EXPECT_EQ(buffer.height(), 3);
+  EXPECT_EQ(Render(buffer), "\n\nx\n");
+}
+
+TEST(BufferTest, ClipsOutsideItsWidth) {
+  Buffer buffer(3, Charset::Ascii);
+  // Clipped symbols still report the columns they would have taken, so text
+  // walking across a row stays in step.
+  EXPECT_EQ(buffer.DrawSymbol(-1, 0, 'a', Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(3, 0, 'a', Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(0, -1, 'a', Style()), 1);
+  EXPECT_EQ(buffer.height(), 0);
+
+  // Lines that run past an edge draw the part that fits.
+  buffer.DrawHorizontalLine(1, 0, 5, Style());
+  buffer.DrawVerticalLine(0, 1, 5, Style());
+  EXPECT_EQ(Render(buffer),
+            " --\n"
+            "|\n"
+            "|\n"
+            "|\n"
+            "|\n"
+            "|\n");
+}
+
+TEST(BufferTest, LinesJoinWhereTheyMeet) {
+  Buffer buffer(3, Charset::Utf8);
+  buffer.DrawHorizontalLine(0, 1, 3, Style());
+  buffer.DrawVerticalLine(1, 0, 3, Style());
+
+  EXPECT_EQ(Render(buffer),
+            " │\n"
+            "─┼─\n"
+            " │\n");
+}
+
+TEST(BufferTest, LineEndsFormCorners) {
+  Buffer buffer(3, Charset::Utf8);
+  buffer.DrawHorizontalLine(1, 0, 2, Style());
+  buffer.DrawVerticalLine(1, 0, 3, Style());
+
+  EXPECT_EQ(Render(buffer),
+            " ╭─\n"
+            " │\n"
+            " │\n");
+}
+
+TEST(BufferTest, LinesOnlyJoinWhereTheyOverlap) {
+  // A cell's glyph follows from the directions lines leave it in, so joining
+  // is a matter of drawing into the same cell rather than of being adjacent.
+  // This keeps drawing order from mattering and keeps text that looks like a
+  // line from being redrawn as one.
+  Buffer separate(3, Charset::Utf8);
+  separate.DrawHorizontalLine(0, 0, 3, Style());
+  separate.DrawVerticalLine(0, 1, 2, Style());
+  EXPECT_EQ(Render(separate),
+            "───\n"
+            "│\n"
+            "│\n");
+
+  Buffer overlapping(3, Charset::Utf8);
+  overlapping.DrawHorizontalLine(0, 0, 3, Style());
+  overlapping.DrawVerticalLine(0, 0, 3, Style());
+  EXPECT_EQ(Render(overlapping),
+            "╭──\n"
+            "│\n"
+            "│\n");
+}
+
+TEST(BufferTest, DrawOrderDoesNotMatter) {
+  Buffer vertical_first(3, Charset::Utf8);
+  vertical_first.DrawVerticalLine(1, 0, 3, Style());
+  vertical_first.DrawHorizontalLine(0, 1, 3, Style());
+
+  EXPECT_EQ(Render(vertical_first),
+            " │\n"
+            "─┼─\n"
+            " │\n");
+}
+
+TEST(BufferTest, Tees) {
+  // Every junction shape comes out of lines overlapping, so a table of them
+  // exercises all four tees and the cross together.
+  Buffer buffer(5, Charset::Utf8);
+  buffer.DrawBox(0, 0, 5, 5, Style());
+  buffer.DrawHorizontalLine(0, 2, 5, Style());
+  buffer.DrawVerticalLine(2, 0, 5, Style());
+  EXPECT_EQ(Render(buffer),
+            "╭─┬─╮\n"
+            "│ │ │\n"
+            "├─┼─┤\n"
+            "│ │ │\n"
+            "╰─┴─╯\n");
+}
+
+TEST(BufferTest, SingleCellLines) {
+  Buffer horizontal(3, Charset::Utf8);
+  horizontal.DrawHorizontalLine(1, 0, 1, Style());
+  EXPECT_EQ(Render(horizontal), " ─\n");
+
+  Buffer vertical(3, Charset::Utf8);
+  vertical.DrawVerticalLine(1, 0, 1, Style());
+  EXPECT_EQ(Render(vertical), " │\n");
+
+  // A line with no length draws nothing at all.
+  Buffer empty(3, Charset::Utf8);
+  empty.DrawHorizontalLine(0, 0, 0, Style());
+  empty.DrawVerticalLine(0, 0, -1, Style());
+  EXPECT_EQ(Render(empty), "");
+}
+
+TEST(BufferTest, LinesDrawOverContent) {
+  // A line replaces whatever text was in the cell, including both halves of a
+  // double-width symbol it lands on.
+  Buffer over_text(5, Charset::Utf8);
+  over_text.DrawText(0, 0, "abcde", Style());
+  over_text.DrawHorizontalLine(1, 0, 3, Style());
+  EXPECT_EQ(Render(over_text), "a───e\n");
+
+  Buffer over_wide(5, Charset::Utf8);
+  over_wide.DrawText(0, 0, "中中", Style());
+  over_wide.DrawVerticalLine(1, 0, 1, Style());
+  EXPECT_EQ(Render(over_wide), " │中\n");
+}
+
+TEST(BufferTest, Box) {
+  Buffer buffer(4, Charset::Utf8);
+  buffer.DrawBox(0, 0, 4, 4, Style());
+  EXPECT_EQ(Render(buffer),
+            "╭──╮\n"
+            "│  │\n"
+            "│  │\n"
+            "╰──╯\n");
+
+  // ASCII can only tell horizontal and vertical apart from everything else.
+  Buffer ascii(4, Charset::Ascii);
+  ascii.DrawBox(0, 0, 4, 3, Style());
+  EXPECT_EQ(Render(ascii),
+            "+--+\n"
+            "|  |\n"
+            "+--+\n");
+
+  // A box with no interior is the single line that bounds it.
+  Buffer flat(4, Charset::Utf8);
+  flat.DrawBox(0, 0, 4, 1, Style());
+  flat.DrawBox(0, 2, 1, 2, Style());
+  EXPECT_EQ(Render(flat),
+            "────\n"
+            "\n"
+            "│\n"
+            "│\n");
+
+  Buffer degenerate(4, Charset::Utf8);
+  degenerate.DrawBox(0, 0, 0, 4, Style());
+  degenerate.DrawBox(0, 0, 4, -1, Style());
+  EXPECT_EQ(Render(degenerate), "");
+}
+
+TEST(BufferTest, TextIsNeverRedrawnAsLines) {
+  Buffer buffer(10, Charset::Utf8);
+  buffer.DrawText(0, 0, "a -+- b", Style());
+  EXPECT_EQ(Render(buffer), "a -+- b\n");
+}
+
+TEST(BufferTest, Text) {
+  Buffer buffer(15, Charset::Utf8);
+  EXPECT_EQ(buffer.DrawText(0, 0, "Hello, World!", Style()), 1);
+  EXPECT_EQ(buffer.DrawText(0, 1, "A\tB\nC", Style()), 2);
+
+  EXPECT_EQ(Render(buffer),
+            "Hello, World!\n"
+            "A       B\n"
+            "C\n");
+
+  // Empty text still occupies the row it started on.
+  EXPECT_EQ(buffer.DrawText(0, 0, "", Style()), 1);
+}
+
+TEST(BufferTest, TabStopsAreMeasuredFromWhereTextBegins) {
+  // Tab stops follow the text's own origin, not the left edge, so a source
+  // line quoted beside a gutter keeps the tab alignment it had in the file.
+  Buffer buffer(20, Charset::Utf8);
+  buffer.DrawText(3, 0, "A\tB", Style());
+  EXPECT_EQ(Render(buffer), "   A       B\n");
+}
+
+TEST(BufferTest, TextControlCharacters) {
+  Buffer buffer(10, Charset::Utf8);
+  // A carriage return returns to the column the text started in.
+  buffer.DrawText(2, 0, "abc\rx", Style());
+  EXPECT_EQ(Render(buffer), "  xbc\n");
+
+  // Anything else with no printable rendering is replaced, so a stray byte
+  // can't shift the columns after it.
+  Buffer utf8(10, Charset::Utf8);
+  utf8.DrawText(0, 0,
+                "a\x01"
+                "b",
+                Style());
+  EXPECT_EQ(Render(utf8), "a�b\n");
+
+  Buffer ascii(10, Charset::Ascii);
+  ascii.DrawText(0, 0,
+                 "a\x01"
+                 "b",
+                 Style());
+  EXPECT_EQ(Render(ascii), "a?b\n");
+}
+
+TEST(BufferTest, AsciiDoesNoUtf8Processing) {
+  // A terminal that isn't decoding UTF-8 renders each byte as some character
+  // of its own, so every byte has to be counted as one column. Replacing the
+  // bytes keeps the column count honest without guessing at an encoding.
+  Buffer buffer(10, Charset::Ascii);
+  buffer.DrawText(0, 0, "a中b", Style());
+  EXPECT_EQ(Render(buffer), "a???b\n");
+  EXPECT_EQ(buffer.MeasureWidth("a中b"), 5);
+
+  // The same goes for text with combining marks, which occupy no columns only
+  // because a UTF-8 terminal folds them into the one before.
+  Buffer marks(10, Charset::Ascii);
+  marks.DrawText(0, 0, AcuteE, Style());
+  EXPECT_EQ(Render(marks), "e??\n");
+
+  // Invalid UTF-8 is not even a category here; bytes are bytes.
+  Buffer invalid(10, Charset::Ascii);
+  invalid.DrawText(0, 0, llvm::StringRef("\xc0\x80z", 3), Style());
+  EXPECT_EQ(Render(invalid), "??z\n");
+
+  // Every symbol is one column wide, whatever it is.
+  EXPECT_EQ(buffer.DrawSymbol(0, 1, U'中', Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(1, 1, CombiningAcute, Style()), 1);
+  EXPECT_EQ(Render(buffer),
+            "a???b\n"
+            "??\n");
+}
+
+TEST(BufferTest, TextInvalidUtf8) {
+  Buffer buffer(10, Charset::Utf8);
+  // An overlong encoding of NUL. It is rejected, and decoding resynchronizes
+  // one byte at a time rather than giving up on the rest of the text.
+  buffer.DrawText(0, 0, llvm::StringRef("\xc0\x80z", 3), Style());
+  EXPECT_EQ(Render(buffer), "��z\n");
+
+  Buffer surrogate(10, Charset::Utf8);
+  surrogate.DrawText(0, 0, llvm::StringRef("\xed\xa0\x80z", 4), Style());
+  EXPECT_EQ(Render(surrogate), "���z\n");
+}
+
+TEST(BufferTest, SymbolsWithNoEncoding) {
+  // Decoding text never yields these, but `DrawSymbol` takes any code point,
+  // including the surrogates and the values past the last one that UTF-8 has no
+  // encoding for.
+  Buffer buffer(10, Charset::Utf8);
+  EXPECT_EQ(buffer.DrawSymbol(0, 0, static_cast<char32_t>(0xd800), Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(1, 0, static_cast<char32_t>(0xdfff), Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(2, 0, static_cast<char32_t>(0x110000), Style()),
+            1);
+  EXPECT_EQ(Render(buffer), "���\n");
+}
+
+TEST(BufferTest, DoubleWidthSymbols) {
+  Buffer buffer(6, Charset::Utf8);
+  buffer.DrawText(0, 0, "中A🔥", Style());
+  EXPECT_EQ(Render(buffer), "中A🔥\n");
+  EXPECT_EQ(buffer.DrawSymbol(0, 1, U'中', Style()), 2);
+}
+
+TEST(BufferTest, DrawingOverADoubleWidthSymbolErasesAllOfIt) {
+  // Overwriting either half has to erase the whole symbol. Leaving the other
+  // half behind would either duplicate part of a glyph or, for the trailing
+  // half, silently drop a column and misalign everything after it.
+  Buffer over_head(4, Charset::Utf8);
+  over_head.DrawSymbol(0, 0, U'中', Style());
+  over_head.DrawSymbol(0, 0, 'A', Style());
+  EXPECT_EQ(Render(over_head), "A\n");
+
+  Buffer over_tail(4, Charset::Utf8);
+  over_tail.DrawSymbol(0, 0, U'中', Style());
+  over_tail.DrawSymbol(1, 0, 'B', Style());
+  EXPECT_EQ(Render(over_tail), " B\n");
+
+  // The same holds when a double-width symbol lands on another one.
+  Buffer over_both(6, Charset::Utf8);
+  over_both.DrawSymbol(0, 0, U'中', Style());
+  over_both.DrawSymbol(2, 0, U'中', Style());
+  over_both.DrawSymbol(1, 0, U'国', Style());
+  EXPECT_EQ(Render(over_both), " 国\n");
+}
+
+TEST(BufferTest, DoubleWidthSymbolAtTheRightEdge) {
+  // Splitting one across the edge would leave the terminal rendering half a
+  // character, so it is dropped instead, while still reporting its width.
+  Buffer buffer(3, Charset::Utf8);
+  EXPECT_EQ(buffer.DrawSymbol(2, 0, U'中', Style()), 2);
+  buffer.DrawSymbol(0, 0, 'a', Style());
+  EXPECT_EQ(Render(buffer), "a\n");
+
+  // So text after a clipped symbol doesn't slide into the space it left.
+  Buffer text(2, Charset::Utf8);
+  text.DrawText(0, 0, "a中b", Style());
+  EXPECT_EQ(Render(text), "a\n");
+}
+
+TEST(BufferTest, CombiningMarks) {
+  // Marks render into the column before them, so a base character and its
+  // marks stay in one cell and don't shift what follows.
+  Buffer buffer(10, Charset::Utf8);
+  buffer.DrawText(0, 0, AcuteE, Style());
+  EXPECT_EQ(Render(buffer), AcuteE.str() + "\n");
+  EXPECT_EQ(buffer.MeasureWidth(AcuteE), 1);
+  EXPECT_EQ(buffer.DrawSymbol(5, 0, CombiningAcute, Style()), 0);
+
+  // A mark with nothing before it has nothing to attach to.
+  Buffer orphan(10, Charset::Utf8);
+  orphan.DrawSymbol(0, 0, CombiningAcute, Style());
+  EXPECT_EQ(Render(orphan), "");
+
+  // Drawing over the base takes its marks with it.
+  Buffer overwritten(10, Charset::Utf8);
+  overwritten.DrawText(0, 0, AcuteE, Style());
+  overwritten.DrawText(1, 0, "x", Style());
+  overwritten.DrawSymbol(0, 0, 'o', Style());
+  EXPECT_EQ(Render(overwritten), "ox\n");
+}
+
+TEST(BufferTest, CombiningMarksOnADoubleWidthBase) {
+  // A mark following a double-width symbol arrives at the column past its
+  // continuation, and has to reach back to the symbol itself.
+  Buffer buffer(10, Charset::Utf8);
+  buffer.DrawText(0, 0, ("中" + AcuteE.drop_front(1) + "x").str(), Style());
+  EXPECT_EQ(Render(buffer), ("中" + AcuteE.drop_front(1) + "x\n").str());
+  EXPECT_EQ(buffer.MeasureWidth(("中" + AcuteE.drop_front(1)).str()), 2);
+}
+
+TEST(BufferTest, CombiningMarksAreCapped) {
+  // Marks stack without bound in adversarial text, and every one of them would
+  // otherwise land in a single cell's output.
+  std::string zalgo = "e";
+  for (int i = 0; i < 100; ++i) {
+    zalgo += AcuteE.drop_front(1);
+  }
+
+  Buffer buffer(10, Charset::Utf8);
+  buffer.DrawText(0, 0, zalgo, Style());
+  // The base, some bounded run of marks, and the newline.
+  EXPECT_LT(Render(buffer).size(), 64U);
+  EXPECT_GT(Render(buffer).size(), 1U);
+}
+
+TEST(BufferTest, WrappedText) {
+  Buffer buffer(20, Charset::Ascii);
+  EXPECT_EQ(
+      buffer.DrawWrappedText(
+          0, 0, 10, "This is a long sentence that should be wrapped.", Style()),
+      6);
+
+  EXPECT_EQ(Render(buffer),
+            "This is a\n"
+            "long\n"
+            "sentence\n"
+            "that\n"
+            "should be\n"
+            "wrapped.\n");
+}
+
+TEST(BufferTest, WrappedTextBreaksWordsTooLongToFit) {
+  Buffer buffer(10, Charset::Ascii);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 5, "abcdefghij", Style()), 2);
+  EXPECT_EQ(Render(buffer),
+            "abcde\n"
+            "fghij\n");
+}
+
+TEST(BufferTest, WrappedTextIndents) {
+  // Wrapping is relative to where the text starts, which is what lets a
+  // wrapped block sit beside a gutter.
+  Buffer buffer(12, Charset::Ascii);
+  buffer.DrawText(0, 0, "| ", Style());
+  buffer.DrawWrappedText(2, 0, 6, "alpha beta gamma", Style());
+  EXPECT_EQ(Render(buffer),
+            "| alpha\n"
+            "  beta\n"
+            "  gamma\n");
+}
+
+TEST(BufferTest, WrappedTextLineBreaks) {
+  // Carriage returns are dropped, so CRLF endings break exactly once.
+  Buffer buffer(10, Charset::Ascii);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 10, "a\r\nb", Style()), 2);
+  EXPECT_EQ(Render(buffer),
+            "a\n"
+            "b\n");
+
+  // Spaces that would begin a row are dropped, keeping text aligned.
+  Buffer spaces(10, Charset::Ascii);
+  spaces.DrawWrappedText(0, 0, 5, "aaaaa     bbbbb", Style());
+  EXPECT_EQ(Render(spaces),
+            "aaaaa\n"
+            "bbbbb\n");
+
+  // A wrap region with no columns has nowhere to put anything.
+  Buffer degenerate(10, Charset::Ascii);
+  EXPECT_EQ(degenerate.DrawWrappedText(0, 0, 0, "anything", Style()), 0);
+  EXPECT_EQ(degenerate.DrawWrappedText(0, 0, -1, "anything", Style()), 0);
+  EXPECT_EQ(Render(degenerate), "");
+}
+
+TEST(BufferTest, WrappedTextDropsSymbolsWiderThanTheRegion) {
+  // No row in a one-column region could hold a double-width symbol, and
+  // drawing it anyway would run into whatever is laid out beside the region.
+  Buffer buffer(10, Charset::Utf8);
+  buffer.DrawText(2, 0, "|", Style());
+  buffer.DrawText(2, 1, "|", Style());
+  buffer.DrawWrappedText(0, 0, 1, "中中", Style());
+  EXPECT_EQ(Render(buffer),
+            "  |\n"
+            "  |\n");
+}
+
+TEST(BufferTest, WrappedTextWithDoubleWidthSymbols) {
+  // Wrapping counts columns, not characters, so a double-width word breaks at
+  // half as many of them.
+  Buffer buffer(10, Charset::Utf8);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 4, "中中中", Style()), 2);
+  EXPECT_EQ(Render(buffer),
+            "中中\n"
+            "中\n");
+}
+
+TEST(BufferTest, TrailingBlanksAreDropped) {
+  // Padding out to the buffer's width would put invisible whitespace into
+  // every line of output, which shows up in diffs and in copied text.
+  Buffer buffer(40, Charset::Ascii);
+  buffer.DrawText(0, 0, "hi", Style());
+  EXPECT_EQ(Render(buffer), "hi\n");
+}
+
+TEST(BufferTest, StyledBlanksAreKept) {
+  // A blank cell with a background still paints, so it isn't padding.
+  Buffer buffer(10, Charset::Ascii);
+  buffer.DrawSymbol(0, 0, 'x', Style());
+  buffer.DrawSymbol(3, 0, ' ', Style().Background(AnsiColor::Red));
+  EXPECT_EQ(Render(buffer, ColorMode::Ansi16), "x  \x1b[41m \x1b[0m\n");
+
+  // With color off the background paints nothing, so those cells are padding
+  // again and must not reach the output as trailing spaces.
+  EXPECT_EQ(Render(buffer, ColorMode::NoColor), "x\n");
+}
+
+TEST(BufferTest, RenderMinimizesEscapes) {
+  Buffer buffer(4, Charset::Ascii);
+  Style red_bold = Style().Bold().Foreground(Color(255, 0, 0));
+  buffer.DrawSymbol(0, 0, 'A', red_bold);
+  // Sharing the attributes and changing only the color costs one escape.
+  buffer.DrawSymbol(1, 0, 'B', red_bold.Foreground(Color(0, 0, 255)));
+  // Dropping bold costs a reset and a fresh start.
+  buffer.DrawSymbol(2, 0, 'C', Style().Foreground(Color(0, 0, 255)));
+  buffer.DrawSymbol(3, 0, 'D', Style());
+
+  EXPECT_EQ(Render(buffer, ColorMode::Truecolor),
+            "\x1b[1m\x1b[38;2;255;0;0m"
+            "A"
+            "\x1b[38;2;0;0;255m"
+            "B"
+            "\x1b[0m\x1b[38;2;0;0;255m"
+            "C"
+            "\x1b[0m"
+            "D\n");
+}
+
+TEST(BufferTest, RenderEndsRowsWithoutStyle) {
+  // A style left on at the end of a row would bleed into whatever the terminal
+  // prints next.
+  Buffer buffer(4, Charset::Ascii);
+  buffer.DrawSymbol(0, 0, 'A', Style().Background(AnsiColor::Red));
+  buffer.DrawSymbol(0, 1, 'B', Style().Background(AnsiColor::Red));
+  EXPECT_EQ(Render(buffer, ColorMode::Ansi16),
+            "\x1b[41mA\x1b[0m\n"
+            "\x1b[41mB\x1b[0m\n");
+}
+
+TEST(BufferTest, MeasureWidth) {
+  Buffer utf8(10, Charset::Utf8);
+  EXPECT_EQ(utf8.MeasureWidth(""), 0);
+  EXPECT_EQ(utf8.MeasureWidth("hello"), 5);
+  EXPECT_EQ(utf8.MeasureWidth("中A🔥"), 5);
+  EXPECT_EQ(utf8.MeasureWidth(AcuteE), 1);
+  EXPECT_EQ(utf8.MeasureWidth(llvm::StringRef("\xc0\x80", 2)), 2);
+
+  // Newlines and tabs are not interpreted here, only counted.
+  EXPECT_EQ(utf8.MeasureWidth("a\nb"), 3);
+  EXPECT_EQ(utf8.MeasureWidth("a\tb"), 3);
+
+  // Every byte is a column when the terminal isn't decoding UTF-8.
+  Buffer ascii(10, Charset::Ascii);
+  EXPECT_EQ(ascii.MeasureWidth("hello"), 5);
+  EXPECT_EQ(ascii.MeasureWidth("中A🔥"), 8);
+  EXPECT_EQ(ascii.MeasureWidth(AcuteE), 3);
+}
+
+TEST(BufferTest, BuiltFromCapabilities) {
+  Capabilities capabilities;
+  capabilities.columns = 5;
+  capabilities.charset = Charset::Utf8;
+
+  Buffer buffer(capabilities);
+  EXPECT_EQ(buffer.width(), 5);
+  EXPECT_EQ(buffer.charset(), Charset::Utf8);
+  buffer.DrawHorizontalLine(0, 0, 5, Style());
+  EXPECT_EQ(Render(buffer, capabilities.color_mode), "─────\n");
+}
+
+TEST(BufferTest, CombiningMarkPastTheRightEdge) {
+  // Text walks past the right edge rather than stopping there, so a mark can
+  // arrive at a column well beyond the buffer. Its base was clipped, so the
+  // mark goes with it rather than attaching to the last cell of the row, or to
+  // whatever cell the row-major index happens to land on.
+  Buffer buffer(4, Charset::Utf8);
+  buffer.DrawText(0, 1, "z", Style());
+  buffer.DrawText(0, 0, ("abcde" + AcuteE.drop_front(1)).str(), Style());
+  EXPECT_EQ(Render(buffer),
+            "abcd\n"
+            "z\n");
+
+  // The same past the last row, where the cell index has nothing to land on.
+  Buffer single_row(4, Charset::Utf8);
+  single_row.DrawText(0, 0, ("abcde" + AcuteE.drop_front(1)).str(), Style());
+  EXPECT_EQ(Render(single_row), "abcd\n");
+
+  // A mark exactly at the right edge still attaches to the last cell.
+  Buffer at_edge(4, Charset::Utf8);
+  at_edge.DrawText(0, 0, ("abcd" + AcuteE.drop_front(1)).str(), Style());
+  EXPECT_EQ(Render(at_edge), ("abcd" + AcuteE.drop_front(1) + "\n").str());
+}
+
+TEST(BufferTest, WriteTo) {
+  Buffer buffer(20, Charset::Ascii);
+  buffer.DrawText(0, 0, "hello", Style().Bold());
+  buffer.DrawText(0, 1, "world", Style());
+
+  auto dir = Filesystem::MakeTmpDir();
+  ASSERT_TRUE(dir.ok()) << dir.error();
+  auto file = dir->OpenWriteOnly("out", Filesystem::CreationOptions::CreateNew);
+  ASSERT_TRUE(file.ok()) << file.error();
+  auto written = buffer.WriteTo(*file, ColorMode::Ansi16);
+  EXPECT_TRUE(written.ok()) << written.error();
+  (*std::move(file)).Close().Check();
+
+  // Byte for byte what `Render` produces.
+  auto read_back = dir->ReadFileToString("out");
+  ASSERT_TRUE(read_back.ok()) << read_back.error();
+  EXPECT_EQ(*read_back, Render(buffer, ColorMode::Ansi16));
+  EXPECT_EQ(*read_back, "\x1b[1mhello\x1b[0m\nworld\n");
+}
+
+TEST(BufferTest, RenderAppends) {
+  // Rendering appends, so several buffers can be gathered into one write.
+  Buffer first(10, Charset::Ascii);
+  first.DrawText(0, 0, "one", Style());
+  Buffer second(10, Charset::Ascii);
+  second.DrawText(0, 0, "two", Style());
+
+  llvm::SmallString<64> out;
+  first.Render(out, ColorMode::NoColor);
+  second.Render(out, ColorMode::NoColor);
+  EXPECT_EQ(std::string(out), "one\ntwo\n");
+}
+
+}  // namespace
+}  // namespace Carbon::Terminal

--- a/common/terminal/buffer_test.cpp
+++ b/common/terminal/buffer_test.cpp
@@ -34,7 +34,7 @@ TEST(BufferTest, Empty) {
 
 TEST(BufferTest, GrowsRowsToFitWhatIsDrawn) {
   Buffer buffer(4, Charset::Ascii);
-  EXPECT_EQ(buffer.DrawSymbol(0, 2, 'x', Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(0, 2, 'x', Style()).x, 1);
   EXPECT_EQ(buffer.height(), 3);
   EXPECT_EQ(Render(buffer), "\n\nx\n");
 }
@@ -57,8 +57,8 @@ TEST(BufferTest, DrawsNothingBeforeItsOrigin) {
   Buffer buffer(3, Charset::Ascii);
   // Negative coordinates have nowhere to grow to. The symbols still report the
   // columns they would have taken, so text walking a row stays in step.
-  EXPECT_EQ(buffer.DrawSymbol(-1, 0, 'a', Style()), 1);
-  EXPECT_EQ(buffer.DrawSymbol(0, -1, 'a', Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(-1, 0, 'a', Style()).x, 0);
+  EXPECT_EQ(buffer.DrawSymbol(0, -1, 'a', Style()).x, 1);
   EXPECT_EQ(buffer.height(), 0);
 }
 
@@ -216,8 +216,8 @@ TEST(BufferTest, TextIsNeverRedrawnAsLines) {
 
 TEST(BufferTest, Text) {
   Buffer buffer(15, Charset::Utf8);
-  EXPECT_EQ(buffer.DrawText(0, 0, "Hello, World!", Style()), 1);
-  EXPECT_EQ(buffer.DrawText(0, 1, "A\tB\nC", Style()), 2);
+  EXPECT_EQ(buffer.DrawText(0, 0, "Hello, World!", Style()).y, 0);
+  EXPECT_EQ(buffer.DrawText(0, 1, "A\tB\nC", Style()).y, 2);
 
   EXPECT_EQ(Render(buffer),
             "Hello, World!\n"
@@ -225,7 +225,7 @@ TEST(BufferTest, Text) {
             "C\n");
 
   // Empty text still occupies the row it started on.
-  EXPECT_EQ(buffer.DrawText(0, 0, "", Style()), 1);
+  EXPECT_EQ(buffer.DrawText(0, 0, "", Style()).y, 0);
 }
 
 TEST(BufferTest, TabStopsAreMeasuredFromWhereTextBegins) {
@@ -280,8 +280,8 @@ TEST(BufferTest, AsciiDoesNoUtf8Processing) {
   EXPECT_EQ(Render(invalid), "??z\n");
 
   // Every symbol is one column wide, whatever it is.
-  EXPECT_EQ(buffer.DrawSymbol(0, 1, U'中', Style()), 1);
-  EXPECT_EQ(buffer.DrawSymbol(1, 1, CombiningAcute, Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(0, 1, U'中', Style()).x, 1);
+  EXPECT_EQ(buffer.DrawSymbol(1, 1, CombiningAcute, Style()).x, 2);
   EXPECT_EQ(Render(buffer),
             "a???b\n"
             "??\n");
@@ -304,10 +304,12 @@ TEST(BufferTest, SymbolsWithNoEncoding) {
   // including the surrogates and the values past the last one that UTF-8 has no
   // encoding for.
   Buffer buffer(10, Charset::Utf8);
-  EXPECT_EQ(buffer.DrawSymbol(0, 0, static_cast<char32_t>(0xd800), Style()), 1);
-  EXPECT_EQ(buffer.DrawSymbol(1, 0, static_cast<char32_t>(0xdfff), Style()), 1);
-  EXPECT_EQ(buffer.DrawSymbol(2, 0, static_cast<char32_t>(0x110000), Style()),
+  EXPECT_EQ(buffer.DrawSymbol(0, 0, static_cast<char32_t>(0xd800), Style()).x,
             1);
+  EXPECT_EQ(buffer.DrawSymbol(1, 0, static_cast<char32_t>(0xdfff), Style()).x,
+            2);
+  EXPECT_EQ(
+      buffer.DrawSymbol(2, 0, static_cast<char32_t>(0x110000), Style()).x, 3);
   EXPECT_EQ(Render(buffer), "���\n");
 }
 
@@ -315,7 +317,7 @@ TEST(BufferTest, DoubleWidthSymbols) {
   Buffer buffer(6, Charset::Utf8);
   buffer.DrawText(0, 0, "中A🔥", Style());
   EXPECT_EQ(Render(buffer), "中A🔥\n");
-  EXPECT_EQ(buffer.DrawSymbol(0, 1, U'中', Style()), 2);
+  EXPECT_EQ(buffer.DrawSymbol(0, 1, U'中', Style()).x, 2);
 }
 
 TEST(BufferTest, DrawingOverADoubleWidthSymbolErasesAllOfIt) {
@@ -344,7 +346,7 @@ TEST(BufferTest, DoubleWidthSymbolPastTheEdgeTakesBothColumns) {
   // Splitting one would leave the terminal rendering half a character, so the
   // buffer grows by both of its columns rather than one.
   Buffer buffer(3, Charset::Utf8);
-  EXPECT_EQ(buffer.DrawSymbol(2, 0, U'中', Style()), 2);
+  EXPECT_EQ(buffer.DrawSymbol(2, 0, U'中', Style()).x, 4);
   buffer.DrawSymbol(0, 0, 'a', Style());
   EXPECT_EQ(Render(buffer), "a 中\n");
   EXPECT_GE(buffer.width(), 4);
@@ -357,7 +359,7 @@ TEST(BufferTest, CombiningMarks) {
   buffer.DrawText(0, 0, AcuteE, Style());
   EXPECT_EQ(Render(buffer), AcuteE.str() + "\n");
   EXPECT_EQ(buffer.MeasureWidth(AcuteE), 1);
-  EXPECT_EQ(buffer.DrawSymbol(5, 0, CombiningAcute, Style()), 0);
+  EXPECT_EQ(buffer.DrawSymbol(5, 0, CombiningAcute, Style()).x, 5);
 
   // A mark with nothing before it has nothing to attach to.
   Buffer orphan(10, Charset::Utf8);
@@ -398,10 +400,13 @@ TEST(BufferTest, CombiningMarksAreCapped) {
 
 TEST(BufferTest, WrappedText) {
   Buffer buffer(20, Charset::Ascii);
-  EXPECT_EQ(
-      buffer.DrawWrappedText(
-          0, 0, 10, "This is a long sentence that should be wrapped.", Style()),
-      6);
+  EXPECT_EQ(buffer
+                .DrawWrappedText(0, 0, 10,
+                                 "This is a long sentence that should be "
+                                 "wrapped.",
+                                 Style())
+                .y,
+            5);
 
   EXPECT_EQ(Render(buffer),
             "This is a\n"
@@ -414,7 +419,7 @@ TEST(BufferTest, WrappedText) {
 
 TEST(BufferTest, WrappedTextBreaksWordsTooLongToFit) {
   Buffer buffer(10, Charset::Ascii);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 5, "abcdefghij", Style()), 2);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 5, "abcdefghij", Style()).y, 1);
   EXPECT_EQ(Render(buffer),
             "abcde\n"
             "fghij\n");
@@ -435,7 +440,7 @@ TEST(BufferTest, WrappedTextIndents) {
 TEST(BufferTest, WrappedTextLineBreaks) {
   // Carriage returns are dropped, so CRLF endings break exactly once.
   Buffer buffer(10, Charset::Ascii);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 10, "a\r\nb", Style()), 2);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 10, "a\r\nb", Style()).y, 1);
   EXPECT_EQ(Render(buffer),
             "a\n"
             "b\n");
@@ -449,8 +454,8 @@ TEST(BufferTest, WrappedTextLineBreaks) {
 
   // A wrap region with no columns has nowhere to put anything.
   Buffer degenerate(10, Charset::Ascii);
-  EXPECT_EQ(degenerate.DrawWrappedText(0, 0, 0, "anything", Style()), 0);
-  EXPECT_EQ(degenerate.DrawWrappedText(0, 0, -1, "anything", Style()), 0);
+  EXPECT_EQ(degenerate.DrawWrappedText(0, 0, 0, "anything", Style()).y, 0);
+  EXPECT_EQ(degenerate.DrawWrappedText(0, 0, -1, "anything", Style()).y, 0);
   EXPECT_EQ(Render(degenerate), "");
 }
 
@@ -470,7 +475,7 @@ TEST(BufferTest, WrappedTextWithDoubleWidthSymbols) {
   // Wrapping counts columns, not characters, so a double-width word breaks at
   // half as many of them.
   Buffer buffer(10, Charset::Utf8);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 4, "中中中", Style()), 2);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 4, "中中中", Style()).y, 1);
   EXPECT_EQ(Render(buffer),
             "中中\n"
             "中\n");

--- a/common/terminal/buffer_test.cpp
+++ b/common/terminal/buffer_test.cpp
@@ -348,6 +348,26 @@ TEST(BufferTest, TabStopsAreMeasuredFromWhereTextBegins) {
   EXPECT_EQ(Render(buffer), "   A       B\n");
 }
 
+TEST(BufferTest, TextRowsReturnToTheMargin) {
+  // Text drawn as differently styled spans names one margin across all of them,
+  // so a newline in the middle of it returns to the text's own left edge rather
+  // than to wherever the span it fell in started.
+  Buffer buffer(20, Charset::Ascii);
+  buffer.DrawText(0, 0, "| ", Style());
+  DrawEnd end = buffer.DrawText(2, 0, 2, "plain\nmore ", Style());
+  buffer.DrawText(end.x, end.y, 2, "bold\ntext", Style().Bold());
+  EXPECT_EQ(Render(buffer),
+            "| plain\n"
+            "  more bold\n"
+            "  text\n");
+
+  // Carriage returns return there too, and tab stops are counted from it.
+  Buffer positional(20, Charset::Ascii);
+  positional.DrawText(0, 0, "| ", Style());
+  positional.DrawText(2, 0, 2, "a\tb\rc", Style());
+  EXPECT_EQ(Render(positional), "| c       b\n");
+}
+
 TEST(BufferTest, TextControlCharacters) {
   Buffer buffer(10, Charset::Utf8);
   // A carriage return returns to the column the text started in.
@@ -690,6 +710,24 @@ TEST(BufferTest, WrappedTextFillsTheWidthLeftOfTheMargin) {
             "   otherwise fit\n");
 }
 
+TEST(BufferTest, WrappedTextKeepsAMarkWithTheWhitespaceBeforeIt) {
+  // A combining mark renders into the column before it, which for a mark
+  // following whitespace is that whitespace. Left to begin the word after it,
+  // the mark would move to another row whenever that word wrapped and attach to
+  // whatever preceded it there.
+  Buffer buffer(10, Charset::Utf8);
+  std::string mark = AcuteE.drop_front(1).str();
+  buffer.DrawWrappedText(0, 0, 0, 5, "aaa " + mark + "bbbb", Style());
+  EXPECT_EQ(Render(buffer), "aaa " + mark + "\nbbbb\n");
+
+  // Whitespace stops at the block's edge, so a mark can arrive where none of it
+  // was drawn. It attaches to the last cell written rather than being carried
+  // to the row the next word wraps onto.
+  Buffer filled(10, Charset::Utf8);
+  filled.DrawWrappedText(0, 0, 0, 5, "aaaaa " + mark + "bb", Style());
+  EXPECT_EQ(Render(filled), "aaaaa" + mark + "\nbb\n");
+}
+
 TEST(BufferTest, WrappedTextKeepsCharactersWiderThanTheRegion) {
   // No row in a one-column region could hold a double-width character. Drawing
   // it anyway overruns the region, which is what keeping the text costs here.
@@ -784,10 +822,17 @@ TEST(BufferTest, MeasuringMatchesDrawing) {
     EXPECT_EQ(buffer.MeasureText(2, 1, text),
               buffer.DrawText(2, 1, text, Style()))
         << text;
+
+    // A margin left of where the text starts moves what the positional
+    // characters answer to, and moves it for both of them alike.
+    Buffer block(10, Charset::Utf8);
+    EXPECT_EQ(block.MeasureText(2, 1, 1, text),
+              block.DrawText(2, 1, 1, text, Style()))
+        << text;
   }
   for (llvm::StringRef text :
        {"one two three", "a\nlonger line here", "verylongunbreakableword",
-        "a\tb\tc", "col\tone\nrow\ttwo", ""}) {
+        "a\tb\tc", "col\tone\nrow\ttwo", "e\xcc\x81 \xcc\x81word", ""}) {
     Buffer buffer(10, Charset::Utf8);
     EXPECT_EQ(buffer.MeasureWrappedText(2, 1, 2, 8, text),
               buffer.DrawWrappedText(2, 1, 2, 8, text, Style()))
@@ -795,16 +840,28 @@ TEST(BufferTest, MeasuringMatchesDrawing) {
   }
 }
 
+TEST(BufferTest, MeasureWrapWidth) {
+  Buffer buffer(10, Charset::Utf8);
+  EXPECT_EQ(buffer.MeasureWrapWidth(""), 0);
+  EXPECT_EQ(buffer.MeasureWrapWidth("a bb ccc"), 3);
+  EXPECT_EQ(buffer.MeasureWrapWidth("  spaced  out  "), 6);
+
+  // Newlines and tabs bound a word without taking columns of their own.
+  EXPECT_EQ(buffer.MeasureWrapWidth("a\nbb\tccc"), 3);
+
+  // A word is measured in the columns it takes, not the bytes it holds.
+  EXPECT_EQ(buffer.MeasureWrapWidth("中中 a"), 4);
+}
+
 TEST(BufferTest, WrapWidthIsWhatWrappingDoesNotOverhang) {
-  // What `Metrics::WrapWidth` answers is a fact about wrapping, so it is
-  // checked here against the wrapping it describes rather than only in
-  // `metrics_test`.
+  // The width answered for is a fact about wrapping, so it is checked against
+  // the wrapping it describes.
   Buffer buffer(10, Charset::Utf8);
   // Tabs don't widen the answer: one stops at the block's edge rather than
   // running to a stop outside it, so it can't overhang either.
   for (llvm::StringRef text :
        {"some quite long words here", "some\tquite\tlong words here"}) {
-    int width = buffer.metrics().WrapWidth(text);
+    int width = buffer.MeasureWrapWidth(text);
     Buffer drawn(width, Charset::Utf8);
     drawn.DrawWrappedText(0, 0, 0, width, text, Style());
     llvm::SmallVector<llvm::StringRef> rows;
@@ -945,6 +1002,10 @@ TEST(BufferDeathTest, DrawingMustStartInsideTheGrid) {
                "is outside the");
   EXPECT_DEATH(buffer.DrawText(10, 0, "a", Style()), "is outside the");
   EXPECT_DEATH(buffer.MeasureText(10, 0, "a"), "is outside the");
+
+  // Text begins at or right of the margin its rows return to.
+  EXPECT_DEATH(buffer.DrawText(2, 0, 3, "a", Style()), "left of its margin");
+  EXPECT_DEATH(buffer.MeasureText(2, 0, -1, "a"), "left of its margin");
 }
 
 TEST(BufferDeathTest, LinesMustFitWhatTheyAreDrawnInto) {

--- a/common/terminal/buffer_test.cpp
+++ b/common/terminal/buffer_test.cpp
@@ -8,8 +8,10 @@
 
 #include <limits>
 #include <optional>
+#include <string>
 
 #include "common/filesystem.h"
+#include "common/terminal/metrics.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -40,15 +42,19 @@ TEST(BufferTest, Empty) {
 
 TEST(BufferTest, GrowsRowsToFitWhatIsDrawn) {
   Buffer buffer(4, Charset::Ascii);
-  EXPECT_EQ(buffer.DrawSymbol(0, 2, 'x', Style()).x, 1);
+  EXPECT_EQ(buffer.DrawCodePoint(0, 2, 'x', Style()).x, 1);
   EXPECT_EQ(buffer.height(), 3);
   EXPECT_EQ(Render(buffer), "\n\nx\n");
 }
 
-TEST(BufferTest, GrowsColumnsToFitWhatIsDrawn) {
-  Buffer buffer(3, Charset::Ascii);
+TEST(BufferTest, WidthIsTheTargetUntilSomethingOverhangs) {
+  // `width()` tracks `columns()` while everything stays inside it.
+  Buffer buffer(6, Charset::Ascii);
+  EXPECT_EQ(buffer.columns(), 6);
+  EXPECT_EQ(buffer.width(), 6);
   buffer.DrawHorizontalLine(1, 0, 5, Style());
   buffer.DrawVerticalLine(0, 1, 5, Style());
+  EXPECT_EQ(buffer.width(), 6);
   EXPECT_EQ(Render(buffer),
             " -----\n"
             "|\n"
@@ -56,16 +62,16 @@ TEST(BufferTest, GrowsColumnsToFitWhatIsDrawn) {
             "|\n"
             "|\n"
             "|\n");
-  EXPECT_GE(buffer.width(), 6);
-}
 
-TEST(BufferTest, DrawsNothingBeforeItsOrigin) {
-  Buffer buffer(3, Charset::Ascii);
-  // Negative coordinates have nowhere to grow to. The symbols still report the
-  // columns they would have taken, so text walking a row stays in step.
-  EXPECT_EQ(buffer.DrawSymbol(-1, 0, 'a', Style()).x, 0);
-  EXPECT_EQ(buffer.DrawSymbol(0, -1, 'a', Style()).x, 1);
-  EXPECT_EQ(buffer.height(), 0);
+  // Text that starts inside the width can run past it, and a word wrapping
+  // cannot break is the case that produces.
+  Buffer overhang(4, Charset::Ascii);
+  overhang.DrawWrappedText(0, 0, 0, 4, "ab wordthatislong", Style());
+  EXPECT_EQ(overhang.columns(), 4);
+  EXPECT_GE(overhang.width(), 14);
+  EXPECT_EQ(Render(overhang),
+            "ab\n"
+            "wordthatislong\n");
 }
 
 TEST(BufferTest, WidthGrowsAcrossRowsAlreadyDrawn) {
@@ -81,15 +87,32 @@ TEST(BufferTest, WidthGrowsAcrossRowsAlreadyDrawn) {
             "efghij\n");
 }
 
+TEST(BufferTest, GrowthFromEveryStartingWidth) {
+  // Growth runs in steps, so every starting width reaches the same place by a
+  // different route.
+  for (int start : {1, 2, 3, 5, 17}) {
+    Buffer buffer(start, Charset::Utf8);
+    for (int row = 0; row < 4; ++row) {
+      buffer.DrawText(0, row, "abcdefghijklmnopqrstuvwxyz", Style());
+    }
+    EXPECT_EQ(Render(buffer),
+              "abcdefghijklmnopqrstuvwxyz\n"
+              "abcdefghijklmnopqrstuvwxyz\n"
+              "abcdefghijklmnopqrstuvwxyz\n"
+              "abcdefghijklmnopqrstuvwxyz\n")
+        << start;
+  }
+}
+
 TEST(BufferTest, LinesJoinWhereTheyMeet) {
   Buffer buffer(3, Charset::Utf8);
   buffer.DrawHorizontalLine(0, 1, 3, Style());
   buffer.DrawVerticalLine(1, 0, 3, Style());
 
   EXPECT_EQ(Render(buffer),
-            " │\n"
-            "─┼─\n"
-            " │\n");
+            " ╷\n"
+            "╶┼╴\n"
+            " ╵\n");
 }
 
 TEST(BufferTest, LineEndsFormCorners) {
@@ -98,31 +121,29 @@ TEST(BufferTest, LineEndsFormCorners) {
   buffer.DrawVerticalLine(1, 0, 3, Style());
 
   EXPECT_EQ(Render(buffer),
-            " ╭─\n"
+            " ╭╴\n"
             " │\n"
-            " │\n");
+            " ╵\n");
 }
 
 TEST(BufferTest, LinesOnlyJoinWhereTheyOverlap) {
   // A cell's glyph follows from the directions lines leave it in, so joining
   // is a matter of drawing into the same cell rather than of being adjacent.
-  // This keeps drawing order from mattering and keeps text that looks like a
-  // line from being redrawn as one.
   Buffer separate(3, Charset::Utf8);
   separate.DrawHorizontalLine(0, 0, 3, Style());
   separate.DrawVerticalLine(0, 1, 2, Style());
   EXPECT_EQ(Render(separate),
-            "───\n"
-            "│\n"
-            "│\n");
+            "╶─╴\n"
+            "╷\n"
+            "╵\n");
 
   Buffer overlapping(3, Charset::Utf8);
   overlapping.DrawHorizontalLine(0, 0, 3, Style());
   overlapping.DrawVerticalLine(0, 0, 3, Style());
   EXPECT_EQ(Render(overlapping),
-            "╭──\n"
+            "╭─╴\n"
             "│\n"
-            "│\n");
+            "╵\n");
 }
 
 TEST(BufferTest, DrawOrderDoesNotMatter) {
@@ -131,9 +152,9 @@ TEST(BufferTest, DrawOrderDoesNotMatter) {
   vertical_first.DrawHorizontalLine(0, 1, 3, Style());
 
   EXPECT_EQ(Render(vertical_first),
-            " │\n"
-            "─┼─\n"
-            " │\n");
+            " ╷\n"
+            "╶┼╴\n"
+            " ╵\n");
 }
 
 TEST(BufferTest, Tees) {
@@ -151,33 +172,118 @@ TEST(BufferTest, Tees) {
             "╰─┴─╯\n");
 }
 
-TEST(BufferTest, SingleCellLines) {
+TEST(BufferTest, ALineBetweenOneCenterAndItselfIsAPoint) {
+  // A line of one cell between two centers has no length and no direction, so
+  // it is a point. It is still line art, so anything drawn through it later
+  // joins it rather than replacing it.
   Buffer horizontal(3, Charset::Utf8);
   horizontal.DrawHorizontalLine(1, 0, 1, Style());
-  EXPECT_EQ(Render(horizontal), " ─\n");
+  EXPECT_EQ(Render(horizontal), " ·\n");
 
   Buffer vertical(3, Charset::Utf8);
   vertical.DrawVerticalLine(1, 0, 1, Style());
-  EXPECT_EQ(Render(vertical), " │\n");
+  EXPECT_EQ(Render(vertical), " ·\n");
+
+  Buffer joined(3, Charset::Utf8);
+  joined.DrawHorizontalLine(1, 0, 1, Style());
+  joined.DrawHorizontalLine(0, 0, 3, Style());
+  EXPECT_EQ(Render(joined), "╶─╴\n");
+
+  // ASCII has one glyph for everything that isn't a plain segment.
+  Buffer ascii(3, Charset::Ascii);
+  ascii.DrawVerticalLine(1, 0, 1, Style());
+  EXPECT_EQ(Render(ascii), " +\n");
 
   // A line with no length draws nothing at all.
   Buffer empty(3, Charset::Utf8);
   empty.DrawHorizontalLine(0, 0, 0, Style());
-  empty.DrawVerticalLine(0, 0, -1, Style());
+  empty.DrawVerticalLine(0, 0, 0, Style());
   EXPECT_EQ(Render(empty), "");
+}
+
+TEST(BufferTest, LineEndsDecideWhatMeetsThemAtTheEnd) {
+  // A line ending at a center is met with a corner, because the two lines stop
+  // at the same point. One running out through the edge of its last cell is met
+  // with a tee, because it carries on past whatever arrives there.
+  Buffer corner(4, Charset::Utf8);
+  corner.DrawHorizontalLine(0, 0, 3, Style());
+  corner.DrawVerticalLine(2, 0, 2, Style());
+  EXPECT_EQ(Render(corner),
+            "╶─╮\n"
+            "  ╵\n");
+
+  Buffer tee(4, Charset::Utf8);
+  tee.DrawHorizontalLine(0, 0, 3, Style(), LineEnd::Center, LineEnd::Edge);
+  tee.DrawVerticalLine(2, 0, 2, Style());
+  EXPECT_EQ(Render(tee),
+            "╶─┬\n"
+            "  ╵\n");
+
+  // `start` decides the first cell the way `end` decides the last.
+  Buffer edge_start(4, Charset::Utf8);
+  edge_start.DrawHorizontalLine(1, 0, 2, Style(), LineEnd::Edge);
+  EXPECT_EQ(Render(edge_start), " ─╴\n");
+}
+
+TEST(BufferTest, AnEndAtACenterDrawsHalfALine) {
+  // Two half-lines laid end to end show the gap that says they do not connect,
+  // which ASCII cannot draw.
+  Buffer buffer(6, Charset::Utf8);
+  buffer.DrawHorizontalLine(0, 0, 4, Style());
+  buffer.DrawVerticalLine(0, 1, 3, Style());
+  EXPECT_EQ(Render(buffer),
+            "╶──╴\n"
+            "╷\n"
+            "│\n"
+            "╵\n");
+
+  // Two lines that each stop at their own center, laid end to end, are drawn
+  // with the gap between them that says they do not connect.
+  Buffer apart(6, Charset::Utf8);
+  apart.DrawHorizontalLine(0, 0, 2, Style());
+  apart.DrawHorizontalLine(2, 0, 2, Style());
+  EXPECT_EQ(Render(apart), "╶╴╶╴\n");
+
+  // ASCII has nothing to draw half a line with, so there the two read as one.
+  Buffer ascii(6, Charset::Ascii);
+  ascii.DrawHorizontalLine(0, 0, 2, Style());
+  ascii.DrawHorizontalLine(2, 0, 2, Style());
+  EXPECT_EQ(Render(ascii), "----\n");
+}
+
+TEST(BufferTest, AnEdgeToEdgeLineSpansWholeCells) {
+  // Bounding a run of columns is edge to edge: the line covers all of them
+  // rather than stopping halfway into the first and last.
+  Buffer buffer(4, Charset::Utf8);
+  buffer.DrawHorizontalLine(0, 0, 1, Style(), LineEnd::Edge, LineEnd::Edge);
+  buffer.DrawVerticalLine(0, 1, 1, Style(), LineEnd::Edge, LineEnd::Edge);
+  EXPECT_EQ(Render(buffer),
+            "─\n"
+            "│\n");
+
+  // Two edge-to-edge runs that meet end to end read as one line, without
+  // either having to reach into the other's cells.
+  Buffer split(6, Charset::Utf8);
+  split.DrawVerticalLine(0, 0, 2, Style(), LineEnd::Edge, LineEnd::Edge);
+  split.DrawVerticalLine(0, 2, 2, Style(), LineEnd::Edge, LineEnd::Edge);
+  EXPECT_EQ(Render(split),
+            "│\n"
+            "│\n"
+            "│\n"
+            "│\n");
 }
 
 TEST(BufferTest, LinesDrawOverContent) {
   // A line replaces whatever text was in the cell, including both halves of a
-  // double-width symbol it lands on.
+  // double-width character it lands on.
   Buffer over_text(5, Charset::Utf8);
   over_text.DrawText(0, 0, "abcde", Style());
   over_text.DrawHorizontalLine(1, 0, 3, Style());
-  EXPECT_EQ(Render(over_text), "a───e\n");
+  EXPECT_EQ(Render(over_text), "a╶─╴e\n");
 
   Buffer over_wide(5, Charset::Utf8);
   over_wide.DrawText(0, 0, "中中", Style());
-  over_wide.DrawVerticalLine(1, 0, 1, Style());
+  over_wide.DrawVerticalLine(1, 0, 1, Style(), LineEnd::Edge, LineEnd::Edge);
   EXPECT_EQ(Render(over_wide), " │中\n");
 }
 
@@ -203,14 +309,14 @@ TEST(BufferTest, Box) {
   flat.DrawBox(0, 0, 4, 1, Style());
   flat.DrawBox(0, 2, 1, 2, Style());
   EXPECT_EQ(Render(flat),
-            "────\n"
+            "╶──╴\n"
             "\n"
-            "│\n"
-            "│\n");
+            "╷\n"
+            "╵\n");
 
   Buffer degenerate(4, Charset::Utf8);
   degenerate.DrawBox(0, 0, 0, 4, Style());
-  degenerate.DrawBox(0, 0, 4, -1, Style());
+  degenerate.DrawBox(0, 0, 4, 0, Style());
   EXPECT_EQ(Render(degenerate), "");
 }
 
@@ -230,7 +336,7 @@ TEST(BufferTest, Text) {
             "A       B\n"
             "C\n");
 
-  // Empty text still occupies the row it started on.
+  // Drawing nothing ends where it began.
   EXPECT_EQ(buffer.DrawText(0, 0, "", Style()).y, 0);
 }
 
@@ -285,9 +391,9 @@ TEST(BufferTest, AsciiDoesNoUtf8Processing) {
   invalid.DrawText(0, 0, llvm::StringRef("\xc0\x80z", 3), Style());
   EXPECT_EQ(Render(invalid), "??z\n");
 
-  // Every symbol is one column wide, whatever it is.
-  EXPECT_EQ(buffer.DrawSymbol(0, 1, U'中', Style()).x, 1);
-  EXPECT_EQ(buffer.DrawSymbol(1, 1, CombiningAcute, Style()).x, 2);
+  // Every code point is one column wide, whatever it is.
+  EXPECT_EQ(buffer.DrawCodePoint(0, 1, U'中', Style()).x, 1);
+  EXPECT_EQ(buffer.DrawCodePoint(1, 1, CombiningAcute, Style()).x, 2);
   EXPECT_EQ(Render(buffer),
             "a???b\n"
             "??\n");
@@ -305,55 +411,57 @@ TEST(BufferTest, TextInvalidUtf8) {
   EXPECT_EQ(Render(surrogate), "���z\n");
 }
 
-TEST(BufferTest, SymbolsWithNoEncoding) {
-  // Decoding text never yields these, but `DrawSymbol` takes any code point,
+TEST(BufferTest, CodePointsWithNoEncoding) {
+  // Decoding text never yields these, but `DrawCodePoint` takes any code point,
   // including the surrogates and the values past the last one that UTF-8 has no
   // encoding for.
   Buffer buffer(10, Charset::Utf8);
-  EXPECT_EQ(buffer.DrawSymbol(0, 0, static_cast<char32_t>(0xd800), Style()).x,
-            1);
-  EXPECT_EQ(buffer.DrawSymbol(1, 0, static_cast<char32_t>(0xdfff), Style()).x,
-            2);
-  EXPECT_EQ(buffer.DrawSymbol(2, 0, static_cast<char32_t>(0x110000), Style()).x,
-            3);
+  EXPECT_EQ(
+      buffer.DrawCodePoint(0, 0, static_cast<char32_t>(0xd800), Style()).x, 1);
+  EXPECT_EQ(
+      buffer.DrawCodePoint(1, 0, static_cast<char32_t>(0xdfff), Style()).x, 2);
+  EXPECT_EQ(
+      buffer.DrawCodePoint(2, 0, static_cast<char32_t>(0x110000), Style()).x,
+      3);
   EXPECT_EQ(Render(buffer), "���\n");
 }
 
-TEST(BufferTest, DoubleWidthSymbols) {
+TEST(BufferTest, DoubleWidthCharacters) {
   Buffer buffer(6, Charset::Utf8);
   buffer.DrawText(0, 0, "中A🔥", Style());
   EXPECT_EQ(Render(buffer), "中A🔥\n");
-  EXPECT_EQ(buffer.DrawSymbol(0, 1, U'中', Style()).x, 2);
+  EXPECT_EQ(buffer.DrawCodePoint(0, 1, U'中', Style()).x, 2);
 }
 
-TEST(BufferTest, DrawingOverADoubleWidthSymbolErasesAllOfIt) {
-  // Overwriting either half has to erase the whole symbol. Leaving the other
-  // half behind would either duplicate part of a glyph or, for the trailing
-  // half, silently drop a column and misalign everything after it.
+TEST(BufferTest, DrawingOverADoubleWidthCharacterErasesAllOfIt) {
+  // Overwriting either half has to erase the whole character. Either half left
+  // behind misaligns what follows, because the columns the grid counts for the
+  // cell and the ones the terminal paints stop agreeing.
   Buffer over_head(4, Charset::Utf8);
-  over_head.DrawSymbol(0, 0, U'中', Style());
-  over_head.DrawSymbol(0, 0, 'A', Style());
+  over_head.DrawCodePoint(0, 0, U'中', Style());
+  over_head.DrawCodePoint(0, 0, 'A', Style());
   EXPECT_EQ(Render(over_head), "A\n");
 
   Buffer over_tail(4, Charset::Utf8);
-  over_tail.DrawSymbol(0, 0, U'中', Style());
-  over_tail.DrawSymbol(1, 0, 'B', Style());
+  over_tail.DrawCodePoint(0, 0, U'中', Style());
+  over_tail.DrawCodePoint(1, 0, 'B', Style());
   EXPECT_EQ(Render(over_tail), " B\n");
 
-  // The same holds when a double-width symbol lands on another one.
+  // The same holds when a double-width character lands on another one.
   Buffer over_both(6, Charset::Utf8);
-  over_both.DrawSymbol(0, 0, U'中', Style());
-  over_both.DrawSymbol(2, 0, U'中', Style());
-  over_both.DrawSymbol(1, 0, U'国', Style());
+  over_both.DrawCodePoint(0, 0, U'中', Style());
+  over_both.DrawCodePoint(2, 0, U'中', Style());
+  over_both.DrawCodePoint(1, 0, U'国', Style());
   EXPECT_EQ(Render(over_both), " 国\n");
 }
 
-TEST(BufferTest, DoubleWidthSymbolPastTheEdgeTakesBothColumns) {
-  // Splitting one would leave the terminal rendering half a character, so the
-  // buffer grows by both of its columns rather than one.
+TEST(BufferTest, DoubleWidthCharacterInTheLastColumnTakesBothColumns) {
+  // It starts inside the width, and splitting one would leave the terminal
+  // rendering half a character, so it overhangs by a column rather than being
+  // refused.
   Buffer buffer(3, Charset::Utf8);
-  EXPECT_EQ(buffer.DrawSymbol(2, 0, U'中', Style()).x, 4);
-  buffer.DrawSymbol(0, 0, 'a', Style());
+  EXPECT_EQ(buffer.DrawCodePoint(2, 0, U'中', Style()).x, 4);
+  buffer.DrawCodePoint(0, 0, 'a', Style());
   EXPECT_EQ(Render(buffer), "a 中\n");
   EXPECT_GE(buffer.width(), 4);
 }
@@ -365,24 +473,19 @@ TEST(BufferTest, CombiningMarks) {
   buffer.DrawText(0, 0, AcuteE, Style());
   EXPECT_EQ(Render(buffer), AcuteE.str() + "\n");
   EXPECT_EQ(buffer.MeasureText(0, 0, AcuteE).x, 1);
-  EXPECT_EQ(buffer.DrawSymbol(5, 0, CombiningAcute, Style()).x, 5);
-
-  // A mark with nothing before it has nothing to attach to.
-  Buffer orphan(10, Charset::Utf8);
-  orphan.DrawSymbol(0, 0, CombiningAcute, Style());
-  EXPECT_EQ(Render(orphan), "");
+  EXPECT_EQ(buffer.DrawCodePoint(5, 0, CombiningAcute, Style()).x, 5);
 
   // Drawing over the base takes its marks with it.
   Buffer overwritten(10, Charset::Utf8);
   overwritten.DrawText(0, 0, AcuteE, Style());
   overwritten.DrawText(1, 0, "x", Style());
-  overwritten.DrawSymbol(0, 0, 'o', Style());
+  overwritten.DrawCodePoint(0, 0, 'o', Style());
   EXPECT_EQ(Render(overwritten), "ox\n");
 }
 
 TEST(BufferTest, CombiningMarksOnADoubleWidthBase) {
-  // A mark following a double-width symbol arrives at the column past its
-  // continuation, and has to reach back to the symbol itself.
+  // A mark following a double-width character arrives at the column past its
+  // continuation, and has to reach back to the character itself.
   Buffer buffer(10, Charset::Utf8);
   buffer.DrawText(0, 0, ("中" + AcuteE.drop_front(1) + "x").str(), Style());
   EXPECT_EQ(Render(buffer), ("中" + AcuteE.drop_front(1) + "x\n").str());
@@ -407,7 +510,7 @@ TEST(BufferTest, CombiningMarksAreCapped) {
 TEST(BufferTest, WrappedText) {
   Buffer buffer(20, Charset::Ascii);
   EXPECT_EQ(buffer
-                .DrawWrappedText(0, 0, 10,
+                .DrawWrappedText(0, 0, 0, 10,
                                  "This is a long sentence that should be "
                                  "wrapped.",
                                  Style())
@@ -424,81 +527,182 @@ TEST(BufferTest, WrappedText) {
 }
 
 TEST(BufferTest, WrappedTextKeepsWordsTooLongToFitWhole) {
-  // Breaking one costs a reader more than the overhang does, so it overhangs
-  // and the buffer grows to hold it.
+  // A break is a newline in the rendered text, and one inside a word stops it
+  // being copied out in one piece, so the word overhangs the width instead and
+  // the buffer grows to hold it.
   Buffer buffer(10, Charset::Ascii);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 5, "abcdefghij", Style()).y, 0);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 0, 5, "abcdefghij", Style()).y, 0);
   EXPECT_EQ(Render(buffer), "abcdefghij\n");
 }
 
 TEST(BufferTest, WrappedTextStartsAnOverlongWordOnItsOwnRow) {
-  // It still moves down to a row of its own, so the words before it aren't
-  // pushed out of the region with it.
+  // A word too long for any row moves to one of its own anyway, so it overhangs
+  // from the margin rather than from wherever the previous word ended.
   Buffer buffer(10, Charset::Ascii);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 5, "ab abcdefghij", Style()).y, 1);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 0, 5, "ab abcdefghij", Style()).y, 1);
   EXPECT_EQ(Render(buffer),
             "ab\n"
             "abcdefghij\n");
 }
 
+TEST(BufferTest, WrappedSpansShareOneBlock) {
+  // A block whose spans are styled differently is drawn one span at a time,
+  // each continuing where the last ended and all naming the same margin, so
+  // the rows after the first line up with the block rather than with wherever
+  // the span happened to start.
+  Buffer buffer(20, Charset::Ascii);
+  Buffer::DrawEnd end =
+      buffer.DrawWrappedText(2, 0, 2, 12, "plain words", Style());
+  end = buffer.DrawWrappedText(end.x, end.y, 2, 12, " emphasized more",
+                               Style().Bold());
+  buffer.DrawWrappedText(end.x, end.y, 2, 12, " plain again", Style());
+
+  EXPECT_EQ(Render(buffer),
+            "  plain words\n"
+            "  emphasized\n"
+            "  more plain\n"
+            "  again\n");
+}
+
 TEST(BufferTest, WrappedTextIndents) {
-  // Wrapping is relative to where the text starts, which is what lets a
-  // wrapped block sit beside a gutter.
+  // Wrapping is relative to the margin rather than to where the text starts,
+  // which is what lets a wrapped block sit beside a gutter.
   Buffer buffer(12, Charset::Ascii);
   buffer.DrawText(0, 0, "| ", Style());
-  buffer.DrawWrappedText(2, 0, 6, "alpha beta gamma", Style());
+  buffer.DrawWrappedText(2, 0, 2, 6, "alpha beta gamma", Style());
   EXPECT_EQ(Render(buffer),
             "| alpha\n"
             "  beta\n"
             "  gamma\n");
 }
 
+TEST(BufferTest, WrappedTextExpandsTabsToStops) {
+  // A tab advances to the next stop, and one following a newline the text wrote
+  // is indentation and is kept.
+  Buffer buffer(40, Charset::Ascii);
+  buffer.DrawWrappedText(0, 0, 0, 30, "a\tb\nlonger\tc", Style());
+  EXPECT_EQ(Render(buffer),
+            "a       b\n"
+            "longer  c\n");
+
+  // A tab the text wrote after a newline is indentation, and is kept.
+  Buffer indented(40, Charset::Ascii);
+  indented.DrawWrappedText(0, 0, 0, 30, "a\n\tb", Style());
+  EXPECT_EQ(Render(indented),
+            "a\n"
+            "        b\n");
+}
+
+TEST(BufferTest, WrappedTextTabStopsFollowTheMargin) {
+  // Stops are counted from the block's margin rather than from the buffer's
+  // left edge.
+  Buffer buffer(40, Charset::Ascii);
+  buffer.DrawText(0, 0, "| ", Style());
+  buffer.DrawWrappedText(2, 0, 2, 20, "a\tb", Style());
+  EXPECT_EQ(Render(buffer), "| a       b\n");
+}
+
+TEST(BufferTest, WrappedTextBreaksAtTabs) {
+  // A tab is a break opportunity as well as a jump to a stop.
+  Buffer buffer(40, Charset::Ascii);
+  buffer.DrawWrappedText(0, 0, 0, 8, "aaaa\tbbbb", Style());
+  EXPECT_EQ(Render(buffer),
+            "aaaa\n"
+            "bbbb\n");
+
+  // One reaching past the block stops at its edge, so the span after it
+  // continues from there rather than from a stop outside the block.
+  Buffer clipped(40, Charset::Ascii);
+  EXPECT_EQ(clipped.DrawWrappedText(0, 0, 0, 4, "ab\t", Style()),
+            DrawEnd(4, 0));
+}
+
+TEST(BufferTest, TabWidthComesFromCapabilities) {
+  Capabilities capabilities;
+  capabilities.charset = Charset::Ascii;
+  capabilities.tab_width = 4;
+
+  Buffer buffer(capabilities);
+  buffer.DrawText(0, 0, "a\tb", Style());
+  buffer.DrawWrappedText(0, 1, 0, 20, "a\tb", Style());
+  EXPECT_EQ(Render(buffer),
+            "a   b\n"
+            "a   b\n");
+
+  // A terminal claiming stops a buffer can't draw to is clamped rather than
+  // trusted, the same as one claiming an impossible width.
+  capabilities.tab_width = 0;
+  Buffer clamped(capabilities);
+  clamped.DrawText(0, 0, "a\tb", Style());
+  EXPECT_EQ(Render(clamped), "a b\n");
+}
+
+TEST(BufferTest, WrappedTextKeepsTheBreaksItIsGiven) {
+  // Wrapping only adds breaks. Text that arrives wrapped to some other width
+  // keeps that wrapping rather than being reflowed into this one, even where
+  // its lines would fit together.
+  Buffer buffer(40, Charset::Ascii);
+  EXPECT_EQ(
+      buffer.DrawWrappedText(0, 0, 0, 30, "already\nwrapped\nnarrow", Style())
+          .y,
+      2);
+  EXPECT_EQ(Render(buffer),
+            "already\n"
+            "wrapped\n"
+            "narrow\n");
+
+  // A break the text ends with closes its last line, and a row nothing was
+  // drawn into is not a row, so it doesn't also open an empty one.
+  Buffer trailing(40, Charset::Ascii);
+  trailing.DrawWrappedText(0, 0, 0, 30, "one\ntwo\n", Style());
+  EXPECT_EQ(Render(trailing),
+            "one\n"
+            "two\n");
+}
+
 TEST(BufferTest, WrappedTextLineBreaks) {
   // Carriage returns are dropped, so CRLF endings break exactly once.
   Buffer buffer(10, Charset::Ascii);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 10, "a\r\nb", Style()).y, 1);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 0, 10, "a\r\nb", Style()).y, 1);
   EXPECT_EQ(Render(buffer),
             "a\n"
             "b\n");
 
-  // Spaces that would begin a row are dropped, keeping text aligned.
+  // Whitespace stops at the block's edge, so a wrapped row starts at the
+  // margin.
   Buffer spaces(10, Charset::Ascii);
-  spaces.DrawWrappedText(0, 0, 5, "aaaaa     bbbbb", Style());
+  spaces.DrawWrappedText(0, 0, 0, 5, "aaaaa     bbbbb", Style());
   EXPECT_EQ(Render(spaces),
             "aaaaa\n"
             "bbbbb\n");
-
-  // A wrap region with no columns has nowhere to put anything.
-  Buffer degenerate(10, Charset::Ascii);
-  EXPECT_EQ(degenerate.DrawWrappedText(0, 0, 0, "anything", Style()).y, 0);
-  EXPECT_EQ(degenerate.DrawWrappedText(0, 0, -1, "anything", Style()).y, 0);
-  EXPECT_EQ(Render(degenerate), "");
 }
 
-TEST(BufferTest, WrappedTextWithNoWidthToFit) {
-  // A caller with no width to fit passes one no row reaches, which has to wrap
-  // nothing rather than overflow the column it would name.
-  Buffer buffer(10, Charset::Ascii);
-  llvm::StringRef text = "several words that would otherwise wrap";
-  EXPECT_EQ(buffer.DrawWrappedText(3, 0, std::numeric_limits<int>::max(), text,
-                                   Style()),
-            DrawEnd(3 + static_cast<int>(text.size()), 0));
-  EXPECT_EQ(Render(buffer), "   several words that would otherwise wrap\n");
+TEST(BufferTest, WrappedTextFillsTheWidthLeftOfTheMargin) {
+  // A caller with nothing to divide the width between gives the block all of
+  // what is left of it, which is what wrapping to the terminal is.
+  Buffer buffer(20, Charset::Ascii);
+  buffer.DrawText(0, 0, "-> ", Style());
+  buffer.DrawWrappedText(3, 0, 3, buffer.columns() - 3,
+                         "several words that would otherwise fit", Style());
+  EXPECT_EQ(Render(buffer),
+            "-> several words\n"
+            "   that would\n"
+            "   otherwise fit\n");
 }
 
-TEST(BufferTest, WrappedTextKeepsSymbolsWiderThanTheRegion) {
-  // No row in a one-column region could hold a double-width symbol. Drawing it
-  // anyway overruns the region, which is what keeping the text costs here.
+TEST(BufferTest, WrappedTextKeepsCharactersWiderThanTheRegion) {
+  // No row in a one-column region could hold a double-width character. Drawing
+  // it anyway overruns the region, which is what keeping the text costs here.
   Buffer buffer(10, Charset::Utf8);
-  buffer.DrawWrappedText(0, 0, 1, "中中", Style());
+  buffer.DrawWrappedText(0, 0, 0, 1, "中中", Style());
   EXPECT_EQ(Render(buffer), "中中\n");
 }
 
-TEST(BufferTest, WrappedTextWithDoubleWidthSymbols) {
+TEST(BufferTest, WrappedTextWithDoubleWidthCharacters) {
   // Wrapping counts columns, not characters, so half as many double-width ones
   // fit a row.
   Buffer buffer(10, Charset::Utf8);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 4, "中中 中中", Style()).y, 1);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 0, 4, "中中 中中", Style()).y, 1);
   EXPECT_EQ(Render(buffer),
             "中中\n"
             "中中\n");
@@ -515,8 +719,8 @@ TEST(BufferTest, TrailingBlanksAreDropped) {
 TEST(BufferTest, StyledBlanksAreKept) {
   // A blank cell with a background still paints, so it isn't padding.
   Buffer buffer(10, Charset::Ascii);
-  buffer.DrawSymbol(0, 0, 'x', Style());
-  buffer.DrawSymbol(3, 0, ' ', Style().Background(AnsiColor::Red));
+  buffer.DrawCodePoint(0, 0, 'x', Style());
+  buffer.DrawCodePoint(3, 0, ' ', Style().Background(AnsiColor::Red));
   EXPECT_EQ(Render(buffer, ColorMode::Ansi16), "x  \x1b[41m \x1b[0m\n");
 
   // With color off the background paints nothing, so those cells are padding
@@ -527,12 +731,12 @@ TEST(BufferTest, StyledBlanksAreKept) {
 TEST(BufferTest, RenderMinimizesEscapes) {
   Buffer buffer(4, Charset::Ascii);
   Style red_bold = Style().Bold().Foreground(Color(255, 0, 0));
-  buffer.DrawSymbol(0, 0, 'A', red_bold);
+  buffer.DrawCodePoint(0, 0, 'A', red_bold);
   // Sharing the attributes and changing only the color costs one escape.
-  buffer.DrawSymbol(1, 0, 'B', red_bold.Foreground(Color(0, 0, 255)));
+  buffer.DrawCodePoint(1, 0, 'B', red_bold.Foreground(Color(0, 0, 255)));
   // Dropping bold costs a reset and a fresh start.
-  buffer.DrawSymbol(2, 0, 'C', Style().Foreground(Color(0, 0, 255)));
-  buffer.DrawSymbol(3, 0, 'D', Style());
+  buffer.DrawCodePoint(2, 0, 'C', Style().Foreground(Color(0, 0, 255)));
+  buffer.DrawCodePoint(3, 0, 'D', Style());
 
   EXPECT_EQ(Render(buffer, ColorMode::Truecolor),
             "\x1b[1m\x1b[38;2;255;0;0m"
@@ -543,17 +747,6 @@ TEST(BufferTest, RenderMinimizesEscapes) {
             "C"
             "\x1b[0m"
             "D\n");
-}
-
-TEST(BufferTest, RenderEndsRowsWithoutStyle) {
-  // A style left on at the end of a row would bleed into whatever the terminal
-  // prints next.
-  Buffer buffer(4, Charset::Ascii);
-  buffer.DrawSymbol(0, 0, 'A', Style().Background(AnsiColor::Red));
-  buffer.DrawSymbol(0, 1, 'B', Style().Background(AnsiColor::Red));
-  EXPECT_EQ(Render(buffer, ColorMode::Ansi16),
-            "\x1b[41mA\x1b[0m\n"
-            "\x1b[41mB\x1b[0m\n");
 }
 
 TEST(BufferTest, MeasureText) {
@@ -570,8 +763,8 @@ TEST(BufferTest, MeasureText) {
   EXPECT_EQ(utf8.MeasureText(0, 0, "a\r\nb"), DrawEnd(1, 1));
   EXPECT_EQ(utf8.MeasureText(0, 0, "a\tb"), DrawEnd(9, 0));
 
-  // Measuring starts from where it is told to, which is what the tab stops and
-  // the rows a newline returns to are measured from.
+  // Measuring starts from where it is told to, which is the column a newline
+  // returns to and the origin the tab stops count from.
   EXPECT_EQ(utf8.MeasureText(3, 2, "a\tb"), DrawEnd(12, 2));
   EXPECT_EQ(utf8.MeasureText(3, 2, "a\nb"), DrawEnd(4, 3));
 
@@ -584,7 +777,7 @@ TEST(BufferTest, MeasureText) {
 
 TEST(BufferTest, MeasuringMatchesDrawing) {
   // The point of measuring is to answer what drawing would, so check the two
-  // against each other on the text they used to disagree about.
+  // against each other on the text most likely to make them disagree.
   for (llvm::StringRef text :
        {"hello", "a\tb\tc", "a\nb\r\nc", "中A🔥", "a  b", ""}) {
     Buffer buffer(10, Charset::Utf8);
@@ -592,11 +785,12 @@ TEST(BufferTest, MeasuringMatchesDrawing) {
               buffer.DrawText(2, 1, text, Style()))
         << text;
   }
-  for (llvm::StringRef text : {"one two three", "a\nlonger line here",
-                               "verylongunbreakableword", ""}) {
+  for (llvm::StringRef text :
+       {"one two three", "a\nlonger line here", "verylongunbreakableword",
+        "a\tb\tc", "col\tone\nrow\ttwo", ""}) {
     Buffer buffer(10, Charset::Utf8);
-    EXPECT_EQ(buffer.MeasureWrappedText(2, 1, 8, text),
-              buffer.DrawWrappedText(2, 1, 8, text, Style()))
+    EXPECT_EQ(buffer.MeasureWrappedText(2, 1, 2, 8, text),
+              buffer.DrawWrappedText(2, 1, 2, 8, text, Style()))
         << text;
   }
 }
@@ -606,14 +800,18 @@ TEST(BufferTest, WrapWidthIsWhatWrappingDoesNotOverhang) {
   // checked here against the wrapping it describes rather than only in
   // `metrics_test`.
   Buffer buffer(10, Charset::Utf8);
-  llvm::StringRef text = "some quite long words here";
-  int width = buffer.metrics().WrapWidth(text);
-  Buffer drawn(1, Charset::Utf8);
-  drawn.DrawWrappedText(0, 0, width, text, Style());
-  llvm::SmallVector<llvm::StringRef> rows;
-  llvm::StringRef(Render(drawn)).split(rows, '\n');
-  for (llvm::StringRef row : rows) {
-    EXPECT_LE(static_cast<int>(row.size()), width) << row;
+  // Tabs don't widen the answer: one stops at the block's edge rather than
+  // running to a stop outside it, so it can't overhang either.
+  for (llvm::StringRef text :
+       {"some quite long words here", "some\tquite\tlong words here"}) {
+    int width = buffer.metrics().WrapWidth(text);
+    Buffer drawn(width, Charset::Utf8);
+    drawn.DrawWrappedText(0, 0, 0, width, text, Style());
+    llvm::SmallVector<llvm::StringRef> rows;
+    llvm::StringRef(Render(drawn)).split(rows, '\n');
+    for (llvm::StringRef row : rows) {
+      EXPECT_LE(static_cast<int>(row.size()), width) << row;
+    }
   }
 }
 
@@ -623,17 +821,21 @@ TEST(BufferTest, BuiltFromCapabilities) {
   capabilities.charset = Charset::Utf8;
 
   Buffer buffer(capabilities);
-  EXPECT_EQ(buffer.width(), 5);
+  EXPECT_EQ(buffer.columns(), 5);
   EXPECT_EQ(buffer.charset(), Charset::Utf8);
   buffer.DrawHorizontalLine(0, 0, 5, Style());
-  EXPECT_EQ(Render(buffer, capabilities.color_mode), "─────\n");
+  EXPECT_EQ(Render(buffer, capabilities.color_mode), "╶───╴\n");
 
-  // With no width to start from, the buffer starts at nothing and grows, which
-  // is what it would have done past any starting width anyway.
+  // A terminal that said nothing about its width gets one chosen to be safe
+  // wherever the output ends up, rather than no width at all.
   capabilities.columns = std::nullopt;
-  Buffer grown(capabilities);
-  grown.DrawHorizontalLine(0, 0, 5, Style());
-  EXPECT_EQ(Render(grown, capabilities.color_mode), "─────\n");
+  Buffer fallback(capabilities);
+  EXPECT_EQ(fallback.columns(), DefaultColumns);
+
+  // One claiming a width no grid can hold gets the nearest that can be held.
+  capabilities.columns = Buffer::MaxColumns + 1;
+  Buffer clamped(capabilities);
+  EXPECT_EQ(clamped.columns(), Buffer::MaxColumns);
 }
 
 TEST(BufferTest, CombiningMarkPastTheWidthItStartedWith) {
@@ -644,13 +846,142 @@ TEST(BufferTest, CombiningMarkPastTheWidthItStartedWith) {
   EXPECT_EQ(Render(buffer), ("abcde" + AcuteE.drop_front(1) + "\n").str());
 }
 
+TEST(BufferTest, CombiningMarksSurviveGrowthAndOverdraw) {
+  // Marks live in a side table keyed by cell index, so widening has to move
+  // them with the rows and overdrawing has to take them with the cell.
+  for (int start : {1, 2, 3}) {
+    Buffer buffer(start, Charset::Utf8);
+    buffer.DrawText(0, 0, std::string(AcuteE) + "e" + std::string(AcuteE),
+                    Style());
+    buffer.DrawText(0, 1, "xxxxxxxxxxxx", Style());
+    buffer.DrawCodePoint(0, 0, U'z', Style());
+    std::string rendered = Render(buffer);
+    // The mark on the overdrawn cell went with it; the later one stayed.
+    EXPECT_EQ(rendered.substr(0, rendered.find('\n')),
+              "ze" + std::string(AcuteE))
+        << start;
+  }
+}
+
 TEST(BufferTest, CombiningMarkWithNoBase) {
   // Marks render into the column before them, so one at the start of a row has
-  // nowhere to go rather than attaching to the end of the row above.
+  // nowhere to go rather than attaching to the end of the row above. This is
+  // ordinary input rather than a caller mistake -- a source file can open a
+  // line with a mark -- so it is dropped and drawing goes on.
   Buffer buffer(4, Charset::Utf8);
   buffer.DrawText(0, 0, "ab", Style());
   buffer.DrawText(0, 1, AcuteE.drop_front(1).str(), Style());
   EXPECT_EQ(Render(buffer), "ab\n");
+
+  // Nor does it disturb what is already drawn on the row it lands on.
+  Buffer after(4, Charset::Utf8);
+  after.DrawText(0, 0, "ab", Style());
+  after.DrawCodePoint(0, 0, CombiningAcute, Style());
+  EXPECT_EQ(Render(after), "ab\n");
+}
+
+TEST(BufferTest, OverhangStopsAtTheGridBound) {
+  // An overhanging word is the only thing that reaches the grid's far edge, and
+  // how far it reaches is a fact about the text rather than something a caller
+  // could have checked, so it is clipped there rather than being a mistake.
+  // The column still advances past it, which is what keeps measuring and
+  // drawing answering the same thing.
+  Buffer buffer(4, Charset::Ascii);
+  std::string word(Buffer::MaxColumns + 10, 'x');
+  DrawEnd past(Buffer::MaxColumns + 10, 0);
+  EXPECT_EQ(buffer.MeasureWrappedText(0, 0, 0, 4, word), past);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 0, 4, word, Style()), past);
+  EXPECT_EQ(buffer.width(), Buffer::MaxColumns);
+  EXPECT_EQ(buffer.height(), 1);
+}
+
+TEST(BufferTest, ACharacterStraddlingTheGridBoundIsNotDrawn) {
+  // Whether a character fits the far edge depends on how wide it turns out to
+  // be, and half of one is not something a terminal can render, so one
+  // straddling the bound is past it entirely.
+  Buffer buffer(4, Charset::Utf8);
+  std::string word(Buffer::MaxColumns - 1, 'x');
+  word += "中";
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 0, 4, word, Style()),
+            DrawEnd(Buffer::MaxColumns + 1, 0));
+  EXPECT_EQ(buffer.width(), Buffer::MaxColumns);
+  // Only the run before it reached the output; the character itself did not.
+  EXPECT_EQ(Render(buffer).size(), static_cast<size_t>(Buffer::MaxColumns));
+}
+
+TEST(BufferTest, APointBoxLeavesALineAlone) {
+  // A point is line art with no directions, so drawing one where a line
+  // already runs adds nothing and leaves the line's own directions in place.
+  Buffer buffer(3, Charset::Utf8);
+  buffer.DrawHorizontalLine(0, 0, 3, Style());
+  buffer.DrawBox(1, 0, 1, 1, Style());
+  EXPECT_EQ(Render(buffer), "╶─╴\n");
+
+  // With nothing there, the point is drawn.
+  Buffer empty(3, Charset::Utf8);
+  empty.DrawBox(1, 0, 1, 1, Style());
+  EXPECT_EQ(Render(empty), " ·\n");
+}
+
+TEST(BufferDeathTest, WidthMustFitTheGrid) {
+  // A width comes from `COLUMNS` by way of `Capabilities`, which clamps it. A
+  // caller reaching this constructor has computed the width itself, so a value
+  // the grid can't hold is a mistake rather than bad input.
+  EXPECT_DEATH(Buffer(0, Charset::Ascii), "Buffer width must be in");
+  EXPECT_DEATH(Buffer(-1, Charset::Ascii), "Buffer width must be in");
+  EXPECT_DEATH(Buffer(Buffer::MaxColumns + 1, Charset::Ascii),
+               "Buffer width must be in");
+}
+
+TEST(BufferDeathTest, DrawingMustStartInsideTheGrid) {
+  // A caller placing something already knows the width, since it is what
+  // decided the layout, so landing outside it is a bug in that layout rather
+  // than something to quietly drop. Rows are checked the same way.
+  Buffer buffer(10, Charset::Ascii);
+  EXPECT_DEATH(buffer.DrawCodePoint(10, 0, 'a', Style()), "is outside the");
+  EXPECT_DEATH(buffer.DrawCodePoint(-1, 0, 'a', Style()), "is outside the");
+  EXPECT_DEATH(buffer.DrawCodePoint(0, -1, 'a', Style()), "is outside the");
+  EXPECT_DEATH(buffer.DrawCodePoint(0, Buffer::MaxRows, 'a', Style()),
+               "is outside the");
+  EXPECT_DEATH(buffer.DrawText(10, 0, "a", Style()), "is outside the");
+  EXPECT_DEATH(buffer.MeasureText(10, 0, "a"), "is outside the");
+}
+
+TEST(BufferDeathTest, LinesMustFitWhatTheyAreDrawnInto) {
+  // Nothing about a line is unbreakable, so unlike text it has no reason to
+  // reach outside the width, and one that does came from a wrong extent.
+  Buffer buffer(10, Charset::Ascii);
+  EXPECT_DEATH(buffer.DrawHorizontalLine(6, 0, 5, Style()), "runs outside the");
+  EXPECT_DEATH(buffer.DrawHorizontalLine(0, 0, -1, Style()),
+               "runs outside the");
+  EXPECT_DEATH(buffer.DrawVerticalLine(0, 0, Buffer::MaxRows + 1, Style()),
+               "runs outside the");
+  EXPECT_DEATH(buffer.DrawBox(0, 0, 11, 2, Style()), "runs outside the");
+}
+
+TEST(BufferDeathTest, WrappedBlocksMustFitTheWidth) {
+  // A block is a division of the width rather than something that can exceed
+  // it, and the text has to start inside the block it wraps in.
+  Buffer buffer(10, Charset::Ascii);
+  EXPECT_DEATH(buffer.DrawWrappedText(0, 0, 0, 11, "a", Style()),
+               "does not fit the");
+  EXPECT_DEATH(buffer.DrawWrappedText(4, 0, 4, 8, "a", Style()),
+               "does not fit the");
+  EXPECT_DEATH(buffer.DrawWrappedText(0, 0, 0, 0, "a", Style()),
+               "does not fit the");
+  EXPECT_DEATH(buffer.DrawWrappedText(2, 0, 4, 6, "a", Style()),
+               "does not fit the");
+  EXPECT_DEATH(buffer.MeasureWrappedText(0, 0, 0, 11, "a"), "does not fit the");
+}
+
+TEST(BufferDeathTest, TextMustBeShortEnoughToMeasure) {
+  // Measuring walks the text adding widths, so a long enough run would carry
+  // the column past what an `int` holds. Text this long was built rather than
+  // read off a line.
+  Buffer buffer(10, Charset::Ascii);
+  std::string huge(Buffer::MaxTextBytes + 1, 'x');
+  EXPECT_DEATH(buffer.DrawText(0, 0, huge, Style()), "is past the");
+  EXPECT_DEATH(buffer.MeasureText(0, 0, huge), "is past the");
 }
 
 TEST(BufferTest, WriteTo) {
@@ -670,7 +1001,29 @@ TEST(BufferTest, WriteTo) {
   auto read_back = dir->ReadFileToString("out");
   ASSERT_TRUE(read_back.ok()) << read_back.error();
   EXPECT_EQ(*read_back, Render(buffer, ColorMode::Ansi16));
-  EXPECT_EQ(*read_back, "\x1b[1mhello\x1b[0m\nworld\n");
+  EXPECT_EQ(*read_back, "\x1b[1mhello\n\x1b[0mworld\n");
+}
+
+TEST(BufferTest, StyleCarriesAcrossRows) {
+  // A style is usually still in use on the row below, so turning it off at the
+  // end of a row and back on at the start of the next costs a reset and a fresh
+  // start for nothing.
+  Buffer buffer(4, Charset::Ascii);
+  buffer.DrawText(0, 0, "ab", Style().Bold());
+  buffer.DrawText(0, 1, "cd", Style().Bold());
+  EXPECT_EQ(Render(buffer, ColorMode::Ansi16), "\x1b[1mab\ncd\x1b[0m\n");
+}
+
+TEST(BufferTest, StyleThatPaintsBlanksStopsAtTheRowEnd) {
+  // A terminal fills the rest of a row with the background it is in when the
+  // row ends, so a style that paints where there is no glyph can't be left on
+  // across the newline the way an attribute that only affects a glyph can.
+  Buffer buffer(4, Charset::Ascii);
+  buffer.DrawText(0, 0, "ab", Style().Background(AnsiColor::Red));
+  buffer.DrawText(0, 1, "cd", Style().Background(AnsiColor::Red));
+  EXPECT_EQ(Render(buffer, ColorMode::Ansi16),
+            "\x1b[41mab\x1b[0m\n"
+            "\x1b[41mcd\x1b[0m\n");
 }
 
 TEST(BufferTest, RenderAppends) {

--- a/common/terminal/buffer_test.cpp
+++ b/common/terminal/buffer_test.cpp
@@ -32,32 +32,47 @@ TEST(BufferTest, Empty) {
   EXPECT_EQ(Render(buffer), "");
 }
 
-TEST(BufferTest, GrowsToFitWhatIsDrawn) {
+TEST(BufferTest, GrowsRowsToFitWhatIsDrawn) {
   Buffer buffer(4, Charset::Ascii);
   EXPECT_EQ(buffer.DrawSymbol(0, 2, 'x', Style()), 1);
   EXPECT_EQ(buffer.height(), 3);
   EXPECT_EQ(Render(buffer), "\n\nx\n");
 }
 
-TEST(BufferTest, ClipsOutsideItsWidth) {
+TEST(BufferTest, GrowsColumnsToFitWhatIsDrawn) {
   Buffer buffer(3, Charset::Ascii);
-  // Clipped symbols still report the columns they would have taken, so text
-  // walking across a row stays in step.
-  EXPECT_EQ(buffer.DrawSymbol(-1, 0, 'a', Style()), 1);
-  EXPECT_EQ(buffer.DrawSymbol(3, 0, 'a', Style()), 1);
-  EXPECT_EQ(buffer.DrawSymbol(0, -1, 'a', Style()), 1);
-  EXPECT_EQ(buffer.height(), 0);
-
-  // Lines that run past an edge draw the part that fits.
   buffer.DrawHorizontalLine(1, 0, 5, Style());
   buffer.DrawVerticalLine(0, 1, 5, Style());
   EXPECT_EQ(Render(buffer),
-            " --\n"
+            " -----\n"
             "|\n"
             "|\n"
             "|\n"
             "|\n"
             "|\n");
+  EXPECT_GE(buffer.width(), 6);
+}
+
+TEST(BufferTest, DrawsNothingBeforeItsOrigin) {
+  Buffer buffer(3, Charset::Ascii);
+  // Negative coordinates have nowhere to grow to. The symbols still report the
+  // columns they would have taken, so text walking a row stays in step.
+  EXPECT_EQ(buffer.DrawSymbol(-1, 0, 'a', Style()), 1);
+  EXPECT_EQ(buffer.DrawSymbol(0, -1, 'a', Style()), 1);
+  EXPECT_EQ(buffer.height(), 0);
+}
+
+TEST(BufferTest, WidthGrowsAcrossRowsAlreadyDrawn) {
+  // Rows are stored back to back, so widening has to reflow the ones already
+  // there rather than leaving them where their old width put them.
+  Buffer buffer(2, Charset::Ascii);
+  buffer.DrawText(0, 0, "ab", Style());
+  buffer.DrawText(0, 1, "cd", Style());
+  buffer.DrawText(0, 2, "efghij", Style());
+  EXPECT_EQ(Render(buffer),
+            "ab\n"
+            "cd\n"
+            "efghij\n");
 }
 
 TEST(BufferTest, LinesJoinWhereTheyMeet) {
@@ -325,18 +340,14 @@ TEST(BufferTest, DrawingOverADoubleWidthSymbolErasesAllOfIt) {
   EXPECT_EQ(Render(over_both), " 国\n");
 }
 
-TEST(BufferTest, DoubleWidthSymbolAtTheRightEdge) {
-  // Splitting one across the edge would leave the terminal rendering half a
-  // character, so it is dropped instead, while still reporting its width.
+TEST(BufferTest, DoubleWidthSymbolPastTheEdgeTakesBothColumns) {
+  // Splitting one would leave the terminal rendering half a character, so the
+  // buffer grows by both of its columns rather than one.
   Buffer buffer(3, Charset::Utf8);
   EXPECT_EQ(buffer.DrawSymbol(2, 0, U'中', Style()), 2);
   buffer.DrawSymbol(0, 0, 'a', Style());
-  EXPECT_EQ(Render(buffer), "a\n");
-
-  // So text after a clipped symbol doesn't slide into the space it left.
-  Buffer text(2, Charset::Utf8);
-  text.DrawText(0, 0, "a中b", Style());
-  EXPECT_EQ(Render(text), "a\n");
+  EXPECT_EQ(Render(buffer), "a 中\n");
+  EXPECT_GE(buffer.width(), 4);
 }
 
 TEST(BufferTest, CombiningMarks) {
@@ -548,27 +559,21 @@ TEST(BufferTest, BuiltFromCapabilities) {
   EXPECT_EQ(Render(buffer, capabilities.color_mode), "─────\n");
 }
 
-TEST(BufferTest, CombiningMarkPastTheRightEdge) {
-  // Text walks past the right edge rather than stopping there, so a mark can
-  // arrive at a column well beyond the buffer. Its base was clipped, so the
-  // mark goes with it rather than attaching to the last cell of the row, or to
-  // whatever cell the row-major index happens to land on.
+TEST(BufferTest, CombiningMarkPastTheWidthItStartedWith) {
+  // The buffer grows to hold the text, so a mark arriving past the width it
+  // was constructed with attaches to its base like any other.
   Buffer buffer(4, Charset::Utf8);
-  buffer.DrawText(0, 1, "z", Style());
   buffer.DrawText(0, 0, ("abcde" + AcuteE.drop_front(1)).str(), Style());
-  EXPECT_EQ(Render(buffer),
-            "abcd\n"
-            "z\n");
+  EXPECT_EQ(Render(buffer), ("abcde" + AcuteE.drop_front(1) + "\n").str());
+}
 
-  // The same past the last row, where the cell index has nothing to land on.
-  Buffer single_row(4, Charset::Utf8);
-  single_row.DrawText(0, 0, ("abcde" + AcuteE.drop_front(1)).str(), Style());
-  EXPECT_EQ(Render(single_row), "abcd\n");
-
-  // A mark exactly at the right edge still attaches to the last cell.
-  Buffer at_edge(4, Charset::Utf8);
-  at_edge.DrawText(0, 0, ("abcd" + AcuteE.drop_front(1)).str(), Style());
-  EXPECT_EQ(Render(at_edge), ("abcd" + AcuteE.drop_front(1) + "\n").str());
+TEST(BufferTest, CombiningMarkWithNoBase) {
+  // Marks render into the column before them, so one at the start of a row has
+  // nowhere to go rather than attaching to the end of the row above.
+  Buffer buffer(4, Charset::Utf8);
+  buffer.DrawText(0, 0, "ab", Style());
+  buffer.DrawText(0, 1, AcuteE.drop_front(1).str(), Style());
+  EXPECT_EQ(Render(buffer), "ab\n");
 }
 
 TEST(BufferTest, WriteTo) {

--- a/common/terminal/buffer_test.cpp
+++ b/common/terminal/buffer_test.cpp
@@ -417,12 +417,22 @@ TEST(BufferTest, WrappedText) {
             "wrapped.\n");
 }
 
-TEST(BufferTest, WrappedTextBreaksWordsTooLongToFit) {
+TEST(BufferTest, WrappedTextKeepsWordsTooLongToFitWhole) {
+  // Breaking one costs a reader more than the overhang does, so it overhangs
+  // and the buffer grows to hold it.
   Buffer buffer(10, Charset::Ascii);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 5, "abcdefghij", Style()).y, 1);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 5, "abcdefghij", Style()).y, 0);
+  EXPECT_EQ(Render(buffer), "abcdefghij\n");
+}
+
+TEST(BufferTest, WrappedTextStartsAnOverlongWordOnItsOwnRow) {
+  // It still moves down to a row of its own, so the words before it aren't
+  // pushed out of the region with it.
+  Buffer buffer(10, Charset::Ascii);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 5, "ab abcdefghij", Style()).y, 1);
   EXPECT_EQ(Render(buffer),
-            "abcde\n"
-            "fghij\n");
+            "ab\n"
+            "abcdefghij\n");
 }
 
 TEST(BufferTest, WrappedTextIndents) {
@@ -459,26 +469,22 @@ TEST(BufferTest, WrappedTextLineBreaks) {
   EXPECT_EQ(Render(degenerate), "");
 }
 
-TEST(BufferTest, WrappedTextDropsSymbolsWiderThanTheRegion) {
-  // No row in a one-column region could hold a double-width symbol, and
-  // drawing it anyway would run into whatever is laid out beside the region.
+TEST(BufferTest, WrappedTextKeepsSymbolsWiderThanTheRegion) {
+  // No row in a one-column region could hold a double-width symbol. Drawing it
+  // anyway overruns the region, which is what keeping the text costs here.
   Buffer buffer(10, Charset::Utf8);
-  buffer.DrawText(2, 0, "|", Style());
-  buffer.DrawText(2, 1, "|", Style());
   buffer.DrawWrappedText(0, 0, 1, "中中", Style());
-  EXPECT_EQ(Render(buffer),
-            "  |\n"
-            "  |\n");
+  EXPECT_EQ(Render(buffer), "中中\n");
 }
 
 TEST(BufferTest, WrappedTextWithDoubleWidthSymbols) {
-  // Wrapping counts columns, not characters, so a double-width word breaks at
-  // half as many of them.
+  // Wrapping counts columns, not characters, so half as many double-width ones
+  // fit a row.
   Buffer buffer(10, Charset::Utf8);
-  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 4, "中中中", Style()).y, 1);
+  EXPECT_EQ(buffer.DrawWrappedText(0, 0, 4, "中中 中中", Style()).y, 1);
   EXPECT_EQ(Render(buffer),
             "中中\n"
-            "中\n");
+            "中中\n");
 }
 
 TEST(BufferTest, TrailingBlanksAreDropped) {

--- a/common/terminal/buffer_test.cpp
+++ b/common/terminal/buffer_test.cpp
@@ -8,6 +8,7 @@
 
 #include "common/filesystem.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace Carbon::Terminal {
@@ -17,6 +18,8 @@ namespace {
 // precomposed U+00E9 is a single code point and wouldn't exercise marks at all.
 constexpr char32_t CombiningAcute = 0x0301;
 constexpr llvm::StringLiteral AcuteE = "e\xcc\x81";
+
+using DrawEnd = Buffer::DrawEnd;
 
 auto Render(const Buffer& buffer, ColorMode mode = ColorMode::NoColor)
     -> std::string {
@@ -266,7 +269,7 @@ TEST(BufferTest, AsciiDoesNoUtf8Processing) {
   Buffer buffer(10, Charset::Ascii);
   buffer.DrawText(0, 0, "a中b", Style());
   EXPECT_EQ(Render(buffer), "a???b\n");
-  EXPECT_EQ(buffer.MeasureWidth("a中b"), 5);
+  EXPECT_EQ(buffer.MeasureText(0, 0, "a中b").x, 5);
 
   // The same goes for text with combining marks, which occupy no columns only
   // because a UTF-8 terminal folds them into the one before.
@@ -308,8 +311,8 @@ TEST(BufferTest, SymbolsWithNoEncoding) {
             1);
   EXPECT_EQ(buffer.DrawSymbol(1, 0, static_cast<char32_t>(0xdfff), Style()).x,
             2);
-  EXPECT_EQ(
-      buffer.DrawSymbol(2, 0, static_cast<char32_t>(0x110000), Style()).x, 3);
+  EXPECT_EQ(buffer.DrawSymbol(2, 0, static_cast<char32_t>(0x110000), Style()).x,
+            3);
   EXPECT_EQ(Render(buffer), "���\n");
 }
 
@@ -358,7 +361,7 @@ TEST(BufferTest, CombiningMarks) {
   Buffer buffer(10, Charset::Utf8);
   buffer.DrawText(0, 0, AcuteE, Style());
   EXPECT_EQ(Render(buffer), AcuteE.str() + "\n");
-  EXPECT_EQ(buffer.MeasureWidth(AcuteE), 1);
+  EXPECT_EQ(buffer.MeasureText(0, 0, AcuteE).x, 1);
   EXPECT_EQ(buffer.DrawSymbol(5, 0, CombiningAcute, Style()).x, 5);
 
   // A mark with nothing before it has nothing to attach to.
@@ -380,7 +383,7 @@ TEST(BufferTest, CombiningMarksOnADoubleWidthBase) {
   Buffer buffer(10, Charset::Utf8);
   buffer.DrawText(0, 0, ("中" + AcuteE.drop_front(1) + "x").str(), Style());
   EXPECT_EQ(Render(buffer), ("中" + AcuteE.drop_front(1) + "x\n").str());
-  EXPECT_EQ(buffer.MeasureWidth(("中" + AcuteE.drop_front(1)).str()), 2);
+  EXPECT_EQ(buffer.MeasureText(0, 0, ("中" + AcuteE.drop_front(1)).str()).x, 2);
 }
 
 TEST(BufferTest, CombiningMarksAreCapped) {
@@ -539,23 +542,65 @@ TEST(BufferTest, RenderEndsRowsWithoutStyle) {
             "\x1b[41mB\x1b[0m\n");
 }
 
-TEST(BufferTest, MeasureWidth) {
+TEST(BufferTest, MeasureText) {
   Buffer utf8(10, Charset::Utf8);
-  EXPECT_EQ(utf8.MeasureWidth(""), 0);
-  EXPECT_EQ(utf8.MeasureWidth("hello"), 5);
-  EXPECT_EQ(utf8.MeasureWidth("中A🔥"), 5);
-  EXPECT_EQ(utf8.MeasureWidth(AcuteE), 1);
-  EXPECT_EQ(utf8.MeasureWidth(llvm::StringRef("\xc0\x80", 2)), 2);
+  EXPECT_EQ(utf8.MeasureText(0, 0, ""), DrawEnd(0, 0));
+  EXPECT_EQ(utf8.MeasureText(0, 0, "hello"), DrawEnd(5, 0));
+  EXPECT_EQ(utf8.MeasureText(0, 0, "中A🔥"), DrawEnd(5, 0));
+  EXPECT_EQ(utf8.MeasureText(0, 0, AcuteE), DrawEnd(1, 0));
+  EXPECT_EQ(utf8.MeasureText(0, 0, llvm::StringRef("\xc0\x80", 2)),
+            DrawEnd(2, 0));
 
-  // Newlines and tabs are not interpreted here, only counted.
-  EXPECT_EQ(utf8.MeasureWidth("a\nb"), 3);
-  EXPECT_EQ(utf8.MeasureWidth("a\tb"), 3);
+  // Newlines, carriage returns, and tabs are interpreted as drawing does.
+  EXPECT_EQ(utf8.MeasureText(0, 0, "a\nb"), DrawEnd(1, 1));
+  EXPECT_EQ(utf8.MeasureText(0, 0, "a\r\nb"), DrawEnd(1, 1));
+  EXPECT_EQ(utf8.MeasureText(0, 0, "a\tb"), DrawEnd(9, 0));
+
+  // Measuring starts from where it is told to, which is what the tab stops and
+  // the rows a newline returns to are measured from.
+  EXPECT_EQ(utf8.MeasureText(3, 2, "a\tb"), DrawEnd(12, 2));
+  EXPECT_EQ(utf8.MeasureText(3, 2, "a\nb"), DrawEnd(4, 3));
 
   // Every byte is a column when the terminal isn't decoding UTF-8.
   Buffer ascii(10, Charset::Ascii);
-  EXPECT_EQ(ascii.MeasureWidth("hello"), 5);
-  EXPECT_EQ(ascii.MeasureWidth("中A🔥"), 8);
-  EXPECT_EQ(ascii.MeasureWidth(AcuteE), 3);
+  EXPECT_EQ(ascii.MeasureText(0, 0, "hello"), DrawEnd(5, 0));
+  EXPECT_EQ(ascii.MeasureText(0, 0, "中A🔥"), DrawEnd(8, 0));
+  EXPECT_EQ(ascii.MeasureText(0, 0, AcuteE), DrawEnd(3, 0));
+}
+
+TEST(BufferTest, MeasuringMatchesDrawing) {
+  // The point of measuring is to answer what drawing would, so check the two
+  // against each other on the text they used to disagree about.
+  for (llvm::StringRef text :
+       {"hello", "a\tb\tc", "a\nb\r\nc", "中A🔥", "a  b", ""}) {
+    Buffer buffer(10, Charset::Utf8);
+    EXPECT_EQ(buffer.MeasureText(2, 1, text),
+              buffer.DrawText(2, 1, text, Style()))
+        << text;
+  }
+  for (llvm::StringRef text : {"one two three", "a\nlonger line here",
+                               "verylongunbreakableword", ""}) {
+    Buffer buffer(10, Charset::Utf8);
+    EXPECT_EQ(buffer.MeasureWrappedText(2, 1, 8, text),
+              buffer.DrawWrappedText(2, 1, 8, text, Style()))
+        << text;
+  }
+}
+
+TEST(BufferTest, WrapWidthIsWhatWrappingDoesNotOverhang) {
+  // What `Metrics::WrapWidth` answers is a fact about wrapping, so it is
+  // checked here against the wrapping it describes rather than only in
+  // `metrics_test`.
+  Buffer buffer(10, Charset::Utf8);
+  llvm::StringRef text = "some quite long words here";
+  int width = buffer.metrics().WrapWidth(text);
+  Buffer drawn(1, Charset::Utf8);
+  drawn.DrawWrappedText(0, 0, width, text, Style());
+  llvm::SmallVector<llvm::StringRef> rows;
+  llvm::StringRef(Render(drawn)).split(rows, '\n');
+  for (llvm::StringRef row : rows) {
+    EXPECT_LE(static_cast<int>(row.size()), width) << row;
+  }
 }
 
 TEST(BufferTest, BuiltFromCapabilities) {

--- a/common/terminal/capabilities.cpp
+++ b/common/terminal/capabilities.cpp
@@ -209,7 +209,7 @@ auto Capabilities::Detect(Filesystem::WriteFileRef file,
       ChooseColorMode(preferences.color, ColorEnvironment::FromProcess(),
                       capabilities.is_terminal);
   capabilities.charset = ChooseCharset(preferences.utf8, GetLocale());
-  capabilities.columns = GetColumns(fd).value_or(DefaultColumns);
+  capabilities.columns = GetColumns(fd);
 
   return capabilities;
 }

--- a/common/terminal/capabilities.cpp
+++ b/common/terminal/capabilities.cpp
@@ -64,9 +64,8 @@ static auto EnvironmentEnablesColor(const ColorEnvironment& env,
   // terminal that none of them describe can't be assumed to.
   //
   // `COLORTERM` and `TERM_PROGRAM` stand on their own rather than refining
-  // `TERM`, because the emulator sets them itself and they are specifically
-  // about color, while `TERM` is left unset by anything not launched from a
-  // shell.
+  // `TERM`: `TERM` names a terminfo entry, while these name the emulator and
+  // the color it handles.
   return !env.term.empty() || !env.colorterm.empty() ||
          !env.term_program.empty();
 }

--- a/common/terminal/capabilities.cpp
+++ b/common/terminal/capabilities.cpp
@@ -1,0 +1,217 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/capabilities.h"
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <cstdlib>
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSwitch.h"
+
+namespace Carbon::Terminal {
+
+// Returns the value of `name` in the process environment, empty when unset.
+static auto GetEnv(const char* name) -> llvm::StringRef {
+  const char* value = std::getenv(name);
+  return value ? llvm::StringRef(value) : llvm::StringRef();
+}
+
+auto ColorEnvironment::FromProcess() -> ColorEnvironment {
+  return {.no_color = GetEnv("NO_COLOR"),
+          .clicolor_force = GetEnv("CLICOLOR_FORCE"),
+          .force_color = GetEnv("FORCE_COLOR"),
+          .clicolor = GetEnv("CLICOLOR"),
+          .colorterm = GetEnv("COLORTERM"),
+          .term_program = GetEnv("TERM_PROGRAM"),
+          .term = GetEnv("TERM")};
+}
+
+// Returns whether the environment and the stream call for color, ignoring any
+// explicit preference. See `ChooseColorMode` for the precedence this
+// implements and where it comes from.
+static auto EnvironmentEnablesColor(const ColorEnvironment& env,
+                                    bool is_terminal) -> bool {
+  if (!env.no_color.empty()) {
+    return false;
+  }
+  // The forcing variables use `0` to decline to force, and `FORCE_COLOR` takes
+  // it further as a request to disable.
+  if (env.force_color == "0") {
+    return false;
+  }
+  if (!env.force_color.empty() ||
+      (!env.clicolor_force.empty() && env.clicolor_force != "0")) {
+    return true;
+  }
+  if (env.clicolor == "0") {
+    return false;
+  }
+  if (!is_terminal) {
+    return false;
+  }
+
+  // `dumb` says outright that escape sequences won't render, which outranks
+  // anything below claiming they will.
+  if (env.term == "dumb") {
+    return false;
+  }
+
+  // Any of these identifies the terminal as something that renders escapes. A
+  // terminal that none of them describe can't be assumed to.
+  //
+  // `COLORTERM` and `TERM_PROGRAM` stand on their own rather than refining
+  // `TERM`, because the emulator sets them itself and they are specifically
+  // about color, while `TERM` is left unset by anything not launched from a
+  // shell.
+  return !env.term.empty() || !env.colorterm.empty() ||
+         !env.term_program.empty();
+}
+
+// Returns the richest color escapes the terminal is believed to accept.
+//
+// Every signal here is a heuristic: there is no way to ask a terminal what it
+// supports without writing to it and parsing a reply, which would be far too
+// invasive for a compiler. Guessing too high garbles color on a terminal that
+// can't keep up, and guessing too low only makes output plainer, so unknown
+// terminals get the conservative answer.
+static auto DetectColorDepth(const ColorEnvironment& env) -> ColorMode {
+  // `FORCE_COLOR`'s levels name a depth outright.
+  if (auto mode = llvm::StringSwitch<std::optional<ColorMode>>(env.force_color)
+                      .Case("1", ColorMode::Ansi16)
+                      .Case("2", ColorMode::Ansi256)
+                      .Case("3", ColorMode::Truecolor)
+                      .Default(std::nullopt)) {
+    return *mode;
+  }
+
+  // The convention documented at
+  // https://github.com/termstandard/colors#checking-for-colorterm.
+  if (env.colorterm == "truecolor" || env.colorterm == "24bit") {
+    return ColorMode::Truecolor;
+  }
+
+  // `TERM_PROGRAM` identifies the emulator regardless of how `TERM` is set,
+  // which matters because several of these ship a conservative `TERM` while
+  // rendering far more than it claims.
+  {
+    if (auto mode =
+            llvm::StringSwitch<std::optional<ColorMode>>(env.term_program)
+                .Case("vscode", ColorMode::Truecolor)
+                .Case("iTerm.app", ColorMode::Truecolor)
+                .Case("WarpTerminal", ColorMode::Truecolor)
+                .Case("Hyper", ColorMode::Truecolor)
+                .Case("Tabby", ColorMode::Truecolor)
+                .Case("Terminus", ColorMode::Truecolor)
+                // Apple's Terminal renders only the 256-color palette.
+                .Case("Apple_Terminal", ColorMode::Ansi256)
+                .Default(std::nullopt)) {
+      return *mode;
+    }
+  }
+
+  // The enumerated terminals that stand in for a terminfo lookup.
+  {
+    if (auto mode = llvm::StringSwitch<std::optional<ColorMode>>(env.term)
+                        .Case("xterm-kitty", ColorMode::Truecolor)
+                        .Case("alacritty", ColorMode::Truecolor)
+                        .Case("wezterm", ColorMode::Truecolor)
+                        .Case("ghostty", ColorMode::Truecolor)
+                        .StartsWith("foot", ColorMode::Truecolor)
+                        .StartsWith("contour", ColorMode::Truecolor)
+                        .StartsWith("vte", ColorMode::Truecolor)
+                        .EndsWith("-direct", ColorMode::Truecolor)
+                        .EndsWith("-truecolor", ColorMode::Truecolor)
+                        .EndsWith("-256color", ColorMode::Ansi256)
+                        .EndsWith("-256", ColorMode::Ansi256)
+                        .Default(std::nullopt)) {
+      return *mode;
+    }
+  }
+
+  // Color is called for, but nothing said how much of it works.
+  return ColorMode::Ansi16;
+}
+
+auto ChooseColorMode(Preference preference, const ColorEnvironment& env,
+                     bool is_terminal) -> ColorMode {
+  switch (preference) {
+    case Preference::Never:
+      return ColorMode::NoColor;
+    case Preference::Always:
+      break;
+    case Preference::Auto:
+      if (!EnvironmentEnablesColor(env, is_terminal)) {
+        return ColorMode::NoColor;
+      }
+      break;
+  }
+  return DetectColorDepth(env);
+}
+
+auto ChooseCharset(Preference preference, llvm::StringRef locale) -> Charset {
+  switch (preference) {
+    case Preference::Never:
+      return Charset::Ascii;
+    case Preference::Always:
+      return Charset::Utf8;
+    case Preference::Auto:
+      break;
+  }
+
+  // Locale names spell the encoding several ways: `en_US.UTF-8`, `C.utf8`, and
+  // bare `UTF-8` all appear in the wild.
+  return locale.contains_insensitive("utf-8") ||
+                 locale.contains_insensitive("utf8")
+             ? Charset::Utf8
+             : Charset::Ascii;
+}
+
+// Returns the locale that determines the terminal's character encoding,
+// following the precedence POSIX defines for `LC_CTYPE`.
+static auto GetLocale() -> llvm::StringRef {
+  for (const char* name : {"LC_ALL", "LC_CTYPE", "LANG"}) {
+    if (llvm::StringRef value = GetEnv(name); !value.empty()) {
+      return value;
+    }
+  }
+  return "";
+}
+
+// Returns the terminal's width in columns, or nullopt when there is nothing to
+// ask.
+//
+// `COLUMNS` comes first: when it is exported, the user has deliberately
+// overridden the real width.
+static auto GetColumns(int fd) -> std::optional<int> {
+  int columns = 0;
+  if (llvm::to_integer(GetEnv("COLUMNS"), columns) && columns > 0) {
+    return columns;
+  }
+
+  struct winsize size = {};
+  if (ioctl(fd, TIOCGWINSZ, &size) == 0 && size.ws_col > 0) {
+    return size.ws_col;
+  }
+  return std::nullopt;
+}
+
+auto Capabilities::Detect(Filesystem::WriteFileRef file,
+                          Preferences preferences) -> Capabilities {
+  int fd = file.unix_fd();
+
+  Capabilities capabilities;
+  capabilities.is_terminal = isatty(fd) != 0;
+  capabilities.color_mode =
+      ChooseColorMode(preferences.color, ColorEnvironment::FromProcess(),
+                      capabilities.is_terminal);
+  capabilities.charset = ChooseCharset(preferences.utf8, GetLocale());
+  capabilities.columns = GetColumns(fd).value_or(DefaultColumns);
+
+  return capabilities;
+}
+
+}  // namespace Carbon::Terminal

--- a/common/terminal/capabilities.h
+++ b/common/terminal/capabilities.h
@@ -145,9 +145,9 @@ inline constexpr int DefaultColumns = 80;
 // The columns between tab stops, absent anything saying otherwise.
 //
 // Eight is the interval terminfo records as `it#8` for all but a handful of
-// legacy entries. Unlike a terminal's width, it is worth defaulting rather than
-// leaving unknown, since text with a tab in it has to be given some width to be
-// laid out at all.
+// legacy entries. Nothing measures a terminal's stops, so unlike its width this
+// stands in for no measurement: `Capabilities` carries it as a plain value
+// rather than as one a caller can tell apart from an absence.
 inline constexpr int DefaultTabWidth = 8;
 
 // What the terminal behind a stream can render, and how wide it is.

--- a/common/terminal/capabilities.h
+++ b/common/terminal/capabilities.h
@@ -129,10 +129,32 @@ auto ChooseColorMode(Preference preference, const ColorEnvironment& env,
 // the other way only makes output plainer.
 auto ChooseCharset(Preference preference, llvm::StringRef locale) -> Charset;
 
+// The width to lay out for when nothing says how wide the output is.
+//
+// Layout always has a width to fit, because the alternative is output laid out
+// as if nothing bounded it, which a terminal then wraps at column zero --
+// breaking every indent and gutter it was given, and in the middle of whatever
+// word it lands on. The cost of guessing is asymmetric: a viewer wider than
+// this sees slack on the right, while one narrower sees the wrapping done
+// twice, ours and then its own.
+//
+// Eighty is the traditional terminal width, and narrower ones are rare enough
+// that fitting them would cost more in wasted width everywhere else.
+inline constexpr int DefaultColumns = 80;
+
+// The columns between tab stops, absent anything saying otherwise.
+//
+// Eight is the interval terminfo records as `it#8` for all but a handful of
+// legacy entries. Unlike a terminal's width, it is worth defaulting rather than
+// leaving unknown, since text with a tab in it has to be given some width to be
+// laid out at all.
+inline constexpr int DefaultTabWidth = 8;
+
 // What the terminal behind a stream can render, and how wide it is.
 //
-// Detect this once per stream at startup and pass it down; each field is an
-// environment query or a system call that shouldn't be repeated per diagnostic.
+// Detect this once per stream at startup and pass it down; the fields come from
+// environment queries and system calls that shouldn't be repeated per
+// diagnostic.
 struct Capabilities {
   // Detects the capabilities of the terminal behind `file`, honoring
   // `preferences`.
@@ -157,12 +179,23 @@ struct Capabilities {
   // The terminal's width, or none when nothing says how wide the output is.
   // Positive whenever it is set, so layout can divide by it freely.
   //
-  // There is deliberately no width to fall back on. One that was invented
-  // rather than measured is a claim about the far end of a pipe that nobody
-  // made, and laying out for it wraps and cuts where nothing needed either.
-  // Output with no width to fit is laid out as if nothing bounded it, which
-  // leaves the wrapping to whatever ends up displaying it.
+  // This says what was measured, and nothing is invented to fill it in: an
+  // absence is a real answer about a pipe nobody described. Laying out still
+  // needs a width, and `DefaultColumns` is what a layout falls back to, so
+  // whether this is set decides whether output is fitted to the terminal in
+  // front of it or to a width chosen to be safe wherever it ends up.
   std::optional<int> columns;
+
+  // The columns between the terminal's tab stops, which is what a tab in text
+  // advances to the next of.
+  //
+  // TODO: Nothing sets this away from `DefaultTabWidth`. A terminal's stops are
+  // mutable at runtime -- `hts` sets one and `tbc` clears them -- so the only
+  // report of the live ones is `DECRQPSR`, which few emulators outside `xterm`
+  // answer, or a `DSR-CPR` round trip after writing a tab, which nearly all do.
+  // Either means putting the descriptor in raw mode and reading a reply with a
+  // timeout. Add it when a terminal that disagrees with eight is worth that.
+  int tab_width = DefaultTabWidth;
 };
 
 }  // namespace Carbon::Terminal

--- a/common/terminal/capabilities.h
+++ b/common/terminal/capabilities.h
@@ -1,0 +1,167 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_TERMINAL_CAPABILITIES_H_
+#define CARBON_COMMON_TERMINAL_CAPABILITIES_H_
+
+#include <cstdint>
+
+#include "common/filesystem.h"
+#include "common/terminal/color.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace Carbon::Terminal {
+
+// The encoding the terminal decodes output with.
+//
+// This decides far more than which characters can be drawn: rendering has to
+// count the columns a run of bytes will occupy, and that count only follows
+// from the code points those bytes encode if the terminal agrees about the
+// encoding. Disagreeing misaligns the entire line rather than drawing a single
+// character wrong.
+//
+// No other encoding is modeled. A terminal decoding something else, an ISO 8859
+// part for example, is treated as `Ascii`. That is correct output for any of
+// them, as they all encode printable ASCII as itself, and rendering in one
+// natively would mean carrying its conversion and column-width tables to gain
+// nothing but nicer line drawing, which `Ascii` already has a fallback for. So
+// `Utf8` is used only where the environment says outright that the terminal
+// decodes UTF-8, and `Ascii` does no UTF-8 processing at all.
+enum class Charset : int8_t {
+  // Every byte is one column, and lines are drawn from `-`, `|`, and `+`.
+  //
+  // Bytes outside printable ASCII are replaced rather than passed through,
+  // because a terminal decoding some single-byte encoding will render them as
+  // something, and there is no way to know what.
+  Ascii,
+  // Bytes are decoded as UTF-8, giving double-width characters two columns and
+  // combining marks none, and lines are drawn with box-drawing characters.
+  Utf8,
+};
+
+// Whether to use one of the terminal features detection decides about, where
+// an explicit request overrides what detection would conclude.
+//
+// This is the tri-state that a `--color=never` style flag parses into. It says
+// nothing about which feature is being requested; `Preferences` holds one of
+// these per feature.
+enum class Preference : int8_t {
+  // Decide from the environment and the stream.
+  Auto,
+  // Never use the feature, whatever the environment says.
+  Never,
+  // Use the feature even when the stream isn't a terminal. This is what a
+  // caller wants when piping into a pager, capturing output for later replay,
+  // or writing a test.
+  Always,
+};
+
+// An explicit preference for each feature detection decides about, normally
+// parsed from command line flags.
+struct Preferences {
+  Preference color = Preference::Auto;
+  Preference utf8 = Preference::Auto;
+};
+
+// The environment variables that control whether and how color is used.
+//
+// An unset variable and one set to the empty string mean the same thing
+// throughout: no opinion. Values point into the process environment and are
+// invalidated by anything that modifies it.
+struct ColorEnvironment {
+  // Reads the variables from the process environment.
+  static auto FromProcess() -> ColorEnvironment;
+
+  llvm::StringRef no_color;
+  llvm::StringRef clicolor_force;
+  llvm::StringRef force_color;
+  llvm::StringRef clicolor;
+  llvm::StringRef colorterm;
+  llvm::StringRef term_program;
+  llvm::StringRef term;
+};
+
+// Returns the color mode to render with.
+//
+// Whether to use color at all is decided first, from highest priority to
+// lowest:
+//
+// - An explicit `Never` or `Always` preference.
+// - `NO_COLOR` set to any non-empty value disables color: see
+//   https://no-color.org.
+// - `FORCE_COLOR=0` disables color, following the Node convention.
+// - Any other non-empty `FORCE_COLOR`, or a non-empty `CLICOLOR_FORCE` other
+//   than `0`, enables color even when the stream isn't a terminal.
+// - `CLICOLOR=0` disables color.
+// - `TERM=dumb` disables color, being an explicit statement that escape
+//   sequences won't render.
+// - Otherwise color is used only when the stream is a terminal and something
+//   identifies that terminal: `TERM` set to anything else, or `COLORTERM` or
+//   `TERM_PROGRAM` set at all. The latter two stand on their own rather than
+//   refining `TERM`, because the emulator sets them itself and they are
+//   specifically about color, while `TERM` is left unset by anything not
+//   launched from a shell.
+//
+// How much color to use is then guessed from `FORCE_COLOR`'s level,
+// `COLORTERM`, `TERM_PROGRAM`, and `TERM`, falling back to `Ansi16` when color
+// is called for but nothing says how much of it works. Apart from
+// `FORCE_COLOR`, which is a request rather than a description, none of these
+// enable color on their own, so a rich `COLORTERM` inherited by a redirected
+// stream can't put escape sequences into it.
+//
+// Depth comes from enumerating known terminals rather than from terminfo,
+// which trades a list to maintain here for not depending on databases that are
+// routinely absent from the containers and CI images this runs in. An
+// unrecognized terminal gets the conservative answer.
+//
+// This is separated from `Capabilities::Detect` so that the policy can be
+// tested without touching the process environment.
+auto ChooseColorMode(Preference preference, const ColorEnvironment& env,
+                     bool is_terminal) -> ColorMode;
+
+// Returns the encoding to render with, where `locale` is the value of the
+// first set variable among `LC_ALL`, `LC_CTYPE`, and `LANG`.
+//
+// Only a locale that names UTF-8 gets `Utf8`. Guessing wrong in that direction
+// costs alignment on every line that isn't pure ASCII, while guessing wrong
+// the other way only makes output plainer.
+auto ChooseCharset(Preference preference, llvm::StringRef locale) -> Charset;
+
+// What the terminal behind a stream can render, and how wide it is.
+//
+// Detect this once per stream at startup and pass it down; each field is an
+// environment query or a system call that shouldn't be repeated per diagnostic.
+struct Capabilities {
+  // The width used when the stream has no terminal to ask, chosen to match the
+  // classic terminal size so that redirected output is stable and reproducible.
+  static constexpr int DefaultColumns = 80;
+
+  // Detects the capabilities of the terminal behind `file`, honoring
+  // `preferences`.
+  //
+  // Detection reads the descriptor directly, because `isatty` and `TIOCGWINSZ`
+  // are what answer the question and no stream abstraction exposes them.
+  // LLVM's `raw_ostream::has_colors()` is not a substitute for the enablement
+  // rule above, which recognizes terminals its `TERM` list doesn't.
+  static auto Detect(Filesystem::WriteFileRef file,
+                     Preferences preferences = {}) -> Capabilities;
+
+  // The richest color escapes the terminal is believed to understand.
+  ColorMode color_mode = ColorMode::NoColor;
+
+  // The encoding the terminal decodes output with.
+  Charset charset = Charset::Ascii;
+
+  // Whether the stream is attached to a terminal at all. Note that color can
+  // still be in use when this is false, if the environment forces it.
+  bool is_terminal = false;
+
+  // The terminal's width, or `DefaultColumns` when there is nothing to ask.
+  // Always positive, so layout code can divide by it freely.
+  int columns = DefaultColumns;
+};
+
+}  // namespace Carbon::Terminal
+
+#endif  // CARBON_COMMON_TERMINAL_CAPABILITIES_H_

--- a/common/terminal/capabilities.h
+++ b/common/terminal/capabilities.h
@@ -6,6 +6,7 @@
 #define CARBON_COMMON_TERMINAL_CAPABILITIES_H_
 
 #include <cstdint>
+#include <optional>
 
 #include "common/filesystem.h"
 #include "common/terminal/color.h"
@@ -133,10 +134,6 @@ auto ChooseCharset(Preference preference, llvm::StringRef locale) -> Charset;
 // Detect this once per stream at startup and pass it down; each field is an
 // environment query or a system call that shouldn't be repeated per diagnostic.
 struct Capabilities {
-  // The width used when the stream has no terminal to ask, chosen to match the
-  // classic terminal size so that redirected output is stable and reproducible.
-  static constexpr int DefaultColumns = 80;
-
   // Detects the capabilities of the terminal behind `file`, honoring
   // `preferences`.
   //
@@ -157,9 +154,15 @@ struct Capabilities {
   // still be in use when this is false, if the environment forces it.
   bool is_terminal = false;
 
-  // The terminal's width, or `DefaultColumns` when there is nothing to ask.
-  // Always positive, so layout code can divide by it freely.
-  int columns = DefaultColumns;
+  // The terminal's width, or none when nothing says how wide the output is.
+  // Positive whenever it is set, so layout can divide by it freely.
+  //
+  // There is deliberately no width to fall back on. One that was invented
+  // rather than measured is a claim about the far end of a pipe that nobody
+  // made, and laying out for it wraps and cuts where nothing needed either.
+  // Output with no width to fit is laid out as if nothing bounded it, which
+  // leaves the wrapping to whatever ends up displaying it.
+  std::optional<int> columns;
 };
 
 }  // namespace Carbon::Terminal

--- a/common/terminal/capabilities_test.cpp
+++ b/common/terminal/capabilities_test.cpp
@@ -1,0 +1,264 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/capabilities.h"
+
+#include <gtest/gtest.h>
+
+namespace Carbon::Terminal {
+namespace {
+
+// Detection policy is a pure function of the environment and whether the
+// stream is a terminal, so these tests build the environment directly instead
+// of mutating the process environment, which would leak between tests and race
+// with anything else running.
+auto OnTerminal(const ColorEnvironment& env) -> ColorMode {
+  return ChooseColorMode(Preference::Auto, env, /*is_terminal=*/true);
+}
+
+auto OffTerminal(const ColorEnvironment& env) -> ColorMode {
+  return ChooseColorMode(Preference::Auto, env, /*is_terminal=*/false);
+}
+
+// A terminal that supports color, for tests varying one other variable.
+auto ColorTerminal() -> ColorEnvironment { return {.term = "xterm-256color"}; }
+
+TEST(CapabilitiesTest, ColorNeedsATerminal) {
+  EXPECT_EQ(OnTerminal(ColorTerminal()), ColorMode::Ansi256);
+
+  // Writing to a file or a pipe must stay plain, or every redirected build log
+  // fills with escape sequences.
+  EXPECT_EQ(OffTerminal(ColorTerminal()), ColorMode::NoColor);
+
+  // A terminal that nothing says anything about can't be assumed to render
+  // escapes.
+  EXPECT_EQ(OnTerminal({}), ColorMode::NoColor);
+  EXPECT_EQ(OnTerminal({.term = ""}), ColorMode::NoColor);
+  EXPECT_EQ(OnTerminal({.term = "dumb"}), ColorMode::NoColor);
+}
+
+TEST(CapabilitiesTest, ColorFromTheEmulatorWithoutTerm) {
+  // `TERM` is unset for anything not launched from a shell, but the emulator
+  // sets `COLORTERM` and `TERM_PROGRAM` itself, and both are specifically
+  // about color. Either one identifies the terminal on its own, at whatever
+  // depth it names.
+  EXPECT_EQ(OnTerminal({.colorterm = "truecolor"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.colorterm = "yes"}), ColorMode::Ansi16);
+  EXPECT_EQ(OnTerminal({.term_program = "vscode"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term_program = "unknown"}), ColorMode::Ansi16);
+
+  // An empty value says nothing at all.
+  EXPECT_EQ(OnTerminal({.colorterm = "", .term_program = ""}),
+            ColorMode::NoColor);
+
+  // `dumb` outranks them: it states outright that escapes won't render.
+  EXPECT_EQ(OnTerminal({.colorterm = "truecolor", .term = "dumb"}),
+            ColorMode::NoColor);
+
+  // And none of them enable color off a terminal.
+  EXPECT_EQ(OffTerminal({.colorterm = "truecolor"}), ColorMode::NoColor);
+  EXPECT_EQ(OffTerminal({.term_program = "vscode"}), ColorMode::NoColor);
+}
+
+TEST(CapabilitiesTest, ExplicitPreferenceWins) {
+  ColorEnvironment forcing = {.force_color = "3", .term = "xterm-256color"};
+  EXPECT_EQ(ChooseColorMode(Preference::Never, forcing, /*is_terminal=*/true),
+            ColorMode::NoColor);
+
+  ColorEnvironment disabling = {.no_color = "1", .term = "dumb"};
+  EXPECT_EQ(ChooseColorMode(Preference::Always, disabling,
+                            /*is_terminal=*/false),
+            ColorMode::Ansi16);
+
+  // Forcing color on without any hint of what the terminal handles gets the
+  // depth every color terminal supports.
+  EXPECT_EQ(ChooseColorMode(Preference::Always, {}, /*is_terminal=*/false),
+            ColorMode::Ansi16);
+  EXPECT_EQ(ChooseColorMode(Preference::Always, ColorTerminal(),
+                            /*is_terminal=*/false),
+            ColorMode::Ansi256);
+}
+
+TEST(CapabilitiesTest, NoColor) {
+  // https://no-color.org: any non-empty value disables color, whatever it is.
+  EXPECT_EQ(OnTerminal({.no_color = "1", .term = "xterm-256color"}),
+            ColorMode::NoColor);
+  EXPECT_EQ(OnTerminal({.no_color = "0", .term = "xterm-256color"}),
+            ColorMode::NoColor);
+
+  // Being set to the empty string carries no meaning, so it must not disable
+  // color: an empty variable inherited from a wrapper script would otherwise
+  // silently turn color off everywhere.
+  EXPECT_EQ(OnTerminal({.no_color = "", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+
+  // It outranks the forcing variables.
+  EXPECT_EQ(OnTerminal({.no_color = "1", .force_color = "3"}),
+            ColorMode::NoColor);
+  EXPECT_EQ(OnTerminal({.no_color = "1", .clicolor_force = "1"}),
+            ColorMode::NoColor);
+}
+
+TEST(CapabilitiesTest, ForceColor) {
+  // Color even without a terminal, at the depth the level names.
+  EXPECT_EQ(OffTerminal({.force_color = "1"}), ColorMode::Ansi16);
+  EXPECT_EQ(OffTerminal({.force_color = "2"}), ColorMode::Ansi256);
+  EXPECT_EQ(OffTerminal({.force_color = "3"}), ColorMode::Truecolor);
+
+  // The level overrides what the terminal claims.
+  EXPECT_EQ(OnTerminal({.force_color = "1", .colorterm = "truecolor"}),
+            ColorMode::Ansi16);
+
+  // Any other non-empty value enables color without naming a depth.
+  EXPECT_EQ(OffTerminal({.force_color = "true"}), ColorMode::Ansi16);
+  EXPECT_EQ(OffTerminal({.force_color = "true", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+
+  // Zero disables color outright, even on a capable terminal.
+  EXPECT_EQ(OnTerminal({.force_color = "0", .term = "xterm-256color"}),
+            ColorMode::NoColor);
+}
+
+TEST(CapabilitiesTest, EmptyValuesCarryNoOpinion) {
+  // An empty variable means the same as an unset one throughout, so a wrapper
+  // script that exports one without a value changes nothing.
+  EXPECT_EQ(OffTerminal({.force_color = ""}), ColorMode::NoColor);
+  EXPECT_EQ(OffTerminal({.clicolor_force = ""}), ColorMode::NoColor);
+  EXPECT_EQ(OnTerminal({.no_color = "", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+  EXPECT_EQ(OnTerminal({.clicolor = "", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+  EXPECT_EQ(OnTerminal({.force_color = "", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+}
+
+TEST(CapabilitiesTest, CliColor) {
+  // The BSD convention: `CLICOLOR_FORCE` enables color off a terminal, and
+  // `CLICOLOR=0` disables it on one.
+  EXPECT_EQ(OffTerminal({.clicolor_force = "1"}), ColorMode::Ansi16);
+  EXPECT_EQ(OffTerminal({.clicolor_force = "1", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+  // `0` means "don't force", not "disable", so a terminal still gets color.
+  EXPECT_EQ(OnTerminal({.clicolor_force = "0", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+  EXPECT_EQ(OffTerminal({.clicolor_force = "0"}), ColorMode::NoColor);
+
+  EXPECT_EQ(OnTerminal({.clicolor = "0", .term = "xterm-256color"}),
+            ColorMode::NoColor);
+  EXPECT_EQ(OnTerminal({.clicolor = "1", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+
+  // Forcing beats disabling.
+  EXPECT_EQ(OnTerminal({.clicolor_force = "1", .clicolor = "0"}),
+            ColorMode::Ansi16);
+}
+
+TEST(CapabilitiesTest, ColorDepthFromColorterm) {
+  EXPECT_EQ(OnTerminal({.colorterm = "truecolor", .term = "xterm"}),
+            ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.colorterm = "24bit", .term = "xterm"}),
+            ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.colorterm = "", .term = "xterm"}), ColorMode::Ansi16);
+
+  // `COLORTERM` describes depth, not whether to use color at all, so it must
+  // not smuggle escape sequences into a redirected stream.
+  EXPECT_EQ(OffTerminal({.colorterm = "truecolor", .term = "xterm"}),
+            ColorMode::NoColor);
+}
+
+TEST(CapabilitiesTest, ColorDepthFromTermProgram) {
+  EXPECT_EQ(OnTerminal({.term_program = "vscode", .term = "xterm"}),
+            ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term_program = "iTerm.app", .term = "xterm"}),
+            ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term_program = "WarpTerminal", .term = "xterm"}),
+            ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term_program = "Hyper", .term = "xterm"}),
+            ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term_program = "Tabby", .term = "xterm"}),
+            ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term_program = "Terminus", .term = "xterm"}),
+            ColorMode::Truecolor);
+  // Apple's Terminal renders only the 256-color palette.
+  EXPECT_EQ(OnTerminal({.term_program = "Apple_Terminal", .term = "xterm"}),
+            ColorMode::Ansi256);
+  EXPECT_EQ(OnTerminal({.term_program = "unknown", .term = "xterm-256color"}),
+            ColorMode::Ansi256);
+}
+
+TEST(CapabilitiesTest, ColorDepthFromTerm) {
+  EXPECT_EQ(OnTerminal({.term = "xterm-kitty"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term = "alacritty"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term = "wezterm"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term = "foot-extra"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term = "xterm-direct"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term = "ghostty"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term = "contour-latest"}), ColorMode::Truecolor);
+  EXPECT_EQ(OnTerminal({.term = "xterm-truecolor"}), ColorMode::Truecolor);
+
+  EXPECT_EQ(OnTerminal({.term = "xterm-256color"}), ColorMode::Ansi256);
+  EXPECT_EQ(OnTerminal({.term = "screen-256color"}), ColorMode::Ansi256);
+  EXPECT_EQ(OnTerminal({.term = "putty-256"}), ColorMode::Ansi256);
+
+  // A terminal matching both a truecolor and a 256-color pattern takes the
+  // richer one, so the order these are tried in is load-bearing.
+  EXPECT_EQ(OnTerminal({.term = "vte-256color"}), ColorMode::Truecolor);
+
+  // Known to render color, but with nothing saying how much.
+  EXPECT_EQ(OnTerminal({.term = "xterm"}), ColorMode::Ansi16);
+  EXPECT_EQ(OnTerminal({.term = "linux"}), ColorMode::Ansi16);
+}
+
+TEST(CapabilitiesTest, Charset) {
+  EXPECT_EQ(ChooseCharset(Preference::Auto, "en_US.UTF-8"), Charset::Utf8);
+  EXPECT_EQ(ChooseCharset(Preference::Auto, "C.utf8"), Charset::Utf8);
+  EXPECT_EQ(ChooseCharset(Preference::Auto, "en_US.utf-8"), Charset::Utf8);
+
+  // Drawing box characters into a terminal decoding something else turns them
+  // into several bytes of mojibake and destroys the alignment they were for.
+  EXPECT_EQ(ChooseCharset(Preference::Auto, "C"), Charset::Ascii);
+  EXPECT_EQ(ChooseCharset(Preference::Auto, "POSIX"), Charset::Ascii);
+  EXPECT_EQ(ChooseCharset(Preference::Auto, "en_US.ISO-8859-1"),
+            Charset::Ascii);
+  EXPECT_EQ(ChooseCharset(Preference::Auto, ""), Charset::Ascii);
+
+  EXPECT_EQ(ChooseCharset(Preference::Never, "en_US.UTF-8"), Charset::Ascii);
+  EXPECT_EQ(ChooseCharset(Preference::Always, "C"), Charset::Utf8);
+}
+
+TEST(CapabilitiesTest, Defaults) {
+  // The defaults describe a plain-text sink, which is what a file or a pipe
+  // gets and what tests should use unless exercising something richer.
+  Capabilities capabilities;
+  EXPECT_EQ(capabilities.color_mode, ColorMode::NoColor);
+  EXPECT_EQ(capabilities.charset, Charset::Ascii);
+  EXPECT_FALSE(capabilities.is_terminal);
+  EXPECT_EQ(capabilities.columns, Capabilities::DefaultColumns);
+}
+
+TEST(CapabilitiesTest, Detect) {
+  // Detection reads the real environment, so this pins only what holds
+  // regardless of it. Tests don't run on a terminal, so the width is the
+  // fallback unless `COLUMNS` is exported.
+  for (Filesystem::WriteFileRef stream :
+       {Filesystem::Stdout(), Filesystem::Stderr()}) {
+    Capabilities capabilities = Capabilities::Detect(stream);
+    EXPECT_GT(capabilities.columns, 0);
+    EXPECT_FALSE(capabilities.is_terminal);
+    EXPECT_EQ(capabilities.color_mode, ColorMode::NoColor);
+  }
+
+  EXPECT_EQ(
+      Capabilities::Detect(Filesystem::Stderr(), {.color = Preference::Never,
+                                                  .utf8 = Preference::Never})
+          .color_mode,
+      ColorMode::NoColor);
+  EXPECT_EQ(
+      Capabilities::Detect(Filesystem::Stderr(), {.utf8 = Preference::Always})
+          .charset,
+      Charset::Utf8);
+}
+
+}  // namespace
+}  // namespace Carbon::Terminal

--- a/common/terminal/capabilities_test.cpp
+++ b/common/terminal/capabilities_test.cpp
@@ -234,17 +234,19 @@ TEST(CapabilitiesTest, Defaults) {
   EXPECT_EQ(capabilities.color_mode, ColorMode::NoColor);
   EXPECT_EQ(capabilities.charset, Charset::Ascii);
   EXPECT_FALSE(capabilities.is_terminal);
-  EXPECT_EQ(capabilities.columns, Capabilities::DefaultColumns);
+  EXPECT_FALSE(capabilities.columns.has_value());
 }
 
 TEST(CapabilitiesTest, Detect) {
   // Detection reads the real environment, so this pins only what holds
-  // regardless of it. Tests don't run on a terminal, so the width is the
-  // fallback unless `COLUMNS` is exported.
+  // regardless of it. Tests don't run on a terminal, so there is no width to
+  // find unless `COLUMNS` is exported, and a width that is found is real.
   for (Filesystem::WriteFileRef stream :
        {Filesystem::Stdout(), Filesystem::Stderr()}) {
     Capabilities capabilities = Capabilities::Detect(stream);
-    EXPECT_GT(capabilities.columns, 0);
+    if (capabilities.columns) {
+      EXPECT_GT(*capabilities.columns, 0);
+    }
     EXPECT_FALSE(capabilities.is_terminal);
     EXPECT_EQ(capabilities.color_mode, ColorMode::NoColor);
   }

--- a/common/terminal/capabilities_test.cpp
+++ b/common/terminal/capabilities_test.cpp
@@ -6,6 +6,10 @@
 
 #include <gtest/gtest.h>
 
+#include <utility>
+
+#include "common/filesystem.h"
+
 namespace Carbon::Terminal {
 namespace {
 
@@ -161,8 +165,8 @@ TEST(CapabilitiesTest, ColorDepthFromColorterm) {
             ColorMode::Truecolor);
   EXPECT_EQ(OnTerminal({.colorterm = "", .term = "xterm"}), ColorMode::Ansi16);
 
-  // `COLORTERM` describes depth, not whether to use color at all, so it must
-  // not smuggle escape sequences into a redirected stream.
+  // `COLORTERM` can't enable color off a terminal, so a rich value inherited
+  // by a redirected stream can't smuggle escapes into it.
   EXPECT_EQ(OffTerminal({.colorterm = "truecolor", .term = "xterm"}),
             ColorMode::NoColor);
 }
@@ -238,28 +242,45 @@ TEST(CapabilitiesTest, Defaults) {
 }
 
 TEST(CapabilitiesTest, Detect) {
-  // Detection reads the real environment, so this pins only what holds
-  // regardless of it. Tests don't run on a terminal, so there is no width to
-  // find unless `COLUMNS` is exported, and a width that is found is real.
-  for (Filesystem::WriteFileRef stream :
-       {Filesystem::Stdout(), Filesystem::Stderr()}) {
-    Capabilities capabilities = Capabilities::Detect(stream);
-    if (capabilities.columns) {
-      EXPECT_GT(*capabilities.columns, 0);
-    }
-    EXPECT_FALSE(capabilities.is_terminal);
-    EXPECT_EQ(capabilities.color_mode, ColorMode::NoColor);
-  }
+  // Detection reads the process environment and the descriptor it is handed, so
+  // only what neither can change is pinned here. What the policy decides from
+  // given inputs is tested above, against `ChooseColorMode` and `ChooseCharset`
+  // directly.
+  //
+  // It detects against a file rather than the process's own streams: those are
+  // a pipe under the test runner but a terminal under a debugger, and an
+  // exported `FORCE_COLOR` turns color on for either.
+  auto dir = Filesystem::MakeTmpDir();
+  ASSERT_TRUE(dir.ok()) << dir.error();
+  auto file = dir->OpenWriteOnly("out", Filesystem::CreationOptions::CreateNew);
+  ASSERT_TRUE(file.ok()) << file.error();
 
-  EXPECT_EQ(
-      Capabilities::Detect(Filesystem::Stderr(), {.color = Preference::Never,
-                                                  .utf8 = Preference::Never})
-          .color_mode,
+  Capabilities capabilities = Capabilities::Detect(*file);
+  // A file is never a terminal.
+  EXPECT_FALSE(capabilities.is_terminal);
+  // `COLUMNS` reaches detection from the environment, so whether a width is
+  // found depends on it, but one that is found is usable.
+  if (capabilities.columns) {
+    EXPECT_GT(*capabilities.columns, 0);
+  }
+  EXPECT_GT(capabilities.tab_width, 0);
+
+  // A preference decides on its own, whatever the environment holds. Color
+  // forced on picks a depth from the environment, so only that it is on can be
+  // pinned here.
+  EXPECT_EQ(Capabilities::Detect(
+                *file, {.color = Preference::Never, .utf8 = Preference::Never})
+                .color_mode,
+            ColorMode::NoColor);
+  EXPECT_NE(
+      Capabilities::Detect(*file, {.color = Preference::Always}).color_mode,
       ColorMode::NoColor);
-  EXPECT_EQ(
-      Capabilities::Detect(Filesystem::Stderr(), {.utf8 = Preference::Always})
-          .charset,
-      Charset::Utf8);
+  EXPECT_EQ(Capabilities::Detect(*file, {.utf8 = Preference::Always}).charset,
+            Charset::Utf8);
+  EXPECT_EQ(Capabilities::Detect(*file, {.utf8 = Preference::Never}).charset,
+            Charset::Ascii);
+
+  (*std::move(file)).Close().Check();
 }
 
 }  // namespace

--- a/common/terminal/color.cpp
+++ b/common/terminal/color.cpp
@@ -13,7 +13,6 @@
 
 namespace Carbon::Terminal {
 
-// The number of colors in `AnsiColor`.
 static constexpr int AnsiColorCount = 16;
 
 // Reference values for the 16 ANSI colors.
@@ -21,7 +20,7 @@ static constexpr int AnsiColorCount = 16;
 // Nothing standardizes these: a terminal draws them from the user's palette,
 // which is exactly what makes them worth using. But downsampling an RGB color
 // still needs some notion of where each named color sits, so these use the
-// xterm defaults, which most terminals default to as well.
+// xterm defaults, which terminals vary from but stay recognizably near.
 static constexpr std::array<Color::RgbValue, AnsiColorCount> AnsiColorRgbs = {{
     {.r = 0, .g = 0, .b = 0},        // Black
     {.r = 205, .g = 0, .b = 0},      // Red
@@ -47,14 +46,28 @@ static constexpr std::array<llvm::StringRef, AnsiColorCount> AnsiColorNames = {
     "BrightBlack", "BrightRed",     "BrightGreen", "BrightYellow",
     "BrightBlue",  "BrightMagenta", "BrightCyan",  "BrightWhite"};
 
-// Returns the squared Euclidean distance between two colors, treating the
-// channels as orthogonal axes. This is a crude stand-in for perceptual
-// distance, but it is predictable and exact matches always win.
+// Returns the "redmean" distance between two colors, squared and scaled by 256
+// to keep it in integer arithmetic.
+//
+// Treating the channels as orthogonal axes is cheaper but sits a long way from
+// perceived difference, and downsampling is exactly where that shows: a color
+// picked for a diagnostic lands on whichever of a small fixed set the
+// arithmetic says is closest, and a plain Euclidean fit underweights green,
+// where the eye is most sensitive. Redmean weights the
+// channels by where the pair sits on the red axis, which tracks perception far
+// better for a couple of extra multiplies:
+// https://en.wikipedia.org/wiki/Color_difference#sRGB
+//
+// The formula ends in a square root, which is dropped because only the ordering
+// is used. Scaling by 256 turns the two fractional weights into integers; the
+// result peaks just under 150 million, well inside the range.
 static auto DistanceSquared(Color::RgbValue lhs, Color::RgbValue rhs) -> int {
+  int red_mean = (static_cast<int>(lhs.r) + static_cast<int>(rhs.r)) / 2;
   int dr = static_cast<int>(lhs.r) - static_cast<int>(rhs.r);
   int dg = static_cast<int>(lhs.g) - static_cast<int>(rhs.g);
   int db = static_cast<int>(lhs.b) - static_cast<int>(rhs.b);
-  return dr * dr + dg * dg + db * db;
+  return (512 + red_mean) * dr * dr + 1024 * dg * dg +
+         (767 - red_mean) * db * db;
 }
 
 // Returns the ANSI color whose reference value is nearest to `rgb`.
@@ -138,8 +151,8 @@ static auto NearestPaletteIndex(Color::RgbValue rgb) -> uint8_t {
 // The original ANSI codes cover the first eight colors, and the later "bright"
 // codes cover the rest at a fixed offset.
 static auto AnsiSgrCode(AnsiColor color, ColorTarget target) -> uint8_t {
-  CARBON_DCHECK(target != ColorTarget::Underline,
-                "Underline color has no direct ANSI form.");
+  CARBON_CHECK(target != ColorTarget::Underline,
+               "Underline color has no direct ANSI form.");
   int index = static_cast<int>(color);
   int base = target == ColorTarget::Background ? 40 : 30;
   if (index >= 8) {
@@ -169,13 +182,12 @@ auto Color::AppendEscape(OutputBufferRef out, ColorMode mode,
   }
 
   // Underline colors are only expressible through the extended-color escape,
-  // which `Ansi16` doesn't use, so nothing is emitted and the terminal draws
-  // the underline in the foreground color.
+  // which `Ansi16` doesn't use.
   if (target == ColorTarget::Underline && mode == ColorMode::Ansi16) {
     return;
   }
 
-  CARBON_DCHECK(is_set(), "Only a color that is set can be selected.");
+  CARBON_CHECK(is_set(), "Only a color that is set can be selected.");
 
   if (kind_ == Kind::Ansi) {
     if (target == ColorTarget::Underline) {

--- a/common/terminal/color.cpp
+++ b/common/terminal/color.cpp
@@ -1,0 +1,227 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/color.h"
+
+#include <algorithm>
+#include <array>
+
+#include "common/check.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Format.h"
+
+namespace Carbon::Terminal {
+
+// The number of colors in `AnsiColor`.
+static constexpr int AnsiColorCount = 16;
+
+// Reference values for the 16 ANSI colors.
+//
+// Nothing standardizes these: a terminal draws them from the user's palette,
+// which is exactly what makes them worth using. But downsampling an RGB color
+// still needs some notion of where each named color sits, so these use the
+// xterm defaults, which most terminals default to as well.
+static constexpr std::array<Color::RgbValue, AnsiColorCount> AnsiColorRgbs = {{
+    {.r = 0, .g = 0, .b = 0},        // Black
+    {.r = 205, .g = 0, .b = 0},      // Red
+    {.r = 0, .g = 205, .b = 0},      // Green
+    {.r = 205, .g = 205, .b = 0},    // Yellow
+    {.r = 0, .g = 0, .b = 238},      // Blue
+    {.r = 205, .g = 0, .b = 205},    // Magenta
+    {.r = 0, .g = 205, .b = 205},    // Cyan
+    {.r = 229, .g = 229, .b = 229},  // White
+    {.r = 127, .g = 127, .b = 127},  // BrightBlack
+    {.r = 255, .g = 0, .b = 0},      // BrightRed
+    {.r = 0, .g = 255, .b = 0},      // BrightGreen
+    {.r = 255, .g = 255, .b = 0},    // BrightYellow
+    {.r = 92, .g = 92, .b = 255},    // BrightBlue
+    {.r = 255, .g = 0, .b = 255},    // BrightMagenta
+    {.r = 0, .g = 255, .b = 255},    // BrightCyan
+    {.r = 255, .g = 255, .b = 255},  // BrightWhite
+}};
+
+static constexpr std::array<llvm::StringRef, AnsiColorCount> AnsiColorNames = {
+    "Black",       "Red",           "Green",       "Yellow",
+    "Blue",        "Magenta",       "Cyan",        "White",
+    "BrightBlack", "BrightRed",     "BrightGreen", "BrightYellow",
+    "BrightBlue",  "BrightMagenta", "BrightCyan",  "BrightWhite"};
+
+// Returns the squared Euclidean distance between two colors, treating the
+// channels as orthogonal axes. This is a crude stand-in for perceptual
+// distance, but it is predictable and exact matches always win.
+static auto DistanceSquared(Color::RgbValue lhs, Color::RgbValue rhs) -> int {
+  int dr = static_cast<int>(lhs.r) - static_cast<int>(rhs.r);
+  int dg = static_cast<int>(lhs.g) - static_cast<int>(rhs.g);
+  int db = static_cast<int>(lhs.b) - static_cast<int>(rhs.b);
+  return dr * dr + dg * dg + db * db;
+}
+
+// Returns the ANSI color whose reference value is nearest to `rgb`.
+static auto NearestAnsiColor(Color::RgbValue rgb) -> AnsiColor {
+  int best_index = 0;
+  int best_distance = DistanceSquared(rgb, AnsiColorRgbs[0]);
+  for (int i = 1; i < AnsiColorCount; ++i) {
+    int distance = DistanceSquared(rgb, AnsiColorRgbs[i]);
+    if (distance < best_distance) {
+      best_distance = distance;
+      best_index = i;
+    }
+  }
+  return static_cast<AnsiColor>(best_index);
+}
+
+// The channel values of the 6x6x6 color cube at palette indices 16 through
+// 231. The first step is much larger than the rest, so a channel can't be
+// rounded to the nearest level by dividing.
+static constexpr std::array<uint8_t, 6> CubeLevels = {0,   95,  135,
+                                                      175, 215, 255};
+
+// The midpoints between adjacent entries of `CubeLevels`, which are where the
+// nearest level changes.
+static constexpr std::array<uint8_t, 5> CubeLevelMidpoints = {48, 115, 155, 195,
+                                                              235};
+
+static_assert(
+    [] {
+      for (size_t i = 0; i < CubeLevelMidpoints.size(); ++i) {
+        // Rounded up, so that a value exactly between two levels takes the
+        // higher one.
+        if (CubeLevelMidpoints[i] !=
+            (CubeLevels[i] + CubeLevels[i + 1] + 1) / 2) {
+          return false;
+        }
+      }
+      return true;
+    }(),
+    "Midpoints must stay in step with the levels they separate.");
+
+// Returns the index into `CubeLevels` of the level nearest `value`.
+static auto NearestCubeLevel(uint8_t value) -> int {
+  int level = 0;
+  while (level < static_cast<int>(CubeLevelMidpoints.size()) &&
+         value >= CubeLevelMidpoints[level]) {
+    ++level;
+  }
+  return level;
+}
+
+// Returns the 256-color palette index whose color is nearest to `rgb`.
+static auto NearestPaletteIndex(Color::RgbValue rgb) -> uint8_t {
+  // Only the color cube and the gray ramp are considered. Indices 0 through 15
+  // alias the ANSI colors, whose appearance comes from the user's palette, so
+  // an exact RGB request must never be answered with one.
+  int r_level = NearestCubeLevel(rgb.r);
+  int g_level = NearestCubeLevel(rgb.g);
+  int b_level = NearestCubeLevel(rgb.b);
+  Color::RgbValue cube = {.r = CubeLevels[r_level],
+                          .g = CubeLevels[g_level],
+                          .b = CubeLevels[b_level]};
+
+  // The gray ramp at indices 232 through 255 runs from 8 to 238 in steps of
+  // 10, and is finer than the cube's gray diagonal for near-neutral colors.
+  int average = (static_cast<int>(rgb.r) + static_cast<int>(rgb.g) +
+                 static_cast<int>(rgb.b)) /
+                3;
+  int gray_step = std::clamp((average - 8 + 5) / 10, 0, 23);
+  auto gray_value = static_cast<uint8_t>(8 + 10 * gray_step);
+  Color::RgbValue gray = {.r = gray_value, .g = gray_value, .b = gray_value};
+
+  if (DistanceSquared(rgb, gray) < DistanceSquared(rgb, cube)) {
+    return 232 + gray_step;
+  }
+  return 16 + 36 * r_level + 6 * g_level + b_level;
+}
+
+// Returns the SGR parameter selecting `color` for `target`.
+//
+// The original ANSI codes cover the first eight colors, and the later "bright"
+// codes cover the rest at a fixed offset.
+static auto AnsiSgrCode(AnsiColor color, ColorTarget target) -> uint8_t {
+  CARBON_DCHECK(target != ColorTarget::Underline,
+                "Underline color has no direct ANSI form.");
+  int index = static_cast<int>(color);
+  int base = target == ColorTarget::Background ? 40 : 30;
+  if (index >= 8) {
+    // Bright foregrounds are 90-97 and bright backgrounds 100-107.
+    base += 60;
+  }
+  return base + (index % 8);
+}
+
+// Returns the SGR parameter introducing an extended color for `target`, which
+// is followed by either `;5;<index>` or `;2;<r>;<g>;<b>`.
+static auto ExtendedSgrCode(ColorTarget target) -> uint8_t {
+  switch (target) {
+    case ColorTarget::Foreground:
+      return 38;
+    case ColorTarget::Background:
+      return 48;
+    case ColorTarget::Underline:
+      return 58;
+  }
+}
+
+auto Color::AppendEscape(OutputBufferRef out, ColorMode mode,
+                         ColorTarget target) const -> void {
+  if (mode == ColorMode::NoColor) {
+    return;
+  }
+
+  // Underline colors are only expressible through the extended-color escape,
+  // which `Ansi16` doesn't use, so nothing is emitted and the terminal draws
+  // the underline in the foreground color.
+  if (target == ColorTarget::Underline && mode == ColorMode::Ansi16) {
+    return;
+  }
+
+  CARBON_DCHECK(is_set(), "Only a color that is set can be selected.");
+
+  if (kind_ == Kind::Ansi) {
+    if (target == ColorTarget::Underline) {
+      // Named underline colors go through the palette form of the extended
+      // escape, as there is no direct code for them.
+      out.Append("\x1b[58;5;", static_cast<uint8_t>(ansi()), "m");
+    } else {
+      out.Append("\x1b[", AnsiSgrCode(ansi(), target), "m");
+    }
+    return;
+  }
+
+  switch (mode) {
+    case ColorMode::Truecolor:
+      out.Append("\x1b[", ExtendedSgrCode(target), ";2;", channels_.r, ";",
+                 channels_.g, ";", channels_.b, "m");
+      break;
+
+    case ColorMode::Ansi256:
+      out.Append("\x1b[", ExtendedSgrCode(target), ";5;",
+                 NearestPaletteIndex(channels_), "m");
+      break;
+
+    case ColorMode::Ansi16:
+      out.Append("\x1b[", AnsiSgrCode(NearestAnsiColor(channels_), target),
+                 "m");
+      break;
+
+    case ColorMode::NoColor:
+      CARBON_FATAL("Returned above without emitting anything.");
+  }
+}
+
+auto Color::Print(llvm::raw_ostream& out) const -> void {
+  switch (kind_) {
+    case Kind::None:
+      out << "None";
+      return;
+    case Kind::Ansi:
+      out << AnsiColorNames[static_cast<int>(ansi())];
+      return;
+    case Kind::Rgb:
+      out << llvm::format("#%02x%02x%02x", channels_.r, channels_.g,
+                          channels_.b);
+      return;
+  }
+}
+
+}  // namespace Carbon::Terminal

--- a/common/terminal/color.h
+++ b/common/terminal/color.h
@@ -1,0 +1,165 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_TERMINAL_COLOR_H_
+#define CARBON_COMMON_TERMINAL_COLOR_H_
+
+#include <cstdint>
+
+#include "common/check.h"
+#include "common/ostream.h"
+#include "common/terminal/output_buffer_ref.h"
+
+namespace Carbon::Terminal {
+
+// The color escape sequences a terminal understands.
+//
+// Colors, like the other text attributes, are selected with Select Graphic
+// Rendition (SGR) escape sequences. The sequence and the codes for the original
+// 16 colors come from ECMA-48, published in parallel as ANSI X3.64; terminal
+// emulators have since extended it with the 256-color and 24-bit forms:
+// https://ecma-international.org/publications-and-standards/standards/ecma-48/
+//
+// These form a ladder: each mode can express everything the modes before it
+// can. Colors that the active mode can't express exactly are downsampled to
+// the nearest color it can, so callers author in the richest form and let
+// rendering degrade on its own.
+enum class ColorMode : int8_t {
+  // Emit no escape sequences at all, producing plain text.
+  NoColor,
+  // The 16 colors with SGR codes of their own.
+  Ansi16,
+  // The 256-color palette: the 16 ANSI colors, a 6x6x6 RGB cube, and a 24-step
+  // gray ramp.
+  Ansi256,
+  // Direct 24-bit RGB, commonly called "truecolor".
+  Truecolor,
+};
+
+// The 16 colors with SGR codes of their own, named for ANSI X3.64.
+//
+// Terminals render these through the user's configured palette, which makes
+// them the right choice for output that should blend with the user's theme.
+// The tradeoff is that their rendered appearance is outside our control: a
+// user's "red" may be any color at all.
+enum class AnsiColor : uint8_t {
+  Black,
+  Red,
+  Green,
+  Yellow,
+  Blue,
+  Magenta,
+  Cyan,
+  White,
+  BrightBlack,
+  BrightRed,
+  BrightGreen,
+  BrightYellow,
+  BrightBlue,
+  BrightMagenta,
+  BrightCyan,
+  BrightWhite,
+};
+
+// Which part of a cell's rendering a color applies to.
+enum class ColorTarget : int8_t {
+  Foreground,
+  Background,
+  // The color of the underline itself, independent of the foreground. Only
+  // `Ansi256` and richer modes can express this.
+  Underline,
+};
+
+// A color to render with: one of the 16 named ANSI colors, a 24-bit RGB value,
+// or no color at all.
+//
+// RGB colors render exactly where the terminal supports them, and are
+// downsampled where it doesn't. Downsampling to `Ansi16` measures distance
+// against fixed reference values, but the terminal renders the result from the
+// user's palette, so a downsampled color can land far from the original.
+// Prefer `AnsiColor` wherever output should track the user's theme, and RGB
+// only where an exact color matters.
+//
+// A default-constructed color selects nothing. That is how a `Style` spells
+// leaving one of its colors to the terminal, so this is a value with an empty
+// state rather than something wrapped in an `optional` to get one.
+class Color : public Printable<Color> {
+ public:
+  // Whether a color names a palette entry, gives channel values directly, or
+  // selects nothing.
+  enum class Kind : uint8_t {
+    None,
+    Ansi,
+    Rgb,
+  };
+
+  // The channel values of a 24-bit color.
+  struct RgbValue {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+
+    friend auto operator==(RgbValue lhs, RgbValue rhs) -> bool = default;
+  };
+
+  constexpr Color() = default;
+
+  // Colors convert implicitly from `AnsiColor` so that call sites can read as
+  // `style.Foreground(AnsiColor::Red)`.
+  //
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr Color(AnsiColor ansi)
+      : kind_(Kind::Ansi), channels_{.r = static_cast<uint8_t>(ansi)} {}
+
+  constexpr Color(uint8_t r, uint8_t g, uint8_t b)
+      : kind_(Kind::Rgb), channels_{.r = r, .g = g, .b = b} {}
+
+  auto kind() const -> Kind { return kind_; }
+
+  // Returns whether this selects a color at all.
+  auto is_set() const -> bool { return kind_ != Kind::None; }
+
+  // Returns the named color. Valid only when `kind()` is `Ansi`.
+  auto ansi() const -> AnsiColor {
+    CARBON_DCHECK(kind_ == Kind::Ansi);
+    return static_cast<AnsiColor>(channels_.r);
+  }
+
+  // Returns the channel values. Valid only when `kind()` is `Rgb`.
+  auto rgb() const -> RgbValue {
+    CARBON_DCHECK(kind_ == Kind::Rgb);
+    return channels_;
+  }
+
+  // Appends the escape sequence selecting this color for `target`, which
+  // requires that one is set.
+  //
+  // Appends nothing when `mode` is `NoColor`, or when `target` is `Underline`
+  // and `mode` is `Ansi16`, which has no way to express an underline color.
+  auto AppendEscape(OutputBufferRef out, ColorMode mode,
+                    ColorTarget target) const -> void;
+
+  auto Print(llvm::raw_ostream& out) const -> void;
+
+  // Written out rather than defaulted because the `Printable` base has no
+  // comparison of its own, which would leave a defaulted one deleted.
+  friend auto operator==(Color lhs, Color rhs) -> bool {
+    return lhs.kind_ == rhs.kind_ && lhs.channels_ == rhs.channels_;
+  }
+
+ private:
+  Kind kind_ = Kind::None;
+
+  // The palette index in `r` with the rest zero for `Ansi`, the channel values
+  // for `Rgb`, and all zero for `None`.
+  //
+  // Overlapping the two in a union would leave the bytes past a palette index
+  // unwritten. Every byte carrying part of the value is what lets a whole
+  // `Style` be compared as bytes, and an index fits in a channel anyway.
+  RgbValue channels_ = {.r = 0, .g = 0, .b = 0};
+};
+
+}  // namespace Carbon::Terminal
+
+#endif  // CARBON_COMMON_TERMINAL_COLOR_H_

--- a/common/terminal/color.h
+++ b/common/terminal/color.h
@@ -16,9 +16,10 @@ namespace Carbon::Terminal {
 // The color escape sequences a terminal understands.
 //
 // Colors, like the other text attributes, are selected with Select Graphic
-// Rendition (SGR) escape sequences. The sequence and the codes for the original
-// 16 colors come from ECMA-48, published in parallel as ANSI X3.64; terminal
-// emulators have since extended it with the 256-color and 24-bit forms:
+// Rendition (SGR) escape sequences. The sequence and the codes for the first
+// eight colors come from ECMA-48, published in parallel as ANSI X3.64;
+// terminal emulators added the bright variants, the 256-color palette, and the
+// 24-bit form:
 // https://ecma-international.org/publications-and-standards/standards/ecma-48/
 //
 // These form a ladder: each mode can express everything the modes before it
@@ -37,7 +38,7 @@ enum class ColorMode : int8_t {
   Truecolor,
 };
 
-// The 16 colors with SGR codes of their own, named for ANSI X3.64.
+// The 16 colors with SGR codes of their own.
 //
 // Terminals render these through the user's configured palette, which makes
 // them the right choice for output that should blend with the user's theme.
@@ -122,13 +123,14 @@ class Color : public Printable<Color> {
 
   // Returns the named color. Valid only when `kind()` is `Ansi`.
   auto ansi() const -> AnsiColor {
-    CARBON_DCHECK(kind_ == Kind::Ansi);
+    CARBON_CHECK(kind_ == Kind::Ansi,
+                 "Only a named color has a palette index.");
     return static_cast<AnsiColor>(channels_.r);
   }
 
   // Returns the channel values. Valid only when `kind()` is `Rgb`.
   auto rgb() const -> RgbValue {
-    CARBON_DCHECK(kind_ == Kind::Rgb);
+    CARBON_CHECK(kind_ == Kind::Rgb, "Only an RGB color has channel values.");
     return channels_;
   }
 

--- a/common/terminal/color_test.cpp
+++ b/common/terminal/color_test.cpp
@@ -20,8 +20,9 @@ auto Escape(Color color, ColorMode mode,
 }
 
 TEST(ColorTest, AnsiEscapes) {
-  // Named colors use the original SGR codes in every mode that has color at
-  // all, so the terminal renders them from the user's palette.
+  // Named colors use their own SGR codes rather than the extended forms, in
+  // every mode that has color at all, so the terminal renders them from the
+  // user's palette.
   for (ColorMode mode :
        {ColorMode::Ansi16, ColorMode::Ansi256, ColorMode::Truecolor}) {
     EXPECT_EQ(Escape(AnsiColor::Red, mode), "\x1b[31m");
@@ -47,8 +48,8 @@ TEST(ColorTest, RgbEscapes) {
 }
 
 TEST(ColorTest, UnderlineEscapes) {
-  // Underline colors only exist in the extended-color escapes, so `Ansi16`
-  // leaves the underline in the terminal's default rather than approximating.
+  // Underline colors only exist in the extended-color escapes, so in `Ansi16`
+  // the terminal draws the underline in the foreground color.
   EXPECT_EQ(
       Escape(AnsiColor::Red, ColorMode::Truecolor, ColorTarget::Underline),
       "\x1b[58;5;1m");

--- a/common/terminal/color_test.cpp
+++ b/common/terminal/color_test.cpp
@@ -1,0 +1,170 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/color.h"
+
+#include <gtest/gtest.h>
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+
+namespace Carbon::Terminal {
+namespace {
+
+auto Escape(Color color, ColorMode mode,
+            ColorTarget target = ColorTarget::Foreground) -> std::string {
+  llvm::SmallString<32> escape;
+  color.AppendEscape(escape, mode, target);
+  return std::string(escape);
+}
+
+TEST(ColorTest, AnsiEscapes) {
+  // Named colors use the original SGR codes in every mode that has color at
+  // all, so the terminal renders them from the user's palette.
+  for (ColorMode mode :
+       {ColorMode::Ansi16, ColorMode::Ansi256, ColorMode::Truecolor}) {
+    EXPECT_EQ(Escape(AnsiColor::Red, mode), "\x1b[31m");
+    EXPECT_EQ(Escape(AnsiColor::Black, mode), "\x1b[30m");
+    EXPECT_EQ(Escape(AnsiColor::BrightCyan, mode), "\x1b[96m");
+    EXPECT_EQ(Escape(AnsiColor::Red, mode, ColorTarget::Background),
+              "\x1b[41m");
+    EXPECT_EQ(Escape(AnsiColor::BrightWhite, mode, ColorTarget::Background),
+              "\x1b[107m");
+  }
+
+  EXPECT_EQ(Escape(AnsiColor::Red, ColorMode::NoColor), "");
+}
+
+TEST(ColorTest, RgbEscapes) {
+  Color red(255, 0, 0);
+  EXPECT_EQ(Escape(red, ColorMode::Truecolor), "\x1b[38;2;255;0;0m");
+  EXPECT_EQ(Escape(red, ColorMode::Truecolor, ColorTarget::Background),
+            "\x1b[48;2;255;0;0m");
+  EXPECT_EQ(Escape(red, ColorMode::Ansi256), "\x1b[38;5;196m");
+  EXPECT_EQ(Escape(red, ColorMode::Ansi16), "\x1b[91m");
+  EXPECT_EQ(Escape(red, ColorMode::NoColor), "");
+}
+
+TEST(ColorTest, UnderlineEscapes) {
+  // Underline colors only exist in the extended-color escapes, so `Ansi16`
+  // leaves the underline in the terminal's default rather than approximating.
+  EXPECT_EQ(
+      Escape(AnsiColor::Red, ColorMode::Truecolor, ColorTarget::Underline),
+      "\x1b[58;5;1m");
+  EXPECT_EQ(Escape(AnsiColor::Red, ColorMode::Ansi256, ColorTarget::Underline),
+            "\x1b[58;5;1m");
+  EXPECT_EQ(Escape(AnsiColor::Red, ColorMode::Ansi16, ColorTarget::Underline),
+            "");
+
+  Color green(0, 255, 0);
+  EXPECT_EQ(Escape(green, ColorMode::Truecolor, ColorTarget::Underline),
+            "\x1b[58;2;0;255;0m");
+  EXPECT_EQ(Escape(green, ColorMode::Ansi256, ColorTarget::Underline),
+            "\x1b[58;5;46m");
+  EXPECT_EQ(Escape(green, ColorMode::Ansi16, ColorTarget::Underline), "");
+}
+
+TEST(ColorTest, DownsampleToAnsi16) {
+  // The reference value of each ANSI color must come back as that color, or
+  // downsampling would shift colors that were already expressible. Spelling
+  // the values out here rather than reading them back from the same table the
+  // implementation uses is what makes this catch a wrong table.
+  struct Expected {
+    Color color;
+    llvm::StringRef escape;
+  };
+  Expected cases[] = {
+      {Color(0, 0, 0), "\x1b[30m"},       {Color(205, 0, 0), "\x1b[31m"},
+      {Color(0, 205, 0), "\x1b[32m"},     {Color(205, 205, 0), "\x1b[33m"},
+      {Color(0, 0, 238), "\x1b[34m"},     {Color(205, 0, 205), "\x1b[35m"},
+      {Color(0, 205, 205), "\x1b[36m"},   {Color(229, 229, 229), "\x1b[37m"},
+      {Color(127, 127, 127), "\x1b[90m"}, {Color(255, 0, 0), "\x1b[91m"},
+      {Color(0, 255, 0), "\x1b[92m"},     {Color(255, 255, 0), "\x1b[93m"},
+      {Color(92, 92, 255), "\x1b[94m"},   {Color(255, 0, 255), "\x1b[95m"},
+      {Color(0, 255, 255), "\x1b[96m"},   {Color(255, 255, 255), "\x1b[97m"},
+  };
+  for (const Expected& expected : cases) {
+    EXPECT_EQ(Escape(expected.color, ColorMode::Ansi16), expected.escape)
+        << expected.color;
+  }
+
+  // Colors between the reference values land on the nearest one.
+  EXPECT_EQ(Escape(Color(250, 10, 10), ColorMode::Ansi16), "\x1b[91m");
+  EXPECT_EQ(Escape(Color(10, 10, 10), ColorMode::Ansi16), "\x1b[30m");
+  EXPECT_EQ(Escape(Color(120, 120, 120), ColorMode::Ansi16), "\x1b[90m");
+}
+
+TEST(ColorTest, DownsampleToPalette) {
+  // The corners of the 6x6x6 cube are exactly representable.
+  EXPECT_EQ(Escape(Color(0, 0, 0), ColorMode::Ansi256), "\x1b[38;5;16m");
+  EXPECT_EQ(Escape(Color(255, 255, 255), ColorMode::Ansi256), "\x1b[38;5;231m");
+  EXPECT_EQ(Escape(Color(255, 0, 0), ColorMode::Ansi256), "\x1b[38;5;196m");
+  EXPECT_EQ(Escape(Color(0, 0, 255), ColorMode::Ansi256), "\x1b[38;5;21m");
+
+  // The cube's levels are unevenly spaced, so rounding has to account for that
+  // rather than divide: 95 and 135 are adjacent levels only 40 apart.
+  EXPECT_EQ(Escape(Color(95, 0, 0), ColorMode::Ansi256), "\x1b[38;5;52m");
+  EXPECT_EQ(Escape(Color(130, 0, 0), ColorMode::Ansi256), "\x1b[38;5;88m");
+
+  // Near-neutral colors land on the gray ramp, which is far finer than the
+  // cube's diagonal, except at the ends where the cube wins.
+  EXPECT_EQ(Escape(Color(8, 8, 8), ColorMode::Ansi256), "\x1b[38;5;232m");
+  EXPECT_EQ(Escape(Color(128, 128, 128), ColorMode::Ansi256), "\x1b[38;5;244m");
+  EXPECT_EQ(Escape(Color(238, 238, 238), ColorMode::Ansi256), "\x1b[38;5;255m");
+}
+
+TEST(ColorTest, DownsampleAvoidsPaletteEntries) {
+  // Indices 0 through 15 render from the user's palette, so an exact RGB
+  // request must never be answered with one.
+  for (int r = 0; r < 256; r += 17) {
+    for (int g = 0; g < 256; g += 17) {
+      for (int b = 0; b < 256; b += 17) {
+        Color color(r, g, b);
+        std::string escape = Escape(color, ColorMode::Ansi256);
+        int index = 0;
+        ASSERT_TRUE(llvm::to_integer(
+            llvm::StringRef(escape).drop_front(7).drop_back(1), index))
+            << color;
+        EXPECT_GE(index, 16) << color;
+      }
+    }
+  }
+}
+
+TEST(ColorTest, Equality) {
+  EXPECT_EQ(Color(AnsiColor::Red), Color(AnsiColor::Red));
+  EXPECT_NE(Color(AnsiColor::Red), Color(AnsiColor::Blue));
+  EXPECT_EQ(Color(1, 2, 3), Color(1, 2, 3));
+  EXPECT_NE(Color(1, 2, 3), Color(1, 2, 4));
+
+  // A named color and its reference value are different colors: the terminal
+  // renders one from the palette and the other exactly.
+  EXPECT_NE(Color(AnsiColor::BrightRed), Color(255, 0, 0));
+
+  // A palette index occupies the same byte as the red channel, so these pairs
+  // hold identical channel bytes and are told apart only by their kind.
+  EXPECT_NE(Color(AnsiColor::Red), Color(1, 0, 0));
+  EXPECT_NE(Color(AnsiColor::Black), Color(0, 0, 0));
+  EXPECT_NE(Color(AnsiColor::Black), Color());
+  EXPECT_NE(Color(0, 0, 0), Color());
+  EXPECT_EQ(Color(), Color());
+}
+
+TEST(ColorTest, Unset) {
+  EXPECT_FALSE(Color().is_set());
+  EXPECT_EQ(Color().kind(), Color::Kind::None);
+
+  // Black is a color like any other, however little of it there is.
+  EXPECT_TRUE(Color(AnsiColor::Black).is_set());
+  EXPECT_TRUE(Color(0, 0, 0).is_set());
+}
+
+TEST(ColorTest, Print) {
+  EXPECT_EQ(PrintToString(Color(AnsiColor::BrightMagenta)), "BrightMagenta");
+  EXPECT_EQ(PrintToString(Color(0x12, 0xab, 0xff)), "#12abff");
+  EXPECT_EQ(PrintToString(Color()), "None");
+}
+
+}  // namespace
+}  // namespace Carbon::Terminal

--- a/common/terminal/metrics.cpp
+++ b/common/terminal/metrics.cpp
@@ -16,117 +16,139 @@ namespace Carbon::Terminal {
 // control characters, and unassigned code points.
 static constexpr char32_t Utf8Replacement = U'�';
 
-// Returns whether an ASCII terminal renders `symbol` as itself, in one column.
-static auto IsPrintableAscii(char32_t symbol) -> bool {
-  return symbol >= 0x20 && symbol < 0x7f;
+// Returns whether an ASCII terminal renders `code_point` as itself, in one
+// column.
+static auto IsPrintableAscii(char32_t code_point) -> bool {
+  return code_point >= 0x20 && code_point < 0x7f;
 }
 
-auto EncodeUtf8(char32_t symbol, Utf8Storage& storage) -> llvm::StringRef {
+auto EncodeUtf8(char32_t code_point, Utf8Storage& storage) -> llvm::StringRef {
   // Most of what gets rendered is ASCII, and encoding it is a single byte.
-  if (symbol < 0x80) {
-    storage[0] = static_cast<char>(symbol);
+  if (code_point < 0x80) {
+    storage[0] = static_cast<char>(code_point);
     return llvm::StringRef(storage.data(), 1);
   }
 
   // Surrogates have no encoding of their own, and nothing past the last code
   // point has one at all.
-  if (symbol > 0x10ffff || (symbol >= 0xd800 && symbol < 0xe000)) {
-    symbol = Utf8Replacement;
+  if (code_point > 0x10ffff || (code_point >= 0xd800 && code_point < 0xe000)) {
+    code_point = Utf8Replacement;
   }
 
   // Spelled out rather than handed to a general converter, which walks a range
   // and checks bounds this already knows. Box-drawing characters go through
   // here for every cell of every line drawn.
-  auto trailing = [symbol](int shift) {
-    return static_cast<char>(0x80 | ((symbol >> shift) & 0x3f));
+  auto trailing = [code_point](int shift) {
+    return static_cast<char>(0x80 | ((code_point >> shift) & 0x3f));
   };
-  if (symbol < 0x800) {
-    storage[0] = static_cast<char>(0xc0 | (symbol >> 6));
+  if (code_point < 0x800) {
+    storage[0] = static_cast<char>(0xc0 | (code_point >> 6));
     storage[1] = trailing(0);
     return llvm::StringRef(storage.data(), 2);
   }
-  if (symbol < 0x10000) {
-    storage[0] = static_cast<char>(0xe0 | (symbol >> 12));
+  if (code_point < 0x10000) {
+    storage[0] = static_cast<char>(0xe0 | (code_point >> 12));
     storage[1] = trailing(6);
     storage[2] = trailing(0);
     return llvm::StringRef(storage.data(), 3);
   }
-  storage[0] = static_cast<char>(0xf0 | (symbol >> 18));
+  storage[0] = static_cast<char>(0xf0 | (code_point >> 18));
   storage[1] = trailing(12);
   storage[2] = trailing(6);
   storage[3] = trailing(0);
   return llvm::StringRef(storage.data(), 4);
 }
 
-// Returns the columns `symbol` occupies on a UTF-8 terminal: zero for a
-// combining mark, one or two for a symbol with a glyph of its own, and a
+// Returns the columns `code_point` occupies on a UTF-8 terminal: zero for a
+// combining mark, one or two for one with a glyph of its own, and a
 // negative value when there is no printable rendering for it.
-static auto Utf8SymbolWidth(char32_t symbol) -> int {
+//
+// TODO: This encodes a code point only for LLVM to decode it again.
+// `llvm::sys::unicode::charWidth` computes exactly this and is what
+// `columnWidthUTF8` calls once per code point, but it is file-local to LLVM's
+// `Unicode.cpp`. Exposing it there would let this call it directly. LLVM's own
+// contract already says a string's width is the sum of its code points', so
+// there is nothing in the way of it.
+static auto Utf8CodePointWidth(char32_t code_point) -> int {
   // Printable ASCII is one column, and is most of what gets measured. The
   // general path parses a UTF-8 sequence and searches several code point
   // range tables, which is far more than this needs.
-  if (IsPrintableAscii(symbol)) {
+  if (IsPrintableAscii(code_point)) {
     return 1;
   }
 
   Utf8Storage storage;
-  return llvm::sys::unicode::columnWidthUTF8(EncodeUtf8(symbol, storage));
+  return llvm::sys::unicode::columnWidthUTF8(EncodeUtf8(code_point, storage));
 }
 
 // Removes the first UTF-8 sequence from `text` and returns the code point it
 // encodes.
-static auto TakeUtf8Symbol(llvm::StringRef& text) -> char32_t {
+static auto TakeUtf8CodePoint(llvm::StringRef& text) -> char32_t {
   const auto* begin = reinterpret_cast<const llvm::UTF8*>(text.data());
   const auto* pos = begin;
-  llvm::UTF32 symbol = 0;
-  if (llvm::convertUTF8Sequence(&pos, begin + text.size(), &symbol,
+  llvm::UTF32 code_point = 0;
+  if (llvm::convertUTF8Sequence(&pos, begin + text.size(), &code_point,
                                 llvm::strictConversion) != llvm::conversionOK) {
     text = text.drop_front(1);
     return Utf8Replacement;
   }
   text = text.drop_front(pos - begin);
-  return symbol;
+  return code_point;
 }
 
-auto Metrics::TakeSymbol(llvm::StringRef& text) const -> char32_t {
-  CARBON_DCHECK(!text.empty());
+auto Metrics::TakeCodePoint(llvm::StringRef& text) const -> char32_t {
+  CARBON_CHECK(!text.empty(), "No code point to take.");
   if (charset_ == Charset::Ascii) {
     auto byte = static_cast<unsigned char>(text.front());
     text = text.drop_front();
     return byte;
   }
-  return TakeUtf8Symbol(text);
+  return TakeUtf8CodePoint(text);
 }
 
-auto Metrics::SymbolWidth(char32_t symbol) const -> int {
+auto Metrics::CodePointWidth(char32_t code_point) const -> int {
   if (charset_ == Charset::Ascii) {
     return 1;
   }
-  int width = Utf8SymbolWidth(symbol);
-  // A symbol with no rendering is drawn as the replacement character, which
+  int width = Utf8CodePointWidth(code_point);
+  // A code point with no rendering is drawn as the replacement character, which
   // takes one column.
   return width < 0 ? 1 : width;
 }
 
-auto Metrics::RenderedSymbol(char32_t symbol) const -> char32_t {
+auto Metrics::RenderedCodePoint(char32_t code_point) const -> char32_t {
   if (charset_ == Charset::Ascii) {
-    return IsPrintableAscii(symbol) ? symbol : U'?';
+    return IsPrintableAscii(code_point) ? code_point : U'?';
   }
-  return Utf8SymbolWidth(symbol) < 0 ? Utf8Replacement : symbol;
+  return Utf8CodePointWidth(code_point) < 0 ? Utf8Replacement : code_point;
 }
 
 auto Metrics::Width(llvm::StringRef text) const -> int {
-  CARBON_DCHECK(
-      !text.contains('\t') && !text.contains('\n') && !text.contains('\r'),
-      "Width is only for text whose width is its symbols', but got {0:?}.",
+  // Checked rather than debug-checked: text with one of these in it measures as
+  // though each took one column, which is not what drawing does, and measuring
+  // wrong is invisible in the output. The scan is one more linear pass over
+  // text that is walked linearly anyway.
+  CARBON_CHECK(
+      text.find_first_of("\t\n\r") == llvm::StringRef::npos,
+      "Width is only for text whose width is its code points', but got `{0}`.",
       text);
   if (charset_ == Charset::Ascii) {
     return static_cast<int>(text.size());
   }
 
-  int width = 0;
+  // Text that is valid UTF-8 throughout and printable throughout is the common
+  // case, and LLVM measures a whole run of it in one pass. It answers with a
+  // negative value rather than a width when the text holds anything it can't
+  // measure, which is what the walk below is for: each such code point still
+  // takes the one column the replacement character drawn for it will.
+  int width = llvm::sys::unicode::columnWidthUTF8(text);
+  if (width >= 0) {
+    return width;
+  }
+
+  width = 0;
   while (!text.empty()) {
-    width += SymbolWidth(TakeUtf8Symbol(text));
+    width += CodePointWidth(TakeUtf8CodePoint(text));
   }
   return width;
 }
@@ -148,7 +170,7 @@ auto Metrics::TakeColumns(llvm::StringRef& text, int columns) const
   int taken = 0;
   while (!rest.empty()) {
     llvm::StringRef next = rest;
-    int width = SymbolWidth(TakeSymbol(next));
+    int width = CodePointWidth(TakeCodePoint(next));
     if (taken + width > columns) {
       break;
     }

--- a/common/terminal/metrics.cpp
+++ b/common/terminal/metrics.cpp
@@ -4,8 +4,6 @@
 
 #include "common/terminal/metrics.h"
 
-#include <algorithm>
-
 #include "common/check.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Unicode.h"
@@ -22,6 +20,14 @@ static auto IsPrintableAscii(char32_t code_point) -> bool {
   return code_point >= 0x20 && code_point < 0x7f;
 }
 
+// Spelled out rather than handed to a general converter, which walks a range
+// and checks bounds this already knows. Box-drawing characters go through here
+// for every cell of every line drawn.
+//
+// TODO: Offer this to LLVM, whose `ConvertCodePointToUTF8` is the general
+// converter this replaces. Encoding one code point at a time is what anything
+// writing UTF-8 out of a grid does, so this belongs beside it rather than
+// here; drop this once it is there.
 auto EncodeUtf8(char32_t code_point, Utf8Storage& storage) -> llvm::StringRef {
   // Most of what gets rendered is ASCII, and encoding it is a single byte.
   if (code_point < 0x80) {
@@ -35,24 +41,21 @@ auto EncodeUtf8(char32_t code_point, Utf8Storage& storage) -> llvm::StringRef {
     code_point = Utf8Replacement;
   }
 
-  // Spelled out rather than handed to a general converter, which walks a range
-  // and checks bounds this already knows. Box-drawing characters go through
-  // here for every cell of every line drawn.
   auto trailing = [code_point](int shift) {
-    return static_cast<char>(0x80 | ((code_point >> shift) & 0x3f));
+    return static_cast<char>(0b1000'0000 | ((code_point >> shift) & 0b11'1111));
   };
   if (code_point < 0x800) {
-    storage[0] = static_cast<char>(0xc0 | (code_point >> 6));
+    storage[0] = static_cast<char>(0b1100'0000 | (code_point >> 6));
     storage[1] = trailing(0);
     return llvm::StringRef(storage.data(), 2);
   }
   if (code_point < 0x10000) {
-    storage[0] = static_cast<char>(0xe0 | (code_point >> 12));
+    storage[0] = static_cast<char>(0b1110'0000 | (code_point >> 12));
     storage[1] = trailing(6);
     storage[2] = trailing(0);
     return llvm::StringRef(storage.data(), 3);
   }
-  storage[0] = static_cast<char>(0xf0 | (code_point >> 18));
+  storage[0] = static_cast<char>(0b1111'0000 | (code_point >> 18));
   storage[1] = trailing(12);
   storage[2] = trailing(6);
   storage[3] = trailing(0);
@@ -120,7 +123,17 @@ auto Metrics::RenderedCodePoint(char32_t code_point) const -> char32_t {
   if (charset_ == Charset::Ascii) {
     return IsPrintableAscii(code_point) ? code_point : U'?';
   }
-  return Utf8CodePointWidth(code_point) < 0 ? Utf8Replacement : code_point;
+  // Printable ASCII is most of what gets drawn, and settling it here keeps it
+  // out of the range tables the general answer searches.
+  if (IsPrintableAscii(code_point)) {
+    return code_point;
+  }
+  // Which code points have no rendering is what a negative width names as well,
+  // asked directly rather than through a width that has to encode one to
+  // answer.
+  return llvm::sys::unicode::isPrintable(static_cast<int>(code_point))
+             ? code_point
+             : Utf8Replacement;
 }
 
 auto Metrics::Width(llvm::StringRef text) const -> int {
@@ -149,17 +162,6 @@ auto Metrics::Width(llvm::StringRef text) const -> int {
   width = 0;
   while (!text.empty()) {
     width += CodePointWidth(TakeUtf8CodePoint(text));
-  }
-  return width;
-}
-
-auto Metrics::WrapWidth(llvm::StringRef text) const -> int {
-  int width = 0;
-  while (!text.empty()) {
-    llvm::StringRef word =
-        text.take_until([](char c) { return c == '\n' || IsWrapBreak(c); });
-    width = std::max(width, Width(word));
-    text = text.drop_front(std::max<size_t>(word.size(), 1));
   }
   return width;
 }

--- a/common/terminal/metrics.cpp
+++ b/common/terminal/metrics.cpp
@@ -1,0 +1,163 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/metrics.h"
+
+#include <algorithm>
+
+#include "common/check.h"
+#include "llvm/Support/ConvertUTF.h"
+#include "llvm/Support/Unicode.h"
+
+namespace Carbon::Terminal {
+
+// Stands in for anything a UTF-8 terminal has no rendering for: invalid UTF-8,
+// control characters, and unassigned code points.
+static constexpr char32_t Utf8Replacement = U'�';
+
+// Returns whether an ASCII terminal renders `symbol` as itself, in one column.
+static auto IsPrintableAscii(char32_t symbol) -> bool {
+  return symbol >= 0x20 && symbol < 0x7f;
+}
+
+auto EncodeUtf8(char32_t symbol, Utf8Storage& storage) -> llvm::StringRef {
+  // Most of what gets rendered is ASCII, and encoding it is a single byte.
+  if (symbol < 0x80) {
+    storage[0] = static_cast<char>(symbol);
+    return llvm::StringRef(storage.data(), 1);
+  }
+
+  // Surrogates have no encoding of their own, and nothing past the last code
+  // point has one at all.
+  if (symbol > 0x10ffff || (symbol >= 0xd800 && symbol < 0xe000)) {
+    symbol = Utf8Replacement;
+  }
+
+  // Spelled out rather than handed to a general converter, which walks a range
+  // and checks bounds this already knows. Box-drawing characters go through
+  // here for every cell of every line drawn.
+  auto trailing = [symbol](int shift) {
+    return static_cast<char>(0x80 | ((symbol >> shift) & 0x3f));
+  };
+  if (symbol < 0x800) {
+    storage[0] = static_cast<char>(0xc0 | (symbol >> 6));
+    storage[1] = trailing(0);
+    return llvm::StringRef(storage.data(), 2);
+  }
+  if (symbol < 0x10000) {
+    storage[0] = static_cast<char>(0xe0 | (symbol >> 12));
+    storage[1] = trailing(6);
+    storage[2] = trailing(0);
+    return llvm::StringRef(storage.data(), 3);
+  }
+  storage[0] = static_cast<char>(0xf0 | (symbol >> 18));
+  storage[1] = trailing(12);
+  storage[2] = trailing(6);
+  storage[3] = trailing(0);
+  return llvm::StringRef(storage.data(), 4);
+}
+
+// Returns the columns `symbol` occupies on a UTF-8 terminal: zero for a
+// combining mark, one or two for a symbol with a glyph of its own, and a
+// negative value when there is no printable rendering for it.
+static auto Utf8SymbolWidth(char32_t symbol) -> int {
+  // Printable ASCII is one column, and is most of what gets measured. The
+  // general path parses a UTF-8 sequence and searches several code point
+  // range tables, which is far more than this needs.
+  if (IsPrintableAscii(symbol)) {
+    return 1;
+  }
+
+  Utf8Storage storage;
+  return llvm::sys::unicode::columnWidthUTF8(EncodeUtf8(symbol, storage));
+}
+
+// Removes the first UTF-8 sequence from `text` and returns the code point it
+// encodes.
+static auto TakeUtf8Symbol(llvm::StringRef& text) -> char32_t {
+  const auto* begin = reinterpret_cast<const llvm::UTF8*>(text.data());
+  const auto* pos = begin;
+  llvm::UTF32 symbol = 0;
+  if (llvm::convertUTF8Sequence(&pos, begin + text.size(), &symbol,
+                                llvm::strictConversion) != llvm::conversionOK) {
+    text = text.drop_front(1);
+    return Utf8Replacement;
+  }
+  text = text.drop_front(pos - begin);
+  return symbol;
+}
+
+auto Metrics::TakeSymbol(llvm::StringRef& text) const -> char32_t {
+  CARBON_DCHECK(!text.empty());
+  if (charset_ == Charset::Ascii) {
+    auto byte = static_cast<unsigned char>(text.front());
+    text = text.drop_front();
+    return byte;
+  }
+  return TakeUtf8Symbol(text);
+}
+
+auto Metrics::SymbolWidth(char32_t symbol) const -> int {
+  if (charset_ == Charset::Ascii) {
+    return 1;
+  }
+  int width = Utf8SymbolWidth(symbol);
+  // A symbol with no rendering is drawn as the replacement character, which
+  // takes one column.
+  return width < 0 ? 1 : width;
+}
+
+auto Metrics::RenderedSymbol(char32_t symbol) const -> char32_t {
+  if (charset_ == Charset::Ascii) {
+    return IsPrintableAscii(symbol) ? symbol : U'?';
+  }
+  return Utf8SymbolWidth(symbol) < 0 ? Utf8Replacement : symbol;
+}
+
+auto Metrics::Width(llvm::StringRef text) const -> int {
+  CARBON_DCHECK(
+      !text.contains('\t') && !text.contains('\n') && !text.contains('\r'),
+      "Width is only for text whose width is its symbols', but got {0:?}.",
+      text);
+  if (charset_ == Charset::Ascii) {
+    return static_cast<int>(text.size());
+  }
+
+  int width = 0;
+  while (!text.empty()) {
+    width += SymbolWidth(TakeUtf8Symbol(text));
+  }
+  return width;
+}
+
+auto Metrics::WrapWidth(llvm::StringRef text) const -> int {
+  int width = 0;
+  while (!text.empty()) {
+    llvm::StringRef word =
+        text.take_until([](char c) { return c == '\n' || IsWrapBreak(c); });
+    width = std::max(width, Width(word));
+    text = text.drop_front(std::max<size_t>(word.size(), 1));
+  }
+  return width;
+}
+
+auto Metrics::TakeColumns(llvm::StringRef& text, int columns) const
+    -> llvm::StringRef {
+  llvm::StringRef rest = text;
+  int taken = 0;
+  while (!rest.empty()) {
+    llvm::StringRef next = rest;
+    int width = SymbolWidth(TakeSymbol(next));
+    if (taken + width > columns) {
+      break;
+    }
+    taken += width;
+    rest = next;
+  }
+  llvm::StringRef prefix = text.drop_back(rest.size());
+  text = rest;
+  return prefix;
+}
+
+}  // namespace Carbon::Terminal

--- a/common/terminal/metrics.cpp
+++ b/common/terminal/metrics.cpp
@@ -120,14 +120,17 @@ auto Metrics::CodePointWidth(char32_t code_point) const -> int {
 }
 
 auto Metrics::RenderedCodePoint(char32_t code_point) const -> char32_t {
-  if (charset_ == Charset::Ascii) {
-    return IsPrintableAscii(code_point) ? code_point : U'?';
-  }
   // Printable ASCII is most of what gets drawn, and settling it here keeps it
   // out of the range tables the general answer searches.
   if (IsPrintableAscii(code_point)) {
     return code_point;
   }
+
+  // Fallback if we can't use unicode.
+  if (charset_ == Charset::Ascii) {
+    return U'?';
+  }
+
   // Which code points have no rendering is what a negative width names as well,
   // asked directly rather than through a width that has to encode one to
   // answer.

--- a/common/terminal/metrics.h
+++ b/common/terminal/metrics.h
@@ -1,0 +1,116 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_TERMINAL_METRICS_H_
+#define CARBON_COMMON_TERMINAL_METRICS_H_
+
+#include <array>
+#include <cstddef>
+
+#include "common/terminal/capabilities.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace Carbon::Terminal {
+
+// The most bytes one code point encodes to in UTF-8, and storage for one.
+inline constexpr size_t MaxUtf8Bytes = 4;
+using Utf8Storage = std::array<char, MaxUtf8Bytes>;
+
+// Encodes `symbol` as UTF-8 into `storage`, returning the bytes written.
+//
+// Code points with no valid encoding, including surrogates and anything past
+// U+10FFFF, become the replacement character.
+auto EncodeUtf8(char32_t symbol, Utf8Storage& storage) -> llvm::StringRef;
+
+// Returns whether wrapped text can be broken at `c`.
+//
+// This is the one definition of where a break can fall, so that measuring what
+// text wraps into and drawing it wrapped agree about it. Carriage returns
+// count, so that a CRLF ending breaks only on its newline.
+constexpr auto IsWrapBreak(char c) -> bool {
+  return c == ' ' || c == '\t' || c == '\r';
+}
+
+// How many columns a terminal spends on text, given the charset it decodes
+// with.
+//
+// Which bytes make up a column depends on the charset, so every question about
+// the size of text is a question about the charset as well, and this is what
+// answers both at once. `Buffer` holds one and lays its cells out with it;
+// anything deciding where to put something asks one directly rather than
+// keeping its own idea of how wide a string is.
+//
+// There is deliberately nothing here that converts between a byte offset and a
+// column. Two counts over one string that don't convert implicitly are the one
+// pair in rendering that must not be taken for each other -- which byte a
+// column lands on depends on the encoding, and which column a byte lands in
+// depends on the width of everything before it -- and the mistake is invisible
+// when it happens, moving a caret a few columns on the inputs nobody tests.
+// `TakeColumns` is what a caller wanting to cut text at a column uses, and it
+// hands back the text rather than an offset into it, so the two counts never
+// meet.
+class Metrics {
+ public:
+  explicit constexpr Metrics(Charset charset) : charset_(charset) {}
+
+  constexpr auto charset() const -> Charset { return charset_; }
+
+  // Removes the next symbol from `text`, which must not be empty, and returns
+  // it: one byte under `Charset::Ascii`, and one decoded code point under
+  // `Charset::Utf8`.
+  //
+  // A byte that doesn't start a valid sequence yields the replacement
+  // character and is consumed on its own, so decoding resynchronizes at the
+  // next byte rather than discarding the rest of the text.
+  auto TakeSymbol(llvm::StringRef& text) const -> char32_t;
+
+  // Returns the columns `symbol` occupies once drawn, which is what drawing it
+  // advances by. A combining mark is zero, since it renders into the column
+  // before it, and anything with no printable rendering is one, since it is
+  // drawn as a replacement character.
+  auto SymbolWidth(char32_t symbol) const -> int;
+
+  // Returns the symbol a terminal decoding this charset is actually given for
+  // `symbol`, which is a replacement character where it has no dependable
+  // rendering of its own.
+  //
+  // Under `Charset::Ascii` that is anything outside printable ASCII, because a
+  // terminal decoding some single-byte encoding will draw such a byte as
+  // something and there is no way to know what. Under `Charset::Utf8` it is
+  // anything with no printable rendering at all, including invalid UTF-8.
+  auto RenderedSymbol(char32_t symbol) const -> char32_t;
+
+  // Returns the columns `text` occupies once drawn.
+  //
+  // `text` must hold no character that drawing gives a width other than its
+  // symbols', so no tab, newline, or carriage return. Those are positional --
+  // what a tab advances by depends on where the text began -- which makes them
+  // questions about a drawing rather than about the text, and `Buffer` answers
+  // those.
+  auto Width(llvm::StringRef text) const -> int;
+
+  // Returns the fewest columns `text` wraps into without overhanging them,
+  // which is the width of its widest word since wrapping never breaks one.
+  //
+  // Wrapping into fewer still draws everything, so this is what to ask when a
+  // layout has somewhere else to put text that doesn't fit, rather than a
+  // reason to drop it.
+  auto WrapWidth(llvm::StringRef text) const -> int;
+
+  // Removes and returns the longest prefix of `text` that occupies at most
+  // `columns` columns.
+  //
+  // A symbol that would straddle the end stops the walk before it, so a cut
+  // never lands inside one and the prefix is never wider than asked for -- it
+  // can be one column narrower, where a double-width symbol sits on the
+  // boundary. `Width` on the result is what says which it was.
+  auto TakeColumns(llvm::StringRef& text, int columns) const -> llvm::StringRef;
+
+ private:
+  Charset charset_;
+};
+
+}  // namespace Carbon::Terminal
+
+#endif  // CARBON_COMMON_TERMINAL_METRICS_H_

--- a/common/terminal/metrics.h
+++ b/common/terminal/metrics.h
@@ -23,16 +23,6 @@ using Utf8Storage = std::array<char, MaxUtf8Bytes>;
 // U+10FFFF, become the replacement character.
 auto EncodeUtf8(char32_t code_point, Utf8Storage& storage) -> llvm::StringRef;
 
-// Returns whether wrapped text can be broken at `c`.
-//
-// This is the one definition of where wrapping may introduce a break, so that
-// measuring what text wraps into and drawing it wrapped agree about it.
-// Carriage returns count so that a CRLF ending is whitespace rather than part
-// of the word before it; what becomes of the `\r` is then up to the drawing.
-constexpr auto IsWrapBreak(char c) -> bool {
-  return c == ' ' || c == '\t' || c == '\r';
-}
-
 // How many columns a terminal spends on text, given the charset it decodes
 // with.
 //
@@ -76,6 +66,15 @@ class Metrics {
   // `Charset::Utf8` a combining mark is zero, since it renders into the column
   // before it, and anything with no printable rendering is one, since it is
   // drawn as a replacement character.
+  //
+  // A combining mark is the only thing zero is ever the answer for, which is
+  // what lets `Buffer` read a zero as one: a code point to fold into the cell
+  // before it rather than give a cell of its own. A code point that takes no
+  // column without combining with anything, such as U+200C ZERO WIDTH
+  // NON-JOINER, has no printable rendering here and takes the column its
+  // replacement character does. Terminals disagree about those -- some give
+  // them a column and some don't -- so drawing one as itself would leave the
+  // columns counted here and the columns painted disagreeing from there on.
   auto CodePointWidth(char32_t code_point) const -> int;
 
   // Returns the code point to render for `code_point`, which is a replacement
@@ -84,8 +83,8 @@ class Metrics {
   // Under `Charset::Ascii` that is anything outside printable ASCII, because a
   // terminal decoding some single-byte encoding will draw such a byte as
   // something and there is no way to know what. Under `Charset::Utf8` it is
-  // anything with no printable rendering at all. A surrogate is left as it is
-  // and replaced when it is encoded, since it has no encoding to render.
+  // anything with no printable rendering at all, which includes the surrogates
+  // and so covers everything UTF-8 has no encoding for as well.
   auto RenderedCodePoint(char32_t code_point) const -> char32_t;
 
   // Returns the columns `text` occupies once drawn.
@@ -96,13 +95,6 @@ class Metrics {
   // them questions about a drawing rather than about the text, and `Buffer`
   // answers those.
   auto Width(llvm::StringRef text) const -> int;
-
-  // Returns the fewest columns `text` wraps into without overhanging them,
-  // which is the width of its widest word since wrapping never breaks one.
-  //
-  // Wrapping into fewer columns still draws everything; the excess overhangs.
-  // So this is a layout preference rather than a minimum.
-  auto WrapWidth(llvm::StringRef text) const -> int;
 
   // Removes and returns the longest prefix of `text` that occupies at most
   // `columns` columns.

--- a/common/terminal/metrics.h
+++ b/common/terminal/metrics.h
@@ -17,17 +17,18 @@ namespace Carbon::Terminal {
 inline constexpr size_t MaxUtf8Bytes = 4;
 using Utf8Storage = std::array<char, MaxUtf8Bytes>;
 
-// Encodes `symbol` as UTF-8 into `storage`, returning the bytes written.
+// Encodes `code_point` as UTF-8 into `storage`, returning the bytes written.
 //
 // Code points with no valid encoding, including surrogates and anything past
 // U+10FFFF, become the replacement character.
-auto EncodeUtf8(char32_t symbol, Utf8Storage& storage) -> llvm::StringRef;
+auto EncodeUtf8(char32_t code_point, Utf8Storage& storage) -> llvm::StringRef;
 
 // Returns whether wrapped text can be broken at `c`.
 //
-// This is the one definition of where a break can fall, so that measuring what
-// text wraps into and drawing it wrapped agree about it. Carriage returns
-// count, so that a CRLF ending breaks only on its newline.
+// This is the one definition of where wrapping may introduce a break, so that
+// measuring what text wraps into and drawing it wrapped agree about it.
+// Carriage returns count so that a CRLF ending is whitespace rather than part
+// of the word before it; what becomes of the `\r` is then up to the drawing.
 constexpr auto IsWrapBreak(char c) -> bool {
   return c == ' ' || c == '\t' || c == '\r';
 }
@@ -41,70 +42,75 @@ constexpr auto IsWrapBreak(char c) -> bool {
 // anything deciding where to put something asks one directly rather than
 // keeping its own idea of how wide a string is.
 //
-// There is deliberately nothing here that converts between a byte offset and a
-// column. Two counts over one string that don't convert implicitly are the one
-// pair in rendering that must not be taken for each other -- which byte a
-// column lands on depends on the encoding, and which column a byte lands in
-// depends on the width of everything before it -- and the mistake is invisible
-// when it happens, moving a caret a few columns on the inputs nobody tests.
-// `TakeColumns` is what a caller wanting to cut text at a column uses, and it
-// hands back the text rather than an offset into it, so the two counts never
-// meet.
+// Nothing here converts between a byte offset and a column: which byte a column
+// lands on depends on the encoding, and which column a byte lands in depends on
+// the width of everything before it. `TakeColumns` hands back the text it cut
+// rather than an offset into it, so a caller never holds one count where the
+// other belongs.
+//
+// TODO: Every width here is a sum over code points taken in logical order,
+// which is only the width on screen for left-to-right text. Bidirectional text
+// reorders, so a run's width still adds up but `TakeColumns` has no meaning:
+// the prefix occupying the first N columns need not be a prefix of the string.
+// Settle this together with the question `Buffer`'s own TODO describes, since
+// both turn on what a client hands over.
 class Metrics {
  public:
   explicit constexpr Metrics(Charset charset) : charset_(charset) {}
 
   constexpr auto charset() const -> Charset { return charset_; }
 
-  // Removes the next symbol from `text`, which must not be empty, and returns
-  // it: one byte under `Charset::Ascii`, and one decoded code point under
-  // `Charset::Utf8`.
+  // Removes the next code point from `text`, which must not be empty, and
+  // returns it: one byte under `Charset::Ascii`, and one decoded code point
+  // under `Charset::Utf8`.
   //
   // A byte that doesn't start a valid sequence yields the replacement
   // character and is consumed on its own, so decoding resynchronizes at the
   // next byte rather than discarding the rest of the text.
-  auto TakeSymbol(llvm::StringRef& text) const -> char32_t;
+  auto TakeCodePoint(llvm::StringRef& text) const -> char32_t;
 
-  // Returns the columns `symbol` occupies once drawn, which is what drawing it
-  // advances by. A combining mark is zero, since it renders into the column
+  // Returns the columns `code_point` occupies once drawn, which is what drawing
+  // it advances by.
+  //
+  // Under `Charset::Ascii` every code point is one column. Under
+  // `Charset::Utf8` a combining mark is zero, since it renders into the column
   // before it, and anything with no printable rendering is one, since it is
   // drawn as a replacement character.
-  auto SymbolWidth(char32_t symbol) const -> int;
+  auto CodePointWidth(char32_t code_point) const -> int;
 
-  // Returns the symbol a terminal decoding this charset is actually given for
-  // `symbol`, which is a replacement character where it has no dependable
-  // rendering of its own.
+  // Returns the code point to render for `code_point`, which is a replacement
+  // character where it has no dependable rendering of its own.
   //
   // Under `Charset::Ascii` that is anything outside printable ASCII, because a
   // terminal decoding some single-byte encoding will draw such a byte as
   // something and there is no way to know what. Under `Charset::Utf8` it is
-  // anything with no printable rendering at all, including invalid UTF-8.
-  auto RenderedSymbol(char32_t symbol) const -> char32_t;
+  // anything with no printable rendering at all. A surrogate is left as it is
+  // and replaced when it is encoded, since it has no encoding to render.
+  auto RenderedCodePoint(char32_t code_point) const -> char32_t;
 
   // Returns the columns `text` occupies once drawn.
   //
   // `text` must hold no character that drawing gives a width other than its
-  // symbols', so no tab, newline, or carriage return. Those are positional --
-  // what a tab advances by depends on where the text began -- which makes them
-  // questions about a drawing rather than about the text, and `Buffer` answers
-  // those.
+  // code points', so no tab, newline, or carriage return. Those are positional
+  // -- what a tab advances by depends on where the text began -- which makes
+  // them questions about a drawing rather than about the text, and `Buffer`
+  // answers those.
   auto Width(llvm::StringRef text) const -> int;
 
   // Returns the fewest columns `text` wraps into without overhanging them,
   // which is the width of its widest word since wrapping never breaks one.
   //
-  // Wrapping into fewer still draws everything, so this is what to ask when a
-  // layout has somewhere else to put text that doesn't fit, rather than a
-  // reason to drop it.
+  // Wrapping into fewer columns still draws everything; the excess overhangs.
+  // So this is a layout preference rather than a minimum.
   auto WrapWidth(llvm::StringRef text) const -> int;
 
   // Removes and returns the longest prefix of `text` that occupies at most
   // `columns` columns.
   //
-  // A symbol that would straddle the end stops the walk before it, so a cut
+  // A code point that would straddle the end stops the walk before it, so a cut
   // never lands inside one and the prefix is never wider than asked for -- it
-  // can be one column narrower, where a double-width symbol sits on the
-  // boundary. `Width` on the result is what says which it was.
+  // can be one column narrower, where a double-width character sits on the
+  // boundary.
   auto TakeColumns(llvm::StringRef& text, int columns) const -> llvm::StringRef;
 
  private:

--- a/common/terminal/metrics_test.cpp
+++ b/common/terminal/metrics_test.cpp
@@ -7,6 +7,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 #include "llvm/ADT/StringRef.h"
 
 namespace Carbon::Terminal {
@@ -46,11 +48,30 @@ TEST(MetricsTest, CodePointWidth) {
   EXPECT_EQ(ascii.CodePointWidth(U'́'), 1);
 }
 
+TEST(MetricsTest, OnlyCombiningMarksAreZeroColumns) {
+  // Drawing reads a width of zero as "renders into the cell before this one",
+  // so a code point that takes no column without combining with anything has to
+  // measure as something else. Terminals disagree about these -- Terminal.app
+  // gives U+200C a column and VS Code's terminal gives it none -- so each is
+  // drawn as a replacement character, which takes exactly one.
+  Metrics utf8(Charset::Utf8);
+  for (char32_t code_point : {U'\u200b', U'\u200c', U'\u200d', U'\ufeff'}) {
+    EXPECT_EQ(utf8.CodePointWidth(code_point), 1)
+        << static_cast<uint32_t>(code_point);
+    EXPECT_EQ(utf8.RenderedCodePoint(code_point), U'�')
+        << static_cast<uint32_t>(code_point);
+  }
+}
+
 TEST(MetricsTest, RenderedCodePoint) {
   Metrics utf8(Charset::Utf8);
   EXPECT_EQ(utf8.RenderedCodePoint(U'a'), U'a');
   EXPECT_EQ(utf8.RenderedCodePoint(U'中'), U'中');
   EXPECT_EQ(utf8.RenderedCodePoint(U''), U'�');
+
+  // Code points that UTF-8 has no encoding for have no rendering either.
+  EXPECT_EQ(utf8.RenderedCodePoint(static_cast<char32_t>(0xd800)), U'�');
+  EXPECT_EQ(utf8.RenderedCodePoint(static_cast<char32_t>(0x110000)), U'�');
 
   // An ASCII terminal is only given what it draws as itself, because there is
   // no telling what it would draw for anything else.
@@ -58,19 +79,6 @@ TEST(MetricsTest, RenderedCodePoint) {
   EXPECT_EQ(ascii.RenderedCodePoint(U'a'), U'a');
   EXPECT_EQ(ascii.RenderedCodePoint(U'中'), U'?');
   EXPECT_EQ(ascii.RenderedCodePoint(U''), U'?');
-}
-
-TEST(MetricsTest, WrapWidth) {
-  Metrics utf8(Charset::Utf8);
-  EXPECT_EQ(utf8.WrapWidth(""), 0);
-  EXPECT_EQ(utf8.WrapWidth("a bb ccc"), 3);
-  EXPECT_EQ(utf8.WrapWidth("  spaced  out  "), 6);
-
-  // Newlines and tabs bound a word without taking columns of their own.
-  EXPECT_EQ(utf8.WrapWidth("a\nbb\tccc"), 3);
-
-  // A word is measured in the columns it takes, not the bytes it holds.
-  EXPECT_EQ(utf8.WrapWidth("中中 a"), 4);
 }
 
 TEST(MetricsTest, TakeColumns) {

--- a/common/terminal/metrics_test.cpp
+++ b/common/terminal/metrics_test.cpp
@@ -1,0 +1,144 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/metrics.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "llvm/ADT/StringRef.h"
+
+namespace Carbon::Terminal {
+namespace {
+
+// "e" followed by U+0301 COMBINING ACUTE ACCENT, which is one column because
+// the mark renders into the column the "e" is in.
+static constexpr llvm::StringLiteral AcuteE = "é";
+
+TEST(MetricsTest, Width) {
+  Metrics utf8(Charset::Utf8);
+  EXPECT_EQ(utf8.Width(""), 0);
+  EXPECT_EQ(utf8.Width("hello"), 5);
+  EXPECT_EQ(utf8.Width("中中"), 4);
+  EXPECT_EQ(utf8.Width("a中b"), 4);
+  EXPECT_EQ(utf8.Width(AcuteE), 1);
+
+  // Every byte is a column when the terminal isn't decoding UTF-8.
+  Metrics ascii(Charset::Ascii);
+  EXPECT_EQ(ascii.Width("hello"), 5);
+  EXPECT_EQ(ascii.Width("中中"), 6);
+  EXPECT_EQ(ascii.Width(AcuteE), 3);
+}
+
+TEST(MetricsTest, SymbolWidth) {
+  Metrics utf8(Charset::Utf8);
+  EXPECT_EQ(utf8.SymbolWidth(U'a'), 1);
+  EXPECT_EQ(utf8.SymbolWidth(U'中'), 2);
+  // A combining mark renders into the column before it.
+  EXPECT_EQ(utf8.SymbolWidth(U'́'), 0);
+  // Something with no rendering is drawn as a replacement, which is a column.
+  EXPECT_EQ(utf8.SymbolWidth(U''), 1);
+
+  Metrics ascii(Charset::Ascii);
+  EXPECT_EQ(ascii.SymbolWidth(U'a'), 1);
+  EXPECT_EQ(ascii.SymbolWidth(U'中'), 1);
+  EXPECT_EQ(ascii.SymbolWidth(U'́'), 1);
+}
+
+TEST(MetricsTest, RenderedSymbol) {
+  Metrics utf8(Charset::Utf8);
+  EXPECT_EQ(utf8.RenderedSymbol(U'a'), U'a');
+  EXPECT_EQ(utf8.RenderedSymbol(U'中'), U'中');
+  EXPECT_EQ(utf8.RenderedSymbol(U''), U'�');
+
+  // An ASCII terminal is only given what it draws as itself, because there is
+  // no telling what it would draw for anything else.
+  Metrics ascii(Charset::Ascii);
+  EXPECT_EQ(ascii.RenderedSymbol(U'a'), U'a');
+  EXPECT_EQ(ascii.RenderedSymbol(U'中'), U'?');
+  EXPECT_EQ(ascii.RenderedSymbol(U''), U'?');
+}
+
+TEST(MetricsTest, WrapWidth) {
+  Metrics utf8(Charset::Utf8);
+  EXPECT_EQ(utf8.WrapWidth(""), 0);
+  EXPECT_EQ(utf8.WrapWidth("a bb ccc"), 3);
+  EXPECT_EQ(utf8.WrapWidth("  spaced  out  "), 6);
+
+  // Newlines and tabs bound a word as break characters, not as columns of
+  // their own.
+  EXPECT_EQ(utf8.WrapWidth("a\nbb\tccc"), 3);
+
+  // A word is measured in the columns it takes, not the bytes it holds.
+  EXPECT_EQ(utf8.WrapWidth("中中 a"), 4);
+}
+
+TEST(MetricsTest, TakeColumns) {
+  Metrics utf8(Charset::Utf8);
+  llvm::StringRef text = "abcde";
+  EXPECT_EQ(utf8.TakeColumns(text, 3), "abc");
+  EXPECT_EQ(text, "de");
+
+  // Taking more than there is takes all of it.
+  EXPECT_EQ(utf8.TakeColumns(text, 10), "de");
+  EXPECT_EQ(text, "");
+
+  // Taking nothing takes nothing, and a negative width is no different.
+  text = "abcde";
+  EXPECT_EQ(utf8.TakeColumns(text, 0), "");
+  EXPECT_EQ(utf8.TakeColumns(text, -1), "");
+  EXPECT_EQ(text, "abcde");
+}
+
+TEST(MetricsTest, TakeColumnsKeepsWideSymbolsWhole) {
+  Metrics utf8(Charset::Utf8);
+  // A symbol that would straddle the end stops the walk before it, so the
+  // prefix comes back a column short rather than half a character wide.
+  llvm::StringRef text = "中中中";
+  llvm::StringRef prefix = utf8.TakeColumns(text, 3);
+  EXPECT_EQ(prefix, "中");
+  EXPECT_EQ(utf8.Width(prefix), 2);
+  EXPECT_EQ(text, "中中");
+
+  // Asking for exactly what one takes takes it.
+  text = "中中中";
+  EXPECT_EQ(utf8.TakeColumns(text, 4), "中中");
+  EXPECT_EQ(text, "中");
+}
+
+TEST(MetricsTest, TakeColumnsUnderAscii) {
+  // Every byte is a column, so a multi-byte character is cut like any other
+  // run of bytes.
+  Metrics ascii(Charset::Ascii);
+  llvm::StringRef text = "中";
+  EXPECT_EQ(ascii.TakeColumns(text, 2).size(), 2u);
+  EXPECT_EQ(text.size(), 1u);
+}
+
+TEST(MetricsTest, TakeSymbolResynchronizesOnInvalidUtf8) {
+  Metrics utf8(Charset::Utf8);
+  // A byte that starts no valid sequence is consumed on its own, so the text
+  // after it is still decoded rather than being discarded.
+  llvm::StringRef text =
+      "\xff"
+      "a";
+  EXPECT_EQ(utf8.TakeSymbol(text), U'�');
+  EXPECT_EQ(utf8.TakeSymbol(text), U'a');
+  EXPECT_TRUE(text.empty());
+}
+
+TEST(MetricsTest, EncodeUtf8) {
+  Utf8Storage storage;
+  EXPECT_EQ(EncodeUtf8(U'a', storage), "a");
+  EXPECT_EQ(EncodeUtf8(U'é', storage), "é");
+  EXPECT_EQ(EncodeUtf8(U'中', storage), "中");
+  EXPECT_EQ(EncodeUtf8(U'\U0001f525', storage), "\U0001f525");
+
+  // A code point with no encoding of its own becomes the replacement.
+  EXPECT_EQ(EncodeUtf8(static_cast<char32_t>(0xd800), storage), "�");
+  EXPECT_EQ(EncodeUtf8(static_cast<char32_t>(0x110000), storage), "�");
+}
+
+}  // namespace
+}  // namespace Carbon::Terminal

--- a/common/terminal/metrics_test.cpp
+++ b/common/terminal/metrics_test.cpp
@@ -31,33 +31,33 @@ TEST(MetricsTest, Width) {
   EXPECT_EQ(ascii.Width(AcuteE), 3);
 }
 
-TEST(MetricsTest, SymbolWidth) {
+TEST(MetricsTest, CodePointWidth) {
   Metrics utf8(Charset::Utf8);
-  EXPECT_EQ(utf8.SymbolWidth(U'a'), 1);
-  EXPECT_EQ(utf8.SymbolWidth(U'中'), 2);
+  EXPECT_EQ(utf8.CodePointWidth(U'a'), 1);
+  EXPECT_EQ(utf8.CodePointWidth(U'中'), 2);
   // A combining mark renders into the column before it.
-  EXPECT_EQ(utf8.SymbolWidth(U'́'), 0);
+  EXPECT_EQ(utf8.CodePointWidth(U'́'), 0);
   // Something with no rendering is drawn as a replacement, which is a column.
-  EXPECT_EQ(utf8.SymbolWidth(U''), 1);
+  EXPECT_EQ(utf8.CodePointWidth(U''), 1);
 
   Metrics ascii(Charset::Ascii);
-  EXPECT_EQ(ascii.SymbolWidth(U'a'), 1);
-  EXPECT_EQ(ascii.SymbolWidth(U'中'), 1);
-  EXPECT_EQ(ascii.SymbolWidth(U'́'), 1);
+  EXPECT_EQ(ascii.CodePointWidth(U'a'), 1);
+  EXPECT_EQ(ascii.CodePointWidth(U'中'), 1);
+  EXPECT_EQ(ascii.CodePointWidth(U'́'), 1);
 }
 
-TEST(MetricsTest, RenderedSymbol) {
+TEST(MetricsTest, RenderedCodePoint) {
   Metrics utf8(Charset::Utf8);
-  EXPECT_EQ(utf8.RenderedSymbol(U'a'), U'a');
-  EXPECT_EQ(utf8.RenderedSymbol(U'中'), U'中');
-  EXPECT_EQ(utf8.RenderedSymbol(U''), U'�');
+  EXPECT_EQ(utf8.RenderedCodePoint(U'a'), U'a');
+  EXPECT_EQ(utf8.RenderedCodePoint(U'中'), U'中');
+  EXPECT_EQ(utf8.RenderedCodePoint(U''), U'�');
 
   // An ASCII terminal is only given what it draws as itself, because there is
   // no telling what it would draw for anything else.
   Metrics ascii(Charset::Ascii);
-  EXPECT_EQ(ascii.RenderedSymbol(U'a'), U'a');
-  EXPECT_EQ(ascii.RenderedSymbol(U'中'), U'?');
-  EXPECT_EQ(ascii.RenderedSymbol(U''), U'?');
+  EXPECT_EQ(ascii.RenderedCodePoint(U'a'), U'a');
+  EXPECT_EQ(ascii.RenderedCodePoint(U'中'), U'?');
+  EXPECT_EQ(ascii.RenderedCodePoint(U''), U'?');
 }
 
 TEST(MetricsTest, WrapWidth) {
@@ -66,8 +66,7 @@ TEST(MetricsTest, WrapWidth) {
   EXPECT_EQ(utf8.WrapWidth("a bb ccc"), 3);
   EXPECT_EQ(utf8.WrapWidth("  spaced  out  "), 6);
 
-  // Newlines and tabs bound a word as break characters, not as columns of
-  // their own.
+  // Newlines and tabs bound a word without taking columns of their own.
   EXPECT_EQ(utf8.WrapWidth("a\nbb\tccc"), 3);
 
   // A word is measured in the columns it takes, not the bytes it holds.
@@ -91,9 +90,9 @@ TEST(MetricsTest, TakeColumns) {
   EXPECT_EQ(text, "abcde");
 }
 
-TEST(MetricsTest, TakeColumnsKeepsWideSymbolsWhole) {
+TEST(MetricsTest, TakeColumnsKeepsWideCharactersWhole) {
   Metrics utf8(Charset::Utf8);
-  // A symbol that would straddle the end stops the walk before it, so the
+  // A character that would straddle the end stops the walk before it, so the
   // prefix comes back a column short rather than half a character wide.
   llvm::StringRef text = "中中中";
   llvm::StringRef prefix = utf8.TakeColumns(text, 3);
@@ -101,7 +100,7 @@ TEST(MetricsTest, TakeColumnsKeepsWideSymbolsWhole) {
   EXPECT_EQ(utf8.Width(prefix), 2);
   EXPECT_EQ(text, "中中");
 
-  // Asking for exactly what one takes takes it.
+  // A request landing on a character boundary takes the whole prefix.
   text = "中中中";
   EXPECT_EQ(utf8.TakeColumns(text, 4), "中中");
   EXPECT_EQ(text, "中");
@@ -112,19 +111,19 @@ TEST(MetricsTest, TakeColumnsUnderAscii) {
   // run of bytes.
   Metrics ascii(Charset::Ascii);
   llvm::StringRef text = "中";
-  EXPECT_EQ(ascii.TakeColumns(text, 2).size(), 2u);
-  EXPECT_EQ(text.size(), 1u);
+  EXPECT_EQ(ascii.TakeColumns(text, 2).size(), 2U);
+  EXPECT_EQ(text.size(), 1U);
 }
 
-TEST(MetricsTest, TakeSymbolResynchronizesOnInvalidUtf8) {
+TEST(MetricsTest, TakeCodePointResynchronizesOnInvalidUtf8) {
   Metrics utf8(Charset::Utf8);
   // A byte that starts no valid sequence is consumed on its own, so the text
   // after it is still decoded rather than being discarded.
   llvm::StringRef text =
       "\xff"
       "a";
-  EXPECT_EQ(utf8.TakeSymbol(text), U'�');
-  EXPECT_EQ(utf8.TakeSymbol(text), U'a');
+  EXPECT_EQ(utf8.TakeCodePoint(text), U'�');
+  EXPECT_EQ(utf8.TakeCodePoint(text), U'a');
   EXPECT_TRUE(text.empty());
 }
 
@@ -138,6 +137,16 @@ TEST(MetricsTest, EncodeUtf8) {
   // A code point with no encoding of its own becomes the replacement.
   EXPECT_EQ(EncodeUtf8(static_cast<char32_t>(0xd800), storage), "�");
   EXPECT_EQ(EncodeUtf8(static_cast<char32_t>(0x110000), storage), "�");
+}
+
+TEST(MetricsDeathTest, WidthRejectsPositionalCharacters) {
+  // A tab's width is a fact about a drawing rather than about the text, so
+  // answering for one here would be answering a question this can't see the
+  // inputs to.
+  Metrics metrics(Charset::Utf8);
+  EXPECT_DEATH((void)metrics.Width("a\tb"), "Width is only for text whose");
+  EXPECT_DEATH((void)metrics.Width("a\nb"), "Width is only for text whose");
+  EXPECT_DEATH((void)metrics.Width("a\rb"), "Width is only for text whose");
 }
 
 }  // namespace

--- a/common/terminal/output_buffer_ref.h
+++ b/common/terminal/output_buffer_ref.h
@@ -12,7 +12,6 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Endian.h"
 
 namespace Carbon::Terminal {
 
@@ -72,6 +71,33 @@ class OutputBufferRef {
   // written as a single four-byte store whose last byte is discarded.
   static constexpr size_t NumberBytes = 4;
 
+  // The decimal text of a number, and how many digits it took. The digits are
+  // at the front and the length in the byte after them, so a whole entry is one
+  // store and the length says how far of it to keep.
+  struct NumberText {
+    std::array<char, NumberBytes - 1> digits;
+    uint8_t length;
+  };
+  static_assert(sizeof(NumberText) == NumberBytes,
+                "A number is written by storing a whole entry at once.");
+
+  // The text of every value a number piece can hold. A kilobyte of table, in
+  // exchange for a lookup where computing the digits would branch on the value
+  // three times.
+  static constexpr std::array<NumberText, 256> NumberTexts = [] {
+    std::array<NumberText, 256> texts = {};
+    for (int value = 0; value < 256; ++value) {
+      NumberText& text = texts[value];
+      text.length = 1 + (value >= 10) + (value >= 100);
+      int rest = value;
+      for (int digit = text.length; digit > 0; --digit) {
+        text.digits[digit - 1] = static_cast<char>('0' + rest % 10);
+        rest /= 10;
+      }
+    }
+    return texts;
+  }();
+
   // Returns the most bytes a piece can append. A number contributes the bound
   // above rather than the digits it will take, so the bound for a sequence
   // doesn't depend on any of the values in it.
@@ -104,23 +130,15 @@ class OutputBufferRef {
   }
   template <std::same_as<uint8_t> T>
   static auto WritePiece(char* out, T piece) -> char* {
-    // Written without branching on the value. Escape sequences carry color
-    // channels and palette indices, which are spread across the whole range, so
-    // a branch per digit is one the processor can't predict, and there are four
-    // numbers in a truecolor escape. The cost is then the same for every value,
-    // which loses a little where a number is always short and wins a great deal
-    // where it isn't.
-    //
-    // All three digits are packed low byte first, shifted down to drop the
-    // leading zeros, and stored at once. The store always covers four bytes,
-    // which is why a number reserves that many, and the cursor advances only
-    // over the digits that count.
-    uint32_t digits = static_cast<uint32_t>('0' + piece / 100) |
-                      static_cast<uint32_t>('0' + piece / 10 % 10) << 8 |
-                      static_cast<uint32_t>('0' + piece % 10) << 16;
-    int length = 1 + (piece >= 10) + (piece >= 100);
-    llvm::support::endian::write32le(out, digits >> (3 - length) * 8);
-    return out + length;
+    // One load and one store, with no branch on the value. Escape sequences
+    // carry color channels and palette indices, which are spread across the
+    // whole range, so a branch per digit is one the processor can't predict,
+    // and there are four numbers in a truecolor escape. The store always covers
+    // four bytes, which is why a number reserves that many, and the cursor
+    // advances only over the digits that count.
+    const NumberText& text = NumberTexts[piece];
+    std::memcpy(out, &text, sizeof(text));
+    return out + text.length;
   }
 
   // Appends a piece on its own, growing the buffer to fit it.

--- a/common/terminal/output_buffer_ref.h
+++ b/common/terminal/output_buffer_ref.h
@@ -1,0 +1,145 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_TERMINAL_OUTPUT_BUFFER_REF_H_
+#define CARBON_COMMON_TERMINAL_OUTPUT_BUFFER_REF_H_
+
+#include <array>
+#include <concepts>
+#include <cstdint>
+#include <cstring>
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Endian.h"
+
+namespace Carbon::Terminal {
+
+// A reference to the buffer a terminal rendering is assembled into.
+//
+// This owns nothing. It refers to a buffer the caller holds, which must outlive
+// it, and converts implicitly from one so that rendering goes into storage the
+// caller already has.
+//
+// Rendering assembles bytes here rather than streaming them: a stream call per
+// literal and per number costs measurably more than handing over a finished
+// sequence, and code that wants a stream prints the buffer once it is complete.
+//
+// Appending is shaped around what terminal output is made of, which is a great
+// many short escape sequences, each a handful of literal bytes around a number
+// that never exceeds 255. Taking a whole sequence at a time grows the buffer
+// once per sequence rather than once per byte, and that difference is much of
+// what rendering costs.
+class OutputBufferRef {
+ public:
+  // Implicit, so that call sites pass the buffer they already hold rather than
+  // naming this type.
+  //
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  OutputBufferRef(llvm::SmallVectorImpl<char>& bytes) : bytes_(&bytes) {}
+
+  // Appends `pieces`, each of which is either text, appended as it is, or a
+  // `uint8_t`, appended in decimal.
+  //
+  // No other type is accepted, so the two can never be taken for each other,
+  // and nothing needs one: the literal bytes of an escape sequence are always
+  // text, and every number one carries is a channel value, a palette index, or
+  // an SGR code, none of which exceed 255.
+  //
+  // No piece may point into the buffer, which appending can reallocate.
+  template <typename... PieceT>
+  auto Append(const PieceT&... pieces) -> void {
+    if constexpr (sizeof...(pieces) == 1) {
+      // A lone piece has nothing to assemble, and the buffer's own append is
+      // already the single growth and single copy this is after.
+      (AppendPiece(pieces), ...);
+    } else {
+      // Growing to the bound before writing keeps how far the buffer grows
+      // independent of the piece values, so computing one can't hold that up.
+      // Only the trim afterwards depends on how many digits a number took.
+      size_t begin = bytes_->size();
+      bytes_->resize_for_overwrite(begin + (AppendedSize(pieces) + ... + 0));
+      char* data = bytes_->data();
+      char* cursor = data + begin;
+      ((cursor = WritePiece(cursor, pieces)), ...);
+      bytes_->truncate(cursor - data);
+    }
+  }
+
+ private:
+  // The room a number needs: its three digits, plus one more because it is
+  // written as a single four-byte store whose last byte is discarded.
+  static constexpr size_t NumberBytes = 4;
+
+  // Returns the most bytes a piece can append. A number contributes the bound
+  // above rather than the digits it will take, so the bound for a sequence
+  // doesn't depend on any of the values in it.
+  template <size_t N>
+  static constexpr auto AppendedSize(const char (& /*piece*/)[N]) -> size_t {
+    return N - 1;
+  }
+  static constexpr auto AppendedSize(llvm::StringRef piece) -> size_t {
+    return piece.size();
+  }
+  template <std::same_as<uint8_t> T>
+  static constexpr auto AppendedSize(T /*piece*/) -> size_t {
+    return NumberBytes;
+  }
+
+  // Writes a piece at `out` and returns the position past it. There must be
+  // `AppendedSize(piece)` bytes of room, as nothing here checks.
+  template <size_t N>
+  static auto WritePiece(char* out, const char (&piece)[N]) -> char* {
+    std::memcpy(out, piece, N - 1);
+    return out + N - 1;
+  }
+  static auto WritePiece(char* out, llvm::StringRef piece) -> char* {
+    // An empty `StringRef` may hold a null pointer, which `memcpy` doesn't
+    // accept even for an empty copy.
+    if (!piece.empty()) {
+      std::memcpy(out, piece.data(), piece.size());
+    }
+    return out + piece.size();
+  }
+  template <std::same_as<uint8_t> T>
+  static auto WritePiece(char* out, T piece) -> char* {
+    // Written without branching on the value. Escape sequences carry color
+    // channels and palette indices, which are spread across the whole range, so
+    // a branch per digit is one the processor can't predict, and there are four
+    // numbers in a truecolor escape. The cost is then the same for every value,
+    // which loses a little where a number is always short and wins a great deal
+    // where it isn't.
+    //
+    // All three digits are packed low byte first, shifted down to drop the
+    // leading zeros, and stored at once. The store always covers four bytes,
+    // which is why a number reserves that many, and the cursor advances only
+    // over the digits that count.
+    uint32_t digits = static_cast<uint32_t>('0' + piece / 100) |
+                      static_cast<uint32_t>('0' + piece / 10 % 10) << 8 |
+                      static_cast<uint32_t>('0' + piece % 10) << 16;
+    int length = 1 + (piece >= 10) + (piece >= 100);
+    llvm::support::endian::write32le(out, digits >> (3 - length) * 8);
+    return out + length;
+  }
+
+  // Appends a piece on its own, growing the buffer to fit it.
+  template <size_t N>
+  auto AppendPiece(const char (&piece)[N]) -> void {
+    bytes_->append(piece, piece + N - 1);
+  }
+  auto AppendPiece(llvm::StringRef piece) -> void {
+    bytes_->append(piece.begin(), piece.end());
+  }
+  template <std::same_as<uint8_t> T>
+  auto AppendPiece(T piece) -> void {
+    std::array<char, NumberBytes> digits;
+    bytes_->append(digits.data(), WritePiece(digits.data(), piece));
+  }
+
+  llvm::SmallVectorImpl<char>* bytes_;
+};
+
+}  // namespace Carbon::Terminal
+
+#endif  // CARBON_COMMON_TERMINAL_OUTPUT_BUFFER_REF_H_

--- a/common/terminal/output_buffer_ref_test.cpp
+++ b/common/terminal/output_buffer_ref_test.cpp
@@ -1,0 +1,99 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/output_buffer_ref.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "llvm/ADT/SmallString.h"
+
+namespace Carbon::Terminal {
+namespace {
+
+using ::testing::Eq;
+
+// A single piece and several pieces are appended by different code, so both
+// appear throughout these tests rather than in one case of their own.
+
+TEST(OutputBufferRefTest, Text) {
+  llvm::SmallString<16> bytes;
+  OutputBufferRef out = bytes;
+  out.Append("one");
+  out.Append(llvm::StringRef(" two"));
+  out.Append(std::string(" three"));
+  out.Append(" four", llvm::StringRef(" five"));
+  EXPECT_THAT(bytes, Eq("one two three four five"));
+}
+
+TEST(OutputBufferRefTest, EmptyPieces) {
+  llvm::SmallString<16> bytes;
+  OutputBufferRef out = bytes;
+  out.Append();
+  out.Append("");
+  out.Append("", llvm::StringRef(), "kept", llvm::StringRef(""));
+  EXPECT_THAT(bytes, Eq("kept"));
+}
+
+TEST(OutputBufferRefTest, NumbersUseEveryDigitCount) {
+  llvm::SmallString<16> bytes;
+  OutputBufferRef out = bytes;
+  for (uint8_t value : {0, 9, 10, 99, 100, 255}) {
+    out.Append(value);
+    out.Append(" ", value, " ");
+  }
+  EXPECT_THAT(bytes, Eq("0 0 9 9 10 10 99 99 100 100 255 255 "));
+}
+
+// A number takes fewer bytes than it reserves unless it has three digits, so
+// pieces after one in the same call are what catch a misplaced write.
+TEST(OutputBufferRefTest, NumbersFollowedByMorePieces) {
+  llvm::SmallString<32> bytes;
+  OutputBufferRef out = bytes;
+  out.Append("\x1b[", static_cast<uint8_t>(38), ";2;", static_cast<uint8_t>(1),
+             ";", static_cast<uint8_t>(22), ";", static_cast<uint8_t>(255),
+             "m");
+  EXPECT_THAT(bytes, Eq("\x1b[38;2;1;22;255m"));
+}
+
+TEST(OutputBufferRefTest, AppendsAfterExistingContents) {
+  llvm::SmallString<16> bytes = llvm::StringRef("before:");
+  OutputBufferRef out = bytes;
+  out.Append(static_cast<uint8_t>(7));
+  EXPECT_THAT(bytes, Eq("before:7"));
+}
+
+// Appending has to work the same however the buffer is laid out, and a number
+// leaves the buffer grown further than it wrote, so reallocation is where a
+// size mistake would show up.
+TEST(OutputBufferRefTest, AppendsPastInlineCapacity) {
+  llvm::SmallString<8> bytes;
+  OutputBufferRef out = bytes;
+  std::string expected;
+  for (int i = 0; i < 100; ++i) {
+    out.Append("x", static_cast<uint8_t>(i));
+    expected += "x" + std::to_string(i);
+  }
+  EXPECT_THAT(bytes, Eq(expected));
+  EXPECT_THAT(bytes.size(), Eq(expected.size()));
+}
+
+// References to one buffer all append to it, and none of them own it, so the
+// buffer keeps everything written through any of them.
+TEST(OutputBufferRefTest, ReferencesShareTheirBuffer) {
+  llvm::SmallString<16> bytes;
+  OutputBufferRef first = bytes;
+  first.Append("a");
+  {
+    OutputBufferRef second = bytes;
+    second.Append("b");
+  }
+  OutputBufferRef copy = first;
+  copy.Append("c");
+  first.Append("d");
+  EXPECT_THAT(bytes, Eq("abcd"));
+}
+
+}  // namespace
+}  // namespace Carbon::Terminal

--- a/common/terminal/output_buffer_ref_test.cpp
+++ b/common/terminal/output_buffer_ref_test.cpp
@@ -46,8 +46,8 @@ TEST(OutputBufferRefTest, NumbersUseEveryDigitCount) {
   EXPECT_THAT(bytes, Eq("0 0 9 9 10 10 99 99 100 100 255 255 "));
 }
 
-// A number takes fewer bytes than it reserves unless it has three digits, so
-// pieces after one in the same call are what catch a misplaced write.
+// A number always writes fewer bytes than it reserves, so pieces after one in
+// the same call are what catch a misplaced write.
 TEST(OutputBufferRefTest, NumbersFollowedByMorePieces) {
   llvm::SmallString<32> bytes;
   OutputBufferRef out = bytes;

--- a/common/terminal/pressure_test.cpp
+++ b/common/terminal/pressure_test.cpp
@@ -108,6 +108,9 @@ TEST(PressureTest, WrappedTextSurvivesHostileBytes) {
         EXPECT_LE(buffer.height(), end.y + 1) << text;
         EXPECT_GE(end.x, 0) << text;
         EXPECT_EQ(buffer.MeasureWrappedText(0, 0, 0, width, text), end) << text;
+        // The width wrapping this wouldn't overhang is a fact about the text
+        // rather than about the block it was drawn into.
+        EXPECT_GE(buffer.MeasureWrapWidth(text), 0) << text;
 
         RenderAndCheck(buffer, ColorMode::Truecolor);
       }
@@ -145,8 +148,6 @@ TEST(PressureTest, MetricsSurviveHostileBytes) {
         ++steps;
         ASSERT_LE(steps, text.size()) << "TakeCodePoint failed to consume";
       }
-
-      EXPECT_GE(metrics.WrapWidth(text), 0) << text;
     }
   }
 }

--- a/common/terminal/pressure_test.cpp
+++ b/common/terminal/pressure_test.cpp
@@ -1,0 +1,196 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Adversarial inputs across the terminal library's surface.
+//
+// The library draws whatever a source file contains, for a terminal whose width
+// came from an environment variable. Both are things a user controls, and
+// neither may crash, read out of bounds, or quietly produce a position that is
+// wrong. The tests here feed each entry point the inputs most likely to do one
+// of those, and assert that what comes back is coherent rather than asserting
+// any particular rendering.
+//
+// What is deliberately not here: anything a caller is checked for getting
+// wrong, which is text past `MaxTextBytes` and coordinates outside the width
+// laid out for. Those are death tests in `buffer_test`. What remains is the
+// text and the width, neither of which a caller can validate ahead of drawing.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "common/terminal/buffer.h"
+#include "common/terminal/capabilities.h"
+#include "common/terminal/metrics.h"
+#include "common/terminal/style.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace Carbon::Terminal {
+namespace {
+
+// Byte sequences that stress column accounting.
+auto HostileText() -> std::vector<std::string> {
+  return {
+      "",
+      "\x01\x02\x7f",               // C0 controls and delete
+      "\xff\xfe\xfd",               // never valid UTF-8
+      "\xe4\xb8",                   // truncated multi-byte sequence
+      "\xe4\xb8\x96\xe4\xb8",       // valid then truncated
+      "\xcc\x81",                   // combining mark with no base
+      "e\xcc\x81\xcc\x82\xcc\x83",  // a base with several marks
+      "\xf0\x9f\x94\xa5",           // outside the basic plane
+      "\xed\xa0\x80",               // a surrogate, which UTF-8 forbids
+      "\xc0\x80",                   // overlong encoding of NUL
+      "中中中",                     // double-width throughout
+      "a\tb\nc\r\nd",               // every positional character
+      "\t\t\t\t\t\t\t\t",           // nothing but tabs
+      "\n\n\n",                     // nothing but newlines
+      std::string(4096, ' '),       // a long run of blanks
+      std::string(1024, '\t'),      // a long run of tabs
+  };
+}
+
+// Renders `buffer` and checks the bytes are coherent. Everything here draws
+// with the default style, so what a style leaves behind is `buffer_test`'s to
+// cover; this is about the text surviving at all.
+auto RenderAndCheck(const Buffer& buffer, ColorMode mode) -> std::string {
+  llvm::SmallString<256> out;
+  buffer.Render(out, mode);
+  std::string rendered(out);
+  if (rendered.empty()) {
+    return rendered;
+  }
+  EXPECT_EQ(rendered.back(), '\n');
+  return rendered;
+}
+
+TEST(PressureTest, DrawTextSurvivesHostileBytes) {
+  for (Charset charset : {Charset::Ascii, Charset::Utf8}) {
+    for (const std::string& text : HostileText()) {
+      for (int x : {0, 1, 7}) {
+        Buffer buffer(8, charset);
+        Buffer::DrawEnd end = buffer.DrawText(x, 0, text, Style());
+
+        // The end is where drawing would carry on, which is not always a cell
+        // that exists: text ending in a newline leaves it on a row nothing was
+        // drawn on. Nor does the width follow from it, since the grid grows by
+        // halves and overshoots. What must hold is that the end names a
+        // non-negative cell, and that no row was created past where drawing
+        // ended.
+        EXPECT_GE(end.y, 0) << text;
+        EXPECT_LE(buffer.height(), end.y + 1) << text;
+        EXPECT_GE(end.x, 0) << text;
+
+        // Measuring answers what drawing did.
+        EXPECT_EQ(buffer.MeasureText(x, 0, text), end) << text;
+
+        RenderAndCheck(buffer, ColorMode::Ansi16);
+      }
+    }
+  }
+}
+
+TEST(PressureTest, WrappedTextSurvivesHostileBytes) {
+  for (Charset charset : {Charset::Ascii, Charset::Utf8}) {
+    for (const std::string& text : HostileText()) {
+      // A width of one is the tightest anything can be asked to wrap into.
+      for (int width : {1, 2, 3, 80}) {
+        Buffer buffer(width, charset);
+        Buffer::DrawEnd end =
+            buffer.DrawWrappedText(0, 0, 0, width, text, Style());
+
+        EXPECT_GE(end.y, 0) << text;
+        EXPECT_LE(buffer.height(), end.y + 1) << text;
+        EXPECT_GE(end.x, 0) << text;
+        EXPECT_EQ(buffer.MeasureWrappedText(0, 0, 0, width, text), end) << text;
+
+        RenderAndCheck(buffer, ColorMode::Truecolor);
+      }
+    }
+  }
+}
+
+TEST(PressureTest, MetricsSurviveHostileBytes) {
+  for (Charset charset : {Charset::Ascii, Charset::Utf8}) {
+    Metrics metrics(charset);
+    for (const std::string& text : HostileText()) {
+      // `Width` requires text with no positional characters in it, which is
+      // checked, so only the rest is measured here.
+      if (llvm::StringRef(text).find_first_of("\t\n\r") ==
+          llvm::StringRef::npos) {
+        int width = metrics.Width(text);
+        EXPECT_GE(width, 0) << text;
+
+        // Cutting at any column gives back a prefix that is no wider than
+        // asked for and that leaves the rest of the string behind it.
+        for (int columns : {-1, 0, 1, 2, width, width + 1}) {
+          llvm::StringRef rest = text;
+          llvm::StringRef prefix = metrics.TakeColumns(rest, columns);
+          EXPECT_EQ(prefix.size() + rest.size(), text.size()) << text;
+          EXPECT_LE(metrics.Width(prefix), std::max(columns, 0)) << text;
+        }
+      }
+
+      // Taking code points consumes the whole string however invalid it is,
+      // rather than stalling on a byte it can't decode.
+      llvm::StringRef rest = text;
+      size_t steps = 0;
+      while (!rest.empty()) {
+        metrics.TakeCodePoint(rest);
+        ++steps;
+        ASSERT_LE(steps, text.size()) << "TakeCodePoint failed to consume";
+      }
+
+      EXPECT_GE(metrics.WrapWidth(text), 0) << text;
+    }
+  }
+}
+
+TEST(PressureTest, OverlappingDrawsLeaveNoHalfCharacters) {
+  // Double-width characters, lines, and text all writing over each other is
+  // where a stale continuation cell would show up as a rendering with half a
+  // character in it.
+  Buffer buffer(8, Charset::Utf8);
+  for (int pass = 0; pass < 3; ++pass) {
+    buffer.DrawText(0, 0, "中中中中", Style());
+    buffer.DrawHorizontalLine(1, 0, 3, Style());
+    buffer.DrawText(2, 0, "中", Style());
+    buffer.DrawVerticalLine(3, 0, 2, Style());
+    buffer.DrawCodePoint(4, 0, U'中', Style());
+    buffer.DrawCodePoint(5, 0, U'x', Style());
+    buffer.DrawText(0, 0, "ab", Style());
+  }
+
+  // `Render` encodes every cell it emits, so this checks the overdraws leave a
+  // grid that renders at all rather than that no half character survived.
+  std::string rendered = RenderAndCheck(buffer, ColorMode::NoColor);
+  Metrics metrics(Charset::Utf8);
+  llvm::StringRef rest = rendered;
+  while (!rest.empty()) {
+    EXPECT_NE(metrics.TakeCodePoint(rest), 0xfffd) << rendered;
+  }
+}
+
+TEST(PressureTest, CapabilitiesWidthNeverBreaksTheBuffer) {
+  // A width claimed by the environment can be anything at all.
+  for (int columns :
+       {-1, 0, 1, 2, 80, Buffer::MaxColumns - 1, Buffer::MaxColumns,
+        Buffer::MaxColumns + 1, 1 << 20, std::numeric_limits<int>::max()}) {
+    Capabilities capabilities = {.charset = Charset::Utf8, .columns = columns};
+    Buffer buffer(capabilities);
+    // Whatever was claimed, what comes out is a width that can be laid out for
+    // and drawn into.
+    EXPECT_GE(buffer.columns(), 1) << columns;
+    EXPECT_LE(buffer.columns(), Buffer::MaxColumns) << columns;
+    buffer.DrawText(0, 0, "中x", Style());
+    RenderAndCheck(buffer, ColorMode::Ansi256);
+  }
+}
+
+}  // namespace
+}  // namespace Carbon::Terminal

--- a/common/terminal/style.cpp
+++ b/common/terminal/style.cpp
@@ -1,0 +1,162 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/style.h"
+
+#include <array>
+
+#include "common/check.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+
+namespace Carbon::Terminal {
+
+// Returns the SGR parameter selecting `shape`, or an empty string for `None`.
+//
+// The shaped underlines are colon-separated subparameters of the plain
+// underline code. Terminals that predate them are also the ones limited to the
+// 16 ANSI colors, and they mishandle the subparameters rather than ignoring
+// them, so in that mode every shape degrades to a plain underline.
+static auto UnderlineSgrParam(UnderlineShape shape, ColorMode mode)
+    -> llvm::StringRef {
+  if (mode == ColorMode::Ansi16 && shape != UnderlineShape::None) {
+    return "4";
+  }
+  switch (shape) {
+    case UnderlineShape::None:
+      return "";
+    case UnderlineShape::Single:
+      return "4";
+    case UnderlineShape::Double:
+      return "4:2";
+    case UnderlineShape::Curly:
+      return "4:3";
+    case UnderlineShape::Dotted:
+      return "4:4";
+    case UnderlineShape::Dashed:
+      return "4:5";
+  }
+}
+
+auto Style::NeedsResetFrom(const Style& from) const -> bool {
+  auto drops = [](bool from_set, bool to_set) { return from_set && !to_set; };
+  return drops(from.bold_, bold_) || drops(from.dim_, dim_) ||
+         drops(from.italic_, italic_) || drops(from.reverse_, reverse_) ||
+         drops(from.strikethrough_, strikethrough_) ||
+         drops(from.underline(), underline()) ||
+         drops(from.foreground_.is_set(), foreground_.is_set()) ||
+         drops(from.background_.is_set(), background_.is_set()) ||
+         drops(from.underline_color_.is_set(), underline_color_.is_set());
+}
+
+auto Style::AppendDiff(OutputBufferRef out, ColorMode mode,
+                       const Style& from) const -> void {
+  CARBON_DCHECK(!NeedsResetFrom(from),
+                "Cannot reach this style from `from` without a reset.");
+
+  // Attributes combine into a single SGR sequence, in ascending code order.
+  std::array<llvm::StringRef, 6> params;
+  int param_count = 0;
+  auto add_if = [&](bool from_set, bool to_set, llvm::StringRef param) {
+    if (to_set && !from_set) {
+      CARBON_DCHECK(param_count < static_cast<int>(params.size()));
+      params[param_count++] = param;
+    }
+  };
+  add_if(from.bold_, bold_, "1");
+  add_if(from.dim_, dim_, "2");
+  add_if(from.italic_, italic_, "3");
+  llvm::StringRef underline_param = UnderlineSgrParam(underline_shape_, mode);
+  if (underline_param != UnderlineSgrParam(from.underline_shape_, mode)) {
+    params[param_count++] = underline_param;
+  }
+  add_if(from.reverse_, reverse_, "7");
+  add_if(from.strikethrough_, strikethrough_, "9");
+
+  if (param_count > 0) {
+    out.Append("\x1b[", params[0]);
+    for (int i = 1; i < param_count; ++i) {
+      out.Append(";", params[i]);
+    }
+    out.Append("m");
+  }
+
+  if (foreground_.is_set() && foreground_ != from.foreground_) {
+    foreground_.AppendEscape(out, mode, ColorTarget::Foreground);
+  }
+  if (background_.is_set() && background_ != from.background_) {
+    background_.AppendEscape(out, mode, ColorTarget::Background);
+  }
+  if (underline_color_.is_set() && underline_color_ != from.underline_color_) {
+    underline_color_.AppendEscape(out, mode, ColorTarget::Underline);
+  }
+}
+
+auto Style::AppendColorTransitionTo(OutputBufferRef out, const Style& target,
+                                    ColorMode mode) const -> void {
+  CARBON_DCHECK(mode != ColorMode::NoColor);
+  if (*this == target) {
+    return;
+  }
+
+  if (target.NeedsResetFrom(*this)) {
+    out.Append(ResetEscape);
+    target.AppendDiff(out, mode, Style());
+    return;
+  }
+  target.AppendDiff(out, mode, *this);
+}
+
+// Returns the name of `shape`, for printing a style.
+static auto UnderlineShapeName(UnderlineShape shape) -> llvm::StringRef {
+  switch (shape) {
+    case UnderlineShape::None:
+      return "None";
+    case UnderlineShape::Single:
+      return "Single";
+    case UnderlineShape::Double:
+      return "Double";
+    case UnderlineShape::Curly:
+      return "Curly";
+    case UnderlineShape::Dotted:
+      return "Dotted";
+    case UnderlineShape::Dashed:
+      return "Dashed";
+  }
+}
+
+auto Style::Print(llvm::raw_ostream& out) const -> void {
+  out << "Style(";
+  llvm::ListSeparator sep;
+  if (bold_) {
+    out << sep << "bold";
+  }
+  if (dim_) {
+    out << sep << "dim";
+  }
+  if (italic_) {
+    out << sep << "italic";
+  }
+  if (reverse_) {
+    out << sep << "reverse";
+  }
+  if (strikethrough_) {
+    out << sep << "strikethrough";
+  }
+  if (underline()) {
+    out << sep << "underline=" << UnderlineShapeName(underline_shape_);
+  }
+  if (foreground_.is_set()) {
+    out << sep << "foreground=" << foreground_;
+  }
+  if (background_.is_set()) {
+    out << sep << "background=" << background_;
+  }
+  if (underline_color_.is_set()) {
+    out << sep << "underline_color=" << underline_color_;
+  }
+  out << ")";
+}
+
+}  // namespace Carbon::Terminal

--- a/common/terminal/style.cpp
+++ b/common/terminal/style.cpp
@@ -52,16 +52,22 @@ auto Style::NeedsResetFrom(const Style& from) const -> bool {
 
 auto Style::AppendDiff(OutputBufferRef out, ColorMode mode,
                        const Style& from) const -> void {
-  CARBON_DCHECK(!NeedsResetFrom(from),
-                "Cannot reach this style from `from` without a reset.");
+  CARBON_CHECK(!NeedsResetFrom(from),
+               "Cannot reach this style from `from` without a reset.");
 
   // Attributes combine into a single SGR sequence, in ascending code order.
+  // Every write goes through `add` so the bound is checked in one place.
   std::array<llvm::StringRef, 6> params;
   int param_count = 0;
+  auto add = [&](llvm::StringRef param) {
+    CARBON_CHECK(param_count < static_cast<int>(params.size()),
+                 "More SGR parameters than the {0} there is room for.",
+                 params.size());
+    params[param_count++] = param;
+  };
   auto add_if = [&](bool from_set, bool to_set, llvm::StringRef param) {
     if (to_set && !from_set) {
-      CARBON_DCHECK(param_count < static_cast<int>(params.size()));
-      params[param_count++] = param;
+      add(param);
     }
   };
   add_if(from.bold_, bold_, "1");
@@ -69,7 +75,11 @@ auto Style::AppendDiff(OutputBufferRef out, ColorMode mode,
   add_if(from.italic_, italic_, "3");
   llvm::StringRef underline_param = UnderlineSgrParam(underline_shape_, mode);
   if (underline_param != UnderlineSgrParam(from.underline_shape_, mode)) {
-    params[param_count++] = underline_param;
+    // Turning an underline off needs a reset, which is the caller's to do, so
+    // reaching here with nothing to select would emit an empty parameter.
+    CARBON_CHECK(!underline_param.empty(),
+                 "Removing an underline cannot be done with a diff.");
+    add(underline_param);
   }
   add_if(from.reverse_, reverse_, "7");
   add_if(from.strikethrough_, strikethrough_, "9");
@@ -95,7 +105,8 @@ auto Style::AppendDiff(OutputBufferRef out, ColorMode mode,
 
 auto Style::AppendColorTransitionTo(OutputBufferRef out, const Style& target,
                                     ColorMode mode) const -> void {
-  CARBON_DCHECK(mode != ColorMode::NoColor);
+  CARBON_CHECK(mode != ColorMode::NoColor,
+               "Color transitions are only reached when color is in use.");
   if (*this == target) {
     return;
   }

--- a/common/terminal/style.h
+++ b/common/terminal/style.h
@@ -22,8 +22,7 @@ namespace Carbon::Terminal {
 // Only `Single` is universally understood. The rest are selected with
 // colon-separated subparameters of the Select Graphic Rendition (SGR)
 // underline code, which terminals limited to 16 colors mishandle, so in that
-// mode they degrade to `Single` rather than disappearing, and an underline
-// always marks what it was meant to mark.
+// mode they degrade to `Single` rather than disappearing.
 enum class UnderlineShape : int8_t {
   None,
   Single,
@@ -69,36 +68,36 @@ class Style : public Printable<Style> {
     return result;
   }
 
-  // Returns this style with the bold attribute set.
+  // Returns this style with the bold attribute set to `value`.
   auto Bold(bool value = true) const -> Style {
     Style result = *this;
     result.bold_ = value;
     return result;
   }
 
-  // Returns this style with the dim (faint) attribute set.
+  // Returns this style with the dim (faint) attribute set to `value`.
   auto Dim(bool value = true) const -> Style {
     Style result = *this;
     result.dim_ = value;
     return result;
   }
 
-  // Returns this style with the italic attribute set.
+  // Returns this style with the italic attribute set to `value`.
   auto Italic(bool value = true) const -> Style {
     Style result = *this;
     result.italic_ = value;
     return result;
   }
 
-  // Returns this style with reverse video set, which has the terminal swap
-  // foreground and background when it renders.
+  // Returns this style with reverse video set to `value`, which has the
+  // terminal swap foreground and background when it renders.
   auto Reverse(bool value = true) const -> Style {
     Style result = *this;
     result.reverse_ = value;
     return result;
   }
 
-  // Returns this style with the strikethrough attribute set.
+  // Returns this style with the strikethrough attribute set to `value`.
   auto Strikethrough(bool value = true) const -> Style {
     Style result = *this;
     result.strikethrough_ = value;
@@ -123,7 +122,6 @@ class Style : public Printable<Style> {
     return result;
   }
 
-  // These return an unset color where the style leaves one to the terminal.
   auto foreground() const -> Color { return foreground_; }
   auto background() const -> Color { return background_; }
   auto underline_color() const -> Color { return underline_color_; }
@@ -140,9 +138,9 @@ class Style : public Printable<Style> {
   // Returns whether this style paints anything where there is no glyph.
   //
   // Attributes that only affect a glyph's own pixels, such as the foreground
-  // color or weight, are invisible on a blank cell. A background color,
-  // reverse video, an underline, or a strikethrough all paint the cell itself.
-  // Rendering uses this to decide which trailing blanks can be dropped.
+  // color or weight, are invisible on a blank cell. Rendering uses this to drop
+  // trailing blanks, and to decide when a style must be turned off before a
+  // newline.
   auto IsVisibleOnBlank() const -> bool {
     return background_.is_set() || reverse_ || strikethrough_ || underline();
   }
@@ -156,10 +154,10 @@ class Style : public Printable<Style> {
   //
   // SGR adds attributes one at a time, but its codes for removing them are
   // entangled and unevenly supported: one code clears both bold and dim, and
-  // the code to clear an underline collides with double-underline on some
-  // terminals. Dropping any attribute therefore costs a full reset and a fresh
-  // start, so runs of related output are cheapest to render when they share
-  // attributes and vary only in color.
+  // the code some terminals use to clear bold is double-underline in ECMA-48.
+  // Dropping anything therefore costs a full reset and a fresh start, so a run
+  // is cheapest when every style in it sets the same attributes and the same
+  // colors, differing only in the color values.
   auto AppendTransitionTo(OutputBufferRef out, const Style& target,
                           ColorMode mode) const -> void {
     // Rendering calls this for every cell it emits, and with color off no
@@ -173,7 +171,7 @@ class Style : public Printable<Style> {
   auto Print(llvm::raw_ostream& out) const -> void;
 
   // Rendering compares the style of every cell against the one in use, so this
-  // compares the bytes rather than the nine members that make them up. The
+  // compares the bytes rather than member by member. The
   // assertion is what makes that valid: every bit of a style belongs to a
   // member, as the members are all byte-aligned and always initialized, so none
   // of the bytes are padding.
@@ -194,8 +192,8 @@ class Style : public Printable<Style> {
   // exactly when the transition needs a reset.
   auto NeedsResetFrom(const Style& from) const -> bool;
 
-  // Appends the escapes adding everything this style sets that `from` does
-  // not. Requires `!NeedsResetFrom(from)`.
+  // Appends the escapes taking `from` to this style, which requires that this
+  // style drops nothing `from` set: `!NeedsResetFrom(from)`.
   auto AppendDiff(OutputBufferRef out, ColorMode mode, const Style& from) const
       -> void;
 

--- a/common/terminal/style.h
+++ b/common/terminal/style.h
@@ -1,0 +1,248 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_COMMON_TERMINAL_STYLE_H_
+#define CARBON_COMMON_TERMINAL_STYLE_H_
+
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+#include "common/ostream.h"
+#include "common/terminal/color.h"
+#include "common/terminal/output_buffer_ref.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace Carbon::Terminal {
+
+// The shapes an underline can take.
+//
+// Only `Single` is universally understood. The rest are selected with
+// colon-separated subparameters of the Select Graphic Rendition (SGR)
+// underline code, which terminals limited to 16 colors mishandle, so in that
+// mode they degrade to `Single` rather than disappearing, and an underline
+// always marks what it was meant to mark.
+enum class UnderlineShape : int8_t {
+  None,
+  Single,
+  Double,
+  Curly,
+  Dotted,
+  Dashed,
+};
+
+// A set of colors and text attributes to render with.
+//
+// Styles are values, and are composed by chaining, which keeps a named style
+// readable at its definition:
+//
+// ```cpp
+// const Style Error = Style().Bold().Foreground(AnsiColor::BrightRed);
+// const Style ErrorSquiggle = Error.Underline(UnderlineShape::Curly);
+// ```
+//
+// A style authored for a rich terminal stays meaningful on a poor one. Colors
+// the active `ColorMode` can't express are downsampled, an underline shape it
+// can't express becomes a plain underline, and an underline color it can't
+// express is left to the terminal. `NoColor` drops everything.
+class Style : public Printable<Style> {
+ public:
+  // A default-constructed style sets nothing, and is both the style a terminal
+  // starts in and the one it is returned to.
+  constexpr Style() = default;
+
+  // Returns this style with the foreground color set, where an unset color
+  // leaves the foreground to the terminal.
+  auto Foreground(Color color) const -> Style {
+    Style result = *this;
+    result.foreground_ = color;
+    return result;
+  }
+
+  // Returns this style with the background color set, where an unset color
+  // leaves the background to the terminal.
+  auto Background(Color color) const -> Style {
+    Style result = *this;
+    result.background_ = color;
+    return result;
+  }
+
+  // Returns this style with the bold attribute set.
+  auto Bold(bool value = true) const -> Style {
+    Style result = *this;
+    result.bold_ = value;
+    return result;
+  }
+
+  // Returns this style with the dim (faint) attribute set.
+  auto Dim(bool value = true) const -> Style {
+    Style result = *this;
+    result.dim_ = value;
+    return result;
+  }
+
+  // Returns this style with the italic attribute set.
+  auto Italic(bool value = true) const -> Style {
+    Style result = *this;
+    result.italic_ = value;
+    return result;
+  }
+
+  // Returns this style with reverse video set, which has the terminal swap
+  // foreground and background when it renders.
+  auto Reverse(bool value = true) const -> Style {
+    Style result = *this;
+    result.reverse_ = value;
+    return result;
+  }
+
+  // Returns this style with the strikethrough attribute set.
+  auto Strikethrough(bool value = true) const -> Style {
+    Style result = *this;
+    result.strikethrough_ = value;
+    return result;
+  }
+
+  // Returns this style with the given underline shape, where
+  // `UnderlineShape::None` removes one.
+  auto Underline(UnderlineShape shape = UnderlineShape::Single) const -> Style {
+    Style result = *this;
+    result.underline_shape_ = shape;
+    return result;
+  }
+
+  // Returns this style with the underline drawn in its own color.
+  //
+  // Only `Ansi256` and richer modes can express this; elsewhere the underline
+  // is drawn in the foreground color, as it is when the color is unset.
+  auto UnderlineColor(Color color) const -> Style {
+    Style result = *this;
+    result.underline_color_ = color;
+    return result;
+  }
+
+  // These return an unset color where the style leaves one to the terminal.
+  auto foreground() const -> Color { return foreground_; }
+  auto background() const -> Color { return background_; }
+  auto underline_color() const -> Color { return underline_color_; }
+  auto underline_shape() const -> UnderlineShape { return underline_shape_; }
+  auto underline() const -> bool {
+    return underline_shape_ != UnderlineShape::None;
+  }
+  auto bold() const -> bool { return bold_; }
+  auto dim() const -> bool { return dim_; }
+  auto italic() const -> bool { return italic_; }
+  auto reverse() const -> bool { return reverse_; }
+  auto strikethrough() const -> bool { return strikethrough_; }
+
+  // Returns whether this style paints anything where there is no glyph.
+  //
+  // Attributes that only affect a glyph's own pixels, such as the foreground
+  // color or weight, are invisible on a blank cell. A background color,
+  // reverse video, an underline, or a strikethrough all paint the cell itself.
+  // Rendering uses this to decide which trailing blanks can be dropped.
+  auto IsVisibleOnBlank() const -> bool {
+    return background_.is_set() || reverse_ || strikethrough_ || underline();
+  }
+
+  // Appends the escape sequences that move the terminal from this style to
+  // `target`.
+  //
+  // This is the only way styles reach a terminal, because turning a style on
+  // and turning it back off are both transitions: from and to the default
+  // style respectively.
+  //
+  // SGR adds attributes one at a time, but its codes for removing them are
+  // entangled and unevenly supported: one code clears both bold and dim, and
+  // the code to clear an underline collides with double-underline on some
+  // terminals. Dropping any attribute therefore costs a full reset and a fresh
+  // start, so runs of related output are cheapest to render when they share
+  // attributes and vary only in color.
+  auto AppendTransitionTo(OutputBufferRef out, const Style& target,
+                          ColorMode mode) const -> void {
+    // Rendering calls this for every cell it emits, and with color off no
+    // transition can produce anything, so that case is settled here rather than
+    // across a call.
+    if (mode != ColorMode::NoColor) {
+      AppendColorTransitionTo(out, target, mode);
+    }
+  }
+
+  auto Print(llvm::raw_ostream& out) const -> void;
+
+  // Rendering compares the style of every cell against the one in use, so this
+  // compares the bytes rather than the nine members that make them up. The
+  // assertion is what makes that valid: every bit of a style belongs to a
+  // member, as the members are all byte-aligned and always initialized, so none
+  // of the bytes are padding.
+  friend auto operator==(const Style& lhs, const Style& rhs) -> bool {
+    static_assert(std::has_unique_object_representations_v<Style>);
+    return std::memcmp(&lhs, &rhs, sizeof(Style)) == 0;
+  }
+
+ private:
+  // Turns every attribute and color off.
+  static constexpr llvm::StringRef ResetEscape = "\x1b[0m";
+
+  // Appends the transition to `target`, where `mode` has color.
+  auto AppendColorTransitionTo(OutputBufferRef out, const Style& target,
+                               ColorMode mode) const -> void;
+
+  // Returns whether `from` sets anything this style leaves unset, which is
+  // exactly when the transition needs a reset.
+  auto NeedsResetFrom(const Style& from) const -> bool;
+
+  // Appends the escapes adding everything this style sets that `from` does
+  // not. Requires `!NeedsResetFrom(from)`.
+  auto AppendDiff(OutputBufferRef out, ColorMode mode, const Style& from) const
+      -> void;
+
+  Color foreground_;
+  Color background_;
+  Color underline_color_;
+  UnderlineShape underline_shape_ = UnderlineShape::None;
+  bool bold_ = false;
+  bool dim_ = false;
+  bool italic_ = false;
+  bool reverse_ = false;
+  bool strikethrough_ = false;
+};
+
+// Streams `text` with `style` applied and then removed again:
+//
+// ```cpp
+// out << Styled("error", ErrorStyle, mode) << ": " << message << "\n";
+// ```
+//
+// This is the whole API for output that is a stream of styled runs. Reach for
+// `Buffer` instead when output needs to be positioned in two dimensions.
+//
+// The text is referenced, not copied, so it must outlive the printing.
+class Styled : public Printable<Styled> {
+ public:
+  Styled(llvm::StringRef text, const Style& style, ColorMode mode)
+      : text_(text), style_(style), mode_(mode) {}
+
+  auto Print(llvm::raw_ostream& out) const -> void {
+    // The escapes and the text they wrap reach the stream as one write, both
+    // because that is cheaper and because it keeps a styled run from being
+    // split across writes that something else could interleave with.
+    llvm::SmallString<128> storage;
+    OutputBufferRef bytes = storage;
+    Style().AppendTransitionTo(bytes, style_, mode_);
+    bytes.Append(text_);
+    style_.AppendTransitionTo(bytes, Style(), mode_);
+    out << storage;
+  }
+
+ private:
+  llvm::StringRef text_;
+  Style style_;
+  ColorMode mode_;
+};
+
+}  // namespace Carbon::Terminal
+
+#endif  // CARBON_COMMON_TERMINAL_STYLE_H_

--- a/common/terminal/style.h
+++ b/common/terminal/style.h
@@ -171,10 +171,13 @@ class Style : public Printable<Style> {
   auto Print(llvm::raw_ostream& out) const -> void;
 
   // Rendering compares the style of every cell against the one in use, so this
-  // compares the bytes rather than member by member. The
-  // assertion is what makes that valid: every bit of a style belongs to a
-  // member, as the members are all byte-aligned and always initialized, so none
-  // of the bytes are padding.
+  // compares the bytes rather than member by member. The assertion is what
+  // makes that valid: every bit of a style belongs to a member, as the members
+  // are all byte-aligned and always initialized, so none of the bytes are
+  // padding.
+  //
+  // Written out rather than defaulted because the `Printable` base has no
+  // comparison of its own, which would leave a defaulted one deleted.
   friend auto operator==(const Style& lhs, const Style& rhs) -> bool {
     static_assert(std::has_unique_object_representations_v<Style>);
     return std::memcmp(&lhs, &rhs, sizeof(Style)) == 0;

--- a/common/terminal/style_test.cpp
+++ b/common/terminal/style_test.cpp
@@ -6,7 +6,12 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+#include <vector>
+
 #include "common/raw_string_ostream.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/FormatVariadic.h"
 
 namespace Carbon::Terminal {
 namespace {
@@ -46,8 +51,8 @@ TEST(StyleTest, Attributes) {
                     ColorMode::Truecolor),
             "\x1b[3;4:3;7;9m\x1b[58;2;0;255;0m");
 
-  // Every attribute at once, which is as many parameters as one sequence can
-  // carry.
+  // Every attribute at once, which is the most parameters a diff can produce
+  // and the bound `AppendDiff` sizes its array for.
   EXPECT_EQ(Escapes(Style()
                         .Bold()
                         .Dim()
@@ -114,8 +119,8 @@ TEST(StyleTest, TransitionAddsWithoutReset) {
 TEST(StyleTest, TransitionResetsToDrop) {
   Style red_bold = Style().Bold().Foreground(Color(255, 0, 0));
 
-  // SGR can't remove one attribute without a full reset, so dropping bold
-  // costs a reset and a fresh start.
+  // Attributes are removed with a reset and a fresh start rather than SGR's
+  // entangled off-codes, so dropping bold costs both.
   EXPECT_EQ(Transition(red_bold, Style().Foreground(Color(255, 0, 0)),
                        ColorMode::Truecolor),
             "\x1b[0m\x1b[38;2;255;0;0m");
@@ -205,7 +210,7 @@ TEST(StyleTest, Ansi16Transitions) {
                  ColorMode::Ansi16),
       "");
 
-  // Attributes and the 16 colors still transition normally.
+  // The 16 colors still transition normally.
   EXPECT_EQ(Transition(Style().Foreground(AnsiColor::Red),
                        Style().Foreground(AnsiColor::Blue), ColorMode::Ansi16),
             "\x1b[34m");
@@ -246,6 +251,54 @@ TEST(StyleTest, Print) {
                               .Background(Color(1, 2, 3))),
             "Style(dim, italic, underline=Curly, background=#010203, "
             "underline_color=#000001)");
+}
+
+TEST(StyleTest, EveryPairOfStylesHasATransition) {
+  // Every pair of styles has to have a transition, including the ones that
+  // drop an attribute and so need a reset rather than a diff.
+  std::vector<Style> styles = {
+      Style(),
+      Style().Bold(),
+      Style().Dim().Italic(),
+      Style().Reverse().Strikethrough(),
+      Style().Underline(UnderlineShape::Curly),
+      Style().Underline(UnderlineShape::Double).UnderlineColor(AnsiColor::Red),
+      Style().Foreground(AnsiColor::BrightRed).Background(AnsiColor::Black),
+      Style().Foreground(Color(1, 2, 3)).Background(Color(250, 251, 252)),
+      Style()
+          .Bold()
+          .Dim()
+          .Italic()
+          .Reverse()
+          .Strikethrough()
+          .Underline(UnderlineShape::Dashed)
+          .Foreground(Color(9, 9, 9))
+          .Background(AnsiColor::White)
+          .UnderlineColor(Color(4, 5, 6)),
+  };
+  for (ColorMode mode : {ColorMode::NoColor, ColorMode::Ansi16,
+                         ColorMode::Ansi256, ColorMode::Truecolor}) {
+    for (auto [from_index, from] : llvm::enumerate(styles)) {
+      for (auto [to_index, to] : llvm::enumerate(styles)) {
+        std::string out = Transition(from, to, mode);
+        std::string pair =
+            llvm::formatv("{0} -> {1}", from_index, to_index).str();
+        if (mode == ColorMode::NoColor) {
+          // Nothing is said at all when nothing can be shown.
+          EXPECT_TRUE(out.empty()) << pair;
+        } else if (from == to) {
+          // Staying where it already is costs nothing, whatever the mode.
+          EXPECT_TRUE(out.empty()) << pair;
+        } else if (mode == ColorMode::Truecolor) {
+          // Truecolor is the one mode that can express every field, so no two
+          // distinct styles render the same and every step has to say
+          // something. The narrower modes round colors together, so there two
+          // styles can genuinely be one and the transition is empty.
+          EXPECT_FALSE(out.empty()) << pair;
+        }
+      }
+    }
+  }
 }
 
 }  // namespace

--- a/common/terminal/style_test.cpp
+++ b/common/terminal/style_test.cpp
@@ -1,0 +1,252 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/terminal/style.h"
+
+#include <gtest/gtest.h>
+
+#include "common/raw_string_ostream.h"
+
+namespace Carbon::Terminal {
+namespace {
+
+auto Transition(const Style& from, const Style& to, ColorMode mode)
+    -> std::string {
+  llvm::SmallString<64> out;
+  from.AppendTransitionTo(out, to, mode);
+  return std::string(out);
+}
+
+// Turning a style on is the transition from the default style, and turning it
+// off is the transition back to it.
+auto Escapes(const Style& style, ColorMode mode) -> std::string {
+  return Transition(Style(), style, mode);
+}
+
+auto Reset(const Style& style, ColorMode mode) -> std::string {
+  return Transition(style, Style(), mode);
+}
+
+TEST(StyleTest, Attributes) {
+  EXPECT_EQ(Escapes(Style().Bold(), ColorMode::Truecolor), "\x1b[1m");
+  EXPECT_EQ(Escapes(Style().Dim(), ColorMode::Truecolor), "\x1b[2m");
+  EXPECT_EQ(Escapes(Style().Italic(), ColorMode::Truecolor), "\x1b[3m");
+  EXPECT_EQ(Escapes(Style().Underline(), ColorMode::Truecolor), "\x1b[4m");
+  EXPECT_EQ(Escapes(Style().Reverse(), ColorMode::Truecolor), "\x1b[7m");
+  EXPECT_EQ(Escapes(Style().Strikethrough(), ColorMode::Truecolor), "\x1b[9m");
+
+  // Attributes combine into a single sequence, in ascending code order.
+  EXPECT_EQ(Escapes(Style()
+                        .Italic()
+                        .Reverse()
+                        .Underline(UnderlineShape::Curly)
+                        .UnderlineColor(Color(0, 255, 0))
+                        .Strikethrough(),
+                    ColorMode::Truecolor),
+            "\x1b[3;4:3;7;9m\x1b[58;2;0;255;0m");
+
+  // Every attribute at once, which is as many parameters as one sequence can
+  // carry.
+  EXPECT_EQ(Escapes(Style()
+                        .Bold()
+                        .Dim()
+                        .Italic()
+                        .Underline(UnderlineShape::Double)
+                        .Reverse()
+                        .Strikethrough(),
+                    ColorMode::Truecolor),
+            "\x1b[1;2;3;4:2;7;9m");
+}
+
+TEST(StyleTest, AttributesAndColors) {
+  Style style = Style().Bold().Foreground(Color(255, 0, 0));
+  EXPECT_EQ(Escapes(style, ColorMode::Truecolor), "\x1b[1m\x1b[38;2;255;0;0m");
+  EXPECT_EQ(Reset(style, ColorMode::Truecolor), "\x1b[0m");
+
+  EXPECT_EQ(Escapes(style, ColorMode::NoColor), "");
+  EXPECT_EQ(Reset(style, ColorMode::NoColor), "");
+
+  // A style that set nothing has nothing to reset.
+  EXPECT_EQ(Reset(Style(), ColorMode::Truecolor), "");
+}
+
+TEST(StyleTest, UnderlineShapesDegradeInAnsi16) {
+  // The shaped underlines are colon subparameters, which the terminals limited
+  // to 16 colors mishandle. They become plain underlines rather than
+  // disappearing, so they still mark what they were meant to mark.
+  for (UnderlineShape shape :
+       {UnderlineShape::Single, UnderlineShape::Double, UnderlineShape::Curly,
+        UnderlineShape::Dotted, UnderlineShape::Dashed}) {
+    EXPECT_EQ(Escapes(Style().Underline(shape), ColorMode::Ansi16), "\x1b[4m");
+  }
+
+  EXPECT_EQ(
+      Escapes(Style().Underline(UnderlineShape::Double), ColorMode::Ansi256),
+      "\x1b[4:2m");
+  EXPECT_EQ(
+      Escapes(Style().Underline(UnderlineShape::Dotted), ColorMode::Truecolor),
+      "\x1b[4:4m");
+  EXPECT_EQ(
+      Escapes(Style().Underline(UnderlineShape::Dashed), ColorMode::Truecolor),
+      "\x1b[4:5m");
+}
+
+TEST(StyleTest, TransitionAddsWithoutReset) {
+  Style red_bold = Style().Bold().Foreground(Color(255, 0, 0));
+  Style blue_bold = Style().Bold().Foreground(Color(0, 0, 255));
+
+  // Bold carries over, so only the color has to change.
+  EXPECT_EQ(Transition(red_bold, blue_bold, ColorMode::Truecolor),
+            "\x1b[38;2;0;0;255m");
+
+  // Adding an attribute needs no reset either.
+  EXPECT_EQ(Transition(red_bold, red_bold.Italic(), ColorMode::Truecolor),
+            "\x1b[3m");
+
+  // Nor does changing the shape of an underline that is already on.
+  EXPECT_EQ(
+      Transition(Style().Underline(), Style().Underline(UnderlineShape::Curly),
+                 ColorMode::Truecolor),
+      "\x1b[4:3m");
+}
+
+TEST(StyleTest, TransitionResetsToDrop) {
+  Style red_bold = Style().Bold().Foreground(Color(255, 0, 0));
+
+  // SGR can't remove one attribute without a full reset, so dropping bold
+  // costs a reset and a fresh start.
+  EXPECT_EQ(Transition(red_bold, Style().Foreground(Color(255, 0, 0)),
+                       ColorMode::Truecolor),
+            "\x1b[0m\x1b[38;2;255;0;0m");
+
+  // Dropping the color is the same story.
+  EXPECT_EQ(Transition(red_bold, Style().Bold(), ColorMode::Truecolor),
+            "\x1b[0m\x1b[1m");
+
+  // Returning to no style at all is just the reset.
+  EXPECT_EQ(Transition(red_bold, Style(), ColorMode::Truecolor), "\x1b[0m");
+}
+
+TEST(StyleTest, TransitionToSelfIsEmpty) {
+  Style style = Style().Bold().Italic().Foreground(AnsiColor::Red);
+  EXPECT_EQ(Transition(style, style, ColorMode::Truecolor), "");
+  EXPECT_EQ(Transition(Style(), Style(), ColorMode::Truecolor), "");
+}
+
+TEST(StyleTest, NoColorWritesNothing) {
+  Style style = Style().Bold().Foreground(Color(1, 2, 3));
+  EXPECT_EQ(Escapes(style, ColorMode::NoColor), "");
+  EXPECT_EQ(Reset(style, ColorMode::NoColor), "");
+  EXPECT_EQ(Transition(style, Style().Italic(), ColorMode::NoColor), "");
+}
+
+TEST(StyleTest, IsVisibleOnBlank) {
+  // Attributes that only affect a glyph's own pixels leave a blank cell blank.
+  EXPECT_FALSE(Style().IsVisibleOnBlank());
+  EXPECT_FALSE(Style().Bold().IsVisibleOnBlank());
+  EXPECT_FALSE(Style().Dim().Italic().IsVisibleOnBlank());
+  EXPECT_FALSE(Style().Foreground(AnsiColor::Red).IsVisibleOnBlank());
+
+  // These paint the cell itself.
+  EXPECT_TRUE(Style().Background(AnsiColor::Red).IsVisibleOnBlank());
+  EXPECT_TRUE(Style().Reverse().IsVisibleOnBlank());
+  EXPECT_TRUE(Style().Underline().IsVisibleOnBlank());
+  EXPECT_TRUE(Style().Strikethrough().IsVisibleOnBlank());
+}
+
+TEST(StyleTest, EqualityComparesEveryField) {
+  // The comparison is over the bytes of a style rather than its fields, which
+  // is only right as long as every byte belongs to a field.
+  Style base = Style();
+  EXPECT_EQ(base, Style());
+  EXPECT_NE(base, base.Bold());
+  EXPECT_NE(base, base.Dim());
+  EXPECT_NE(base, base.Italic());
+  EXPECT_NE(base, base.Reverse());
+  EXPECT_NE(base, base.Strikethrough());
+  EXPECT_NE(base, base.Underline());
+  EXPECT_NE(base, base.Foreground(AnsiColor::Red));
+  EXPECT_NE(base, base.Background(AnsiColor::Red));
+  EXPECT_NE(base, base.UnderlineColor(AnsiColor::Red));
+
+  // Including fields that differ only in value.
+  EXPECT_NE(Style().Foreground(AnsiColor::Red),
+            Style().Foreground(AnsiColor::Blue));
+  EXPECT_NE(Style().Underline(UnderlineShape::Curly),
+            Style().Underline(UnderlineShape::Dotted));
+
+  // And colors that a byte comparison could confuse, as an unset color and
+  // these two both hold nothing but zeroes in their channels.
+  EXPECT_NE(base, base.Foreground(AnsiColor::Black));
+  EXPECT_NE(base, base.Foreground(Color(0, 0, 0)));
+  EXPECT_NE(base.Foreground(AnsiColor::Black), base.Foreground(Color(0, 0, 0)));
+}
+
+TEST(StyleTest, ColorsCanBeCleared) {
+  Style red = Style().Foreground(AnsiColor::Red);
+  EXPECT_TRUE(red.foreground().is_set());
+
+  Style cleared = red.Foreground(Color());
+  EXPECT_FALSE(cleared.foreground().is_set());
+  EXPECT_EQ(cleared, Style());
+
+  // Dropping a color is a reset like dropping an attribute.
+  llvm::SmallString<64> bytes;
+  red.AppendTransitionTo(bytes, cleared, ColorMode::Ansi16);
+  EXPECT_EQ(bytes, "\x1b[0m");
+}
+
+TEST(StyleTest, Ansi16Transitions) {
+  // Every shape renders as a plain underline here, so switching between two of
+  // them is not a change the terminal can see.
+  EXPECT_EQ(
+      Transition(Style().Underline(), Style().Underline(UnderlineShape::Curly),
+                 ColorMode::Ansi16),
+      "");
+
+  // Attributes and the 16 colors still transition normally.
+  EXPECT_EQ(Transition(Style().Foreground(AnsiColor::Red),
+                       Style().Foreground(AnsiColor::Blue), ColorMode::Ansi16),
+            "\x1b[34m");
+}
+
+TEST(StyleTest, ChainingLeavesTheOriginalAlone) {
+  const Style base = Style().Bold();
+  const Style derived = base.Foreground(AnsiColor::Red);
+
+  EXPECT_EQ(base, Style().Bold());
+  EXPECT_EQ(derived, Style().Bold().Foreground(AnsiColor::Red));
+  EXPECT_NE(base, derived);
+
+  EXPECT_EQ(Style().Bold().Bold(false), Style());
+  EXPECT_EQ(Style().Underline().Underline(UnderlineShape::None), Style());
+}
+
+TEST(StyleTest, StyledStreaming) {
+  RawStringOstream out;
+  out << Styled("error", Style().Bold().Foreground(AnsiColor::BrightRed),
+                ColorMode::Ansi16)
+      << ": bad";
+  EXPECT_EQ(out.TakeStr(), "\x1b[1m\x1b[91merror\x1b[0m: bad");
+
+  out << Styled("error", Style().Bold(), ColorMode::NoColor) << ": bad";
+  EXPECT_EQ(out.TakeStr(), "error: bad");
+}
+
+TEST(StyleTest, Print) {
+  EXPECT_EQ(PrintToString(Style()), "Style()");
+  EXPECT_EQ(PrintToString(Style().Bold().Foreground(AnsiColor::Red)),
+            "Style(bold, foreground=Red)");
+  EXPECT_EQ(PrintToString(Style()
+                              .Dim()
+                              .Italic()
+                              .Underline(UnderlineShape::Curly)
+                              .UnderlineColor(Color(0, 0, 1))
+                              .Background(Color(1, 2, 3))),
+            "Style(dim, italic, underline=Curly, background=#010203, "
+            "underline_color=#000001)");
+}
+
+}  // namespace
+}  // namespace Carbon::Terminal

--- a/common/terminal/terminal_benchmark.cpp
+++ b/common/terminal/terminal_benchmark.cpp
@@ -165,7 +165,7 @@ static void BM_DrawText(benchmark::State& state, Charset charset,
 
   int row = 0;
   for (auto _ : state) {
-    row = buffer.DrawText(0, row, text, Style()) + row;
+    row = buffer.DrawText(0, row, text, Style()).y + 1;
     benchmark::DoNotOptimize(row);
     // Reuse a bounded band of rows so this measures drawing rather than the
     // buffer's growth.

--- a/common/terminal/terminal_benchmark.cpp
+++ b/common/terminal/terminal_benchmark.cpp
@@ -22,11 +22,10 @@ static auto RandomColor(absl::BitGen& bitgen) -> Color {
           absl::Uniform<uint8_t>(bitgen)};
 }
 
-// Benchmarks style transitions using a data-dependency feedback loop where the
-// next style index depends on the bytes written in the previous iteration.
+// Benchmarks style transitions with a store-to-load dependency on the rendered
+// buffer, so each iteration waits on the one before it.
 static void BM_StyleTransition(benchmark::State& state, ColorMode mode) {
-  // We use a somewhat large pool of colors to prevent branch prediction from
-  // learning much about the innards.
+  // A large pool of styles keeps branch prediction from learning the innards.
   constexpr int PoolSize = 1024;
   std::array<Style, PoolSize> styles;
 
@@ -46,17 +45,17 @@ static void BM_StyleTransition(benchmark::State& state, ColorMode mode) {
                     .UnderlineColor(RandomColor(bitgen));
   }
 
-  // We accumulate the style transitions in a reused buffer. This should have a
-  // small overhead per-iteration, but a stable one.
+  // The style transitions accumulate in a reused buffer, for a small but
+  // stable per-iteration overhead.
   llvm::SmallString<1024> str;
 
   int current_idx = 0;
   for (auto _ : state) {
     int next_idx = (current_idx + 1) % PoolSize;
     styles[current_idx].AppendTransitionTo(str, styles[next_idx], mode);
-    // We know that the string is null terminated, and so we can read that byte
-    // to create a data dependency from iteration to iteration. We also block
-    // the optimizer from guessing what this returns.
+    // Reading the string's terminator makes each iteration wait on the store
+    // the one before it made, and blocks the optimizer from guessing the
+    // value.
     uint8_t last_byte = str.c_str()[str.size()];
     benchmark::DoNotOptimize(last_byte);
     current_idx = (next_idx + last_byte) % PoolSize;
@@ -75,8 +74,8 @@ static void BM_BufferRender(benchmark::State& state, ColorMode mode) {
   const int width = state.range(0);
   const int height = state.range(1);
 
-  // Given the significantly larger body of work, we can use a much smaller pool
-  // without worrying about branch prediction skewing results.
+  // Given the significantly larger body of work, a much smaller pool suffices
+  // without branch prediction skewing results.
   constexpr int PoolSize = 16;
   llvm::SmallVector<Buffer, PoolSize> buffers;
 
@@ -105,8 +104,8 @@ static void BM_BufferRender(benchmark::State& state, ColorMode mode) {
 
     for (int y = 0; y < height; ++y) {
       for (int x = 0; x < width; ++x) {
-        buffer.DrawSymbol(x, y, U'A' + absl::Uniform(bitgen, 0, 26),
-                          get_style(x, y));
+        buffer.DrawCodePoint(x, y, U'A' + absl::Uniform(bitgen, 0, 26),
+                             get_style(x, y));
       }
     }
 
@@ -116,16 +115,16 @@ static void BM_BufferRender(benchmark::State& state, ColorMode mode) {
     buffers.push_back(std::move(buffer));
   }
 
-  // We accumulate the rendered output in a reused buffer. This should have a
-  // small overhead per-iteration, but a stable one.
+  // The rendered output accumulates in a reused buffer, for a small but
+  // stable per-iteration overhead.
   llvm::SmallString<1 << 16> str;
 
   int current_idx = 0;
   for (auto _ : state) {
     buffers[current_idx].Render(str, mode);
-    // We know that the string is null terminated, and so we can read that byte
-    // to create a data dependency from iteration to iteration. We also block
-    // the optimizer from guessing what this returns.
+    // Reading the string's terminator makes each iteration wait on the store
+    // the one before it made, and blocks the optimizer from guessing the
+    // value.
     uint8_t last_byte = str.c_str()[str.size()];
     benchmark::DoNotOptimize(last_byte);
     current_idx = (current_idx + 1 + last_byte) % PoolSize;
@@ -198,9 +197,7 @@ static void BM_DrawBox(benchmark::State& state, Charset charset) {
   int y = 0;
   for (auto _ : state) {
     buffer.DrawBox(0, y, BoxWidth, BoxHeight, style);
-    // Placing the next box from the buffer's height makes each iteration wait
-    // on the one before it rather than overlapping with it.
-    y = buffer.height() % (Rows - BoxHeight);
+    y = (y + BoxHeight) % (Rows - BoxHeight);
     benchmark::DoNotOptimize(y);
   }
 }
@@ -220,8 +217,8 @@ static void BM_RenderLineArt(benchmark::State& state, ColorMode mode) {
 
   for (int i = 0; i < PoolSize; ++i) {
     Buffer buffer(Width, Charset::Utf8);
-    // A column of nested boxes, so that the rendered rows are mostly line art
-    // with junctions wherever the boxes meet.
+    // Overlapping boxes offset by a row and two columns each, so the rendered
+    // rows carry line art and junctions wherever the edges cross.
     for (int box = 0; box < 4; ++box) {
       buffer.DrawBox(box * 2, box, BoxWidth + 2 * box, BoxHeight,
                      Style().Foreground(RandomColor(bitgen)));
@@ -234,9 +231,9 @@ static void BM_RenderLineArt(benchmark::State& state, ColorMode mode) {
   int current_idx = 0;
   for (auto _ : state) {
     buffers[current_idx].Render(str, mode);
-    // We know that the string is null terminated, and so we can read that byte
-    // to create a data dependency from iteration to iteration. We also block
-    // the optimizer from guessing what this returns.
+    // Reading the string's terminator makes each iteration wait on the store
+    // the one before it made, and blocks the optimizer from guessing the
+    // value.
     uint8_t last_byte = str.c_str()[str.size()];
     benchmark::DoNotOptimize(last_byte);
     current_idx = (current_idx + 1 + last_byte) % PoolSize;

--- a/common/terminal/terminal_benchmark.cpp
+++ b/common/terminal/terminal_benchmark.cpp
@@ -1,0 +1,250 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <benchmark/benchmark.h>
+
+#include <array>
+
+#include "absl/random/random.h"
+#include "common/terminal/buffer.h"
+#include "common/terminal/capabilities.h"
+#include "common/terminal/color.h"
+#include "common/terminal/style.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace Carbon::Terminal {
+namespace {
+
+static auto RandomColor(absl::BitGen& bitgen) -> Color {
+  return {absl::Uniform<uint8_t>(bitgen), absl::Uniform<uint8_t>(bitgen),
+          absl::Uniform<uint8_t>(bitgen)};
+}
+
+// Benchmarks style transitions using a data-dependency feedback loop where the
+// next style index depends on the bytes written in the previous iteration.
+static void BM_StyleTransition(benchmark::State& state, ColorMode mode) {
+  // We use a somewhat large pool of colors to prevent branch prediction from
+  // learning much about the innards.
+  constexpr int PoolSize = 1024;
+  std::array<Style, PoolSize> styles;
+
+  absl::BitGen bitgen;
+
+  // Generate a pool of styles. All styles have the same set of attributes
+  // enabled (bold, italic, foreground color, background color, underline
+  // color, and underline style), but with different random RGB values. This is
+  // the case where no reset is needed and only colors change.
+  for (int i = 0; i < PoolSize; ++i) {
+    styles[i] = Style()
+                    .Bold()
+                    .Italic()
+                    .Foreground(RandomColor(bitgen))
+                    .Background(RandomColor(bitgen))
+                    .Underline(UnderlineShape::Curly)
+                    .UnderlineColor(RandomColor(bitgen));
+  }
+
+  // We accumulate the style transitions in a reused buffer. This should have a
+  // small overhead per-iteration, but a stable one.
+  llvm::SmallString<1024> str;
+
+  int current_idx = 0;
+  for (auto _ : state) {
+    int next_idx = (current_idx + 1) % PoolSize;
+    styles[current_idx].AppendTransitionTo(str, styles[next_idx], mode);
+    // We know that the string is null terminated, and so we can read that byte
+    // to create a data dependency from iteration to iteration. We also block
+    // the optimizer from guessing what this returns.
+    uint8_t last_byte = str.c_str()[str.size()];
+    benchmark::DoNotOptimize(last_byte);
+    current_idx = (next_idx + last_byte) % PoolSize;
+    str.clear();
+  }
+}
+BENCHMARK_CAPTURE(BM_StyleTransition, NoColor, ColorMode::NoColor);
+BENCHMARK_CAPTURE(BM_StyleTransition, Ansi16, ColorMode::Ansi16);
+BENCHMARK_CAPTURE(BM_StyleTransition, Ansi256, ColorMode::Ansi256);
+BENCHMARK_CAPTURE(BM_StyleTransition, Truecolor, ColorMode::Truecolor);
+
+// Benchmarks `Buffer::Render` for terminal-sized screens using a
+// data-dependency feedback loop where the next buffer index depends on the
+// bytes written in the previous iteration.
+static void BM_BufferRender(benchmark::State& state, ColorMode mode) {
+  const int width = state.range(0);
+  const int height = state.range(1);
+
+  // Given the significantly larger body of work, we can use a much smaller pool
+  // without worrying about branch prediction skewing results.
+  constexpr int PoolSize = 16;
+  llvm::SmallVector<Buffer, PoolSize> buffers;
+
+  absl::BitGen bitgen;
+
+  // Generate a pool of buffers. To ensure workload consistency but without
+  // being identical, cell (x, y) in all buffers have:
+  // - The same style attributes enabled (fg, bg, bold, italic etc.).
+  // - Different random color and character values.
+  // - A different shape (a box of varying aspect ratio starting at (1, 1) with
+  //   constant perimeter of 60 cells).
+  for (int i = 0; i < PoolSize; ++i) {
+    Buffer buffer(width, Charset::Utf8);
+
+    auto get_style = [&](int x, int y) {
+      if ((x + y) % 3 == 0) {
+        return Style().Foreground(RandomColor(bitgen)).Bold();
+      }
+      if ((x + y) % 3 == 1) {
+        return Style().Background(RandomColor(bitgen)).Italic();
+      }
+      return Style()
+          .Underline(UnderlineShape::Single)
+          .UnderlineColor(RandomColor(bitgen));
+    };
+
+    for (int y = 0; y < height; ++y) {
+      for (int x = 0; x < width; ++x) {
+        buffer.DrawSymbol(x, y, U'A' + absl::Uniform(bitgen, 0, 26),
+                          get_style(x, y));
+      }
+    }
+
+    int box_height = 6 + i;
+    buffer.DrawBox(1, 1, 32 - box_height, box_height, get_style(1, 1));
+
+    buffers.push_back(std::move(buffer));
+  }
+
+  // We accumulate the rendered output in a reused buffer. This should have a
+  // small overhead per-iteration, but a stable one.
+  llvm::SmallString<1 << 16> str;
+
+  int current_idx = 0;
+  for (auto _ : state) {
+    buffers[current_idx].Render(str, mode);
+    // We know that the string is null terminated, and so we can read that byte
+    // to create a data dependency from iteration to iteration. We also block
+    // the optimizer from guessing what this returns.
+    uint8_t last_byte = str.c_str()[str.size()];
+    benchmark::DoNotOptimize(last_byte);
+    current_idx = (current_idx + 1 + last_byte) % PoolSize;
+    str.clear();
+  }
+}
+BENCHMARK_CAPTURE(BM_BufferRender, NoColor, ColorMode::NoColor)
+    ->Args({80, 24})
+    ->Args({120, 40});
+BENCHMARK_CAPTURE(BM_BufferRender, Ansi16, ColorMode::Ansi16)
+    ->Args({80, 24})
+    ->Args({120, 40});
+BENCHMARK_CAPTURE(BM_BufferRender, Ansi256, ColorMode::Ansi256)
+    ->Args({80, 24})
+    ->Args({120, 40});
+BENCHMARK_CAPTURE(BM_BufferRender, Truecolor, ColorMode::Truecolor)
+    ->Args({80, 24})
+    ->Args({120, 40});
+
+// A line of source of the sort a diagnostic quotes, in the two forms that
+// matter for column measurement. The second has a double-width character and a
+// combining mark, spelled out because the precomposed form is a single code
+// point and wouldn't exercise marks at all.
+static constexpr llvm::StringLiteral AsciiSource =
+    "auto Foo(i32 x) -> i32 { return x * 42; }";
+static constexpr llvm::StringLiteral UnicodeSource =
+    "var 中文: String = \"he\xcc\x81llo\";";
+
+// Benchmarks drawing text, which is where column measurement is paid. The
+// three cases cover the regimes it runs in: no UTF-8 processing at all, UTF-8
+// processing over text that turns out to be ASCII, and UTF-8 processing over
+// text that isn't.
+static void BM_DrawText(benchmark::State& state, Charset charset,
+                        llvm::StringRef text) {
+  constexpr int Width = 120;
+  Buffer buffer(Width, charset);
+
+  int row = 0;
+  for (auto _ : state) {
+    row = buffer.DrawText(0, row, text, Style()) + row;
+    benchmark::DoNotOptimize(row);
+    // Reuse a bounded band of rows so this measures drawing rather than the
+    // buffer's growth.
+    if (row > 64) {
+      row = 0;
+    }
+  }
+}
+BENCHMARK_CAPTURE(BM_DrawText, AsciiCharset, Charset::Ascii, AsciiSource);
+BENCHMARK_CAPTURE(BM_DrawText, Utf8Charset, Charset::Utf8, AsciiSource);
+BENCHMARK_CAPTURE(BM_DrawText, Utf8CharsetWithUnicode, Charset::Utf8,
+                  UnicodeSource);
+
+// The size of the boxes the line art benchmarks draw, chosen so that one is
+// about as large as the frame around a quoted snippet.
+constexpr int BoxWidth = 40;
+constexpr int BoxHeight = 12;
+
+// Benchmarks drawing line art, which is where junction bookkeeping is paid.
+// Every cell of a box is a separate glyph decision, and boxes are drawn over
+// whatever was there before, so this covers clearing as well as drawing.
+static void BM_DrawBox(benchmark::State& state, Charset charset) {
+  constexpr int Width = 120;
+  constexpr int Rows = 64;
+  Buffer buffer(Width, charset);
+  Style style = Style().Foreground(AnsiColor::Blue);
+
+  // Boxes are drawn over a band of rows wider than one box, so that they land
+  // on a mix of blank cells and cells already holding line art.
+  int y = 0;
+  for (auto _ : state) {
+    buffer.DrawBox(0, y, BoxWidth, BoxHeight, style);
+    // Placing the next box from the buffer's height makes each iteration wait
+    // on the one before it rather than overlapping with it.
+    y = buffer.height() % (Rows - BoxHeight);
+    benchmark::DoNotOptimize(y);
+  }
+}
+BENCHMARK_CAPTURE(BM_DrawBox, AsciiCharset, Charset::Ascii);
+BENCHMARK_CAPTURE(BM_DrawBox, Utf8Charset, Charset::Utf8);
+
+// Benchmarks rendering line art, which is the non-ASCII rendering that comes
+// up in practice: the text a diagnostic quotes is nearly always ASCII, while
+// the frames and connectors around it are box-drawing characters that each
+// encode to three bytes.
+static void BM_RenderLineArt(benchmark::State& state, ColorMode mode) {
+  constexpr int Width = 120;
+  constexpr int PoolSize = 16;
+  llvm::SmallVector<Buffer, PoolSize> buffers;
+
+  absl::BitGen bitgen;
+
+  for (int i = 0; i < PoolSize; ++i) {
+    Buffer buffer(Width, Charset::Utf8);
+    // A column of nested boxes, so that the rendered rows are mostly line art
+    // with junctions wherever the boxes meet.
+    for (int box = 0; box < 4; ++box) {
+      buffer.DrawBox(box * 2, box, BoxWidth + 2 * box, BoxHeight,
+                     Style().Foreground(RandomColor(bitgen)));
+    }
+    buffers.push_back(std::move(buffer));
+  }
+
+  llvm::SmallString<1 << 14> str;
+
+  int current_idx = 0;
+  for (auto _ : state) {
+    buffers[current_idx].Render(str, mode);
+    // We know that the string is null terminated, and so we can read that byte
+    // to create a data dependency from iteration to iteration. We also block
+    // the optimizer from guessing what this returns.
+    uint8_t last_byte = str.c_str()[str.size()];
+    benchmark::DoNotOptimize(last_byte);
+    current_idx = (current_idx + 1 + last_byte) % PoolSize;
+    str.clear();
+  }
+}
+BENCHMARK_CAPTURE(BM_RenderLineArt, NoColor, ColorMode::NoColor);
+BENCHMARK_CAPTURE(BM_RenderLineArt, Truecolor, ColorMode::Truecolor);
+
+}  // namespace
+}  // namespace Carbon::Terminal


### PR DESCRIPTION
Rich diagnostic rendering needs a layer underneath it that knows what the attached terminal can do and can position styled text in two dimensions. This adds that layer, both as the foundation the diagnostics rendering work will build on and as something usable directly for ordinary CLI output. Nothing depends on it yet, so it lands and is reviewed on its own.

Four libraries, each with its own tests:

- `color`: a color, either one of the 16 named ANSI colors or a 24-bit RGB value, and the escape sequences that select it at a given color depth.
- `style`: colors plus text attributes, and the escapes that move a terminal from one style to another.
- `capabilities`: what the terminal behind a stream supports, detected from the environment.
- `buffer`: a grid of styled cells that layout code draws into and that renders itself once.

Rationale for the design decisions lives in the headers, next to what it explains. Four things are worth review attention in particular:

- The color detection precedence documented on `ChooseColorMode`. It settles how a `--color` flag, `NO_COLOR`, `CLICOLOR`, `FORCE_COLOR`, and the terminal itself interact. The policy is a pure function of those inputs, so the whole table is tested without touching the process environment.

- `Charset`, which decides whether any UTF-8 processing happens at all. Column counts only follow from code points if the terminal agrees about the encoding, so anything short of a locale naming UTF-8 is treated as bytes.

- `Buffer` owning column accounting instead of its callers, which is what keeps double-width characters, combining marks, and stray bytes from misaligning everything after them.

- The API surface, which is held to operations that nothing else covers. Junctions in line art come only from lines overlapping, and turning a style on or off is spelled as a transition to or from the default style.

`terminal_benchmark` covers style transitions, full-screen rendering, and text drawing. On an M-series laptop, rendering an 80x24 screen in which every cell changes style costs about 14us with color off and 76-95us with it, and drawing a 40-column line of source costs about 140ns without UTF-8 processing and 394ns with it.

Assisted-by: Gemini and Claude