### PR TITLE
Fix top-of-tree Clang build warnings

### DIFF
--- a/common/hashing_test.cpp
+++ b/common/hashing_test.cpp
@@ -491,41 +491,6 @@ struct HashedValue {
 
 using HashedString = HashedValue<std::string>;
 
-template <typename T>
-auto PrintFullWidthHex(llvm::raw_ostream& os, T value) {
-  static_assert(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
-                sizeof(T) == 8);
-  // Given the nature of a format string and the good formatting, a nested
-  // conditional seems like the most readable structure.
-  // NOLINTBEGIN(readability-avoid-nested-conditional-operator)
-  os << llvm::formatv(sizeof(T) == 1   ? "{0:x2}"
-                      : sizeof(T) == 2 ? "{0:x4}"
-                      : sizeof(T) == 4 ? "{0:x8}"
-                                       : "{0:x16}",
-                      static_cast<uint64_t>(value));
-  // NOLINTEND(readability-avoid-nested-conditional-operator)
-}
-
-template <typename T>
-  requires std::integral<T>
-auto operator<<(llvm::raw_ostream& os, HashedValue<T> hv)
-    -> llvm::raw_ostream& {
-  os << "hash " << hv.hash << " for value ";
-  PrintFullWidthHex(os, hv.v);
-  return os;
-}
-
-template <typename T, typename U>
-  requires std::integral<T> && std::integral<U>
-auto operator<<(llvm::raw_ostream& os, HashedValue<std::pair<T, U>> hv)
-    -> llvm::raw_ostream& {
-  os << "hash " << hv.hash << " for pair of ";
-  PrintFullWidthHex(os, hv.v.first);
-  os << " and ";
-  PrintFullWidthHex(os, hv.v.second);
-  return os;
-}
-
 struct Collisions {
   int total;
   int median;

--- a/testing/base/capture_std_streams.h
+++ b/testing/base/capture_std_streams.h
@@ -24,8 +24,8 @@ auto EndStdStreamCapture(std::string& out, std::string& err) -> void;
 // print back out or otherwise expose any of the contents of the captured output
 // that are needed when debugging.
 template <typename FnT>
-static auto CallWithCapturedOutput(std::string& out, std::string& err,
-                                   FnT function) -> auto {
+auto CallWithCapturedOutput(std::string& out, std::string& err, FnT function)
+    -> auto {
   Internal::BeginStdStreamCapture();
   auto result = function();
   Internal::EndStdStreamCapture(out, err);

--- a/toolchain/check/deduce.cpp
+++ b/toolchain/check/deduce.cpp
@@ -196,11 +196,6 @@ class DeductionContext {
     worklist_.AddAll(params, args, want_value);
   }
 
-  template <typename ParamT, typename ArgT>
-  auto AddAll(ParamT param, ArgT arg) -> void {
-    worklist_.AddAll(param, arg);
-  }
-
   // Performs all deductions in the deduction worklist. Returns whether
   // deduction succeeded.
   auto Deduce() -> bool;

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -923,8 +923,12 @@ static auto ReplaceFieldWithConstantValue(EvalContext& eval_context,
 
 // Function template that can be called with an argument of type `T`. Used below
 // to detect which overloads of `GetConstantValue` exist.
+//
+// Marked as maybe unused at it seems the use in a requires isn't tracked by the
+// latest version of Clang's `-Wunused-template`.
+// https://github.com/llvm/llvm-project/issues/218429
 template <typename T>
-static void Accept(T /*arg*/) {}
+[[maybe_unused]] static auto Accept(T /*arg*/) -> void {}
 
 // Determines whether a `GetConstantValue` overload exists for a given ID type.
 // Note that we do not check whether `GetConstantValue` is *callable* with a
@@ -996,13 +1000,6 @@ static auto ReplaceTypeWithConstantValue(EvalContext& eval_context,
                                          Phase* phase) -> bool {
   inst->type_id = GetTypeOfInst(eval_context, inst_id, *inst, phase);
   return IsConstantOrError(*phase);
-}
-
-template <typename... Types>
-static auto KindHasGetConstantValueOverload(TypeEnum<Types...> e) -> bool {
-  static constexpr std::array<bool, SemIR::IdKind::NumTypes> Values = {
-      (HasGetConstantValueOverload<Types>)...};
-  return Values[e.ToIndex()];
 }
 
 static auto ResolveSpecificDeclForSpecificId(EvalContext& eval_context,

--- a/toolchain/driver/clang_runner_test.cpp
+++ b/toolchain/driver/clang_runner_test.cpp
@@ -33,30 +33,6 @@ using ::testing::HasSubstr;
 using Testing::IsSuccess;
 using ::testing::StrEq;
 
-// NOLINTNEXTLINE(modernize-use-trailing-return-type): Macro based function.
-MATCHER_P(TextSymbolNamed, name_matcher, "") {
-  llvm::Expected<llvm::StringRef> name = arg.getName();
-  if (auto error = name.takeError()) {
-    *result_listener << "with an error instead of a name: " << error;
-    return false;
-  }
-  if (!testing::ExplainMatchResult(name_matcher, *name, result_listener)) {
-    return false;
-  }
-  // We have to dig out the section to determine if this was a text symbol.
-  auto expected_section_it = arg.getSection();
-  if (auto error = expected_section_it.takeError()) {
-    *result_listener << "without a section: " << error;
-    return false;
-  }
-  llvm::object::SectionRef section = **expected_section_it;
-  if (!section.isText()) {
-    *result_listener << "in the non-text section: " << *section.getName();
-    return false;
-  }
-  return true;
-}
-
 class ClangRunnerTest : public ::testing::Test {
  public:
   InstallPaths install_paths_ =


### PR DESCRIPTION
`-Wunused-template` was added to `-Wunused`, so clean up the things it found. One of them was a bug in the Clang warning that I've worked around and reported upstream:

https://github.com/llvm/llvm-project/issues/218429