### PR TITLE
Add benchmark for missing bracket fixing and optimize various parts of the algorithm.

### DIFF
--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -221,6 +221,27 @@ cc_library(
     ],
 )
 
+cc_binary(
+    name = "mismatched_brackets_benchmark",
+    testonly = 1,
+    srcs = ["mismatched_brackets_benchmark.cpp"],
+    deps = [
+        ":lex",
+        ":mismatched_brackets",
+        ":token_index",
+        ":tokenized_buffer",
+        "//common:check",
+        "//testing/base:benchmark_main",
+        "//toolchain/base:shared_value_stores",
+        "//toolchain/benchmarking:source_gen_lib",
+        "//toolchain/diagnostics:emitter",
+        "//toolchain/diagnostics:null_diagnostics",
+        "//toolchain/source:source_buffer",
+        "@google_benchmark//:benchmark",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
 cc_test(
     name = "mismatched_brackets_test",
     size = "small",

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -215,6 +215,7 @@ cc_library(
         "//common:check",
         "//common:hashing",
         "//common:map",
+        "//toolchain/base:index_base",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -236,6 +236,7 @@ cc_binary(
         "//toolchain/diagnostics:emitter",
         "//toolchain/diagnostics:null_diagnostics",
         "//toolchain/source:source_buffer",
+        "@abseil-cpp//absl/random",
         "@google_benchmark//:benchmark",
         "@llvm-project//llvm:Support",
     ],

--- a/toolchain/lex/BUILD
+++ b/toolchain/lex/BUILD
@@ -214,9 +214,7 @@ cc_library(
         ":token_kind",
         "//common:check",
         "//common:hashing",
-        "//common:hashtable_key_context",
         "//common:map",
-        "//common:set",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/toolchain/lex/mismatched_brackets.cpp
+++ b/toolchain/lex/mismatched_brackets.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/StringRef.h"
+#include "toolchain/base/index_base.h"
 
 namespace Carbon::Lex {
 
@@ -289,11 +290,15 @@ struct OpenBracketInfo : OpenBracketKey {
 };
 
 // Names a stack of open brackets held in an `OpenStackStore`.
-using OpenStackId = int32_t;
+struct OpenStackId : public IdBase<OpenStackId> {
+  // The empty stack, which every search starts from. Interning gives it no
+  // cell, so it needs an id of its own.
+  static const OpenStackId Empty;
 
-// The empty stack, which every search starts from. Interning gives it no cell,
-// so it needs an id of its own.
-constexpr OpenStackId EmptyOpenStack = -1;
+  using IdBase::IdBase;
+};
+
+inline constexpr OpenStackId OpenStackId::Empty = OpenStackId(NoneIndex);
 
 // What distinguishes one stack from another: the bracket on top, and the stack
 // below it. Only the `OpenBracketKey` part of the bracket takes part, since
@@ -304,17 +309,16 @@ struct OpenStackCellKey {
 
   friend auto operator==(const OpenStackCellKey& lhs,
                          const OpenStackCellKey& rhs) -> bool = default;
+
+  friend auto CarbonHashValue(const OpenStackCellKey& key, uint64_t seed)
+      -> HashCode {
+    static_assert(std::has_unique_object_representations_v<OpenStackCellKey>,
+                  "Padding would leave indeterminate bytes for hashing.");
+    Hasher hasher(seed);
+    hasher.HashRaw(key);
+    return static_cast<HashCode>(hasher);
+  }
 };
-
-static_assert(std::has_unique_object_representations_v<OpenStackCellKey>,
-              "Padding would leave indeterminate bytes for hashing.");
-
-inline auto CarbonHashValue(const OpenStackCellKey& key, uint64_t seed)
-    -> HashCode {
-  Hasher hasher(seed);
-  hasher.HashRaw(key);
-  return static_cast<HashCode>(hasher);
-}
 
 // Holds the open-bracket stacks the search reaches.
 //
@@ -333,7 +337,7 @@ class OpenStackStore {
   auto Push(OpenStackId stack, const OpenBracketInfo& entry) -> OpenStackId {
     auto result =
         intern_.Insert(OpenStackCellKey{.parent = stack, .entry = entry},
-                       static_cast<OpenStackId>(cells_.size()));
+                       OpenStackId(cells_.size()));
     if (result.is_inserted()) {
       cells_.push_back({
           .parent = stack,
@@ -349,30 +353,31 @@ class OpenStackStore {
 
   // The stack below the top of `stack`, which must not be empty.
   auto Pop(OpenStackId stack) const -> OpenStackId {
-    return cells_[stack].parent;
+    return cells_[stack.index].parent;
   }
 
   // The bracket on top of `stack`, which must not be empty.
   auto Top(OpenStackId stack) const -> const OpenBracketInfo& {
-    return cells_[stack].entry;
+    return cells_[stack.index].entry;
   }
 
   auto IsEmpty(OpenStackId stack) const -> bool {
-    return stack == EmptyOpenStack;
+    return stack == OpenStackId::Empty;
   }
 
   auto Depth(OpenStackId stack) const -> int32_t {
-    return IsEmpty(stack) ? 0 : cells_[stack].depth;
+    return IsEmpty(stack) ? 0 : cells_[stack.index].depth;
   }
 
   // Whether any bracket in `stack` is synthetic.
   auto HasSynthetic(OpenStackId stack) const -> bool {
-    return !IsEmpty(stack) && cells_[stack].has_synthetic;
+    return !IsEmpty(stack) && cells_[stack.index].has_synthetic;
   }
 
   // Whether `stack` holds an opener of kind `kind`.
   auto Contains(OpenStackId stack, BracketTokenKind kind) const -> bool {
-    return !IsEmpty(stack) && (cells_[stack].open_kinds & KindBit(kind)) != 0;
+    return !IsEmpty(stack) &&
+           (cells_[stack.index].open_kinds & KindBit(kind)) != 0;
   }
 
  private:
@@ -390,7 +395,7 @@ class OpenStackStore {
   }
 
   auto OpenKinds(OpenStackId stack) const -> uint8_t {
-    return IsEmpty(stack) ? 0 : cells_[stack].open_kinds;
+    return IsEmpty(stack) ? 0 : cells_[stack.index].open_kinds;
   }
 
   llvm::SmallVector<Cell, 0> cells_;
@@ -2283,7 +2288,7 @@ auto RegionSearch::CloseAtRegionEnd() -> llvm::SmallVector<int32_t> {
       finish_cost += CostToCloseAtEnd(open);
       nodes_.push_back(BeamNode{
           .item_index = static_cast<int32_t>(items_.size()),
-          .stack = EmptyOpenStack,
+          .stack = OpenStackId::Empty,
           .cost = finish_cost,
           .parent_edges = {{
               .parent_node_index = parent,
@@ -2318,7 +2323,7 @@ auto RegionSearch::Solve(llvm::SmallVectorImpl<BracketCorrection>& corrections)
     -> void {
   nodes_.push_back(BeamNode{
       .item_index = 0,
-      .stack = EmptyOpenStack,
+      .stack = OpenStackId::Empty,
       .cost = 0,
       .parent_edges = {},
   });

--- a/toolchain/lex/mismatched_brackets.cpp
+++ b/toolchain/lex/mismatched_brackets.cpp
@@ -14,9 +14,7 @@
 
 #include "common/check.h"
 #include "common/hashing.h"
-#include "common/hashtable_key_context.h"
 #include "common/map.h"
-#include "common/set.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/STLExtras.h"
@@ -290,6 +288,115 @@ struct OpenBracketInfo : OpenBracketKey {
   llvm::StringLiteral rule_name = "";
 };
 
+// Names a stack of open brackets held in an `OpenStackStore`.
+using OpenStackId = int32_t;
+
+// The empty stack, which every search starts from. Interning gives it no cell,
+// so it needs an id of its own.
+constexpr OpenStackId EmptyOpenStack = -1;
+
+// What distinguishes one stack from another: the bracket on top, and the stack
+// below it. Only the `OpenBracketKey` part of the bracket takes part, since
+// that is all that distinguishes one search state from another.
+struct OpenStackCellKey {
+  OpenStackId parent;
+  OpenBracketKey entry;
+
+  friend auto operator==(const OpenStackCellKey& lhs,
+                         const OpenStackCellKey& rhs) -> bool = default;
+};
+
+static_assert(std::has_unique_object_representations_v<OpenStackCellKey>,
+              "Padding would leave indeterminate bytes for hashing.");
+
+inline auto CarbonHashValue(const OpenStackCellKey& key, uint64_t seed)
+    -> HashCode {
+  Hasher hasher(seed);
+  hasher.HashRaw(key);
+  return static_cast<HashCode>(hasher);
+}
+
+// Holds the open-bracket stacks the search reaches.
+//
+// A stack only ever changes at the top, so it is stored as the bracket on top
+// plus the id of the stack below it, which lets the many states sharing a
+// prefix share its cells instead of each carrying a copy. Equal stacks are
+// interned to one id, so comparing two stacks is comparing two integers, and a
+// `BeamNode` holds no bracket storage of its own — both of which matter, since
+// the search creates far more states than it keeps and never frees them.
+//
+// Each cell also carries the answers to the questions the rules ask about the
+// whole stack, so that asking them doesn't mean walking it.
+class OpenStackStore {
+ public:
+  // The stack that is `stack` with `entry` pushed onto it.
+  auto Push(OpenStackId stack, const OpenBracketInfo& entry) -> OpenStackId {
+    auto result =
+        intern_.Insert(OpenStackCellKey{.parent = stack, .entry = entry},
+                       static_cast<OpenStackId>(cells_.size()));
+    if (result.is_inserted()) {
+      cells_.push_back({
+          .parent = stack,
+          .entry = entry,
+          .depth = Depth(stack) + 1,
+          .open_kinds =
+              static_cast<uint8_t>(OpenKinds(stack) | KindBit(entry.kind)),
+          .has_synthetic = HasSynthetic(stack) || entry.is_synthetic,
+      });
+    }
+    return result.value();
+  }
+
+  // The stack below the top of `stack`, which must not be empty.
+  auto Pop(OpenStackId stack) const -> OpenStackId {
+    return cells_[stack].parent;
+  }
+
+  // The bracket on top of `stack`, which must not be empty.
+  auto Top(OpenStackId stack) const -> const OpenBracketInfo& {
+    return cells_[stack].entry;
+  }
+
+  auto IsEmpty(OpenStackId stack) const -> bool {
+    return stack == EmptyOpenStack;
+  }
+
+  auto Depth(OpenStackId stack) const -> int32_t {
+    return IsEmpty(stack) ? 0 : cells_[stack].depth;
+  }
+
+  // Whether any bracket in `stack` is synthetic.
+  auto HasSynthetic(OpenStackId stack) const -> bool {
+    return !IsEmpty(stack) && cells_[stack].has_synthetic;
+  }
+
+  // Whether `stack` holds an opener of kind `kind`.
+  auto Contains(OpenStackId stack, BracketTokenKind kind) const -> bool {
+    return !IsEmpty(stack) && (cells_[stack].open_kinds & KindBit(kind)) != 0;
+  }
+
+ private:
+  struct Cell {
+    OpenStackId parent;
+    OpenBracketInfo entry;
+    int32_t depth;
+    // The kinds of every bracket in this stack, as `KindBit`s.
+    uint8_t open_kinds;
+    bool has_synthetic;
+  };
+
+  static auto KindBit(BracketTokenKind kind) -> uint8_t {
+    return static_cast<uint8_t>(1 << static_cast<int>(kind));
+  }
+
+  auto OpenKinds(OpenStackId stack) const -> uint8_t {
+    return IsEmpty(stack) ? 0 : cells_[stack].open_kinds;
+  }
+
+  llvm::SmallVector<Cell, 0> cells_;
+  Map<OpenStackCellKey, OpenStackId> intern_;
+};
+
 }  // namespace
 
 // The `{` opening the branch that the first-on-line `else` at `else_index`
@@ -358,45 +465,77 @@ static auto GetOuterStatementIntroducerIndent(
   return result_indent;
 }
 
-// Computes the indentation that a token's statement or declaration starts at,
-// by scanning back over the current statement to its introducer. This is what
-// a `{` opened by that statement should line its `}` up with, which is often
-// not the indentation of the `{` itself.
-static auto ComputeAssociatedLineIndent(
+// Computes, for every token, the indentation that its statement or declaration
+// starts at. This is what a `{` opened by that statement should line its `}` up
+// with, which is often not the indentation of the `{` itself.
+//
+// The answer for one token is a walk backwards to the start of the statement it
+// belongs to: it steps over tokens, jumps over matched bracket pairs, stops at
+// a `;` or an unmatched brace, and answers with the indentation of the last
+// token it stepped on, or of the enclosing statement introducer if it reaches
+// one.
+//
+// Every step of that walk depends only on the token it is standing on, so the
+// walks from all the tokens share their tails and can be solved in one pass.
+// `walk_result[j]` is what the walk starting at token `j` answers, or
+// `NeedsCaller` when the walk stops before it steps on anything, in which case
+// the answer is the caller's own indentation. Each entry depends only on
+// entries below it, so a single forward pass fills the table, and the answer
+// for token `i` reads the entry for `i - 1`.
+static auto ComputeAssociatedLineIndents(
     llvm::ArrayRef<MismatchedBracketToken> tokens,
-    llvm::ArrayRef<int32_t> match_partner, int32_t token_index) -> int32_t {
-  if (token_index < 0 || token_index >= static_cast<int32_t>(tokens.size())) {
-    return 0;
-  }
-  if (tokens[token_index].kind == Kind::FileEnd) {
-    return 0;
-  }
+    llvm::ArrayRef<int32_t> match_partner) -> llvm::SmallVector<int32_t> {
+  auto num_tokens = static_cast<int32_t>(tokens.size());
 
-  int32_t earliest_indent = tokens[token_index].line_indent;
+  // A walk that stopped without stepping on a token, so it has no indentation
+  // of its own to report.
+  constexpr int32_t NeedsCaller = std::numeric_limits<int32_t>::min();
 
-  for (int32_t j = token_index - 1; j >= 0; --j) {
+  llvm::SmallVector<int32_t> walk_result(num_tokens, NeedsCaller);
+  // The walk from `j` continues at `next`, so it answers what that walk
+  // answers, falling back to `indent` when that walk has nothing to report.
+  auto continue_walk = [&](int32_t next, int32_t indent) {
+    return next >= 0 && walk_result[next] != NeedsCaller ? walk_result[next]
+                                                         : indent;
+  };
+
+  for (int32_t j : llvm::seq(0, num_tokens)) {
     auto kind = tokens[j].kind;
 
+    // A matched closer jumps to its opener, which the walk passes over without
+    // testing it, and continues from the token before it.
     if (IsClosingBracket(kind) && match_partner[j] != -1 &&
         match_partner[j] < j) {
-      j = match_partner[j];
-      earliest_indent = tokens[j].line_indent;
+      int32_t open = match_partner[j];
+      walk_result[j] = continue_walk(open - 1, tokens[open].line_indent);
       continue;
     }
 
+    // The statement ends here, so the walk stops without stepping on this
+    // token. `walk_result[j]` stays `NeedsCaller`.
     if (kind == Kind::Semi || kind == Kind::OpenCurlyBrace ||
         kind == Kind::CloseCurlyBrace) {
-      break;
+      continue;
     }
 
-    earliest_indent = tokens[j].line_indent;
-
+    // The statement introducer this token belongs to answers for it directly.
     if (kind == Kind::StatementIntroducer) {
-      return GetOuterStatementIntroducerIndent(tokens, match_partner, j);
+      walk_result[j] =
+          GetOuterStatementIntroducerIndent(tokens, match_partner, j);
+      continue;
     }
+
+    walk_result[j] = continue_walk(j - 1, tokens[j].line_indent);
   }
 
-  return earliest_indent;
+  llvm::SmallVector<int32_t> indents(num_tokens, 0);
+  for (int32_t i : llvm::seq(0, num_tokens)) {
+    if (tokens[i].kind == Kind::FileEnd) {
+      continue;
+    }
+    indents[i] = continue_walk(i - 1, tokens[i].line_indent);
+  }
+  return indents;
 }
 
 // Determines if a token follows a statement/declaration header, so that a
@@ -505,24 +644,29 @@ struct ParentEdge {
 };
 
 // Node in the beam search tree.
+//
+// The search creates far more nodes than any one layer keeps, and never frees
+// them, so how big a node is decides how much of the search is spent waiting on
+// memory rather than deciding anything. That is why its stack is an id into a
+// shared `OpenStackStore` rather than a stack of its own, and why
+// `parent_edges` has inline room for the one edge a node usually has rather
+// than for the worst case.
 struct BeamNode {
   int32_t item_index;
-  llvm::SmallVector<OpenBracketInfo, 4> stack;
+  OpenStackId stack;
   int32_t cost;
   // The kind of synthetic closer inserted directly before the current item,
   // or Other if none; an inserted closer repairs illegal adjacency with the
   // preceding token.
   Kind closer_inserted = Kind::Other;
-  llvm::SmallVector<ParentEdge, 2> parent_edges;
+  llvm::SmallVector<ParentEdge, 1> parent_edges;
 };
 
-// The parts of a BeamNode the search reads while expanding it. Snapshotting
-// just these (rather than copying the whole node, whose `parent_edges` the
-// expansion never reads) avoids copying that vector per node. A copy — not a
-// reference — is needed because expanding a node pushes onto the node list,
+// The parts of a `BeamNode` the search reads while expanding it. A copy — not a
+// reference — is needed because expanding a node appends to the node list,
 // which may reallocate.
 struct SearchState {
-  llvm::SmallVector<OpenBracketInfo, 4> stack;
+  OpenStackId stack;
   int32_t cost;
   Kind closer_inserted;
 };
@@ -530,52 +674,20 @@ struct SearchState {
 // What makes a search state distinct: the open-bracket stack, plus which
 // closer, if any, was just inserted before the current token. Two nodes in a
 // layer that agree on this are interchangeable and get merged, which is what
-// `RegionSearch::layer_dedup_` looks up. This is a view of a node's state, or
-// of a prospective one that has no node yet, so it must not outlive what it
-// names.
-//
-// Only the `OpenBracketKey` part of each stack entry participates, since that's
-// all `OpenBracketInfo`'s `operator==` compares and all the hash below reads.
+// `RegionSearch::layer_dedup_` is keyed on. Stacks are interned, so this is two
+// integers.
 struct StateKey {
-  llvm::ArrayRef<OpenBracketInfo> stack;
+  OpenStackId stack;
   Kind closer_inserted;
 
-  friend auto operator==(const StateKey& lhs, const StateKey& rhs) -> bool {
-    return lhs.closer_inserted == rhs.closer_inserted && lhs.stack == rhs.stack;
-  }
+  friend auto operator==(const StateKey& lhs, const StateKey& rhs)
+      -> bool = default;
 
-  // Hashes the whole of each stack entry's key, and nothing outside it, so that
-  // equal states always hash equal.
   friend auto CarbonHashValue(const StateKey& key, uint64_t seed) -> HashCode {
     Hasher hasher(seed);
-    hasher.Hash(key.closer_inserted, key.stack.size());
-    for (const OpenBracketKey& entry : key.stack) {
-      hasher.HashRaw(entry);
-    }
+    hasher.Hash(key.stack, key.closer_inserted);
     return static_cast<HashCode>(hasher);
   }
-};
-
-// Lets the dedup table key on the search state itself while storing only a node
-// index, so no stack is copied into the table. Lookups pass a `StateKey`
-// directly; a stored index is translated back into one through the node list.
-//
-// Holds the node list by pointer, not by `ArrayRef`, because inserting a node
-// reallocates it.
-class LayerDedupKeyContext
-    : public TranslatingKeyContext<LayerDedupKeyContext> {
- public:
-  explicit LayerDedupKeyContext(const llvm::SmallVector<BeamNode, 0>* nodes
-                                [[clang::lifetimebound]])
-      : nodes_(nodes) {}
-
-  auto TranslateKey(int32_t node_index) const -> StateKey {
-    const BeamNode& node = (*nodes_)[node_index];
-    return {.stack = node.stack, .closer_inserted = node.closer_inserted};
-  }
-
- private:
-  const llvm::SmallVector<BeamNode, 0>* nodes_;
 };
 
 }  // namespace
@@ -672,18 +784,12 @@ static auto EdgesEqual(const ParentEdge& a, const ParentEdge& b) -> bool {
 }
 
 // Returns true if `kind`'s matching opener appears in `stack` below the top.
-static auto MatchesDeeperOpener(llvm::ArrayRef<OpenBracketInfo> stack,
+static auto MatchesDeeperOpener(const OpenStackStore& stacks, OpenStackId stack,
                                 Kind closing_kind) -> bool {
-  if (!IsClosingBracket(closing_kind) || stack.size() < 2) {
+  if (!IsClosingBracket(closing_kind) || stacks.Depth(stack) < 2) {
     return false;
   }
-  auto req = MatchingOpeningKind(closing_kind);
-  for (const OpenBracketKey& entry : stack.drop_back()) {
-    if (entry.kind == req) {
-      return true;
-    }
-  }
-  return false;
+  return stacks.Contains(stacks.Pop(stack), MatchingOpeningKind(closing_kind));
 }
 
 // Whether the token before the current one ends a value. Unlike
@@ -699,10 +805,10 @@ static auto PrevIsValueLike(const MismatchedBracketToken* prev_token) -> bool {
 
 // Whether the top of `stack` is a synthetic opener inserted directly before
 // `item` — i.e. this path just opened a bracket at this position.
-static auto OpenerSynthesizedHere(llvm::ArrayRef<OpenBracketInfo> stack,
-                                  const Item& item) -> bool {
-  return !stack.empty() && stack.back().is_synthetic &&
-         stack.back().insertion_token_index == item.token.token_index;
+static auto OpenerSynthesizedHere(const OpenStackStore& stacks,
+                                  OpenStackId stack, const Item& item) -> bool {
+  return !stacks.IsEmpty(stack) && stacks.Top(stack).is_synthetic &&
+         stacks.Top(stack).insertion_token_index == item.token.token_index;
 }
 
 // Whether a `]` or `}` was inserted directly before the current token. Such a
@@ -784,9 +890,10 @@ static auto TopCategoryOf(const OpenBracketInfo& top) -> int32_t {
 }
 
 // As `TopCategoryOf`, but for a stack that may be empty.
-static auto TopCategoryOfStack(llvm::ArrayRef<OpenBracketInfo> stack)
+static auto TopCategoryOfStack(const OpenStackStore& stacks, OpenStackId stack)
     -> int32_t {
-  return stack.empty() ? Top::NoneIndex : TopCategoryOf(stack.back());
+  return stacks.IsEmpty(stack) ? Top::NoneIndex
+                               : TopCategoryOf(stacks.Top(stack));
 }
 
 // The category of a synthetic opener of kind `kind`.
@@ -1255,10 +1362,11 @@ static auto ComputeItemCues(const MismatchedBracketToken& token,
 // Computes the cues that depend on the innermost open bracket `top` and the
 // search state, to combine with `item.cues`.
 static auto ComputeTopCues(const OpenBracketInfo& top, const Item& item,
-                           llvm::ArrayRef<OpenBracketInfo> stack) -> CueSet {
+                           const OpenStackStore& stacks, OpenStackId stack)
+    -> CueSet {
   const auto& token = item.token;
   return CueIf(top.is_call_paren, Cue::CallParenTop) |
-         CueIf(MatchesDeeperOpener(stack, token.kind), Cue::Cascade) |
+         CueIf(MatchesDeeperOpener(stacks, stack, token.kind), Cue::Cascade) |
          CueIf(top.token_pos == item.token_start_index - 1, Cue::AfterOpenTop) |
          CueIf(token.line_indent <= top.effective_header_indent,
                Cue::DedentToHeader) |
@@ -1270,10 +1378,11 @@ static auto ComputeTopCues(const OpenBracketInfo& top, const Item& item,
 // to the name of the rule that fired.
 static auto ClassifyCloserInsertion(const OpenBracketInfo& top,
                                     const Item& item,
-                                    llvm::ArrayRef<OpenBracketInfo> stack,
+                                    const OpenStackStore& stacks,
+                                    OpenStackId stack,
                                     llvm::StringLiteral& rule_name)
     -> std::optional<int32_t> {
-  CueSet cues = item.cues | ComputeTopCues(top, item, stack);
+  CueSet cues = item.cues | ComputeTopCues(top, item, stacks, stack);
   const auto* rule = FindMatchingRule(
       CloserRules, CloserRuleIndex, TopCategoryOf(top), item.token.kind, cues);
   if (rule == nullptr || rule->cost == DeclineCost) {
@@ -1514,19 +1623,20 @@ static_assert([] {
 static constexpr auto AdvanceRuleIndex = BuildRuleIndex(AdvanceRules);
 
 // Computes the cues for advancing over `item` in search state `node`.
-static auto ComputeAdvanceCues(const SearchState& node, const Item& item)
+static auto ComputeAdvanceCues(const OpenStackStore& stacks,
+                               const SearchState& node, const Item& item)
     -> CueSet {
-  bool opener_here = OpenerSynthesizedHere(node.stack, item);
+  bool opener_here = OpenerSynthesizedHere(stacks, node.stack, item);
   bool closer_here = node.closer_inserted != Kind::Other;
   CueSet cues = item.cues | CueIf(closer_here, Cue::CloserInserted) |
                 CueIf(CloserFixesLeafAdjacency(node.closer_inserted),
                       Cue::CloserFixesAdjacency) |
                 CueIf(opener_here, Cue::OpenerHere) |
                 CueIf(closer_here || opener_here, Cue::BracketInsertedHere);
-  if (node.stack.empty()) {
+  if (stacks.IsEmpty(node.stack)) {
     return cues;
   }
-  const auto& top = node.stack.back();
+  const auto& top = stacks.Top(node.stack);
   return cues | CueIf(top.is_call_paren, Cue::CallParenTop) |
          CueIf(top.token_pos == item.token_start_index - 1, Cue::AfterOpenTop) |
          CueIf(item.token.line_indent <= top.effective_header_indent,
@@ -1537,11 +1647,12 @@ static auto ComputeAdvanceCues(const SearchState& node, const Item& item)
 
 // Computes the total penalty for advancing over `item` in search state `node`,
 // summing every `AdvanceRules` entry that matches.
-static auto AdvancePenalty(const SearchState& node, const Item& item)
+static auto AdvancePenalty(const OpenStackStore& stacks,
+                           const SearchState& node, const Item& item)
     -> int32_t {
-  return SumMatchingRules(AdvanceRules, AdvanceRuleIndex,
-                          TopCategoryOfStack(node.stack), item.token.kind,
-                          ComputeAdvanceCues(node, item));
+  return SumMatchingRules(
+      AdvanceRules, AdvanceRuleIndex, TopCategoryOfStack(stacks, node.stack),
+      item.token.kind, ComputeAdvanceCues(stacks, node, item));
 }
 
 // Enumerates the distinct optimal repairs, by walking parent edges from each
@@ -1595,30 +1706,60 @@ static auto EnumerateOptimalPaths(llvm::ArrayRef<BeamNode> nodes,
 }
 
 // Finds which of the first optimal path's corrections the optimal repairs
-// disagree about. Each of its corrections is matched against an `equivalent`
-// one in every other path; one with no counterpart in some path is tied.
+// disagree about. Each of its corrections must be answered by one making the
+// same repair, named by `repair_key`, in every other path; one with no
+// counterpart in some path is tied.
+//
+// Repairs are matched by key rather than pairwise, which works because making
+// the same repair is an equivalence relation: the baseline's `n`th correction
+// with a given key is answered by a path exactly when that path has at least
+// `n` corrections with that key. So all that matters is, for each key the
+// baseline uses, the fewest corrections any path has with it.
 static auto FindTiedCorrections(
     llvm::ArrayRef<llvm::SmallVector<BracketCorrection>> all_paths,
-    llvm::function_ref<bool(const BracketCorrection&, const BracketCorrection&)>
-        equivalent) -> llvm::BitVector {
+    llvm::function_ref<uint64_t(const BracketCorrection&)> repair_key)
+    -> llvm::BitVector {
   llvm::ArrayRef<BracketCorrection> baseline_path = all_paths.front();
+
+  // Number the keys the baseline uses, and count how many of its corrections
+  // share each one. A key no baseline correction uses is never asked about, so
+  // it goes unnumbered.
+  Map<uint64_t, int32_t> key_ids;
+  llvm::SmallVector<int32_t> baseline_key_id(baseline_path.size());
+  // Which of the baseline's corrections with the same key this one is, counting
+  // from one: it needs the path to have at least this many.
+  llvm::SmallVector<int32_t> baseline_rank(baseline_path.size());
+  llvm::SmallVector<int32_t> baseline_count;
+  for (auto [corr_idx, corr] : llvm::enumerate(baseline_path)) {
+    auto result = key_ids.Insert(repair_key(corr),
+                                 static_cast<int32_t>(baseline_count.size()));
+    if (result.is_inserted()) {
+      baseline_count.push_back(0);
+    }
+    int32_t key_id = result.value();
+    baseline_key_id[corr_idx] = key_id;
+    baseline_rank[corr_idx] = ++baseline_count[key_id];
+  }
+
+  // The fewest corrections with each key that any path makes.
+  llvm::SmallVector<int32_t> min_count = baseline_count;
+  llvm::SmallVector<int32_t> path_count(baseline_count.size());
+  for (const auto& path : llvm::drop_begin(all_paths)) {
+    std::fill(path_count.begin(), path_count.end(), 0);
+    for (const auto& corr : path) {
+      if (int32_t* key_id = key_ids[repair_key(corr)]) {
+        ++path_count[*key_id];
+      }
+    }
+    for (auto [key_id, count] : llvm::enumerate(path_count)) {
+      min_count[key_id] = std::min(min_count[key_id], count);
+    }
+  }
+
   llvm::BitVector tied(baseline_path.size());
-  llvm::BitVector used;
-  for (const auto& path : all_paths) {
-    used.reset();
-    used.resize(path.size());
-    for (auto [corr_idx, corr] : llvm::enumerate(baseline_path)) {
-      bool found = false;
-      for (auto [path_idx, path_corr] : llvm::enumerate(path)) {
-        if (!used[path_idx] && equivalent(path_corr, corr)) {
-          used.set(path_idx);
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        tied.set(corr_idx);
-      }
+  for (auto [corr_idx, key_id] : llvm::enumerate(baseline_key_id)) {
+    if (min_count[key_id] < baseline_rank[corr_idx]) {
+      tied.set(corr_idx);
     }
   }
   return tied;
@@ -1639,9 +1780,6 @@ static auto ReconstructCorrections(
     return;
   }
 
-  // Two insertions of the same bracket kind are equivalent if every token
-  // between their insertion points is that same kind: inserting a `)` on
-  // either side of an existing `)` produces the same token sequence.
   Map<int32_t, int32_t> token_to_item;
   for (auto [idx, region_item] : llvm::enumerate(items)) {
     token_to_item.Update(region_item.token.token_index.index,
@@ -1649,36 +1787,52 @@ static auto ReconstructCorrections(
   }
   token_to_item.Update(region_end_token.index,
                        static_cast<int32_t>(items.size()));
-  // Compares only the fixes, not the diagnosed brackets: two paths that
-  // blame different brackets but repair the token stream identically don't
-  // disagree about the repair.
-  auto corrections_equivalent = [&](const BracketCorrection& a,
-                                    const BracketCorrection& b) -> bool {
-    if (a.fix_action != b.fix_action || a.fix_token_kind != b.fix_token_kind) {
-      return false;
-    }
-    if (a.fix_token_index == b.fix_token_index) {
-      return true;
-    }
-    if (a.fix_action != BracketFixAction::InsertBefore) {
-      return false;
-    }
-    int32_t* a_item = token_to_item[a.fix_token_index.index];
-    int32_t* b_item = token_to_item[b.fix_token_index.index];
-    if (a_item == nullptr || b_item == nullptr) {
-      return false;
-    }
-    auto [lo, hi] = std::minmax(*a_item, *b_item);
-    for (const Item& between : items.slice(lo, hi - lo)) {
-      if (between.HasAll(Cue::CollapsedBlock) ||
-          ToTokenKind(between.token.kind) != a.fix_token_kind) {
-        return false;
+
+  // For each item, the first item of the run of consecutive items with its own
+  // kind that ends at it. Inserting a bracket anywhere within a run of that
+  // same bracket produces the same token sequence — a `)` on either side of an
+  // existing `)` reads the same — so an insertion point slides back to the
+  // start of such a run, and two that slide to the same place are the same
+  // repair. A collapsed item ends a run, since it stands for a whole bracketed
+  // block rather than one token.
+  llvm::SmallVector<int32_t> run_start(items.size(), 0);
+  for (auto [i, item] : llvm::enumerate(items)) {
+    auto idx = static_cast<int32_t>(i);
+    bool continues_run = idx > 0 && !item.HasAll(Cue::CollapsedBlock) &&
+                         !items[idx - 1].HasAll(Cue::CollapsedBlock) &&
+                         items[idx - 1].token.kind == item.token.kind;
+    run_start[idx] = continues_run ? run_start[idx - 1] : idx;
+  }
+
+  // Names the repair a correction makes, so that two corrections making the
+  // same repair get the same name. This reads only the fix, not the diagnosed
+  // bracket: two paths that blame different brackets but repair the token
+  // stream identically don't disagree about the repair.
+  //
+  // An insertion whose target is in this region is named by the item its
+  // insertion point slides back to; anything else is named by the token it
+  // fixes. Those are separate numbering spaces, so the name records which it
+  // used.
+  auto repair_key = [&](const BracketCorrection& c) -> uint64_t {
+    int32_t position = c.fix_token_index.index;
+    bool position_is_item = false;
+    if (c.fix_action == BracketFixAction::InsertBefore) {
+      if (int32_t* item = token_to_item[c.fix_token_index.index]) {
+        position_is_item = true;
+        position = *item;
+        if (position > 0 && !items[position - 1].HasAll(Cue::CollapsedBlock) &&
+            ToTokenKind(items[position - 1].token.kind) == c.fix_token_kind) {
+          position = run_start[position - 1];
+        }
       }
     }
-    return true;
+    return (static_cast<uint64_t>(c.fix_action) << 40) |
+           (static_cast<uint64_t>(c.fix_token_kind.AsInt()) << 33) |
+           (static_cast<uint64_t>(position_is_item) << 32) |
+           static_cast<uint32_t>(position);
   };
 
-  llvm::BitVector tied = FindTiedCorrections(all_paths, corrections_equivalent);
+  llvm::BitVector tied = FindTiedCorrections(all_paths, repair_key);
   for (auto [corr_idx, corr] : llvm::enumerate(all_paths.front())) {
     corrections.push_back(corr);
     corrections.back().is_tied = tied[corr_idx];
@@ -1810,8 +1964,8 @@ class RegionSearch {
   // any node that was added or became cheaper is appended to it, so that a
   // further epsilon move can be applied to it.
   auto AddToLayer(llvm::SmallVectorImpl<int32_t>& layer, int32_t next_item_idx,
-                  llvm::SmallVector<OpenBracketInfo, 4> next_stack,
-                  Kind closer_inserted, int32_t next_cost, ParentEdge edge,
+                  OpenStackId next_stack, Kind closer_inserted,
+                  int32_t next_cost, ParentEdge edge,
                   llvm::SmallVectorImpl<int32_t>* worklist = nullptr) -> void;
 
   // Merges a newly-found way of reaching the state already in `nodes_[idx]`: a
@@ -1850,17 +2004,18 @@ class RegionSearch {
   // cost of any state still worth expanding.
   int32_t min_goal_cost_ = std::numeric_limits<int32_t>::max();
   llvm::SmallVector<int32_t> current_layer_;
-  // The states in the layer currently being built, named by their index in
-  // `nodes_` and keyed on the state itself, so that reaching a state already in
-  // the layer merges into it. Kept across layers only to reuse its allocation.
-  Set<int32_t, /*SmallSize=*/0, LayerDedupKeyContext> layer_dedup_;
+  // The states in the layer currently being built, keyed on the state itself so
+  // that reaching a state already in the layer merges into it, and giving that
+  // state's index in `nodes_`. Kept across layers only to reuse its allocation.
+  Map<StateKey, int32_t> layer_dedup_;
+  // The open-bracket stacks every state in `nodes_` refers to.
+  OpenStackStore stacks_;
 };
 
 }  // namespace
 
 auto RegionSearch::AddToLayer(llvm::SmallVectorImpl<int32_t>& layer,
-                              int32_t next_item_idx,
-                              llvm::SmallVector<OpenBracketInfo, 4> next_stack,
+                              int32_t next_item_idx, OpenStackId next_stack,
                               Kind closer_inserted, int32_t next_cost,
                               ParentEdge edge,
                               llvm::SmallVectorImpl<int32_t>* worklist)
@@ -1868,22 +2023,21 @@ auto RegionSearch::AddToLayer(llvm::SmallVectorImpl<int32_t>& layer,
   if (next_cost > min_goal_cost_) {
     return;
   }
-  LayerDedupKeyContext key_context(&nodes_);
   StateKey key = {.stack = next_stack, .closer_inserted = closer_inserted};
-  if (auto existing = layer_dedup_.Lookup(key, key_context)) {
-    MergeIntoNode(existing.key(), next_cost, edge, worklist);
+  if (int32_t* existing = layer_dedup_[key]) {
+    MergeIntoNode(*existing, next_cost, edge, worklist);
     return;
   }
   auto new_idx = static_cast<int32_t>(nodes_.size());
   nodes_.push_back(BeamNode{
       .item_index = next_item_idx,
-      .stack = std::move(next_stack),
+      .stack = next_stack,
       .cost = next_cost,
       .closer_inserted = closer_inserted,
       .parent_edges = {edge},
   });
   layer.push_back(new_idx);
-  layer_dedup_.Insert(new_idx, key_context);
+  layer_dedup_.Insert(key, new_idx);
   if (worklist) {
     worklist->push_back(new_idx);
   }
@@ -1922,7 +2076,10 @@ auto RegionSearch::InsertBracketsBefore(int32_t item_idx) -> void {
   // Seed the dedup table with the states already in the layer, so that an
   // insertion reaching one of them merges into it instead of duplicating it.
   for (int32_t idx : current_layer_) {
-    layer_dedup_.Insert(idx, LayerDedupKeyContext(&nodes_));
+    layer_dedup_.Insert(
+        StateKey{.stack = nodes_[idx].stack,
+                 .closer_inserted = nodes_[idx].closer_inserted},
+        idx);
   }
   InsertSyntheticClosers(item_idx);
   InsertSyntheticOpeners(item_idx);
@@ -1937,10 +2094,10 @@ auto RegionSearch::InsertSyntheticClosers(int32_t item_idx) -> void {
   llvm::SmallVector<int32_t> worklist = current_layer_;
   for (size_t head = 0; head < worklist.size(); ++head) {
     const SearchState current = Snapshot(nodes_[worklist[head]]);
-    if (current.cost > min_goal_cost_ || current.stack.empty()) {
+    if (current.cost > min_goal_cost_ || stacks_.IsEmpty(current.stack)) {
       continue;
     }
-    const auto& top = current.stack.back();
+    const auto& top = stacks_.Top(current.stack);
     // Synthetic openers exist only to consume real closers; closing one
     // synthetically would insert a pointless empty pair.
     if (top.is_synthetic) {
@@ -1951,17 +2108,17 @@ auto RegionSearch::InsertSyntheticClosers(int32_t item_idx) -> void {
       continue;
     }
     llvm::StringLiteral rule_name = "";
-    auto cost = ClassifyCloserInsertion(top, item, current.stack, rule_name);
+    auto cost =
+        ClassifyCloserInsertion(top, item, stacks_, current.stack, rule_name);
     if (!cost) {
       continue;
     }
 
-    auto next_stack = current.stack;
-    auto popped = next_stack.pop_back_val();
+    const OpenBracketInfo& popped = top;
+    OpenStackId next_stack = stacks_.Pop(current.stack);
     auto closer_kind = MatchingClosingKind(popped.kind);
     AddToLayer(
-        current_layer_, item_idx, std::move(next_stack), closer_kind,
-        current.cost + *cost,
+        current_layer_, item_idx, next_stack, closer_kind, current.cost + *cost,
         ParentEdge{
             .parent_node_index = worklist[head],
             .correction =
@@ -1988,7 +2145,8 @@ auto RegionSearch::InsertSyntheticOpeners(int32_t item_idx) -> void {
     int32_t node_idx = current_layer_[idx];
     const SearchState current = Snapshot(nodes_[node_idx]);
     if (current.cost > min_goal_cost_ ||
-        current.stack.size() >= MaxSearchStackDepth) {
+        static_cast<size_t>(stacks_.Depth(current.stack)) >=
+            MaxSearchStackDepth) {
       continue;
     }
     for (auto [open_kind, is_struct_brace] : SyntheticOpeners) {
@@ -1998,21 +2156,22 @@ auto RegionSearch::InsertSyntheticOpeners(int32_t item_idx) -> void {
       if (!cost) {
         continue;
       }
-      auto next_stack = current.stack;
-      next_stack.push_back(OpenBracketInfo{
-          OpenBracketKey{
-              .insertion_token_index = item.token.token_index,
-              .line = item.token.line,
-              .line_indent = item.token.line_indent,
-              .effective_header_indent = item.effective_header_indent,
-              .kind = open_kind,
-              .is_synthetic = true,
-              .is_struct_brace = is_struct_brace,
-          },
-          rule_name,
-      });
-      AddToLayer(current_layer_, item_idx, std::move(next_stack),
-                 current.closer_inserted, current.cost + *cost,
+      OpenStackId next_stack = stacks_.Push(
+          current.stack,
+          OpenBracketInfo{
+              OpenBracketKey{
+                  .insertion_token_index = item.token.token_index,
+                  .line = item.token.line,
+                  .line_indent = item.token.line_indent,
+                  .effective_header_indent = item.effective_header_indent,
+                  .kind = open_kind,
+                  .is_synthetic = true,
+                  .is_struct_brace = is_struct_brace,
+              },
+              rule_name,
+          });
+      AddToLayer(current_layer_, item_idx, next_stack, current.closer_inserted,
+                 current.cost + *cost,
                  ParentEdge{.parent_node_index = node_idx});
     }
   }
@@ -2039,10 +2198,10 @@ auto RegionSearch::AdvanceNode(int32_t node_idx, int32_t item_idx,
   const Item& item = items_[item_idx];
   auto kind = item.token.kind;
 
-  auto advance = [&](llvm::SmallVector<OpenBracketInfo, 4> next_stack,
-                     int32_t add_cost, BracketCorrection correction = {},
+  auto advance = [&](OpenStackId next_stack, int32_t add_cost,
+                     BracketCorrection correction = {},
                      bool has_correction = false) {
-    AddToLayer(next_layer, item_idx + 1, std::move(next_stack), Kind::Other,
+    AddToLayer(next_layer, item_idx + 1, next_stack, Kind::Other,
                current.cost + add_cost,
                ParentEdge{.parent_node_index = node_idx,
                           .correction = correction,
@@ -2051,7 +2210,7 @@ auto RegionSearch::AdvanceNode(int32_t node_idx, int32_t item_idx,
 
   // What it costs to advance over this item in this state, per the
   // `AdvanceRules` table.
-  int32_t penalty = AdvancePenalty(current, item);
+  int32_t penalty = AdvancePenalty(stacks_, current, item);
 
   if (item.HasAll(Cue::CollapsedBlock)) {
     advance(current.stack, penalty);
@@ -2060,10 +2219,9 @@ auto RegionSearch::AdvanceNode(int32_t node_idx, int32_t item_idx,
 
   if (IsOpeningBracket(kind)) {
     // Advance, pushing the opener onto the stack.
-    if (current.stack.size() < MaxSearchStackDepth) {
-      auto next_stack = current.stack;
-      next_stack.push_back(RealOpener(item));
-      advance(std::move(next_stack), penalty);
+    if (static_cast<size_t>(stacks_.Depth(current.stack)) <
+        MaxSearchStackDepth) {
+      advance(stacks_.Push(current.stack, RealOpener(item)), penalty);
     }
     // Advance without pushing: replace the unmatched opener with an error
     // token.
@@ -2077,14 +2235,13 @@ auto RegionSearch::AdvanceNode(int32_t node_idx, int32_t item_idx,
 
   if (IsClosingBracket(kind)) {
     // Advance, popping the opener this closer matches.
-    if (!current.stack.empty() &&
-        current.stack.back().kind == MatchingOpeningKind(kind)) {
-      if (auto match_cost = MatchClosePenalty(current.stack.back(), item)) {
-        auto next_stack = current.stack;
-        auto popped = next_stack.pop_back_val();
+    if (!stacks_.IsEmpty(current.stack) &&
+        stacks_.Top(current.stack).kind == MatchingOpeningKind(kind)) {
+      const OpenBracketInfo& popped = stacks_.Top(current.stack);
+      if (auto match_cost = MatchClosePenalty(popped, item)) {
         // Matching a synthetic opener finally pins down where it goes, so this
         // is where it becomes a correction.
-        advance(std::move(next_stack), penalty + *match_cost,
+        advance(stacks_.Pop(current.stack), penalty + *match_cost,
                 popped.is_synthetic ? InsertOpenerCorrection(popped, item.token)
                                     : BracketCorrection{},
                 popped.is_synthetic);
@@ -2113,20 +2270,20 @@ auto RegionSearch::CloseAtRegionEnd() -> llvm::SmallVector<int32_t> {
     }
     // A synthetic opener that never matched a real closer is a meaningless
     // insertion; reject such states rather than dropping it silently.
-    if (llvm::any_of(current.stack, [](const OpenBracketInfo& open) {
-          return open.is_synthetic;
-        })) {
+    if (stacks_.HasSynthetic(current.stack)) {
       continue;
     }
     // Close what's left innermost-first, one node per closer, so that each is
     // reconstructed as its own correction.
     int32_t finish_cost = current.cost;
     int32_t parent = node_idx;
-    for (const auto& open : llvm::reverse(current.stack)) {
+    for (OpenStackId open_stack = current.stack; !stacks_.IsEmpty(open_stack);
+         open_stack = stacks_.Pop(open_stack)) {
+      const OpenBracketInfo& open = stacks_.Top(open_stack);
       finish_cost += CostToCloseAtEnd(open);
       nodes_.push_back(BeamNode{
           .item_index = static_cast<int32_t>(items_.size()),
-          .stack = {},
+          .stack = EmptyOpenStack,
           .cost = finish_cost,
           .parent_edges = {{
               .parent_node_index = parent,
@@ -2161,7 +2318,7 @@ auto RegionSearch::Solve(llvm::SmallVectorImpl<BracketCorrection>& corrections)
     -> void {
   nodes_.push_back(BeamNode{
       .item_index = 0,
-      .stack = {},
+      .stack = EmptyOpenStack,
       .cost = 0,
       .parent_edges = {},
   });
@@ -2291,7 +2448,7 @@ struct TokenAnalysis {
   llvm::SmallVector<int32_t> match_partner;
   Segments segments;
   UnmatchedGroupBrackets unmatched;
-  // See `ComputeAssociatedLineIndent`.
+  // See `ComputeAssociatedLineIndents`.
   llvm::SmallVector<int32_t> effective_header_indent;
   llvm::BitVector is_first_on_line;
   // See `ComputeFollowsStatementHeader` and `ComputeHeaderHasOpenCurlyBrace`.
@@ -2354,14 +2511,13 @@ static auto AnalyzeTokens(llvm::ArrayRef<MismatchedBracketToken> tokens)
   auto segments = ComputeSegments(tokens);
   auto unmatched = FindUnmatchedGroupBrackets(tokens, match_partner);
 
-  llvm::SmallVector<int32_t> effective_header_indent(num_tokens, 0);
+  auto effective_header_indent =
+      ComputeAssociatedLineIndents(tokens, match_partner);
   llvm::BitVector is_first_on_line(num_tokens);
   llvm::BitVector follows_statement_header(num_tokens);
   llvm::BitVector header_has_open_curly_brace(num_tokens);
   for (int32_t i : llvm::seq(0, num_tokens)) {
     is_first_on_line[i] = (i == 0 || tokens[i].line != tokens[i - 1].line);
-    effective_header_indent[i] =
-        ComputeAssociatedLineIndent(tokens, match_partner, i);
     follows_statement_header[i] =
         ComputeFollowsStatementHeader(tokens, match_partner, i);
     if (follows_statement_header[i]) {

--- a/toolchain/lex/mismatched_brackets.cpp
+++ b/toolchain/lex/mismatched_brackets.cpp
@@ -309,16 +309,10 @@ struct OpenStackCellKey {
 
   friend auto operator==(const OpenStackCellKey& lhs,
                          const OpenStackCellKey& rhs) -> bool = default;
-
-  friend auto CarbonHashValue(const OpenStackCellKey& key, uint64_t seed)
-      -> HashCode {
-    static_assert(std::has_unique_object_representations_v<OpenStackCellKey>,
-                  "Padding would leave indeterminate bytes for hashing.");
-    Hasher hasher(seed);
-    hasher.HashRaw(key);
-    return static_cast<HashCode>(hasher);
-  }
 };
+
+static_assert(std::has_unique_object_representations_v<OpenStackCellKey>,
+              "Padding would leave indeterminate bytes for hashing.");
 
 // Holds the open-bracket stacks the search reaches.
 //
@@ -480,13 +474,16 @@ static auto GetOuterStatementIntroducerIndent(
 // token it stepped on, or of the enclosing statement introducer if it reaches
 // one.
 //
-// Every step of that walk depends only on the token it is standing on, so the
-// walks from all the tokens share their tails and can be solved in one pass.
-// `walk_result[j]` is what the walk starting at token `j` answers, or
-// `NeedsCaller` when the walk stops before it steps on anything, in which case
-// the answer is the caller's own indentation. Each entry depends only on
-// entries below it, so a single forward pass fills the table, and the answer
-// for token `i` reads the entry for `i - 1`.
+// Performing a separate walk from every token would be quadratic, so dynamic
+// programming is used to compute all of the walks in one pass. Every step of a
+// walk depends only on the token it is standing on, so the walk from token `j`
+// is one step followed by the walk from some earlier token, and its result can
+// be computed from a table of the earlier walks' results: `walk_result[j]`
+// holds the result of the walk starting at token `j`, or `NeedsCaller` when
+// that walk stops before it steps on anything, in which case the result is the
+// caller's own indentation. Each entry depends only on entries at lower
+// indices, so a single forward pass fills the table, and the answer for token
+// `i` is read from the entry for `i - 1`.
 static auto ComputeAssociatedLineIndents(
     llvm::ArrayRef<MismatchedBracketToken> tokens,
     llvm::ArrayRef<int32_t> match_partner) -> llvm::SmallVector<int32_t> {
@@ -1711,15 +1708,17 @@ static auto EnumerateOptimalPaths(llvm::ArrayRef<BeamNode> nodes,
 }
 
 // Finds which of the first optimal path's corrections the optimal repairs
-// disagree about. Each of its corrections must be answered by one making the
-// same repair, named by `repair_key`, in every other path; one with no
-// counterpart in some path is tied.
+// disagree about, treating the first path as the baseline. Two corrections
+// make the same repair when `repair_key` gives them the same key. A baseline
+// correction is agreed upon when every other path contains a counterpart
+// correction making the same repair; if some path has no counterpart for it,
+// it is marked as tied.
 //
-// Repairs are matched by key rather than pairwise, which works because making
-// the same repair is an equivalence relation: the baseline's `n`th correction
-// with a given key is answered by a path exactly when that path has at least
-// `n` corrections with that key. So all that matters is, for each key the
-// baseline uses, the fewest corrections any path has with it.
+// Counterparts are found by counting corrections per key rather than by
+// pairing corrections up individually: the baseline's `n`th correction with a
+// given key has a counterpart in another path exactly when that path has at
+// least `n` corrections with that key. So it suffices to know, for each key
+// the baseline uses, the fewest corrections any path makes with that key.
 static auto FindTiedCorrections(
     llvm::ArrayRef<llvm::SmallVector<BracketCorrection>> all_paths,
     llvm::function_ref<uint64_t(const BracketCorrection&)> repair_key)

--- a/toolchain/lex/mismatched_brackets_benchmark.cpp
+++ b/toolchain/lex/mismatched_brackets_benchmark.cpp
@@ -4,11 +4,14 @@
 
 #include <benchmark/benchmark.h>
 
-#include <random>
+#include <algorithm>
+#include <memory>
 #include <string>
 #include <utility>
 
+#include "absl/random/random.h"
 #include "common/check.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -93,22 +96,7 @@ class SourceBuilder {
   bool at_line_start_ = true;
 };
 
-// A deterministic generator, so that a benchmark measures the same input on
-// every run and across builds.
-class Rng {
- public:
-  explicit Rng(uint64_t seed) : gen_(seed) {}
-
-  // A number in [0, bound).
-  auto Next(int bound) -> int {
-    return static_cast<int>(gen_() % static_cast<uint64_t>(bound));
-  }
-
- private:
-  std::mt19937_64 gen_;
-};
-
-// The bracket kinds a nesting pattern picks from.
+// The bracket kinds a nesting pattern cycles through.
 constexpr Kind OpenKinds[] = {Kind::OpenParen, Kind::OpenSquareBracket,
                               Kind::OpenCurlyBrace};
 
@@ -178,13 +166,12 @@ enum class NestDamage : uint8_t { None, Innermost, Alternating };
 
 static auto DeepNest(int n, NestDamage damage)
     -> llvm::SmallVector<MismatchedBracketToken> {
-  Rng rng(n);
   SourceBuilder builder;
   AddDeclHeader(builder);
 
   llvm::SmallVector<Kind> open_kinds;
   for (int i = 0; i < n; ++i) {
-    Kind open = OpenKinds[rng.Next(std::size(OpenKinds))];
+    Kind open = OpenKinds[i % std::size(OpenKinds)];
     open_kinds.push_back(open);
     builder.EndLine(IndentWidth * (i + 1)).AddAll({Kind::Leaf, open});
   }
@@ -337,26 +324,15 @@ BENCHMARK(BM_RegionSizeCliff)->RangeMultiplier(2)->Range(128, 2048);
 
 // The benchmarks below run whole generated source files through the lexer, so
 // they measure recovery in the place it actually runs, against source shaped
-// like real Carbon code. Each damaged variant has an undamaged counterpart, and
-// the difference between the two is what recovery costs.
+// like real Carbon code. They are modeled on the compile benchmarks, but where
+// those sweep the phases of compilation, these sweep damage strategies applied
+// to the generated source, including no damage at all: the difference between
+// a damaged variant and the undamaged control is what recovery costs.
 //
 // Note that `SourceGen` seeds itself from entropy, so while the size and shape
-// of the generated file are stable from run to run, its exact contents are not,
-// and neither is which declaration the damage below lands in. Treat a single
-// run of these as approximate; the benchmarks above are the reproducible ones.
-
-// How many lines of generated source each of these benchmarks works on. Big
-// enough to hold many declarations, small enough to keep the suite quick.
-constexpr int TargetSourceLines = 2000;
-
-// The representative source these benchmarks damage. Generated once, since
-// generation is far more expensive than lexing it.
-static auto RepresentativeSource() -> llvm::StringRef {
-  static const auto* source =
-      new std::string(Testing::SourceGen::Global().GenApiFileDenseDecls(
-          TargetSourceLines, Testing::SourceGen::DenseDeclParams{}));
-  return *source;
-}
+// of the generated files are stable from run to run, their exact contents are
+// not, and neither is where the damage below lands. Treat a single run of these
+// as approximate; the benchmarks above are the reproducible ones.
 
 // The byte offsets of every bracket in `text`. Brackets inside comments are
 // included, which is fine: the generated comments contain none.
@@ -390,13 +366,13 @@ static auto DeleteOffsets(llvm::StringRef text, llvm::ArrayRef<size_t> offsets)
 static auto DeleteBrackets(llvm::StringRef text, int one_in) -> std::string {
   auto offsets = BracketOffsets(text);
   CARBON_CHECK(!offsets.empty(), "Generated source has no brackets.");
-  Rng rng(one_in);
+  absl::BitGen rng;
 
   llvm::SmallVector<size_t> deleted;
   int count = std::max<int>(1, offsets.size() / one_in);
   llvm::SmallVector<size_t> remaining = offsets;
   for (int i = 0; i < count && !remaining.empty(); ++i) {
-    int pick = rng.Next(remaining.size());
+    int pick = absl::Uniform<int>(rng, 0, remaining.size());
     deleted.push_back(remaining[pick]);
     remaining.erase(remaining.begin() + pick);
   }
@@ -429,7 +405,7 @@ static auto SplitIntoHunks(llvm::StringRef text)
 // closers that would end it are not.
 static auto TruncateHunks(llvm::StringRef text, int one_in) -> std::string {
   auto hunks = SplitIntoHunks(text);
-  Rng rng(one_in);
+  absl::BitGen rng;
 
   // The hunks with a line that could be truncated at.
   llvm::SmallVector<size_t> candidates;
@@ -444,7 +420,7 @@ static auto TruncateHunks(llvm::StringRef text, int one_in) -> std::string {
 
   int count = std::max<int>(1, candidates.size() / one_in);
   for (int i = 0; i < count && !candidates.empty(); ++i) {
-    int pick = rng.Next(candidates.size());
+    int pick = absl::Uniform<int>(rng, 0, candidates.size());
     auto& hunk = hunks[candidates[pick]];
     candidates.erase(candidates.begin() + pick);
 
@@ -454,7 +430,8 @@ static auto TruncateHunks(llvm::StringRef text, int one_in) -> std::string {
         closing_lines.push_back(index);
       }
     }
-    hunk.resize(closing_lines[rng.Next(closing_lines.size())]);
+    hunk.resize(
+        closing_lines[absl::Uniform<int>(rng, 0, closing_lines.size())]);
   }
 
   llvm::SmallVector<llvm::StringRef> lines;
@@ -481,8 +458,6 @@ class LexBenchHelper {
     return Lex::Lex(value_stores_, *source_, options);
   }
 
-  auto text() const -> llvm::StringRef { return text_; }
-
  private:
   std::string text_;
   SharedValueStores value_stores_;
@@ -491,46 +466,119 @@ class LexBenchHelper {
   std::optional<SourceBuffer> source_;
 };
 
-// Lexes `text` end to end, reporting throughput against its size.
-static auto RunLexBenchmark(benchmark::State& state, std::string text) -> void {
-  LexBenchHelper helper(std::move(text));
-  for (auto _ : state) {
-    TokenizedBuffer buffer = helper.Lex();
-    benchmark::DoNotOptimize(buffer);
+// The damage strategies the whole-file benchmarks sweep. `None` is the
+// control: recovery never runs, so it measures the lexer alone.
+enum class Damage : uint8_t {
+  None,
+  OneBracketDeleted,
+  EighthOfBracketsDeleted,
+  OneHunkTruncated,
+  EighthOfHunksTruncated,
+};
+
+// Applies `damage` to `text`.
+static auto ApplyDamage(std::string text, Damage damage) -> std::string {
+  switch (damage) {
+    case Damage::None:
+      return text;
+    case Damage::OneBracketDeleted:
+      return DeleteBrackets(text, BracketOffsets(text).size());
+    case Damage::EighthOfBracketsDeleted:
+      return DeleteBrackets(text, 8);
+    case Damage::OneHunkTruncated:
+      return TruncateHunks(text, SplitIntoHunks(text).size());
+    case Damage::EighthOfHunksTruncated:
+      return TruncateHunks(text, 8);
   }
-  state.SetBytesProcessed(state.iterations() * helper.text().size());
-  state.counters["lines_per_second"] = benchmark::Counter(
-      helper.text().count('\n'), benchmark::Counter::kIsIterationInvariantRate);
 }
 
-// The control for every damaged variant below: the same source, undamaged, so
-// recovery never runs.
-auto BM_LexRepresentativeSource(benchmark::State& state) -> void {
-  RunLexBenchmark(state, RepresentativeSource().str());
+// Benchmark on multiple files of the same size but with different source code
+// in order to avoid branch prediction perfectly learning a particular file's
+// structure and shape, and to average over where the random damage lands. We
+// enforce an upper bound to avoid excessive benchmark time and a lower bound to
+// avoid anchoring on a single source file that may have unrepresentative
+// content.
+//
+// For simplicity, we compute a number of files from the target line count as a
+// heuristic, clamped to the range below.
+static auto ComputeFileCount(int target_lines) -> int {
+  constexpr int MinFiles = 8;
+  [[maybe_unused]] constexpr int MaxFiles = 128;
+  int file_count = (1024 * 1024) / target_lines;
+#ifndef NDEBUG
+  // Use a smaller number of files in debug builds where lexing is slower,
+  // capping at the release-mode minimum.
+  return std::max(1, std::min(MinFiles, file_count));
+#else
+  return std::max(MinFiles, std::min(MaxFiles, file_count));
+#endif
 }
-BENCHMARK(BM_LexRepresentativeSource);
 
-auto BM_LexOneBracketDeleted(benchmark::State& state) -> void {
-  llvm::StringRef text = RepresentativeSource();
-  RunLexBenchmark(state, DeleteBrackets(text, BracketOffsets(text).size()));
-}
-BENCHMARK(BM_LexOneBracketDeleted);
+// Lexes a batch of generated API files of `state.range(0)` target lines each,
+// damaged according to `D`.
+template <Damage D>
+static auto BM_LexApiFileDenseDecls(benchmark::State& state) -> void {
+  Testing::SourceGen gen;
 
-auto BM_LexEighthOfBracketsDeleted(benchmark::State& state) -> void {
-  RunLexBenchmark(state, DeleteBrackets(RepresentativeSource(), 8));
-}
-BENCHMARK(BM_LexEighthOfBracketsDeleted);
+  int target_lines = state.range(0);
+  int num_files = ComputeFileCount(target_lines);
 
-auto BM_LexOneHunkTruncated(benchmark::State& state) -> void {
-  llvm::StringRef text = RepresentativeSource();
-  RunLexBenchmark(state, TruncateHunks(text, SplitIntoHunks(text).size()));
-}
-BENCHMARK(BM_LexOneHunkTruncated);
+  llvm::SmallVector<std::unique_ptr<LexBenchHelper>> helpers;
+  helpers.reserve(num_files);
 
-auto BM_LexEighthOfHunksTruncated(benchmark::State& state) -> void {
-  RunLexBenchmark(state, TruncateHunks(RepresentativeSource(), 8));
+  double total_bytes = 0.0;
+  double total_lines = 0.0;
+  for ([[maybe_unused]] auto _ : llvm::seq(num_files)) {
+    std::string source =
+        ApplyDamage(gen.GenApiFileDenseDecls(
+                        target_lines, Testing::SourceGen::DenseDeclParams{}),
+                    D);
+    total_bytes += source.size();
+    total_lines += llvm::count(source, '\n');
+    helpers.push_back(std::make_unique<LexBenchHelper>(std::move(source)));
+  }
+
+  state.counters["Bytes"] = benchmark::Counter(
+      total_bytes / num_files, benchmark::Counter::kIsIterationInvariantRate);
+  state.counters["Lines"] = benchmark::Counter(
+      total_lines / num_files, benchmark::Counter::kIsIterationInvariantRate);
+
+  // We benchmark in batches of files to avoid benchmarking any peculiarities of
+  // a single file.
+  while (state.KeepRunningBatch(num_files)) {
+    for (ssize_t i = 0; i < num_files;) {
+      // We block optimizing `i` as that has proven both more effective at
+      // blocking the loop from being optimized away and avoiding disruption of
+      // the generated code that we're benchmarking.
+      benchmark::DoNotOptimize(i);
+
+      TokenizedBuffer buffer = helpers[i]->Lex();
+
+      // We use the lex result to step through the files, establishing a
+      // dependency between each lex and the next. This doesn't fully allow us
+      // to measure latency rather than throughput, but minimizes any skew in
+      // measurements from speculating the start of the next lex.
+      i += static_cast<ssize_t>(buffer.size() != 0);
+    }
+  }
 }
-BENCHMARK(BM_LexEighthOfHunksTruncated);
+
+// Applies the shared range configuration used by every whole-file benchmark:
+// 256-line test cases through 256k-line test cases, matching the compile
+// benchmarks.
+static auto ConfigureLexBenchmark(benchmark::Benchmark* b) -> void {
+  b->RangeMultiplier(4)->Range(256, static_cast<int64_t>(256 * 1024));
+}
+
+BENCHMARK(BM_LexApiFileDenseDecls<Damage::None>)->Apply(ConfigureLexBenchmark);
+BENCHMARK(BM_LexApiFileDenseDecls<Damage::OneBracketDeleted>)
+    ->Apply(ConfigureLexBenchmark);
+BENCHMARK(BM_LexApiFileDenseDecls<Damage::EighthOfBracketsDeleted>)
+    ->Apply(ConfigureLexBenchmark);
+BENCHMARK(BM_LexApiFileDenseDecls<Damage::OneHunkTruncated>)
+    ->Apply(ConfigureLexBenchmark);
+BENCHMARK(BM_LexApiFileDenseDecls<Damage::EighthOfHunksTruncated>)
+    ->Apply(ConfigureLexBenchmark);
 
 }  // namespace
 }  // namespace Carbon::Lex

--- a/toolchain/lex/mismatched_brackets_benchmark.cpp
+++ b/toolchain/lex/mismatched_brackets_benchmark.cpp
@@ -339,6 +339,11 @@ BENCHMARK(BM_RegionSizeCliff)->RangeMultiplier(2)->Range(128, 2048);
 // they measure recovery in the place it actually runs, against source shaped
 // like real Carbon code. Each damaged variant has an undamaged counterpart, and
 // the difference between the two is what recovery costs.
+//
+// Note that `SourceGen` seeds itself from entropy, so while the size and shape
+// of the generated file are stable from run to run, its exact contents are not,
+// and neither is which declaration the damage below lands in. Treat a single
+// run of these as approximate; the benchmarks above are the reproducible ones.
 
 // How many lines of generated source each of these benchmarks works on. Big
 // enough to hold many declarations, small enough to keep the suite quick.

--- a/toolchain/lex/mismatched_brackets_benchmark.cpp
+++ b/toolchain/lex/mismatched_brackets_benchmark.cpp
@@ -1,0 +1,531 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <benchmark/benchmark.h>
+
+#include <random>
+#include <string>
+#include <utility>
+
+#include "common/check.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "toolchain/base/shared_value_stores.h"
+#include "toolchain/benchmarking/source_gen.h"
+#include "toolchain/diagnostics/emitter.h"
+#include "toolchain/diagnostics/null_diagnostics.h"
+#include "toolchain/lex/lex.h"
+#include "toolchain/lex/mismatched_brackets.h"
+#include "toolchain/lex/tokenized_buffer.h"
+#include "toolchain/source/source_buffer.h"
+
+namespace Carbon::Lex {
+namespace {
+
+using Kind = BracketTokenKind;
+
+// How many columns each level of nesting indents by, matching the toolchain's
+// own style.
+constexpr int32_t IndentWidth = 2;
+
+// Builds a token sequence to hand to `FixMismatchedBrackets`, tracking lines
+// and indentation the way formatted source would, since the cost model reads
+// both. Tokens are added to the current line until `EndLine` starts a new one.
+class SourceBuilder {
+ public:
+  // Appends a token to the current line. Everything but a closing bracket,
+  // `,`, `;`, and `.` is written with a space before it, as formatted code
+  // would.
+  auto Add(Kind kind) -> SourceBuilder& {
+    bool spaced = !tokens_.empty() && !IsClosingBracket(kind) &&
+                  kind != Kind::Comma && kind != Kind::Semi &&
+                  kind != Kind::Period;
+    tokens_.push_back({
+        .token_index = TokenIndex(static_cast<int32_t>(tokens_.size())),
+        .kind = kind,
+        .line = line_,
+        .line_indent = indent_,
+        .has_leading_space = spaced && !at_line_start_,
+    });
+    at_line_start_ = false;
+    return *this;
+  }
+
+  // Adds each of `kinds` to the current line.
+  auto AddAll(std::initializer_list<Kind> kinds) -> SourceBuilder& {
+    for (Kind kind : kinds) {
+      Add(kind);
+    }
+    return *this;
+  }
+
+  // Ends the current line, and indents the next one by `indent` columns.
+  auto EndLine(int32_t indent) -> SourceBuilder& {
+    if (!tokens_.empty()) {
+      tokens_.back().is_at_end_of_line = true;
+    }
+    ++line_;
+    indent_ = indent;
+    at_line_start_ = true;
+    return *this;
+  }
+
+  // Ends the current line, keeping the same indentation.
+  auto EndLine() -> SourceBuilder& { return EndLine(indent_); }
+
+  // Terminates the sequence with the `FileEnd` token the algorithm expects.
+  auto Finish() -> llvm::SmallVector<MismatchedBracketToken> {
+    EndLine(0).Add(Kind::FileEnd);
+    tokens_.back().is_at_end_of_line = true;
+    return std::move(tokens_);
+  }
+
+  auto indent() const -> int32_t { return indent_; }
+
+ private:
+  llvm::SmallVector<MismatchedBracketToken> tokens_;
+  int32_t line_ = 1;
+  int32_t indent_ = 0;
+  bool at_line_start_ = true;
+};
+
+// A deterministic generator, so that a benchmark measures the same input on
+// every run and across builds.
+class Rng {
+ public:
+  explicit Rng(uint64_t seed) : gen_(seed) {}
+
+  // A number in [0, bound).
+  auto Next(int bound) -> int {
+    return static_cast<int>(gen_() % static_cast<uint64_t>(bound));
+  }
+
+ private:
+  std::mt19937_64 gen_;
+};
+
+// The bracket kinds a nesting pattern picks from.
+constexpr Kind OpenKinds[] = {Kind::OpenParen, Kind::OpenSquareBracket,
+                              Kind::OpenCurlyBrace};
+
+// Opens a top-level declaration: `fn Name(...) {` at column 0, which is where
+// `FindRegionBoundaries` cuts one region from the next.
+static auto AddDeclHeader(SourceBuilder& builder) -> void {
+  builder.AddAll({Kind::StatementIntroducer, Kind::Leaf, Kind::OpenParen,
+                  Kind::CloseParen, Kind::OpenCurlyBrace});
+}
+
+// `n` unmatched opening parens, one per line, each indenting further, as an
+// unfinished call chain would.
+static auto UnclosedOpeners(int n)
+    -> llvm::SmallVector<MismatchedBracketToken> {
+  SourceBuilder builder;
+  AddDeclHeader(builder);
+  for (int i = 0; i < n; ++i) {
+    builder.EndLine(IndentWidth * (i + 1))
+        .AddAll({Kind::Leaf, Kind::OpenParen});
+  }
+  return builder.Finish();
+}
+
+// `n` closing parens with nothing to close.
+static auto UnmatchedClosers(int n)
+    -> llvm::SmallVector<MismatchedBracketToken> {
+  SourceBuilder builder;
+  AddDeclHeader(builder);
+  builder.EndLine(IndentWidth);
+  for (int i = 0; i < n; ++i) {
+    builder.AddAll({Kind::Leaf, Kind::CloseParen});
+  }
+  return builder.Finish();
+}
+
+// `n` balanced statements, then one whose opening paren is never closed, then
+// `n` more balanced statements: the missing bracket is surrounded by correct
+// code on both sides.
+static auto BalancedRunWithGap(int n)
+    -> llvm::SmallVector<MismatchedBracketToken> {
+  SourceBuilder builder;
+  AddDeclHeader(builder);
+  auto add_call = [&](bool closed) {
+    builder.EndLine(IndentWidth)
+        .AddAll(
+            {Kind::Leaf, Kind::OpenParen, Kind::Leaf, Kind::Comma, Kind::Leaf});
+    if (closed) {
+      builder.Add(Kind::CloseParen);
+    }
+    builder.Add(Kind::Semi);
+  };
+  for (int i = 0; i < n; ++i) {
+    add_call(/*closed=*/true);
+  }
+  add_call(/*closed=*/false);
+  for (int i = 0; i < n; ++i) {
+    add_call(/*closed=*/true);
+  }
+  builder.EndLine(0).Add(Kind::CloseCurlyBrace);
+  return builder.Finish();
+}
+
+// An `n`-deep nest of mixed bracket kinds with one line per level. `damage`
+// picks which levels have their closer omitted: none, only the innermost, or
+// every other level.
+enum class NestDamage : uint8_t { None, Innermost, Alternating };
+
+static auto DeepNest(int n, NestDamage damage)
+    -> llvm::SmallVector<MismatchedBracketToken> {
+  Rng rng(n);
+  SourceBuilder builder;
+  AddDeclHeader(builder);
+
+  llvm::SmallVector<Kind> open_kinds;
+  for (int i = 0; i < n; ++i) {
+    Kind open = OpenKinds[rng.Next(std::size(OpenKinds))];
+    open_kinds.push_back(open);
+    builder.EndLine(IndentWidth * (i + 1)).AddAll({Kind::Leaf, open});
+  }
+
+  for (int i = n - 1; i >= 0; --i) {
+    bool omit = damage == NestDamage::Alternating
+                    ? i % 2 == 1
+                    : damage == NestDamage::Innermost && i == n - 1;
+    builder.EndLine(IndentWidth * (i + 1));
+    if (omit) {
+      builder.Add(Kind::Leaf);
+    } else {
+      builder.Add(MatchingClosingKind(open_kinds[i]));
+    }
+  }
+
+  builder.EndLine(0).Add(Kind::CloseCurlyBrace);
+  return builder.Finish();
+}
+
+// `n` unmatched openers of the same kind in a row, every one of which is an
+// equally good place to insert the missing closer. This is what makes the
+// search find many optimal repairs, which it then has to compare against each
+// other to decide which corrections are tied.
+static auto ManyTiedRepairs(int n)
+    -> llvm::SmallVector<MismatchedBracketToken> {
+  SourceBuilder builder;
+  AddDeclHeader(builder);
+  builder.EndLine(IndentWidth);
+  for (int i = 0; i < n; ++i) {
+    builder.AddAll({Kind::OpenParen, Kind::Leaf});
+  }
+  return builder.Finish();
+}
+
+// `n` top-level declarations, each with one bracket missing, so that the search
+// runs once per region. Scaling here should be flat per declaration.
+static auto ManyDamagedRegions(int n)
+    -> llvm::SmallVector<MismatchedBracketToken> {
+  SourceBuilder builder;
+  for (int i = 0; i < n; ++i) {
+    AddDeclHeader(builder);
+    builder.EndLine(IndentWidth)
+        .AddAll({Kind::Leaf, Kind::OpenParen, Kind::Leaf, Kind::Semi});
+    builder.EndLine(0).Add(Kind::CloseCurlyBrace);
+    builder.EndLine(0);
+  }
+  return builder.Finish();
+}
+
+// Runs `FixMismatchedBrackets` over `tokens`, reporting throughput against the
+// input size so that a sweep shows how cost grows with it.
+static auto RunBenchmark(benchmark::State& state,
+                         llvm::ArrayRef<MismatchedBracketToken> tokens)
+    -> void {
+  for (auto _ : state) {
+    auto corrections = FixMismatchedBrackets(tokens);
+    benchmark::DoNotOptimize(corrections);
+  }
+  state.SetComplexityN(tokens.size());
+  state.counters["tokens_per_second"] = benchmark::Counter(
+      tokens.size(), benchmark::Counter::kIsIterationInvariantRate);
+}
+
+// A damaged region larger than `MaxRegionItemsForSearch` is handed to the naive
+// greedy fallback instead of the search, which is orders of magnitude cheaper.
+// The sweeps below stay under that threshold so that the reported complexity
+// describes the search rather than averaging the two; `BM_RegionSizeCliff`
+// covers the transition itself.
+//
+// Each pattern emits a couple of items per unit of `N`, so these bounds keep
+// the region well under the threshold.
+constexpr int MaxSweepN = 256;
+constexpr int MaxNestSweepN = 128;
+constexpr int MaxStatementSweepN = 64;
+
+auto BM_UnclosedOpeners(benchmark::State& state) -> void {
+  RunBenchmark(state, UnclosedOpeners(state.range(0)));
+}
+BENCHMARK(BM_UnclosedOpeners)
+    ->RangeMultiplier(2)
+    ->Range(2, MaxSweepN)
+    ->Complexity();
+
+auto BM_UnmatchedClosers(benchmark::State& state) -> void {
+  RunBenchmark(state, UnmatchedClosers(state.range(0)));
+}
+BENCHMARK(BM_UnmatchedClosers)
+    ->RangeMultiplier(2)
+    ->Range(2, MaxSweepN)
+    ->Complexity();
+
+auto BM_BalancedRunWithGap(benchmark::State& state) -> void {
+  RunBenchmark(state, BalancedRunWithGap(state.range(0)));
+}
+BENCHMARK(BM_BalancedRunWithGap)
+    ->RangeMultiplier(2)
+    ->Range(2, MaxStatementSweepN)
+    ->Complexity();
+
+// The control: nothing is damaged, so `RegionIsBalanced` skips the search and
+// only the up-front whole-file analysis is measured.
+auto BM_BalancedNest(benchmark::State& state) -> void {
+  RunBenchmark(state, DeepNest(state.range(0), NestDamage::None));
+}
+BENCHMARK(BM_BalancedNest)->RangeMultiplier(2)->Range(2, 1024)->Complexity();
+
+auto BM_NestInnermostMismatched(benchmark::State& state) -> void {
+  RunBenchmark(state, DeepNest(state.range(0), NestDamage::Innermost));
+}
+BENCHMARK(BM_NestInnermostMismatched)
+    ->RangeMultiplier(2)
+    ->Range(2, MaxNestSweepN)
+    ->Complexity();
+
+auto BM_NestAlternatingMismatched(benchmark::State& state) -> void {
+  RunBenchmark(state, DeepNest(state.range(0), NestDamage::Alternating));
+}
+BENCHMARK(BM_NestAlternatingMismatched)
+    ->RangeMultiplier(2)
+    ->Range(2, MaxNestSweepN)
+    ->Complexity();
+
+auto BM_ManyTiedRepairs(benchmark::State& state) -> void {
+  RunBenchmark(state, ManyTiedRepairs(state.range(0)));
+}
+BENCHMARK(BM_ManyTiedRepairs)
+    ->RangeMultiplier(2)
+    ->Range(2, MaxSweepN)
+    ->Complexity();
+
+// Damage spread across many small regions rather than concentrated in one, to
+// check that the per-region cost stays flat as a file grows.
+auto BM_ManyDamagedRegions(benchmark::State& state) -> void {
+  RunBenchmark(state, ManyDamagedRegions(state.range(0)));
+}
+BENCHMARK(BM_ManyDamagedRegions)
+    ->RangeMultiplier(2)
+    ->Range(2, 1024)
+    ->Complexity();
+
+// Sweeps one damaged region across `MaxRegionItemsForSearch`, where the search
+// gives way to the naive fallback. The cost climbs to the threshold and then
+// drops sharply, so this is the shape of the worst case: the most expensive
+// input is the largest region the search still accepts.
+auto BM_RegionSizeCliff(benchmark::State& state) -> void {
+  RunBenchmark(state, UnclosedOpeners(state.range(0)));
+}
+BENCHMARK(BM_RegionSizeCliff)->RangeMultiplier(2)->Range(128, 2048);
+
+// The benchmarks below run whole generated source files through the lexer, so
+// they measure recovery in the place it actually runs, against source shaped
+// like real Carbon code. Each damaged variant has an undamaged counterpart, and
+// the difference between the two is what recovery costs.
+
+// How many lines of generated source each of these benchmarks works on. Big
+// enough to hold many declarations, small enough to keep the suite quick.
+constexpr int TargetSourceLines = 2000;
+
+// The representative source these benchmarks damage. Generated once, since
+// generation is far more expensive than lexing it.
+static auto RepresentativeSource() -> llvm::StringRef {
+  static const auto* source =
+      new std::string(Testing::SourceGen::Global().GenApiFileDenseDecls(
+          TargetSourceLines, Testing::SourceGen::DenseDeclParams{}));
+  return *source;
+}
+
+// The byte offsets of every bracket in `text`. Brackets inside comments are
+// included, which is fine: the generated comments contain none.
+static auto BracketOffsets(llvm::StringRef text) -> llvm::SmallVector<size_t> {
+  llvm::SmallVector<size_t> offsets;
+  for (auto [offset, c] : llvm::enumerate(text)) {
+    if (llvm::StringRef("()[]{}").contains(c)) {
+      offsets.push_back(offset);
+    }
+  }
+  return offsets;
+}
+
+// Deletes the brackets at `offsets`, which must be sorted, closing up the text
+// so that nothing marks where they were.
+static auto DeleteOffsets(llvm::StringRef text, llvm::ArrayRef<size_t> offsets)
+    -> std::string {
+  std::string result;
+  result.reserve(text.size());
+  size_t prev = 0;
+  for (size_t offset : offsets) {
+    result.append(text.substr(prev, offset - prev));
+    prev = offset + 1;
+  }
+  result.append(text.substr(prev));
+  return result;
+}
+
+// Deletes one in every `one_in` brackets, chosen at random. With `one_in` equal
+// to the bracket count this deletes a single bracket.
+static auto DeleteBrackets(llvm::StringRef text, int one_in) -> std::string {
+  auto offsets = BracketOffsets(text);
+  CARBON_CHECK(!offsets.empty(), "Generated source has no brackets.");
+  Rng rng(one_in);
+
+  llvm::SmallVector<size_t> deleted;
+  int count = std::max<int>(1, offsets.size() / one_in);
+  llvm::SmallVector<size_t> remaining = offsets;
+  for (int i = 0; i < count && !remaining.empty(); ++i) {
+    int pick = rng.Next(remaining.size());
+    deleted.push_back(remaining[pick]);
+    remaining.erase(remaining.begin() + pick);
+  }
+  llvm::sort(deleted);
+  return DeleteOffsets(text, deleted);
+}
+
+// Splits `text` into the blank-line separated hunks a generated file falls into
+// naturally, returning each hunk's lines.
+static auto SplitIntoHunks(llvm::StringRef text)
+    -> llvm::SmallVector<llvm::SmallVector<llvm::StringRef>> {
+  llvm::SmallVector<llvm::StringRef> lines;
+  text.split(lines, '\n');
+
+  llvm::SmallVector<llvm::SmallVector<llvm::StringRef>> hunks;
+  hunks.emplace_back();
+  for (llvm::StringRef line : lines) {
+    if (line.trim().empty()) {
+      hunks.emplace_back();
+    } else {
+      hunks.back().push_back(line);
+    }
+  }
+  return hunks;
+}
+
+// Truncates one in every `one_in` hunks partway through, by dropping everything
+// from a random line that closes a bracket to the end of that hunk. This is
+// what a declaration still being typed looks like: the body is there, the
+// closers that would end it are not.
+static auto TruncateHunks(llvm::StringRef text, int one_in) -> std::string {
+  auto hunks = SplitIntoHunks(text);
+  Rng rng(one_in);
+
+  // The hunks with a line that could be truncated at.
+  llvm::SmallVector<size_t> candidates;
+  for (auto [index, hunk] : llvm::enumerate(hunks)) {
+    if (llvm::any_of(hunk, [](llvm::StringRef line) {
+          return line.contains(')') || line.contains('}') || line.contains(']');
+        })) {
+      candidates.push_back(index);
+    }
+  }
+  CARBON_CHECK(!candidates.empty(), "Generated source has no closing bracket.");
+
+  int count = std::max<int>(1, candidates.size() / one_in);
+  for (int i = 0; i < count && !candidates.empty(); ++i) {
+    int pick = rng.Next(candidates.size());
+    auto& hunk = hunks[candidates[pick]];
+    candidates.erase(candidates.begin() + pick);
+
+    llvm::SmallVector<size_t> closing_lines;
+    for (auto [index, line] : llvm::enumerate(hunk)) {
+      if (line.contains(')') || line.contains('}') || line.contains(']')) {
+        closing_lines.push_back(index);
+      }
+    }
+    hunk.resize(closing_lines[rng.Next(closing_lines.size())]);
+  }
+
+  llvm::SmallVector<llvm::StringRef> lines;
+  for (const auto& hunk : hunks) {
+    lines.append(hunk.begin(), hunk.end());
+    lines.push_back("");
+  }
+  return llvm::join(lines, "\n");
+}
+
+// Lexes a fixed source text, which is what recovery runs inside of.
+class LexBenchHelper {
+ public:
+  explicit LexBenchHelper(std::string text) : text_(std::move(text)) {
+    CARBON_CHECK(fs_.addFile(filename_, /*ModificationTime=*/0,
+                             llvm::MemoryBuffer::getMemBuffer(text_)));
+    source_ = SourceBuffer::MakeFromFile(fs_, filename_,
+                                         Diagnostics::ConsoleConsumer());
+  }
+
+  auto Lex() -> TokenizedBuffer {
+    Lex::LexOptions options;
+    options.consumer = &Diagnostics::NullConsumer();
+    return Lex::Lex(value_stores_, *source_, options);
+  }
+
+  auto text() const -> llvm::StringRef { return text_; }
+
+ private:
+  std::string text_;
+  SharedValueStores value_stores_;
+  llvm::vfs::InMemoryFileSystem fs_;
+  std::string filename_ = "benchmark.carbon";
+  std::optional<SourceBuffer> source_;
+};
+
+// Lexes `text` end to end, reporting throughput against its size.
+static auto RunLexBenchmark(benchmark::State& state, std::string text) -> void {
+  LexBenchHelper helper(std::move(text));
+  for (auto _ : state) {
+    TokenizedBuffer buffer = helper.Lex();
+    benchmark::DoNotOptimize(buffer);
+  }
+  state.SetBytesProcessed(state.iterations() * helper.text().size());
+  state.counters["lines_per_second"] = benchmark::Counter(
+      helper.text().count('\n'), benchmark::Counter::kIsIterationInvariantRate);
+}
+
+// The control for every damaged variant below: the same source, undamaged, so
+// recovery never runs.
+auto BM_LexRepresentativeSource(benchmark::State& state) -> void {
+  RunLexBenchmark(state, RepresentativeSource().str());
+}
+BENCHMARK(BM_LexRepresentativeSource);
+
+auto BM_LexOneBracketDeleted(benchmark::State& state) -> void {
+  llvm::StringRef text = RepresentativeSource();
+  RunLexBenchmark(state, DeleteBrackets(text, BracketOffsets(text).size()));
+}
+BENCHMARK(BM_LexOneBracketDeleted);
+
+auto BM_LexEighthOfBracketsDeleted(benchmark::State& state) -> void {
+  RunLexBenchmark(state, DeleteBrackets(RepresentativeSource(), 8));
+}
+BENCHMARK(BM_LexEighthOfBracketsDeleted);
+
+auto BM_LexOneHunkTruncated(benchmark::State& state) -> void {
+  llvm::StringRef text = RepresentativeSource();
+  RunLexBenchmark(state, TruncateHunks(text, SplitIntoHunks(text).size()));
+}
+BENCHMARK(BM_LexOneHunkTruncated);
+
+auto BM_LexEighthOfHunksTruncated(benchmark::State& state) -> void {
+  RunLexBenchmark(state, TruncateHunks(RepresentativeSource(), 8));
+}
+BENCHMARK(BM_LexEighthOfHunksTruncated);
+
+}  // namespace
+}  // namespace Carbon::Lex

--- a/toolchain/lex/mismatched_brackets_benchmark.cpp
+++ b/toolchain/lex/mismatched_brackets_benchmark.cpp
@@ -11,9 +11,9 @@
 
 #include "absl/random/random.h"
 #include "common/check.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -66,6 +66,13 @@ class SourceBuilder {
     return *this;
   }
 
+  // Opens a top-level declaration: `fn Name(...) {` at column 0, which is
+  // where `FindRegionBoundaries` cuts one region from the next.
+  auto AddDeclHeader() -> SourceBuilder& {
+    return AddAll({Kind::StatementIntroducer, Kind::Leaf, Kind::OpenParen,
+                   Kind::CloseParen, Kind::OpenCurlyBrace});
+  }
+
   // Ends the current line, and indents the next one by `indent` columns.
   auto EndLine(int32_t indent) -> SourceBuilder& {
     if (!tokens_.empty()) {
@@ -100,19 +107,12 @@ class SourceBuilder {
 constexpr Kind OpenKinds[] = {Kind::OpenParen, Kind::OpenSquareBracket,
                               Kind::OpenCurlyBrace};
 
-// Opens a top-level declaration: `fn Name(...) {` at column 0, which is where
-// `FindRegionBoundaries` cuts one region from the next.
-static auto AddDeclHeader(SourceBuilder& builder) -> void {
-  builder.AddAll({Kind::StatementIntroducer, Kind::Leaf, Kind::OpenParen,
-                  Kind::CloseParen, Kind::OpenCurlyBrace});
-}
-
 // `n` unmatched opening parens, one per line, each indenting further, as an
 // unfinished call chain would.
 static auto UnclosedOpeners(int n)
     -> llvm::SmallVector<MismatchedBracketToken> {
   SourceBuilder builder;
-  AddDeclHeader(builder);
+  builder.AddDeclHeader();
   for (int i = 0; i < n; ++i) {
     builder.EndLine(IndentWidth * (i + 1))
         .AddAll({Kind::Leaf, Kind::OpenParen});
@@ -124,7 +124,7 @@ static auto UnclosedOpeners(int n)
 static auto UnmatchedClosers(int n)
     -> llvm::SmallVector<MismatchedBracketToken> {
   SourceBuilder builder;
-  AddDeclHeader(builder);
+  builder.AddDeclHeader();
   builder.EndLine(IndentWidth);
   for (int i = 0; i < n; ++i) {
     builder.AddAll({Kind::Leaf, Kind::CloseParen});
@@ -138,7 +138,7 @@ static auto UnmatchedClosers(int n)
 static auto BalancedRunWithGap(int n)
     -> llvm::SmallVector<MismatchedBracketToken> {
   SourceBuilder builder;
-  AddDeclHeader(builder);
+  builder.AddDeclHeader();
   auto add_call = [&](bool closed) {
     builder.EndLine(IndentWidth)
         .AddAll(
@@ -167,7 +167,7 @@ enum class NestDamage : uint8_t { None, Innermost, Alternating };
 static auto DeepNest(int n, NestDamage damage)
     -> llvm::SmallVector<MismatchedBracketToken> {
   SourceBuilder builder;
-  AddDeclHeader(builder);
+  builder.AddDeclHeader();
 
   llvm::SmallVector<Kind> open_kinds;
   for (int i = 0; i < n; ++i) {
@@ -199,7 +199,7 @@ static auto DeepNest(int n, NestDamage damage)
 static auto ManyTiedRepairs(int n)
     -> llvm::SmallVector<MismatchedBracketToken> {
   SourceBuilder builder;
-  AddDeclHeader(builder);
+  builder.AddDeclHeader();
   builder.EndLine(IndentWidth);
   for (int i = 0; i < n; ++i) {
     builder.AddAll({Kind::OpenParen, Kind::Leaf});
@@ -213,7 +213,7 @@ static auto ManyDamagedRegions(int n)
     -> llvm::SmallVector<MismatchedBracketToken> {
   SourceBuilder builder;
   for (int i = 0; i < n; ++i) {
-    AddDeclHeader(builder);
+    builder.AddDeclHeader();
     builder.EndLine(IndentWidth)
         .AddAll({Kind::Leaf, Kind::OpenParen, Kind::Leaf, Kind::Semi});
     builder.EndLine(0).Add(Kind::CloseCurlyBrace);
@@ -329,117 +329,77 @@ BENCHMARK(BM_RegionSizeCliff)->RangeMultiplier(2)->Range(128, 2048);
 // to the generated source, including no damage at all: the difference between
 // a damaged variant and the undamaged control is what recovery costs.
 //
-// Note that `SourceGen` seeds itself from entropy, so while the size and shape
-// of the generated files are stable from run to run, their exact contents are
-// not, and neither is where the damage below lands. Treat a single run of these
-// as approximate; the benchmarks above are the reproducible ones.
+// To keep the signal-to-noise ratio of these benchmarks high, the damage
+// follows the same discipline `SourceGen` applies to the code itself: every
+// total is a deterministic function of the input size, and only placement is
+// randomly shuffled. A fixed number of the generated classes are damaged, each
+// in the same structural way, so the number of damaged tokens, their bracket
+// kinds, and their nesting depths never vary; and since every generated class
+// has the same structure, moving the damage between classes doesn't change how
+// much work it creates. (`SourceGen` seeds itself from entropy, so the exact
+// bytes still differ from file to file and run to run, but the shape and
+// amount of both the code and the damage do not.)
 
-// The byte offsets of every bracket in `text`. Brackets inside comments are
-// included, which is fine: the generated comments contain none.
-static auto BracketOffsets(llvm::StringRef text) -> llvm::SmallVector<size_t> {
-  llvm::SmallVector<size_t> offsets;
-  for (auto [offset, c] : llvm::enumerate(text)) {
-    if (llvm::StringRef("()[]{}").contains(c)) {
-      offsets.push_back(offset);
+// The structural landmarks of one generated class definition that damage is
+// applied relative to.
+struct GeneratedClass {
+  // The `class Thing {` line.
+  size_t open_line;
+  // The closing `}` line.
+  size_t close_line;
+  // The last line of each function and method declaration, which is the line
+  // holding the declaration's closing paren.
+  llvm::SmallVector<size_t> decl_end_lines;
+};
+
+// Finds every class definition in the lines of a generated source file. The
+// generator writes each `class Thing {` and its matching `}` in column zero,
+// and ends every function and method declaration with `) -> Type;`, so those
+// are the landmarks this looks for.
+static auto FindClasses(llvm::ArrayRef<llvm::StringRef> lines)
+    -> llvm::SmallVector<GeneratedClass> {
+  llvm::SmallVector<GeneratedClass> classes;
+  bool in_class = false;
+  for (auto [index, line] : llvm::enumerate(lines)) {
+    if (line.starts_with("class ")) {
+      CARBON_CHECK(!in_class);
+      classes.push_back({.open_line = index, .close_line = index});
+      in_class = true;
+    } else if (line == "}") {
+      CARBON_CHECK(in_class);
+      classes.back().close_line = index;
+      in_class = false;
+    } else if (in_class && line.contains(") -> ")) {
+      classes.back().decl_end_lines.push_back(index);
     }
   }
-  return offsets;
+  CARBON_CHECK(!in_class && !classes.empty(),
+               "Generated source has no classes to damage.");
+
+  // The damage plan below relies on the classes being interchangeable.
+  for (const auto& gen_class : classes) {
+    CARBON_CHECK(
+        !gen_class.decl_end_lines.empty() &&
+            gen_class.decl_end_lines.size() ==
+                classes.front().decl_end_lines.size(),
+        "Generated classes are expected to be structurally identical.");
+  }
+  return classes;
 }
 
-// Deletes the brackets at `offsets`, which must be sorted, closing up the text
-// so that nothing marks where they were.
-static auto DeleteOffsets(llvm::StringRef text, llvm::ArrayRef<size_t> offsets)
-    -> std::string {
-  std::string result;
-  result.reserve(text.size());
-  size_t prev = 0;
-  for (size_t offset : offsets) {
-    result.append(text.substr(prev, offset - prev));
-    prev = offset + 1;
-  }
-  result.append(text.substr(prev));
-  return result;
-}
+// How many of the generated classes each damage strategy harms: one in this
+// many, rounded down, but always at least one.
+constexpr int DamagedClassOneIn = 8;
 
-// Deletes one in every `one_in` brackets, chosen at random. With `one_in` equal
-// to the bracket count this deletes a single bracket.
-static auto DeleteBrackets(llvm::StringRef text, int one_in) -> std::string {
-  auto offsets = BracketOffsets(text);
-  CARBON_CHECK(!offsets.empty(), "Generated source has no brackets.");
-  absl::BitGen rng;
-
-  llvm::SmallVector<size_t> deleted;
-  int count = std::max<int>(1, offsets.size() / one_in);
-  llvm::SmallVector<size_t> remaining = offsets;
-  for (int i = 0; i < count && !remaining.empty(); ++i) {
-    int pick = absl::Uniform<int>(rng, 0, remaining.size());
-    deleted.push_back(remaining[pick]);
-    remaining.erase(remaining.begin() + pick);
-  }
-  llvm::sort(deleted);
-  return DeleteOffsets(text, deleted);
-}
-
-// Splits `text` into the blank-line separated hunks a generated file falls into
-// naturally, returning each hunk's lines.
-static auto SplitIntoHunks(llvm::StringRef text)
-    -> llvm::SmallVector<llvm::SmallVector<llvm::StringRef>> {
-  llvm::SmallVector<llvm::StringRef> lines;
-  text.split(lines, '\n');
-
-  llvm::SmallVector<llvm::SmallVector<llvm::StringRef>> hunks;
-  hunks.emplace_back();
-  for (llvm::StringRef line : lines) {
-    if (line.trim().empty()) {
-      hunks.emplace_back();
-    } else {
-      hunks.back().push_back(line);
-    }
-  }
-  return hunks;
-}
-
-// Truncates one in every `one_in` hunks partway through, by dropping everything
-// from a random line that closes a bracket to the end of that hunk. This is
-// what a declaration still being typed looks like: the body is there, the
-// closers that would end it are not.
-static auto TruncateHunks(llvm::StringRef text, int one_in) -> std::string {
-  auto hunks = SplitIntoHunks(text);
-  absl::BitGen rng;
-
-  // The hunks with a line that could be truncated at.
-  llvm::SmallVector<size_t> candidates;
-  for (auto [index, hunk] : llvm::enumerate(hunks)) {
-    if (llvm::any_of(hunk, [](llvm::StringRef line) {
-          return line.contains(')') || line.contains('}') || line.contains(']');
-        })) {
-      candidates.push_back(index);
-    }
-  }
-  CARBON_CHECK(!candidates.empty(), "Generated source has no closing bracket.");
-
-  int count = std::max<int>(1, candidates.size() / one_in);
-  for (int i = 0; i < count && !candidates.empty(); ++i) {
-    int pick = absl::Uniform<int>(rng, 0, candidates.size());
-    auto& hunk = hunks[candidates[pick]];
-    candidates.erase(candidates.begin() + pick);
-
-    llvm::SmallVector<size_t> closing_lines;
-    for (auto [index, line] : llvm::enumerate(hunk)) {
-      if (line.contains(')') || line.contains('}') || line.contains(']')) {
-        closing_lines.push_back(index);
-      }
-    }
-    hunk.resize(
-        closing_lines[absl::Uniform<int>(rng, 0, closing_lines.size())]);
-  }
-
-  llvm::SmallVector<llvm::StringRef> lines;
-  for (const auto& hunk : hunks) {
-    lines.append(hunk.begin(), hunk.end());
-    lines.push_back("");
-  }
-  return llvm::join(lines, "\n");
+// Selects which classes to damage: a deterministic count of trues, randomly
+// placed by a shuffle.
+static auto PickDamagedClasses(size_t num_classes, absl::BitGen& rng)
+    -> llvm::SmallVector<bool> {
+  size_t num_damaged = std::max<size_t>(1, num_classes / DamagedClassOneIn);
+  llvm::SmallVector<bool> damaged(num_classes, false);
+  std::fill_n(damaged.begin(), num_damaged, true);
+  std::shuffle(damaged.begin(), damaged.end(), rng);
+  return damaged;
 }
 
 // Lexes a fixed source text, which is what recovery runs inside of.
@@ -467,29 +427,96 @@ class LexBenchHelper {
 };
 
 // The damage strategies the whole-file benchmarks sweep. `None` is the
-// control: recovery never runs, so it measures the lexer alone.
+// control: recovery never runs, so it measures the lexer alone. Each of the
+// others damages one in `DamagedClassOneIn` of the generated classes, all in
+// the same structural way:
+//
+// - `DeclParenDeleted` deletes the closing paren of one declaration in each
+//   damaged class: a single-character typo whose damage stays inside the
+//   class.
+// - `ClassBraceDeleted` deletes each damaged class's closing brace, leaving
+//   its opening brace with nothing to match.
+// - `ClassTruncated` cuts each damaged class off halfway through its members,
+//   which is what a declaration still being typed looks like: the body is
+//   there, the closers that would end it are not.
 enum class Damage : uint8_t {
   None,
-  OneBracketDeleted,
-  EighthOfBracketsDeleted,
-  OneHunkTruncated,
-  EighthOfHunksTruncated,
+  DeclParenDeleted,
+  ClassBraceDeleted,
+  ClassTruncated,
 };
 
 // Applies `damage` to `text`.
 static auto ApplyDamage(std::string text, Damage damage) -> std::string {
-  switch (damage) {
-    case Damage::None:
-      return text;
-    case Damage::OneBracketDeleted:
-      return DeleteBrackets(text, BracketOffsets(text).size());
-    case Damage::EighthOfBracketsDeleted:
-      return DeleteBrackets(text, 8);
-    case Damage::OneHunkTruncated:
-      return TruncateHunks(text, SplitIntoHunks(text).size());
-    case Damage::EighthOfHunksTruncated:
-      return TruncateHunks(text, 8);
+  if (damage == Damage::None) {
+    return text;
   }
+
+  llvm::SmallVector<llvm::StringRef> lines;
+  llvm::StringRef(text).split(lines, '\n');
+  // The text ends with a newline, so drop the empty line after the last one
+  // rather than treating it as a line of its own.
+  CARBON_CHECK(!lines.empty() && lines.back().empty());
+  lines.pop_back();
+
+  auto classes = FindClasses(lines);
+  absl::BitGen rng;
+  llvm::SmallVector<bool> damaged = PickDamagedClasses(classes.size(), rng);
+
+  // The planned damage: lines to drop entirely, and single columns to delete.
+  llvm::SmallVector<bool> drop_line(lines.size(), false);
+  llvm::SmallVector<int32_t> delete_column(lines.size(), -1);
+
+  for (auto [class_index, gen_class] : llvm::enumerate(classes)) {
+    if (!damaged[class_index]) {
+      continue;
+    }
+    switch (damage) {
+      case Damage::None:
+        CARBON_FATAL("Handled above.");
+      case Damage::DeclParenDeleted: {
+        // Every declaration has exactly one closing paren, at the same depth,
+        // so which one loses it is a structurally neutral choice.
+        size_t line = gen_class.decl_end_lines[absl::Uniform<size_t>(
+            rng, 0, gen_class.decl_end_lines.size())];
+        size_t column = lines[line].find(") -> ");
+        CARBON_CHECK(column != llvm::StringRef::npos);
+        delete_column[line] = static_cast<int32_t>(column);
+        break;
+      }
+      case Damage::ClassBraceDeleted: {
+        drop_line[gen_class.close_line] = true;
+        break;
+      }
+      case Damage::ClassTruncated: {
+        // Drop everything after the class's midpoint declaration, including
+        // the closing brace. Every class is cut at the same structural point.
+        size_t cut =
+            gen_class.decl_end_lines[gen_class.decl_end_lines.size() / 2];
+        for (size_t line = cut + 1; line <= gen_class.close_line; ++line) {
+          drop_line[line] = true;
+        }
+        break;
+      }
+    }
+  }
+
+  // Reassemble the file with the damage applied.
+  std::string result;
+  result.reserve(text.size());
+  for (auto [index, line] : llvm::enumerate(lines)) {
+    if (drop_line[index]) {
+      continue;
+    }
+    if (delete_column[index] >= 0) {
+      result.append(line.substr(0, delete_column[index]));
+      result.append(line.substr(delete_column[index] + 1));
+    } else {
+      result.append(line);
+    }
+    result.push_back('\n');
+  }
+  return result;
 }
 
 // Benchmark on multiple files of the same size but with different source code
@@ -571,13 +598,11 @@ static auto ConfigureLexBenchmark(benchmark::Benchmark* b) -> void {
 }
 
 BENCHMARK(BM_LexApiFileDenseDecls<Damage::None>)->Apply(ConfigureLexBenchmark);
-BENCHMARK(BM_LexApiFileDenseDecls<Damage::OneBracketDeleted>)
+BENCHMARK(BM_LexApiFileDenseDecls<Damage::DeclParenDeleted>)
     ->Apply(ConfigureLexBenchmark);
-BENCHMARK(BM_LexApiFileDenseDecls<Damage::EighthOfBracketsDeleted>)
+BENCHMARK(BM_LexApiFileDenseDecls<Damage::ClassBraceDeleted>)
     ->Apply(ConfigureLexBenchmark);
-BENCHMARK(BM_LexApiFileDenseDecls<Damage::OneHunkTruncated>)
-    ->Apply(ConfigureLexBenchmark);
-BENCHMARK(BM_LexApiFileDenseDecls<Damage::EighthOfHunksTruncated>)
+BENCHMARK(BM_LexApiFileDenseDecls<Damage::ClassTruncated>)
     ->Apply(ConfigureLexBenchmark);
 
 }  // namespace


### PR DESCRIPTION
Replaces several quadratic-time steps in the algorithm with linear or n log n implementations. Worst-case runtime before hitting the complexity bailout drops from 25ms to about 12ms, and typical runtime is single-digit ms on my development machine.

Assisted-by: Claude Code