### PR TITLE
Add `--verbose` / `-v` flag to autoupdate.

### DIFF
--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -54,12 +54,12 @@ def main() -> None:
         m = re.search(r"-(\w+)/bin$", link)
         if m:
             build_mode = m[1]
-            print(f"Detected --compiation_mode: {build_mode}")
+            print(f"Detected --compilation_mode: {build_mode}")
         else:
             exit(f"Build mode not found in `bazel-bin` symlink: {link}")
     elif args.verbose:
         print(
-            "Detected --compiation_mode: none (no `./bazel-bin`), "
+            "Detected --compilation_mode: none (no `./bazel-bin`), "
             + f"falling back to {build_mode}"
         )
 

--- a/toolchain/autoupdate_testdata.py
+++ b/toolchain/autoupdate_testdata.py
@@ -21,6 +21,19 @@ from pathlib import Path
 
 
 def main() -> None:
+    # Parse arguments.
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("--non-fatal-checks", action="store_true")
+    parser.add_argument(
+        "--print_slowest_tests", default=0, help="Forwarded to file_test"
+    )
+    parser.add_argument("--threads", help="Forwarded to file_test")
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Produce verbose output"
+    )
+    parser.add_argument("files", nargs="*")
+    args = parser.parse_args()
+
     bazel = str(Path(__file__).parents[1] / "scripts" / "run_bazel.py")
     configs = []
     # Use the most recently used build mode, or `fastbuild` if missing
@@ -41,18 +54,14 @@ def main() -> None:
         m = re.search(r"-(\w+)/bin$", link)
         if m:
             build_mode = m[1]
+            print(f"Detected --compiation_mode: {build_mode}")
         else:
             exit(f"Build mode not found in `bazel-bin` symlink: {link}")
-
-    # Parse arguments.
-    parser = argparse.ArgumentParser(__doc__)
-    parser.add_argument("--non-fatal-checks", action="store_true")
-    parser.add_argument(
-        "--print_slowest_tests", default=0, help="Forwarded to file_test"
-    )
-    parser.add_argument("--threads", help="Forwarded to file_test")
-    parser.add_argument("files", nargs="*")
-    args = parser.parse_args()
+    elif args.verbose:
+        print(
+            "Detected --compiation_mode: none (no `./bazel-bin`), "
+            + f"falling back to {build_mode}"
+        )
 
     if args.non_fatal_checks:
         if build_mode == "optimize":
@@ -95,6 +104,8 @@ def main() -> None:
                 f"{args.files[0]}"
             )
         argv.append("--file_tests=" + ",".join(file_tests))
+    if args.verbose:
+        print(shlex.join(argv))
     # Provide an empty stdin so that the driver tests that read from stdin
     # don't block waiting for input. This matches the behavior of `bazel test`.
     result = subprocess.run(argv)


### PR DESCRIPTION
With this set, autoupdate will print messages indicating what it's doing, such as the command that it's invoking to execute bazel. For example:

```console
$ ./toolchain/autoupdate_testdata.py -v toolchain/check/testdata/basics/empty.carbon 
Detected --compilation_mode: fastbuild
/home/zygoloid/carbon-lang/scripts/run_bazel.py run -c fastbuild --experimental_convenience_symlinks=ignore --ui_event_filters=-info,-stdout,-stderr,-finish //toolchain/testing:file_test -- --autoupdate --print_slowest_tests 0 --file_tests=toolchain/check/testdata/basics/empty.carbon
[... normal output ...]
```