### PR TITLE
Add "file://" document filter to vscode extension

### DIFF
--- a/utils/vscode/src/extension.ts
+++ b/utils/vscode/src/extension.ts
@@ -290,7 +290,7 @@ export function activate(context: ExtensionContext) {
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
-      { language: 'carbon' },
+      { scheme: 'file', language: 'carbon' },
     ],
   };
 

--- a/utils/vscode/tsconfig.json
+++ b/utils/vscode/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "es2020",
     "lib": ["es2020"],
     "outDir": "out",


### PR DESCRIPTION
Currently VSCode extension will try share diff views / scratch files with Carbon language server. This results in following error:

> Request textDocument/semanticTokens/full failed.
  Message: in call to `textDocument/semanticTokens/full`, JSON parse failed: clangd only supports 'file' URI scheme for workspace files at (root).textDocument.uri
  Code: -32602 

The change here updates vscode extension to filter for `file://*/**.carbon` URIs, this matches how clangd extension does it: https://github.com/clangd/vscode-clangd/blob/893dd905c2a6a7844fe32592796ef593e6f3bca6/src/clangd-context.ts#L18

Also updates tsconfig.json to node16 module resolution, this is done since [automatic dependabot PR](https://github.com/carbon-language/carbon-lang/pull/7575) seems to have broken the build. 

```
src/extension.ts:28:8 - error TS2307: Cannot find module 'vscode-languageclient/node' or its corresponding type declarations.
  There are types at '/usr/local/google/home/davidloftus/carbon-lang/utils/vscode/node_modules/vscode-languageclient/lib/node/main.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

28 } from 'vscode-languageclient/node';
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/extension.ts:28
```

[vscode-languageserver-node](https://github.com/microsoft/vscode-languageserver-node/blame/93d5fe6f443dd6c8fe37f422c271d618edd121af/README.md#L159) recomends updating to node16.