### PR TITLE
Use `jj_prek.sh` to run `prek` in `new_proposal.py` with `jj`

### DIFF
--- a/proposals/scripts/new_proposal.py
+++ b/proposals/scripts/new_proposal.py
@@ -168,10 +168,11 @@ def main() -> None:
     if Path(".jj").is_dir():
         jj_bin = _find_tool("jj")
         git_bin = None
+        prek_bin = "scripts/jj_prek.sh"
     else:
         git_bin = _find_tool("git")
         jj_bin = None
-    prek_bin = _find_tool("prek")
+        prek_bin = _find_tool("prek")
 
     # Verify there are no uncommitted changes (jj has no equivalent).
     if git_bin:
@@ -274,10 +275,7 @@ def main() -> None:
     else:
         assert jj_bin  # For mypy.
 
-        _run(
-            [prek_bin, "run", "--files", "$(jj diff --name-only)"],
-            check=False,
-        )
+        _run([prek_bin], check=False)
         _run([jj_bin, "describe", "-m", final_desc])
         _run([jj_bin, "git", "push"])
 


### PR DESCRIPTION
Recently noticed this issue when creating a proposal using `new_proposal.py` in a `jj` workspace.