### PR TITLE
Diagnose redundant redeclarations in impl files

### DIFF
--- a/toolchain/check/merge.cpp
+++ b/toolchain/check/merge.cpp
@@ -136,6 +136,11 @@ auto DiagnoseIfInvalidRedecl(Context& context, Lex::TokenKind decl_kind,
                              prev_decl.loc_id);
       return;
     }
+    if (!new_decl.is_definition) {
+      DiagnoseRedundant(context, decl_kind, name_id, new_decl.loc_id,
+                        prev_decl.loc_id);
+      return;
+    }
     return;
   }
 

--- a/toolchain/check/testdata/class/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/class/no_definition_in_impl_file.carbon
@@ -16,11 +16,18 @@ library "[[@TEST_NAME]]";
 
 class A;
 
-// --- todo_fail_decl_in_api_definition_in_impl.impl.carbon
+// --- fail_decl_in_api_definition_in_impl.impl.carbon
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: This should be diagnosed per #3762: A declaration should always add new information.
+// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `class A` is redundant [RedeclRedundant]
+// CHECK:STDERR: class A;
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: class A;
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 class A;
 
 class A {}
@@ -55,6 +62,14 @@ class C;
 
 impl library "[[@TEST_NAME]]";
 
+// CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE+12]]:1: error: redeclaration of `class C` is redundant [RedeclRedundant]
+// CHECK:STDERR: class C;
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_decl_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: class C;
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE+4]]:1: error: no definition found for declaration in impl file [MissingDefinitionInImpl]
 // CHECK:STDERR: class C;
 // CHECK:STDERR: ^~~~~~~~

--- a/toolchain/check/testdata/class/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/class/no_definition_in_impl_file.carbon
@@ -16,19 +16,9 @@ library "[[@TEST_NAME]]";
 
 class A;
 
-// --- fail_decl_in_api_definition_in_impl.impl.carbon
+// --- decl_in_api_definition_in_impl.impl.carbon
 
 impl library "[[@TEST_NAME]]";
-
-// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `class A` is redundant [RedeclRedundant]
-// CHECK:STDERR: class A;
-// CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
-// CHECK:STDERR: decl_in_api_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
-// CHECK:STDERR: class A;
-// CHECK:STDERR: ^~~~~~~~
-// CHECK:STDERR:
-class A;
 
 class A {}
 
@@ -76,6 +66,28 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR:
 class C;
 
+// --- decl_in_api_decl_and_definition_in_impl.carbon
+
+library "[[@TEST_NAME]]";
+
+class D;
+
+// --- fail_decl_in_api_decl_and_definition_in_impl.impl.carbon
+
+impl library "[[@TEST_NAME]]";
+
+// CHECK:STDERR: fail_decl_in_api_decl_and_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `class D` is redundant [RedeclRedundant]
+// CHECK:STDERR: class D;
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR: fail_decl_in_api_decl_and_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_decl_and_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: class D;
+// CHECK:STDERR: ^~~~~~~~
+// CHECK:STDERR:
+class D;
+
+class D {}
+
 // --- decl_only_in_impl.carbon
 
 library "[[@TEST_NAME]]";
@@ -85,7 +97,7 @@ library "[[@TEST_NAME]]";
 impl library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_decl_only_in_impl.impl.carbon:[[@LINE+4]]:1: error: no definition found for declaration in impl file [MissingDefinitionInImpl]
-// CHECK:STDERR: class D;
+// CHECK:STDERR: class E;
 // CHECK:STDERR: ^~~~~~~~
 // CHECK:STDERR:
-class D;
+class E;

--- a/toolchain/check/testdata/function/declaration/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/function/declaration/no_definition_in_impl_file.carbon
@@ -16,11 +16,18 @@ library "[[@TEST_NAME]]";
 
 fn A();
 
-// --- todo_fail_decl_in_api_definition_in_impl.impl.carbon
+// --- fail_decl_in_api_definition_in_impl.impl.carbon
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: This should be diagnosed per #3762: A declaration should always add new information.
+// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `fn A` is redundant [RedeclRedundant]
+// CHECK:STDERR: fn A();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: fn A();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 fn A();
 
 fn A() {}
@@ -55,6 +62,14 @@ fn C();
 
 impl library "[[@TEST_NAME]]";
 
+// CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE+12]]:1: error: redeclaration of `fn C` is redundant [RedeclRedundant]
+// CHECK:STDERR: fn C();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_decl_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: fn C();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE+4]]:1: error: no definition found for declaration in impl file [MissingDefinitionInImpl]
 // CHECK:STDERR: fn C();
 // CHECK:STDERR: ^~~~~~~

--- a/toolchain/check/testdata/function/declaration/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/function/declaration/no_definition_in_impl_file.carbon
@@ -16,19 +16,9 @@ library "[[@TEST_NAME]]";
 
 fn A();
 
-// --- fail_decl_in_api_definition_in_impl.impl.carbon
+// --- decl_in_api_definition_in_impl.impl.carbon
 
 impl library "[[@TEST_NAME]]";
-
-// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `fn A` is redundant [RedeclRedundant]
-// CHECK:STDERR: fn A();
-// CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
-// CHECK:STDERR: decl_in_api_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
-// CHECK:STDERR: fn A();
-// CHECK:STDERR: ^~~~~~~
-// CHECK:STDERR:
-fn A();
 
 fn A() {}
 
@@ -76,6 +66,28 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR:
 fn C();
 
+// --- decl_in_api_decl_and_definition_in_impl.carbon
+
+library "[[@TEST_NAME]]";
+
+fn D();
+
+// --- fail_decl_in_api_decl_and_definition_in_impl.impl.carbon
+
+impl library "[[@TEST_NAME]]";
+
+// CHECK:STDERR: fail_decl_in_api_decl_and_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `fn D` is redundant [RedeclRedundant]
+// CHECK:STDERR: fn D();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR: fail_decl_in_api_decl_and_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_decl_and_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: fn D();
+// CHECK:STDERR: ^~~~~~~
+// CHECK:STDERR:
+fn D();
+
+fn D() {}
+
 // --- decl_only_in_impl.carbon
 
 library "[[@TEST_NAME]]";
@@ -85,7 +97,7 @@ library "[[@TEST_NAME]]";
 impl library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_decl_only_in_impl.impl.carbon:[[@LINE+4]]:1: error: no definition found for declaration in impl file [MissingDefinitionInImpl]
-// CHECK:STDERR: fn D();
+// CHECK:STDERR: fn E();
 // CHECK:STDERR: ^~~~~~~
 // CHECK:STDERR:
-fn D();
+fn E();

--- a/toolchain/check/testdata/interface/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/interface/no_definition_in_impl_file.carbon
@@ -16,19 +16,9 @@ library "[[@TEST_NAME]]";
 
 interface A;
 
-// --- fail_decl_in_api_definition_in_impl.impl.carbon
+// --- decl_in_api_definition_in_impl.impl.carbon
 
 impl library "[[@TEST_NAME]]";
-
-// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `interface A` is redundant [RedeclRedundant]
-// CHECK:STDERR: interface A;
-// CHECK:STDERR: ^~~~~~~~~~~~
-// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
-// CHECK:STDERR: decl_in_api_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
-// CHECK:STDERR: interface A;
-// CHECK:STDERR: ^~~~~~~~~~~~
-// CHECK:STDERR:
-interface A;
 
 interface A {}
 
@@ -76,6 +66,28 @@ impl library "[[@TEST_NAME]]";
 // CHECK:STDERR:
 interface C;
 
+// --- decl_in_api_decl_and_definition_in_impl.carbon
+
+library "[[@TEST_NAME]]";
+
+interface D;
+
+// --- fail_decl_in_api_decl_and_definition_in_impl.impl.carbon
+
+impl library "[[@TEST_NAME]]";
+
+// CHECK:STDERR: fail_decl_in_api_decl_and_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `interface D` is redundant [RedeclRedundant]
+// CHECK:STDERR: interface D;
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR: fail_decl_in_api_decl_and_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_decl_and_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: interface D;
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
+interface D;
+
+interface D {}
+
 // --- decl_only_in_impl.carbon
 
 library "[[@TEST_NAME]]";
@@ -85,7 +97,7 @@ library "[[@TEST_NAME]]";
 impl library "[[@TEST_NAME]]";
 
 // CHECK:STDERR: fail_decl_only_in_impl.impl.carbon:[[@LINE+4]]:1: error: no definition found for declaration in impl file [MissingDefinitionInImpl]
-// CHECK:STDERR: interface D;
+// CHECK:STDERR: interface E;
 // CHECK:STDERR: ^~~~~~~~~~~~
 // CHECK:STDERR:
-interface D;
+interface E;

--- a/toolchain/check/testdata/interface/no_definition_in_impl_file.carbon
+++ b/toolchain/check/testdata/interface/no_definition_in_impl_file.carbon
@@ -16,11 +16,18 @@ library "[[@TEST_NAME]]";
 
 interface A;
 
-// --- todo_fail_decl_in_api_definition_in_impl.impl.carbon
+// --- fail_decl_in_api_definition_in_impl.impl.carbon
 
 impl library "[[@TEST_NAME]]";
 
-// TODO: This should be diagnosed per #3762: A declaration should always add new information.
+// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE+8]]:1: error: redeclaration of `interface A` is redundant [RedeclRedundant]
+// CHECK:STDERR: interface A;
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR: fail_decl_in_api_definition_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_definition_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: interface A;
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 interface A;
 
 interface A {}
@@ -55,6 +62,14 @@ interface C;
 
 impl library "[[@TEST_NAME]]";
 
+// CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE+12]]:1: error: redeclaration of `interface C` is redundant [RedeclRedundant]
+// CHECK:STDERR: interface C;
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE-5]]:1: in import [InImport]
+// CHECK:STDERR: decl_in_api_decl_in_impl.carbon:4:1: note: previously declared here [RedeclPrevDecl]
+// CHECK:STDERR: interface C;
+// CHECK:STDERR: ^~~~~~~~~~~~
+// CHECK:STDERR:
 // CHECK:STDERR: fail_decl_in_api_decl_in_impl.impl.carbon:[[@LINE+4]]:1: error: no definition found for declaration in impl file [MissingDefinitionInImpl]
 // CHECK:STDERR: interface C;
 // CHECK:STDERR: ^~~~~~~~~~~~


### PR DESCRIPTION
While forward declarations in impl files are allowed, having one in the impl file is redundant when we also have one in the API file.