### PR TITLE
Fix crash exporting a Carbon function to C++ without a code generator.

### DIFF
--- a/toolchain/lower/testdata/interop/cpp/function/export/call_not_emitted.carbon
+++ b/toolchain/lower/testdata/interop/cpp/function/export/call_not_emitted.carbon
@@ -1,0 +1,43 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// INCLUDE-FILE: toolchain/testing/testdata/min_prelude/destroy.carbon
+// EXTRA-ARGS: --output=%t --output-last-input-only
+//
+// AUTOUPDATE
+// TIP: To test this file alone, run:
+// TIP:   bazel test //toolchain/testing:file_test --test_arg=--file_tests=toolchain/lower/testdata/interop/cpp/function/export/call_not_emitted.carbon
+// TIP: To dump output, run:
+// TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/interop/cpp/function/export/call_not_emitted.carbon
+
+// --- not_emitted.carbon
+library "[[@TEST_NAME]]";
+import Cpp;
+
+class C {}
+
+fn F(c: C);
+
+// This CppFile is compiled without a Clang CodeGenerator. Ensure this doesn't
+// crash.
+inline Cpp '''
+void G() { Carbon::F(Carbon::C()); }
+''';
+
+// --- emitted.carbon
+library "[[@TEST_NAME]]";
+import library "not_emitted";
+
+// CHECK:STDOUT: ; ---
+// CHECK:STDOUT: ; ModuleID = 'emitted.carbon'
+// CHECK:STDOUT: source_filename = "emitted.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.dbg.cu = !{!0}
+// CHECK:STDOUT: !llvm.module.flags = !{!2, !3}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !1 = !DIFile(filename: "emitted.carbon", directory: "")
+// CHECK:STDOUT: !2 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !3 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT:

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -393,6 +393,7 @@ cc_library(
         "//common:raw_string_ostream",
         "//toolchain/base:kind_switch",
         "@llvm-project//clang:ast",
+        "@llvm-project//clang:basic",
         "@llvm-project//clang:codegen",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Support",

--- a/toolchain/sem_ir/mangler.cpp
+++ b/toolchain/sem_ir/mangler.cpp
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/ModuleBuilder.h"
 #include "common/raw_string_ostream.h"
 #include "llvm/IR/Module.h"
@@ -270,10 +271,12 @@ auto Mangler::MangleWithPlatform(SemIR::FunctionId function_id,
   CARBON_CHECK(sem_ir_.cpp_file());
   // The only platform mangling that's relevant for us is applying a global
   // prefix, if the platform has one.
-  if (char prefix = sem_ir_.cpp_file()
-                        ->code_generator()
-                        ->GetModule()
-                        ->getDataLayout()
+  // TODO: Cache this rather than parsing the data layout string each time we
+  // need it.
+  if (char prefix = llvm::DataLayout(sem_ir_.cpp_file()
+                                         ->ast_context()
+                                         .getTargetInfo()
+                                         .getDataLayoutString())
                         .getGlobalPrefix()) {
     os << prefix;
   }


### PR DESCRIPTION
We can't rely on a `clang::CodeGenerator` existing when compiling C++ code; we don't build one unless we're actually emitting code for the current file any more.