### PR TITLE
Step through splices when checking for a bound method.

### DIFF
--- a/toolchain/check/call.cpp
+++ b/toolchain/check/call.cpp
@@ -171,7 +171,8 @@ static auto BuildCalleeSpecificFunction(
   auto generic_callee_id = callee_id;
 
   // Strip off a bound_method so that we can form a constant specific callee.
-  auto bound_method = context.insts().TryGetAs<SemIR::BoundMethod>(callee_id);
+  auto bound_method = SemIR::TryGetCalleeAsBoundMethod(
+      context.sem_ir(), callee_id, SemIR::SpecificId::None);
   if (bound_method) {
     generic_callee_id = bound_method->function_decl_id;
   }

--- a/toolchain/check/testdata/array/init_dependent_bound.carbon
+++ b/toolchain/check/testdata/array/init_dependent_bound.carbon
@@ -54,15 +54,7 @@ fn G(template N: i32) {
   //@dump-sem-ir-end
 }
 
-// CHECK:STDERR: fail_todo_init_template_dependent_bound.carbon:[[@LINE+7]]:10: error: unable to monomorphize specific `G(3)` [ResolvingSpecificHere]
-// CHECK:STDERR: fn H() { G(3); }
-// CHECK:STDERR:          ^
-// CHECK:STDERR: fail_todo_init_template_dependent_bound.carbon:[[@LINE-7]]:3: note: value of type `<bound method>` is not callable [CallToNonCallable]
-// CHECK:STDERR:   var unused arr: array(i32, N) = (1, 2, 3);
-// CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
 fn H() { G(3); }
-
 
 // CHECK:STDOUT: --- generic_empty.carbon
 // CHECK:STDOUT:
@@ -178,6 +170,7 @@ fn H() { G(3); }
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
 // CHECK:STDOUT:   %pattern_type.6b6: type = pattern_type %i32 [concrete]
 // CHECK:STDOUT:   %N.patt.38a: %pattern_type.6b6 = symbolic_binding_pattern N, 0, template [template]
@@ -247,8 +240,8 @@ fn H() { G(3); }
 // CHECK:STDOUT:       %bound_method.69b: <bound method> = bound_method %.723, %impl.elem0.ef2
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %inst.splice_block.edd: <instruction> = inst_value [concrete] {
-// CHECK:STDOUT:     %.432: <error> = splice_block <error> [concrete = <error>] {}
+// CHECK:STDOUT:   %inst.call: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %Destroy.Op.call: init %empty_tuple.type = call %.6fe(%.723)
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -338,8 +331,8 @@ fn H() { G(3); }
 // CHECK:STDOUT:   %.loc11_3.6 => constants.%inst.splice_block.adf
 // CHECK:STDOUT:   %.loc11_3.7 => <bound method>
 // CHECK:STDOUT:   %.loc11_3.8 => invalid
-// CHECK:STDOUT:   %.loc11_3.9 => constants.%inst.splice_block.edd
-// CHECK:STDOUT:   %.loc11_3.10 => <error>
-// CHECK:STDOUT:   %.loc11_3.11 => <error>
+// CHECK:STDOUT:   %.loc11_3.9 => constants.%inst.call
+// CHECK:STDOUT:   %.loc11_3.10 => constants.%empty_tuple.type
+// CHECK:STDOUT:   %.loc11_3.11 => invalid
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/class/destroy_calls.carbon
+++ b/toolchain/check/testdata/class/destroy_calls.carbon
@@ -86,7 +86,7 @@ fn F(generic T: type) {
 
 fn G() { F({}); }
 
-// --- fail_todo_generic_use_inside_template.carbon
+// --- generic_use_inside_template.carbon
 library "[[@TEST_NAME]]";
 
 class C(template T: type) {}
@@ -97,13 +97,6 @@ fn F(template T: type) {
 }
 //@dump-sem-ir-end
 
-// CHECK:STDERR: fail_todo_generic_use_inside_template.carbon:[[@LINE+7]]:10: error: unable to monomorphize specific `F({})` [ResolvingSpecificHere]
-// CHECK:STDERR: fn G() { F({}); }
-// CHECK:STDERR:          ^
-// CHECK:STDERR: fail_todo_generic_use_inside_template.carbon:[[@LINE-7]]:3: note: value of type `<bound method>` is not callable [CallToNonCallable]
-// CHECK:STDERR:   var unused v: C(T) = {};
-// CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
 fn G() { F({}); }
 
 // CHECK:STDOUT: --- implicit_return.carbon
@@ -563,7 +556,7 @@ fn G() { F({}); }
 // CHECK:STDOUT:   %specific_impl_fn.loc7_3.2 => constants.%Destroy.Op.1a2547.2
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
-// CHECK:STDOUT: --- fail_todo_generic_use_inside_template.carbon
+// CHECK:STDOUT: --- generic_use_inside_template.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
@@ -572,6 +565,7 @@ fn G() { F({}); }
 // CHECK:STDOUT:   %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0, template [template]
 // CHECK:STDOUT:   %T: type = symbolic_binding T, 0, template [template]
 // CHECK:STDOUT:   %C.type: type = generic_class_type @C [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
 // CHECK:STDOUT:   %C.generic: %C.type = struct_value () [concrete]
 // CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
 // CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
@@ -644,8 +638,8 @@ fn G() { F({}); }
 // CHECK:STDOUT:       %bound_method: <bound method> = bound_method %.36e, %impl.elem0
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %inst.splice_block.edd: <instruction> = inst_value [concrete] {
-// CHECK:STDOUT:     %.432: <error> = splice_block <error> [concrete = <error>] {}
+// CHECK:STDOUT:   %inst.call: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %Destroy.Op.call: init %empty_tuple.type = call %.99b(%.36e)
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -781,8 +775,8 @@ fn G() { F({}); }
 // CHECK:STDOUT:   %.loc7_3.29 => constants.%inst.splice_block.b81
 // CHECK:STDOUT:   %.loc7_3.30 => <bound method>
 // CHECK:STDOUT:   %.loc7_3.31 => invalid
-// CHECK:STDOUT:   %.loc7_3.32 => constants.%inst.splice_block.edd
-// CHECK:STDOUT:   %.loc7_3.33 => <error>
-// CHECK:STDOUT:   %.loc7_3.34 => <error>
+// CHECK:STDOUT:   %.loc7_3.32 => constants.%inst.call
+// CHECK:STDOUT:   %.loc7_3.33 => constants.%empty_tuple.type
+// CHECK:STDOUT:   %.loc7_3.34 => invalid
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/eval/call.carbon
+++ b/toolchain/check/testdata/eval/call.carbon
@@ -79,16 +79,9 @@ fn G(generic N: i32) {
   var unused a: array(i32, F(N)) = (0, 1, 2);
 }
 
-// CHECK:STDERR: fail_todo_dependent_call.carbon:[[@LINE+7]]:10: error: unable to monomorphize specific `G(3)` [ResolvingSpecificHere]
-// CHECK:STDERR: fn H() { G(3); }
-// CHECK:STDERR:          ^
-// CHECK:STDERR: fail_todo_dependent_call.carbon:[[@LINE-6]]:3: note: value of type `<bound method>` is not callable [CallToNonCallable]
-// CHECK:STDERR:   var unused a: array(i32, F(N)) = (0, 1, 2);
-// CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// CHECK:STDERR:
 fn H() { G(3); }
 
-// --- fail_todo_dependent_call_type.carbon
+// --- dependent_call_type.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -97,18 +90,13 @@ eval fn F(_: i32) -> type {
   return C;
 }
 
+//@dump-sem-ir-begin
 fn UseFGenerically(generic X: i32) {
   var unused v: F(X) = {};
 }
+//@dump-sem-ir-end
 
 fn UseFSpecifically() {
-  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE+7]]:3: error: unable to monomorphize specific `UseFGenerically(3)` [ResolvingSpecificHere]
-  // CHECK:STDERR:   UseFGenerically(3);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~
-  // CHECK:STDERR: fail_todo_dependent_call_type.carbon:[[@LINE-7]]:3: note: value of type `<bound method>` is not callable [CallToNonCallable]
-  // CHECK:STDERR:   var unused v: F(X) = {};
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   UseFGenerically(3);
 }
 
@@ -174,6 +162,219 @@ fn H() {
   //@dump-sem-ir-end
 }
 
+// CHECK:STDOUT: --- dependent_call_type.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %C: type = class_type @C [concrete]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %pattern_type.6b6: type = pattern_type %i32 [concrete]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %.Self.frozen: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %X.patt: %pattern_type.6b6 = symbolic_binding_pattern X, 0 [symbolic]
+// CHECK:STDOUT:   %X: %i32 = symbolic_binding X, 0 [symbolic]
+// CHECK:STDOUT:   %UseFGenerically.type: type = fn_type @UseFGenerically [concrete]
+// CHECK:STDOUT:   %UseFGenerically: %UseFGenerically.type = struct_value () [concrete]
+// CHECK:STDOUT:   %F.call: init type = call %F(%X) [template]
+// CHECK:STDOUT:   %require_complete.d08: <witness> = require_complete_type %F.call [template]
+// CHECK:STDOUT:   %pattern_type.231: type = pattern_type %F.call [template]
+// CHECK:STDOUT:   %v.patt.bcc: %pattern_type.231 = ref_binding_pattern v [template]
+// CHECK:STDOUT:   %v.var_patt.53d: %pattern_type.231 = var_pattern %v.patt.bcc [template]
+// CHECK:STDOUT:   %empty_struct: %empty_struct_type = struct_value () [concrete]
+// CHECK:STDOUT:   %ImplicitAs.type.0ff: type = generic_interface_type @ImplicitAs [concrete]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.0ff = struct_value () [concrete]
+// CHECK:STDOUT:   %.4e499d.1: @UseFGenerically.%.loc11_3.12 (@UseFGenerically.%.loc11_3.12) = splice_inst @UseFGenerically.%.loc11_3.11 [template]
+// CHECK:STDOUT:   %.6c2dfb.1: @UseFGenerically.%.loc11_3.15 (@UseFGenerically.%.loc11_3.15) = splice_inst @UseFGenerically.%.loc11_3.14 [template]
+// CHECK:STDOUT:   %.031: @UseFGenerically.%.loc11_3.18 (@UseFGenerically.%.loc11_3.18) = splice_inst @UseFGenerically.%.loc11_3.17 [template]
+// CHECK:STDOUT:   %.88d: @UseFGenerically.%.loc11_3.21 (@UseFGenerically.%.loc11_3.21) = splice_inst @UseFGenerically.%.loc11_3.20 [template]
+// CHECK:STDOUT:   %.1d7: %F.call = splice_inst @UseFGenerically.%.loc11_3.23 [template]
+// CHECK:STDOUT:   %.55e: %F.call = splice_inst @UseFGenerically.%.loc11_3.25 [template]
+// CHECK:STDOUT:   %Destroy.type: type = facet_type <@Destroy> [concrete]
+// CHECK:STDOUT:   %Self.0e7: %Destroy.type = symbolic_binding Self, 0 [symbolic]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.d3e: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Self.0e7) [symbolic]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.42b: %Destroy.WithSelf.Op.type.d3e = struct_value () [symbolic]
+// CHECK:STDOUT:   %Destroy.assoc_type: type = assoc_entity_type @Destroy [concrete]
+// CHECK:STDOUT:   %assoc0.ae8: %Destroy.assoc_type = assoc_entity element0, imports.%Core.import_ref.918 [concrete]
+// CHECK:STDOUT:   %.885: %F.call = splice_inst @UseFGenerically.%.loc11_3.27 [template]
+// CHECK:STDOUT:   %.0c8: @UseFGenerically.%.loc11_3.30 (@UseFGenerically.%.loc11_3.30) = splice_inst @UseFGenerically.%.loc11_3.29 [template]
+// CHECK:STDOUT:   %.6cb: @UseFGenerically.%.loc11_3.33 (@UseFGenerically.%.loc11_3.33) = splice_inst @UseFGenerically.%.loc11_3.32 [template]
+// CHECK:STDOUT:   %int_3.410: %i32 = int_value 3 [concrete]
+// CHECK:STDOUT:   %pattern_type.98b: type = pattern_type %C [concrete]
+// CHECK:STDOUT:   %v.patt.5c6: %pattern_type.98b = ref_binding_pattern v [concrete]
+// CHECK:STDOUT:   %v.var_patt.a6f: %pattern_type.98b = var_pattern %v.patt.5c6 [concrete]
+// CHECK:STDOUT:   %.2e6: <instruction> = call_action (%ImplicitAs.generic, %F.call), false [template]
+// CHECK:STDOUT:   %.53a: type = type_of_inst %.2e6 [template]
+// CHECK:STDOUT:   %.4e499d.2: %.53a = splice_inst %.2e6 [template]
+// CHECK:STDOUT:   %.b1d: <instruction> = access_member_action %.4e499d.2, Convert [template]
+// CHECK:STDOUT:   %.7df: type = type_of_inst %.b1d [template]
+// CHECK:STDOUT:   %.6c2dfb.2: %.7df = splice_inst %.b1d [template]
+// CHECK:STDOUT:   %.f27: <instruction> = compound_member_access_action %empty_struct, %.6c2dfb.2 [template]
+// CHECK:STDOUT:   %.396: type = type_of_inst %.f27 [template]
+// CHECK:STDOUT:   %.114: %.396 = splice_inst %.f27 [template]
+// CHECK:STDOUT:   %.f4b: <instruction> = call_action (%.114), true [template]
+// CHECK:STDOUT:   %.eb2: type = type_of_inst %.f4b [template]
+// CHECK:STDOUT:   %.1c7: %.eb2 = splice_inst %.f4b [template]
+// CHECK:STDOUT:   %.0b5: %C = splice_inst %.f4b [template]
+// CHECK:STDOUT:   %inst.as_compatible.e86: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.daf: %C = as_compatible %.1c7 [template = %.0b5]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.ecf: <instruction> = convert_to_category_action %.0b5, element10 [template]
+// CHECK:STDOUT:   %.b86: %C = splice_inst %.ecf [template]
+// CHECK:STDOUT:   %inst.as_compatible.9d0: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.9fb: ref %C = as_compatible @UseFGenerically.%v.var
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %Destroy.Op.type.1d8f74.2: type = fn_type @Destroy.Op.loc11_3.2 [concrete]
+// CHECK:STDOUT:   %Destroy.Op.1a2547.2: %Destroy.Op.type.1d8f74.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %custom_witness.df9cc1.2: <witness> = custom_witness (%Destroy.Op.1a2547.2), @Destroy [concrete]
+// CHECK:STDOUT:   %Destroy.facet.1a5: %Destroy.type = facet_value %C, (%custom_witness.df9cc1.2) [concrete]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.7f2: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Destroy.facet.1a5) [concrete]
+// CHECK:STDOUT:   %.da8: type = fn_type_with_self_type %Destroy.WithSelf.Op.type.7f2, %Destroy.facet.1a5 [concrete]
+// CHECK:STDOUT:   %inst.splice_block: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.7ba: <bound method> = splice_block %bound_method.767 {
+// CHECK:STDOUT:       %impl.elem0.96c: %.da8 = impl_witness_access %custom_witness.df9cc1.2, element0 [concrete = %Destroy.Op.1a2547.2]
+// CHECK:STDOUT:       %bound_method.767: <bound method> = bound_method %.9fb, %impl.elem0.96c
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.call: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %Destroy.Op.call: init %empty_tuple.type = call %.7ba(%.9fb)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Core.import_ref.918: @Destroy.WithSelf.%Destroy.WithSelf.Op.type (%Destroy.WithSelf.Op.type.d3e) = import_ref Core//prelude/parts/destroy, loc{{\d+_\d+}}, loaded [symbolic = @Destroy.WithSelf.%Destroy.WithSelf.Op (constants.%Destroy.WithSelf.Op.42b)]
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   %UseFGenerically.decl: %UseFGenerically.type = fn_decl @UseFGenerically [concrete = constants.%UseFGenerically] {
+// CHECK:STDOUT:     %X.patt.loc10_29.1: %pattern_type.6b6 = symbolic_binding_pattern X, 0 [symbolic = %X.patt.loc10_29.2 (constants.%X.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.loc10: type = splice_block %i32 [concrete = constants.%i32] {
+// CHECK:STDOUT:       %.Self.frozen: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.frozen]
+// CHECK:STDOUT:       %i32: type = type_literal constants.%i32 [concrete = constants.%i32]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %X.loc10_29.2: %i32 = symbolic_binding X, 0 [symbolic = %X.loc10_29.1 (constants.%X)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @UseFGenerically(%X.loc10_29.2: %i32) {
+// CHECK:STDOUT:   %X.patt.loc10_29.2: %pattern_type.6b6 = symbolic_binding_pattern X, 0 [symbolic = %X.patt.loc10_29.2 (constants.%X.patt)]
+// CHECK:STDOUT:   %X.loc10_29.1: %i32 = symbolic_binding X, 0 [symbolic = %X.loc10_29.1 (constants.%X)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %F.call.loc11_20.2: init type = call constants.%F(%X.loc10_29.1) [template = %F.call.loc11_20.2 (constants.%F.call)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %F.call.loc11_20.2 [template = %require_complete (constants.%require_complete.d08)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %F.call.loc11_20.2 [template = %pattern_type (constants.%pattern_type.231)]
+// CHECK:STDOUT:   %v.patt.loc11_15.2: @UseFGenerically.%pattern_type (%pattern_type.231) = ref_binding_pattern v [template = %v.patt.loc11_15.2 (constants.%v.patt.bcc)]
+// CHECK:STDOUT:   %v.var_patt.loc11_3.2: @UseFGenerically.%pattern_type (%pattern_type.231) = var_pattern %v.patt.loc11_15.2 [template = %v.var_patt.loc11_3.2 (constants.%v.var_patt.53d)]
+// CHECK:STDOUT:   %.loc11_3.11: <instruction> = call_action (constants.%ImplicitAs.generic, constants.%F.call), false [template]
+// CHECK:STDOUT:   %.loc11_3.12: type = type_of_inst %.loc11_3.11 [template]
+// CHECK:STDOUT:   %.loc11_3.13: @UseFGenerically.%.loc11_3.12 (@UseFGenerically.%.loc11_3.12) = splice_inst %.loc11_3.11 [template = %.loc11_3.13 (constants.%.4e499d.1)]
+// CHECK:STDOUT:   %.loc11_3.14: <instruction> = access_member_action %.loc11_3.1, Convert [template]
+// CHECK:STDOUT:   %.loc11_3.15: type = type_of_inst %.loc11_3.14 [template]
+// CHECK:STDOUT:   %.loc11_3.16: @UseFGenerically.%.loc11_3.15 (@UseFGenerically.%.loc11_3.15) = splice_inst %.loc11_3.14 [template = %.loc11_3.16 (constants.%.6c2dfb.1)]
+// CHECK:STDOUT:   %.loc11_3.17: <instruction> = compound_member_access_action %.loc11_25, %.loc11_3.2 [template]
+// CHECK:STDOUT:   %.loc11_3.18: type = type_of_inst %.loc11_3.17 [template]
+// CHECK:STDOUT:   %.loc11_3.19: @UseFGenerically.%.loc11_3.18 (@UseFGenerically.%.loc11_3.18) = splice_inst %.loc11_3.17 [template = %.loc11_3.19 (constants.%.031)]
+// CHECK:STDOUT:   %.loc11_3.20: <instruction> = call_action (%.loc11_3.3), true [template]
+// CHECK:STDOUT:   %.loc11_3.21: type = type_of_inst %.loc11_3.20 [template]
+// CHECK:STDOUT:   %.loc11_3.22: @UseFGenerically.%.loc11_3.21 (@UseFGenerically.%.loc11_3.21) = splice_inst %.loc11_3.20 [template = %.loc11_3.22 (constants.%.88d)]
+// CHECK:STDOUT:   %.loc11_3.23: <instruction> = refine_type_action %.loc11_3.5, %F.call.loc11_20.2 [template]
+// CHECK:STDOUT:   %.loc11_3.24: @UseFGenerically.%F.call.loc11_20.2 (%F.call) = splice_inst %.loc11_3.23 [template = %.loc11_3.24 (constants.%.1d7)]
+// CHECK:STDOUT:   %.loc11_3.25: <instruction> = convert_to_category_action %.loc11_3.6, element10 [template]
+// CHECK:STDOUT:   %.loc11_3.26: @UseFGenerically.%F.call.loc11_20.2 (%F.call) = splice_inst %.loc11_3.25 [template = %.loc11_3.26 (constants.%.55e)]
+// CHECK:STDOUT:   %.loc11_3.27: <instruction> = refine_type_action %v.var, %F.call.loc11_20.2 [template]
+// CHECK:STDOUT:   %.loc11_3.28: @UseFGenerically.%F.call.loc11_20.2 (%F.call) = splice_inst %.loc11_3.27 [template = %.loc11_3.28 (constants.%.885)]
+// CHECK:STDOUT:   %.loc11_3.29: <instruction> = compound_member_access_action %.loc11_3.8, constants.%assoc0.ae8 [template]
+// CHECK:STDOUT:   %.loc11_3.30: type = type_of_inst %.loc11_3.29 [template]
+// CHECK:STDOUT:   %.loc11_3.31: @UseFGenerically.%.loc11_3.30 (@UseFGenerically.%.loc11_3.30) = splice_inst %.loc11_3.29 [template = %.loc11_3.31 (constants.%.0c8)]
+// CHECK:STDOUT:   %.loc11_3.32: <instruction> = call_action (%.loc11_3.9), true [template]
+// CHECK:STDOUT:   %.loc11_3.33: type = type_of_inst %.loc11_3.32 [template]
+// CHECK:STDOUT:   %.loc11_3.34: @UseFGenerically.%.loc11_3.33 (@UseFGenerically.%.loc11_3.33) = splice_inst %.loc11_3.32 [template = %.loc11_3.34 (constants.%.6cb)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %v.var: ref @UseFGenerically.%F.call.loc11_20.2 (%F.call) = var_storage %v.var_patt.loc11_3.1
+// CHECK:STDOUT:     %.loc11_25: %empty_struct_type = struct_literal () [concrete = constants.%empty_struct]
+// CHECK:STDOUT:     %.loc11_3.1: @UseFGenerically.%.loc11_3.12 (@UseFGenerically.%.loc11_3.12) = splice_inst %.loc11_3.11 [template = %.loc11_3.13 (constants.%.4e499d.1)]
+// CHECK:STDOUT:     %.loc11_3.2: @UseFGenerically.%.loc11_3.15 (@UseFGenerically.%.loc11_3.15) = splice_inst %.loc11_3.14 [template = %.loc11_3.16 (constants.%.6c2dfb.1)]
+// CHECK:STDOUT:     %.loc11_3.3: @UseFGenerically.%.loc11_3.18 (@UseFGenerically.%.loc11_3.18) = splice_inst %.loc11_3.17 [template = %.loc11_3.19 (constants.%.031)]
+// CHECK:STDOUT:     %.loc11_3.4: @UseFGenerically.%.loc11_3.21 (@UseFGenerically.%.loc11_3.21) = splice_inst %.loc11_3.20 [template = %.loc11_3.22 (constants.%.88d)]
+// CHECK:STDOUT:     %.loc11_3.5: @UseFGenerically.%F.call.loc11_20.2 (%F.call) = converted %.loc11_25, %.loc11_3.4 [template = %.loc11_3.22 (constants.%.88d)]
+// CHECK:STDOUT:     %.loc11_3.6: @UseFGenerically.%F.call.loc11_20.2 (%F.call) = splice_inst %.loc11_3.23 [template = %.loc11_3.24 (constants.%.1d7)]
+// CHECK:STDOUT:     %.loc11_3.7: @UseFGenerically.%F.call.loc11_20.2 (%F.call) = splice_inst %.loc11_3.25 [template = %.loc11_3.26 (constants.%.55e)]
+// CHECK:STDOUT:     assign %v.var, %.loc11_3.7
+// CHECK:STDOUT:     %.loc11_20.1: type = splice_block %.loc11_20.3 [template = %F.call.loc11_20.2 (constants.%F.call)] {
+// CHECK:STDOUT:       %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:       %X.ref: %i32 = name_ref X, %X.loc10_29.2 [symbolic = %X.loc10_29.1 (constants.%X)]
+// CHECK:STDOUT:       %F.call.loc11_20.1: init type = call %F.ref(%X.ref) [template = %F.call.loc11_20.2 (constants.%F.call)]
+// CHECK:STDOUT:       %.loc11_20.2: type = value_of_initializer %F.call.loc11_20.1 [template = %F.call.loc11_20.2 (constants.%F.call)]
+// CHECK:STDOUT:       %.loc11_20.3: type = converted %F.call.loc11_20.1, %.loc11_20.2 [template = %F.call.loc11_20.2 (constants.%F.call)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %v: ref @UseFGenerically.%F.call.loc11_20.2 (%F.call) = wrapper_binding v, %v.var
+// CHECK:STDOUT:     name_binding_decl {
+// CHECK:STDOUT:       %v.patt.loc11_15.1: @UseFGenerically.%pattern_type (%pattern_type.231) = ref_binding_pattern v [template = %v.patt.loc11_15.2 (constants.%v.patt.bcc)]
+// CHECK:STDOUT:       %v.var_patt.loc11_3.1: @UseFGenerically.%pattern_type (%pattern_type.231) = var_pattern %v.patt.loc11_15.1 [template = %v.var_patt.loc11_3.2 (constants.%v.var_patt.53d)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %.loc11_3.8: @UseFGenerically.%F.call.loc11_20.2 (%F.call) = splice_inst %.loc11_3.27 [template = %.loc11_3.28 (constants.%.885)]
+// CHECK:STDOUT:     %.loc11_3.9: @UseFGenerically.%.loc11_3.30 (@UseFGenerically.%.loc11_3.30) = splice_inst %.loc11_3.29 [template = %.loc11_3.31 (constants.%.0c8)]
+// CHECK:STDOUT:     %.loc11_3.10: @UseFGenerically.%.loc11_3.33 (@UseFGenerically.%.loc11_3.33) = splice_inst %.loc11_3.32 [template = %.loc11_3.34 (constants.%.6cb)]
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Destroy.Op.loc11_3.1(%self.param: ref %empty_struct_type) = "no_op";
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @Destroy.Op.loc11_3.2(%self.param: ref %C) {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @UseFGenerically(constants.%X) {
+// CHECK:STDOUT:   %X.patt.loc10_29.2 => constants.%X.patt
+// CHECK:STDOUT:   %X.loc10_29.1 => constants.%X
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @UseFGenerically(constants.%int_3.410) {
+// CHECK:STDOUT:   %X.patt.loc10_29.2 => constants.%X.patt
+// CHECK:STDOUT:   %X.loc10_29.1 => constants.%int_3.410
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %F.call.loc11_20.2 => constants.%C
+// CHECK:STDOUT:   %require_complete => constants.%complete_type.357
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.98b
+// CHECK:STDOUT:   %v.patt.loc11_15.2 => constants.%v.patt.5c6
+// CHECK:STDOUT:   %v.var_patt.loc11_3.2 => constants.%v.var_patt.a6f
+// CHECK:STDOUT:   %.loc11_3.11 => constants.%.2e6
+// CHECK:STDOUT:   %.loc11_3.12 => constants.%.53a
+// CHECK:STDOUT:   %.loc11_3.13 => constants.%.4e499d.2
+// CHECK:STDOUT:   %.loc11_3.14 => constants.%.b1d
+// CHECK:STDOUT:   %.loc11_3.15 => constants.%.7df
+// CHECK:STDOUT:   %.loc11_3.16 => constants.%.6c2dfb.2
+// CHECK:STDOUT:   %.loc11_3.17 => constants.%.f27
+// CHECK:STDOUT:   %.loc11_3.18 => constants.%.396
+// CHECK:STDOUT:   %.loc11_3.19 => constants.%.114
+// CHECK:STDOUT:   %.loc11_3.20 => constants.%.f4b
+// CHECK:STDOUT:   %.loc11_3.21 => constants.%.eb2
+// CHECK:STDOUT:   %.loc11_3.22 => constants.%.1c7
+// CHECK:STDOUT:   %.loc11_3.23 => constants.%inst.as_compatible.e86
+// CHECK:STDOUT:   %.loc11_3.24 => constants.%.0b5
+// CHECK:STDOUT:   %.loc11_3.25 => constants.%.ecf
+// CHECK:STDOUT:   %.loc11_3.26 => constants.%.b86
+// CHECK:STDOUT:   %.loc11_3.27 => constants.%inst.as_compatible.9d0
+// CHECK:STDOUT:   %.loc11_3.28 => invalid
+// CHECK:STDOUT:   %.loc11_3.29 => constants.%inst.splice_block
+// CHECK:STDOUT:   %.loc11_3.30 => <bound method>
+// CHECK:STDOUT:   %.loc11_3.31 => invalid
+// CHECK:STDOUT:   %.loc11_3.32 => constants.%inst.call
+// CHECK:STDOUT:   %.loc11_3.33 => constants.%empty_tuple.type
+// CHECK:STDOUT:   %.loc11_3.34 => invalid
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
 // CHECK:STDOUT: --- return_in_place_discarded.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/testdata/generic/template_dependence.carbon
+++ b/toolchain/check/testdata/generic/template_dependence.carbon
@@ -10,7 +10,7 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/check/testdata/generic/template_dependence.carbon
 
-// --- fail_todo_type.carbon
+// --- type.carbon
 
 library "[[@TEST_NAME]]";
 
@@ -20,13 +20,6 @@ fn F[template T: type](x: T**) -> T* {
 }
 
 fn G(x: ()**) -> ()* {
-  // CHECK:STDERR: fail_todo_type.carbon:[[@LINE+7]]:10: error: unable to monomorphize specific `F(())` [ResolvingSpecificHere]
-  // CHECK:STDERR:   return F(x);
-  // CHECK:STDERR:          ^
-  // CHECK:STDERR: fail_todo_type.carbon:[[@LINE-7]]:10: note: value of type `<bound method>` is not callable [CallToNonCallable]
-  // CHECK:STDERR:   return *x;
-  // CHECK:STDERR:          ^~
-  // CHECK:STDERR:
   return F(x);
 }
 //@dump-sem-ir-end
@@ -42,7 +35,7 @@ fn F(template T: type, generic U: type) -> (T, U) {
 //@dump-sem-ir-end
 
 
-// CHECK:STDOUT: --- fail_todo_type.carbon
+// CHECK:STDOUT: --- type.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {
 // CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
@@ -102,13 +95,21 @@ fn F(template T: type, generic U: type) -> (T, U) {
 // CHECK:STDOUT:   %Copy.WithSelf.Op.type.9ea: type = fn_type @Copy.WithSelf.Op, @Copy.WithSelf(%Copy.facet) [concrete]
 // CHECK:STDOUT:   %.b77: type = fn_type_with_self_type %Copy.WithSelf.Op.type.9ea, %Copy.facet [concrete]
 // CHECK:STDOUT:   %inst.splice_block.64f: <instruction> = inst_value [concrete] {
-// CHECK:STDOUT:     %.aaa: <bound method> = splice_block %bound_method {
+// CHECK:STDOUT:     %.aaa: <bound method> = splice_block %bound_method.661 {
 // CHECK:STDOUT:       %impl.elem0.227: %.b77 = impl_witness_access %Copy.impl_witness.5e7, element0 [concrete = %ptr.as.Copy.impl.Op.ee1]
-// CHECK:STDOUT:       %bound_method: <bound method> = bound_method %.34a, %impl.elem0.227
+// CHECK:STDOUT:       %bound_method.661: <bound method> = bound_method %.34a, %impl.elem0.227
 // CHECK:STDOUT:     }
 // CHECK:STDOUT:   }
-// CHECK:STDOUT:   %inst.splice_block.edd: <instruction> = inst_value [concrete] {
-// CHECK:STDOUT:     %.432: <error> = splice_block <error> [concrete = <error>] {}
+// CHECK:STDOUT:   %ptr.as.Copy.impl.Op.specific_fn: <specific function> = specific_function %ptr.as.Copy.impl.Op.ee1, @ptr.as.Copy.impl.Op(%empty_tuple.type) [concrete]
+// CHECK:STDOUT:   %inst.splice_block.a80: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.e72: init %ptr.843 = splice_block %ptr.as.Copy.impl.Op.call {
+// CHECK:STDOUT:       %specific_fn: <specific function> = specific_function %impl.elem0.227, @ptr.as.Copy.impl.Op(%empty_tuple.type) [concrete = %ptr.as.Copy.impl.Op.specific_fn]
+// CHECK:STDOUT:       %bound_method.b01: <bound method> = bound_method %.34a, %specific_fn
+// CHECK:STDOUT:       %ptr.as.Copy.impl.Op.call: init %ptr.843 = call %bound_method.b01(%.34a)
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.splice_block.333: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.932: init %ptr.843 = splice_block %.e72 {}
 // CHECK:STDOUT:   }
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
@@ -251,11 +252,11 @@ fn F(template T: type, generic U: type) -> (T, U) {
 // CHECK:STDOUT:   %.loc6_10.8 => constants.%inst.splice_block.64f
 // CHECK:STDOUT:   %.loc6_10.9 => <bound method>
 // CHECK:STDOUT:   %.loc6_10.10 => invalid
-// CHECK:STDOUT:   %.loc6_10.11 => constants.%inst.splice_block.edd
-// CHECK:STDOUT:   %.loc6_10.12 => <error>
-// CHECK:STDOUT:   %.loc6_10.13 => <error>
-// CHECK:STDOUT:   %.loc6_12.2 => <error>
-// CHECK:STDOUT:   %.loc6_12.3 => <error>
+// CHECK:STDOUT:   %.loc6_10.11 => constants.%inst.splice_block.a80
+// CHECK:STDOUT:   %.loc6_10.12 => constants.%ptr.843
+// CHECK:STDOUT:   %.loc6_10.13 => invalid
+// CHECK:STDOUT:   %.loc6_12.2 => constants.%inst.splice_block.333
+// CHECK:STDOUT:   %.loc6_12.3 => invalid
 // CHECK:STDOUT: }
 // CHECK:STDOUT:
 // CHECK:STDOUT: --- mixed.carbon

--- a/toolchain/check/testdata/interop/cpp/class/import/template.carbon
+++ b/toolchain/check/testdata/interop/cpp/class/import/template.carbon
@@ -126,7 +126,7 @@ template<typename T>
 struct A {};
 ''';
 
-// @dump-sem-ir-begin
+//@dump-sem-ir-begin
 fn F(generic T: type) {
   let unused a: Cpp.A(T) = Cpp.A(T).A();
 }
@@ -134,9 +134,9 @@ fn F(generic T: type) {
 fn G() {
   F(i32);
 }
-// @dump-sem-ir-end
+//@dump-sem-ir-end
 
-// --- fail_todo_var_cpp_template_constructor.carbon
+// --- var_cpp_template_constructor.carbon
 
 library "[[@TEST_NAME]]";
 import Cpp inline '''
@@ -144,18 +144,13 @@ template<typename T>
 struct A {};
 ''';
 
+//@dump-sem-ir-begin
 fn F(generic T: type) {
   var unused a: Cpp.A(T) = Cpp.A(T).A();
 }
+//@dump-sem-ir-end
 
 fn G() {
-  // CHECK:STDERR: fail_todo_var_cpp_template_constructor.carbon:[[@LINE+7]]:3: error: unable to monomorphize specific `F(i32)` [ResolvingSpecificHere]
-  // CHECK:STDERR:   F(i32);
-  // CHECK:STDERR:   ^
-  // CHECK:STDERR: fail_todo_var_cpp_template_constructor.carbon:[[@LINE-7]]:3: note: value of type `<bound method>` is not callable [CallToNonCallable]
-  // CHECK:STDERR:   var unused a: Cpp.A(T) = Cpp.A(T).A();
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   F(i32);
 }
 
@@ -492,5 +487,463 @@ fn G() {
 // CHECK:STDOUT:   %B.elem => constants.%B.elem.1e0
 // CHECK:STDOUT:   %struct_type.a => constants.%struct_type.a.b63
 // CHECK:STDOUT:   %complete_type.loc13_1.2 => constants.%complete_type.594
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- let_cpp_template_constructor.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %.Self.frozen: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
+// CHECK:STDOUT:   %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %A.type: type = cpp_type_template_type A [concrete]
+// CHECK:STDOUT:   %A.template: %A.type = struct_value () [concrete]
+// CHECK:STDOUT:   %.ae6cd7.1: @F.%.loc10_24.5 (@F.%.loc10_24.5) = splice_inst @F.%.loc10_24.4 [template]
+// CHECK:STDOUT:   %.535: type = splice_inst @F.%.loc10_24.7 [template]
+// CHECK:STDOUT:   %require_complete.01e: <witness> = require_complete_type %.535 [template]
+// CHECK:STDOUT:   %pattern_type.281: type = pattern_type %.535 [template]
+// CHECK:STDOUT:   %a.patt.4ab: %pattern_type.281 = value_binding_pattern a [template]
+// CHECK:STDOUT:   %.ae6cd7.2: @F.%.loc10_35.3 (@F.%.loc10_35.3) = splice_inst @F.%.loc10_35.2 [template]
+// CHECK:STDOUT:   %.4bf: @F.%.loc10_36.3 (@F.%.loc10_36.3) = splice_inst @F.%.loc10_36.2 [template]
+// CHECK:STDOUT:   %.7cc: @F.%.loc10_39.4 (@F.%.loc10_39.4) = splice_inst @F.%.loc10_39.3 [template]
+// CHECK:STDOUT:   %.14b: %.535 = splice_inst @F.%.loc10_39.6 [template]
+// CHECK:STDOUT:   %G.type: type = fn_type @G [concrete]
+// CHECK:STDOUT:   %G: %G.type = struct_value () [concrete]
+// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F, @F(%i32) [concrete]
+// CHECK:STDOUT:   %A: type = class_type @A [concrete]
+// CHECK:STDOUT:   %inst.splice_block.72dff3.1: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.22ed96.1: type = splice_block imports.%A.decl [concrete = %A] {}
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.splice_block.c26: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.4e4: type = splice_block %A [concrete = %A] {}
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %pattern_type.b78: type = pattern_type %A [concrete]
+// CHECK:STDOUT:   %a.patt.117: %pattern_type.b78 = value_binding_pattern a [concrete]
+// CHECK:STDOUT:   %inst.splice_block.72dff3.2: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.22ed96.2: type = splice_block imports.%A.decl [concrete = %A] {}
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A.A.cpp_overload_set.type: type = cpp_overload_set_type @A.A.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %A.A.cpp_overload_set.value: %A.A.cpp_overload_set.type = cpp_overload_set_value @A.A.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %inst.name_ref: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %A.ref: %A.A.cpp_overload_set.type = name_ref A, imports.%A.A.cpp_overload_set.value [concrete = %A.A.cpp_overload_set.value]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ptr.303: type = ptr_type %A [concrete]
+// CHECK:STDOUT:   %A__carbon_thunk.type: type = fn_type @A__carbon_thunk [concrete]
+// CHECK:STDOUT:   %A__carbon_thunk: %A__carbon_thunk.type = struct_value () [concrete]
+// CHECK:STDOUT:   %inst.splice_block.76c: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.78f: init %A = splice_block %.38d {
+// CHECK:STDOUT:       %.3a8: ref %A = temporary_storage
+// CHECK:STDOUT:       %addr: %ptr.303 = addr_of %.3a8
+// CHECK:STDOUT:       %A__carbon_thunk.call: init %empty_tuple.type = call imports.%A__carbon_thunk.decl(%addr)
+// CHECK:STDOUT:       %.38d: init %A to %.3a8 = mark_in_place_init %A__carbon_thunk.call
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.splice_block.b90: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.114: %A = splice_block %.f4b {
+// CHECK:STDOUT:       %.146: ref %A = temporary %.3a8, %.78f
+// CHECK:STDOUT:       %.f4b: %A = acquire_value %.146
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .A = %A.template
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A.template: %A.type = struct_value () [concrete = constants.%A.template]
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [concrete = constants.%A] {} {}
+// CHECK:STDOUT:   %A.A.cpp_overload_set.value: %A.A.cpp_overload_set.type = cpp_overload_set_value @A.A.cpp_overload_set [concrete = constants.%A.A.cpp_overload_set.value]
+// CHECK:STDOUT:   %A__carbon_thunk.decl: %A__carbon_thunk.type = fn_decl @A__carbon_thunk [concrete = constants.%A__carbon_thunk] {
+// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %T.patt.loc9_15.1: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc9_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.loc9_17.1: type = splice_block %.loc9_17.2 [concrete = type] {
+// CHECK:STDOUT:       %.Self.frozen: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.frozen]
+// CHECK:STDOUT:       %.loc9_17.2: type = type_literal type [concrete = type]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %T.loc9_15.2: type = symbolic_binding T, 0 [symbolic = %T.loc9_15.1 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %G.decl: %G.type = fn_decl @G [concrete = constants.%G] {} {}
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F(%T.loc9_15.2: type) {
+// CHECK:STDOUT:   %T.patt.loc9_15.2: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc9_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %T.loc9_15.1: type = symbolic_binding T, 0 [symbolic = %T.loc9_15.1 (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %.loc10_24.4: <instruction> = call_template_action clang_decl_id6C000002, (%T.loc9_15.1) [template]
+// CHECK:STDOUT:   %.loc10_24.5: type = type_of_inst %.loc10_24.4 [template]
+// CHECK:STDOUT:   %.loc10_24.6: @F.%.loc10_24.5 (@F.%.loc10_24.5) = splice_inst %.loc10_24.4 [template = %.loc10_24.6 (constants.%.ae6cd7.1)]
+// CHECK:STDOUT:   %.loc10_24.7: <instruction> = convert_to_value_action %.loc10_24.2, type [template]
+// CHECK:STDOUT:   %.loc10_24.8: type = splice_inst %.loc10_24.7 [template = %.loc10_24.8 (constants.%.535)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %.loc10_24.8 [template = %require_complete (constants.%require_complete.01e)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %.loc10_24.8 [template = %pattern_type (constants.%pattern_type.281)]
+// CHECK:STDOUT:   %a.patt.loc10_15.2: @F.%pattern_type (%pattern_type.281) = value_binding_pattern a [template = %a.patt.loc10_15.2 (constants.%a.patt.4ab)]
+// CHECK:STDOUT:   %.loc10_35.2: <instruction> = call_template_action clang_decl_id6C000002, (%T.loc9_15.1) [template]
+// CHECK:STDOUT:   %.loc10_35.3: type = type_of_inst %.loc10_35.2 [template]
+// CHECK:STDOUT:   %.loc10_35.4: @F.%.loc10_35.3 (@F.%.loc10_35.3) = splice_inst %.loc10_35.2 [template = %.loc10_35.4 (constants.%.ae6cd7.2)]
+// CHECK:STDOUT:   %.loc10_36.2: <instruction> = access_member_action %.loc10_35.1, A [template]
+// CHECK:STDOUT:   %.loc10_36.3: type = type_of_inst %.loc10_36.2 [template]
+// CHECK:STDOUT:   %.loc10_36.4: @F.%.loc10_36.3 (@F.%.loc10_36.3) = splice_inst %.loc10_36.2 [template = %.loc10_36.4 (constants.%.4bf)]
+// CHECK:STDOUT:   %.loc10_39.3: <instruction> = call_action (%.loc10_36.1), false [template]
+// CHECK:STDOUT:   %.loc10_39.4: type = type_of_inst %.loc10_39.3 [template]
+// CHECK:STDOUT:   %.loc10_39.5: @F.%.loc10_39.4 (@F.%.loc10_39.4) = splice_inst %.loc10_39.3 [template = %.loc10_39.5 (constants.%.7cc)]
+// CHECK:STDOUT:   %.loc10_39.6: <instruction> = convert_to_value_action %.loc10_39.1, %.loc10_24.8 [template]
+// CHECK:STDOUT:   %.loc10_39.7: @F.%.loc10_24.8 (%.535) = splice_inst %.loc10_39.6 [template = %.loc10_39.7 (constants.%.14b)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %Cpp.ref.loc10_28: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %A.ref.loc10_31: %A.type = name_ref A, imports.%A.template [concrete = constants.%A.template]
+// CHECK:STDOUT:     %T.ref.loc10_34: type = name_ref T, %T.loc9_15.2 [symbolic = %T.loc9_15.1 (constants.%T)]
+// CHECK:STDOUT:     %.loc10_35.1: @F.%.loc10_35.3 (@F.%.loc10_35.3) = splice_inst %.loc10_35.2 [template = %.loc10_35.4 (constants.%.ae6cd7.2)]
+// CHECK:STDOUT:     %.loc10_36.1: @F.%.loc10_36.3 (@F.%.loc10_36.3) = splice_inst %.loc10_36.2 [template = %.loc10_36.4 (constants.%.4bf)]
+// CHECK:STDOUT:     %.loc10_39.1: @F.%.loc10_39.4 (@F.%.loc10_39.4) = splice_inst %.loc10_39.3 [template = %.loc10_39.5 (constants.%.7cc)]
+// CHECK:STDOUT:     %.loc10_39.2: @F.%.loc10_24.8 (%.535) = splice_inst %.loc10_39.6 [template = %.loc10_39.7 (constants.%.14b)]
+// CHECK:STDOUT:     %.loc10_24.1: type = splice_block %.loc10_24.3 [template = %.loc10_24.8 (constants.%.535)] {
+// CHECK:STDOUT:       %Cpp.ref.loc10_17: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:       %A.ref.loc10_20: %A.type = name_ref A, imports.%A.template [concrete = constants.%A.template]
+// CHECK:STDOUT:       %T.ref.loc10_23: type = name_ref T, %T.loc9_15.2 [symbolic = %T.loc9_15.1 (constants.%T)]
+// CHECK:STDOUT:       %.loc10_24.2: @F.%.loc10_24.5 (@F.%.loc10_24.5) = splice_inst %.loc10_24.4 [template = %.loc10_24.6 (constants.%.ae6cd7.1)]
+// CHECK:STDOUT:       %.loc10_24.3: type = splice_inst %.loc10_24.7 [template = %.loc10_24.8 (constants.%.535)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %a: @F.%.loc10_24.8 (%.535) = wrapper_binding a, %.loc10_39.2
+// CHECK:STDOUT:     name_binding_decl {
+// CHECK:STDOUT:       %a.patt.loc10_15.1: @F.%pattern_type (%pattern_type.281) = value_binding_pattern a [template = %a.patt.loc10_15.2 (constants.%a.patt.4ab)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: fn @G() {
+// CHECK:STDOUT: !entry:
+// CHECK:STDOUT:   %F.ref: %F.type = name_ref F, file.%F.decl [concrete = constants.%F]
+// CHECK:STDOUT:   %i32: type = type_literal constants.%i32 [concrete = constants.%i32]
+// CHECK:STDOUT:   %F.specific_fn: <specific function> = specific_function %F.ref, @F(constants.%i32) [concrete = constants.%F.specific_fn]
+// CHECK:STDOUT:   %F.call: init %empty_tuple.type = call %F.specific_fn()
+// CHECK:STDOUT:   return
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%T) {
+// CHECK:STDOUT:   %T.patt.loc9_15.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc9_15.1 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%i32) {
+// CHECK:STDOUT:   %T.patt.loc9_15.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc9_15.1 => constants.%i32
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %.loc10_24.4 => constants.%inst.splice_block.72dff3.1
+// CHECK:STDOUT:   %.loc10_24.5 => type
+// CHECK:STDOUT:   %.loc10_24.6 => constants.%A
+// CHECK:STDOUT:   %.loc10_24.7 => constants.%inst.splice_block.c26
+// CHECK:STDOUT:   %.loc10_24.8 => constants.%A
+// CHECK:STDOUT:   %require_complete => constants.%complete_type.357
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.b78
+// CHECK:STDOUT:   %a.patt.loc10_15.2 => constants.%a.patt.117
+// CHECK:STDOUT:   %.loc10_35.2 => constants.%inst.splice_block.72dff3.2
+// CHECK:STDOUT:   %.loc10_35.3 => type
+// CHECK:STDOUT:   %.loc10_35.4 => constants.%A
+// CHECK:STDOUT:   %.loc10_36.2 => constants.%inst.name_ref
+// CHECK:STDOUT:   %.loc10_36.3 => constants.%A.A.cpp_overload_set.type
+// CHECK:STDOUT:   %.loc10_36.4 => constants.%A.A.cpp_overload_set.value
+// CHECK:STDOUT:   %.loc10_39.3 => constants.%inst.splice_block.76c
+// CHECK:STDOUT:   %.loc10_39.4 => constants.%A
+// CHECK:STDOUT:   %.loc10_39.5 => invalid
+// CHECK:STDOUT:   %.loc10_39.6 => constants.%inst.splice_block.b90
+// CHECK:STDOUT:   %.loc10_39.7 => invalid
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: --- var_cpp_template_constructor.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %.Self.frozen: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
+// CHECK:STDOUT:   %T.patt: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %T: type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %A.type: type = cpp_type_template_type A [concrete]
+// CHECK:STDOUT:   %A.template: %A.type = struct_value () [concrete]
+// CHECK:STDOUT:   %.ae6cd7.1: @F.%.loc10_24.5 (@F.%.loc10_24.5) = splice_inst @F.%.loc10_24.4 [template]
+// CHECK:STDOUT:   %.535: type = splice_inst @F.%.loc10_24.7 [template]
+// CHECK:STDOUT:   %require_complete.01e: <witness> = require_complete_type %.535 [template]
+// CHECK:STDOUT:   %pattern_type.281: type = pattern_type %.535 [template]
+// CHECK:STDOUT:   %a.patt.44a: %pattern_type.281 = ref_binding_pattern a [template]
+// CHECK:STDOUT:   %a.var_patt.5fb: %pattern_type.281 = var_pattern %a.patt.44a [template]
+// CHECK:STDOUT:   %.ae6cd7.2: @F.%.loc10_35.3 (@F.%.loc10_35.3) = splice_inst @F.%.loc10_35.2 [template]
+// CHECK:STDOUT:   %.4bf: @F.%.loc10_36.3 (@F.%.loc10_36.3) = splice_inst @F.%.loc10_36.2 [template]
+// CHECK:STDOUT:   %.7cc: @F.%.loc10_39.3 (@F.%.loc10_39.3) = splice_inst @F.%.loc10_39.2 [template]
+// CHECK:STDOUT:   %ImplicitAs.type.0ff: type = generic_interface_type @ImplicitAs [concrete]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.0ff = struct_value () [concrete]
+// CHECK:STDOUT:   %.847f2c.1: @F.%.loc10_3.12 (@F.%.loc10_3.12) = splice_inst @F.%.loc10_3.11 [template]
+// CHECK:STDOUT:   %.7fa0c8.1: @F.%.loc10_3.15 (@F.%.loc10_3.15) = splice_inst @F.%.loc10_3.14 [template]
+// CHECK:STDOUT:   %.8da: @F.%.loc10_3.18 (@F.%.loc10_3.18) = splice_inst @F.%.loc10_3.17 [template]
+// CHECK:STDOUT:   %.9e9: @F.%.loc10_3.21 (@F.%.loc10_3.21) = splice_inst @F.%.loc10_3.20 [template]
+// CHECK:STDOUT:   %.9f8: %.535 = splice_inst @F.%.loc10_3.23 [template]
+// CHECK:STDOUT:   %.073: %.535 = splice_inst @F.%.loc10_3.25 [template]
+// CHECK:STDOUT:   %Destroy.type: type = facet_type <@Destroy> [concrete]
+// CHECK:STDOUT:   %Self.0e7: %Destroy.type = symbolic_binding Self, 0 [symbolic]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.d3e: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Self.0e7) [symbolic]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.42b: %Destroy.WithSelf.Op.type.d3e = struct_value () [symbolic]
+// CHECK:STDOUT:   %Destroy.assoc_type: type = assoc_entity_type @Destroy [concrete]
+// CHECK:STDOUT:   %assoc0.ae8: %Destroy.assoc_type = assoc_entity element0, imports.%Core.import_ref.918 [concrete]
+// CHECK:STDOUT:   %.cb8: %.535 = splice_inst @F.%.loc10_3.27 [template]
+// CHECK:STDOUT:   %.495: @F.%.loc10_3.30 (@F.%.loc10_3.30) = splice_inst @F.%.loc10_3.29 [template]
+// CHECK:STDOUT:   %.013: @F.%.loc10_3.33 (@F.%.loc10_3.33) = splice_inst @F.%.loc10_3.32 [template]
+// CHECK:STDOUT:   %int_32: Core.IntLiteral = int_value 32 [concrete]
+// CHECK:STDOUT:   %i32: type = class_type @Int, @Int(%int_32) [concrete]
+// CHECK:STDOUT:   %A: type = class_type @A [concrete]
+// CHECK:STDOUT:   %inst.splice_block.72dff3.1: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.22ed96.1: type = splice_block imports.%A.decl [concrete = %A] {}
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.splice_block.c26: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.4e4: type = splice_block %A [concrete = %A] {}
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %complete_type.357: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %pattern_type.b78: type = pattern_type %A [concrete]
+// CHECK:STDOUT:   %a.patt.198: %pattern_type.b78 = ref_binding_pattern a [concrete]
+// CHECK:STDOUT:   %a.var_patt.47b: %pattern_type.b78 = var_pattern %a.patt.198 [concrete]
+// CHECK:STDOUT:   %inst.splice_block.72dff3.2: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.22ed96.2: type = splice_block imports.%A.decl [concrete = %A] {}
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A.A.cpp_overload_set.type: type = cpp_overload_set_type @A.A.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %A.A.cpp_overload_set.value: %A.A.cpp_overload_set.type = cpp_overload_set_value @A.A.cpp_overload_set [concrete]
+// CHECK:STDOUT:   %inst.name_ref: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %A.ref: %A.A.cpp_overload_set.type = name_ref A, imports.%A.A.cpp_overload_set.value [concrete = %A.A.cpp_overload_set.value]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %ptr.303: type = ptr_type %A [concrete]
+// CHECK:STDOUT:   %A__carbon_thunk.type: type = fn_type @A__carbon_thunk [concrete]
+// CHECK:STDOUT:   %A__carbon_thunk: %A__carbon_thunk.type = struct_value () [concrete]
+// CHECK:STDOUT:   %inst.splice_block.76c: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.78f: init %A = splice_block %.38d {
+// CHECK:STDOUT:       %.3a8: ref %A = temporary_storage
+// CHECK:STDOUT:       %addr: %ptr.303 = addr_of %.3a8
+// CHECK:STDOUT:       %A__carbon_thunk.call: init %empty_tuple.type = call imports.%A__carbon_thunk.decl(%addr)
+// CHECK:STDOUT:       %.38d: init %A to %.3a8 = mark_in_place_init %A__carbon_thunk.call
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.04f: <instruction> = call_action (%ImplicitAs.generic, %.535), false [template]
+// CHECK:STDOUT:   %.5a1: type = type_of_inst %.04f [template]
+// CHECK:STDOUT:   %.847f2c.2: %.5a1 = splice_inst %.04f [template]
+// CHECK:STDOUT:   %.5d9: <instruction> = access_member_action %.847f2c.2, Convert [template]
+// CHECK:STDOUT:   %.831: type = type_of_inst %.5d9 [template]
+// CHECK:STDOUT:   %.7fa0c8.2: %.831 = splice_inst %.5d9 [template]
+// CHECK:STDOUT:   %.98e: <instruction> = compound_member_access_action %.78f, %.7fa0c8.2 [template]
+// CHECK:STDOUT:   %.81d: type = type_of_inst %.98e [template]
+// CHECK:STDOUT:   %.472: %.81d = splice_inst %.98e [template]
+// CHECK:STDOUT:   %.6bc: <instruction> = call_action (%.472), true [template]
+// CHECK:STDOUT:   %.133: type = type_of_inst %.6bc [template]
+// CHECK:STDOUT:   %.da3: %.133 = splice_inst %.6bc [template]
+// CHECK:STDOUT:   %.d73: %A = splice_inst %.6bc [template]
+// CHECK:STDOUT:   %inst.as_compatible.7b3: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.4c2: %A = as_compatible %.da3 [template = %.d73]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.33e: <instruction> = convert_to_category_action %.d73, element10 [template]
+// CHECK:STDOUT:   %.4ee: %A = splice_inst %.33e [template]
+// CHECK:STDOUT:   %inst.as_compatible.b4e: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.463: ref %A = as_compatible @F.%a.var
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A.cpp_destructor.type: type = fn_type @A.cpp_destructor [concrete]
+// CHECK:STDOUT:   %A.cpp_destructor: %A.cpp_destructor.type = struct_value () [concrete]
+// CHECK:STDOUT:   %custom_witness.294: <witness> = custom_witness (%A.cpp_destructor), @Destroy [concrete]
+// CHECK:STDOUT:   %Destroy.facet.bf5: %Destroy.type = facet_value %A, (%custom_witness.294) [concrete]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.d24: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Destroy.facet.bf5) [concrete]
+// CHECK:STDOUT:   %.429: type = fn_type_with_self_type %Destroy.WithSelf.Op.type.d24, %Destroy.facet.bf5 [concrete]
+// CHECK:STDOUT:   %inst.splice_block.688: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.471: <bound method> = splice_block %bound_method {
+// CHECK:STDOUT:       %impl.elem0: %.429 = impl_witness_access %custom_witness.294, element0 [concrete = %A.cpp_destructor]
+// CHECK:STDOUT:       %bound_method: <bound method> = bound_method %.463, %impl.elem0
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.call: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %A.cpp_destructor.call: init %empty_tuple.type = call %.471(%.463)
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .A = %A.template
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %A.template: %A.type = struct_value () [concrete = constants.%A.template]
+// CHECK:STDOUT:   %Core.import_ref.918: @Destroy.WithSelf.%Destroy.WithSelf.Op.type (%Destroy.WithSelf.Op.type.d3e) = import_ref Core//prelude/parts/destroy, loc{{\d+_\d+}}, loaded [symbolic = @Destroy.WithSelf.%Destroy.WithSelf.Op (constants.%Destroy.WithSelf.Op.42b)]
+// CHECK:STDOUT:   %A.decl: type = class_decl @A [concrete = constants.%A] {} {}
+// CHECK:STDOUT:   %A.A.cpp_overload_set.value: %A.A.cpp_overload_set.type = cpp_overload_set_value @A.A.cpp_overload_set [concrete = constants.%A.A.cpp_overload_set.value]
+// CHECK:STDOUT:   %A__carbon_thunk.decl: %A__carbon_thunk.type = fn_decl @A__carbon_thunk [concrete = constants.%A__carbon_thunk] {
+// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %T.patt.loc9_15.1: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc9_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.loc9_17.1: type = splice_block %.loc9_17.2 [concrete = type] {
+// CHECK:STDOUT:       %.Self.frozen: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.frozen]
+// CHECK:STDOUT:       %.loc9_17.2: type = type_literal type [concrete = type]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %T.loc9_15.2: type = symbolic_binding T, 0 [symbolic = %T.loc9_15.1 (constants.%T)]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F(%T.loc9_15.2: type) {
+// CHECK:STDOUT:   %T.patt.loc9_15.2: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc9_15.2 (constants.%T.patt)]
+// CHECK:STDOUT:   %T.loc9_15.1: type = symbolic_binding T, 0 [symbolic = %T.loc9_15.1 (constants.%T)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %.loc10_24.4: <instruction> = call_template_action clang_decl_id5C000002, (%T.loc9_15.1) [template]
+// CHECK:STDOUT:   %.loc10_24.5: type = type_of_inst %.loc10_24.4 [template]
+// CHECK:STDOUT:   %.loc10_24.6: @F.%.loc10_24.5 (@F.%.loc10_24.5) = splice_inst %.loc10_24.4 [template = %.loc10_24.6 (constants.%.ae6cd7.1)]
+// CHECK:STDOUT:   %.loc10_24.7: <instruction> = convert_to_value_action %.loc10_24.2, type [template]
+// CHECK:STDOUT:   %.loc10_24.8: type = splice_inst %.loc10_24.7 [template = %.loc10_24.8 (constants.%.535)]
+// CHECK:STDOUT:   %require_complete: <witness> = require_complete_type %.loc10_24.8 [template = %require_complete (constants.%require_complete.01e)]
+// CHECK:STDOUT:   %pattern_type: type = pattern_type %.loc10_24.8 [template = %pattern_type (constants.%pattern_type.281)]
+// CHECK:STDOUT:   %a.patt.loc10_15.2: @F.%pattern_type (%pattern_type.281) = ref_binding_pattern a [template = %a.patt.loc10_15.2 (constants.%a.patt.44a)]
+// CHECK:STDOUT:   %a.var_patt.loc10_3.2: @F.%pattern_type (%pattern_type.281) = var_pattern %a.patt.loc10_15.2 [template = %a.var_patt.loc10_3.2 (constants.%a.var_patt.5fb)]
+// CHECK:STDOUT:   %.loc10_35.2: <instruction> = call_template_action clang_decl_id5C000002, (%T.loc9_15.1) [template]
+// CHECK:STDOUT:   %.loc10_35.3: type = type_of_inst %.loc10_35.2 [template]
+// CHECK:STDOUT:   %.loc10_35.4: @F.%.loc10_35.3 (@F.%.loc10_35.3) = splice_inst %.loc10_35.2 [template = %.loc10_35.4 (constants.%.ae6cd7.2)]
+// CHECK:STDOUT:   %.loc10_36.2: <instruction> = access_member_action %.loc10_35.1, A [template]
+// CHECK:STDOUT:   %.loc10_36.3: type = type_of_inst %.loc10_36.2 [template]
+// CHECK:STDOUT:   %.loc10_36.4: @F.%.loc10_36.3 (@F.%.loc10_36.3) = splice_inst %.loc10_36.2 [template = %.loc10_36.4 (constants.%.4bf)]
+// CHECK:STDOUT:   %.loc10_39.2: <instruction> = call_action (%.loc10_36.1), false [template]
+// CHECK:STDOUT:   %.loc10_39.3: type = type_of_inst %.loc10_39.2 [template]
+// CHECK:STDOUT:   %.loc10_39.4: @F.%.loc10_39.3 (@F.%.loc10_39.3) = splice_inst %.loc10_39.2 [template = %.loc10_39.4 (constants.%.7cc)]
+// CHECK:STDOUT:   %.loc10_3.11: <instruction> = call_action (constants.%ImplicitAs.generic, constants.%.535), false [template]
+// CHECK:STDOUT:   %.loc10_3.12: type = type_of_inst %.loc10_3.11 [template]
+// CHECK:STDOUT:   %.loc10_3.13: @F.%.loc10_3.12 (@F.%.loc10_3.12) = splice_inst %.loc10_3.11 [template = %.loc10_3.13 (constants.%.847f2c.1)]
+// CHECK:STDOUT:   %.loc10_3.14: <instruction> = access_member_action %.loc10_3.1, Convert [template]
+// CHECK:STDOUT:   %.loc10_3.15: type = type_of_inst %.loc10_3.14 [template]
+// CHECK:STDOUT:   %.loc10_3.16: @F.%.loc10_3.15 (@F.%.loc10_3.15) = splice_inst %.loc10_3.14 [template = %.loc10_3.16 (constants.%.7fa0c8.1)]
+// CHECK:STDOUT:   %.loc10_3.17: <instruction> = compound_member_access_action %.loc10_39.1, %.loc10_3.2 [template]
+// CHECK:STDOUT:   %.loc10_3.18: type = type_of_inst %.loc10_3.17 [template]
+// CHECK:STDOUT:   %.loc10_3.19: @F.%.loc10_3.18 (@F.%.loc10_3.18) = splice_inst %.loc10_3.17 [template = %.loc10_3.19 (constants.%.8da)]
+// CHECK:STDOUT:   %.loc10_3.20: <instruction> = call_action (%.loc10_3.3), true [template]
+// CHECK:STDOUT:   %.loc10_3.21: type = type_of_inst %.loc10_3.20 [template]
+// CHECK:STDOUT:   %.loc10_3.22: @F.%.loc10_3.21 (@F.%.loc10_3.21) = splice_inst %.loc10_3.20 [template = %.loc10_3.22 (constants.%.9e9)]
+// CHECK:STDOUT:   %.loc10_3.23: <instruction> = refine_type_action %.loc10_3.5, %.loc10_24.8 [template]
+// CHECK:STDOUT:   %.loc10_3.24: @F.%.loc10_24.8 (%.535) = splice_inst %.loc10_3.23 [template = %.loc10_3.24 (constants.%.9f8)]
+// CHECK:STDOUT:   %.loc10_3.25: <instruction> = convert_to_category_action %.loc10_3.6, element10 [template]
+// CHECK:STDOUT:   %.loc10_3.26: @F.%.loc10_24.8 (%.535) = splice_inst %.loc10_3.25 [template = %.loc10_3.26 (constants.%.073)]
+// CHECK:STDOUT:   %.loc10_3.27: <instruction> = refine_type_action %a.var, %.loc10_24.8 [template]
+// CHECK:STDOUT:   %.loc10_3.28: @F.%.loc10_24.8 (%.535) = splice_inst %.loc10_3.27 [template = %.loc10_3.28 (constants.%.cb8)]
+// CHECK:STDOUT:   %.loc10_3.29: <instruction> = compound_member_access_action %.loc10_3.8, constants.%assoc0.ae8 [template]
+// CHECK:STDOUT:   %.loc10_3.30: type = type_of_inst %.loc10_3.29 [template]
+// CHECK:STDOUT:   %.loc10_3.31: @F.%.loc10_3.30 (@F.%.loc10_3.30) = splice_inst %.loc10_3.29 [template = %.loc10_3.31 (constants.%.495)]
+// CHECK:STDOUT:   %.loc10_3.32: <instruction> = call_action (%.loc10_3.9), true [template]
+// CHECK:STDOUT:   %.loc10_3.33: type = type_of_inst %.loc10_3.32 [template]
+// CHECK:STDOUT:   %.loc10_3.34: @F.%.loc10_3.33 (@F.%.loc10_3.33) = splice_inst %.loc10_3.32 [template = %.loc10_3.34 (constants.%.013)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn() {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %a.var: ref @F.%.loc10_24.8 (%.535) = var_storage %a.var_patt.loc10_3.1
+// CHECK:STDOUT:     %Cpp.ref.loc10_28: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:     %A.ref.loc10_31: %A.type = name_ref A, imports.%A.template [concrete = constants.%A.template]
+// CHECK:STDOUT:     %T.ref.loc10_34: type = name_ref T, %T.loc9_15.2 [symbolic = %T.loc9_15.1 (constants.%T)]
+// CHECK:STDOUT:     %.loc10_35.1: @F.%.loc10_35.3 (@F.%.loc10_35.3) = splice_inst %.loc10_35.2 [template = %.loc10_35.4 (constants.%.ae6cd7.2)]
+// CHECK:STDOUT:     %.loc10_36.1: @F.%.loc10_36.3 (@F.%.loc10_36.3) = splice_inst %.loc10_36.2 [template = %.loc10_36.4 (constants.%.4bf)]
+// CHECK:STDOUT:     %.loc10_39.1: @F.%.loc10_39.3 (@F.%.loc10_39.3) = splice_inst %.loc10_39.2 [template = %.loc10_39.4 (constants.%.7cc)]
+// CHECK:STDOUT:     %.loc10_3.1: @F.%.loc10_3.12 (@F.%.loc10_3.12) = splice_inst %.loc10_3.11 [template = %.loc10_3.13 (constants.%.847f2c.1)]
+// CHECK:STDOUT:     %.loc10_3.2: @F.%.loc10_3.15 (@F.%.loc10_3.15) = splice_inst %.loc10_3.14 [template = %.loc10_3.16 (constants.%.7fa0c8.1)]
+// CHECK:STDOUT:     %.loc10_3.3: @F.%.loc10_3.18 (@F.%.loc10_3.18) = splice_inst %.loc10_3.17 [template = %.loc10_3.19 (constants.%.8da)]
+// CHECK:STDOUT:     %.loc10_3.4: @F.%.loc10_3.21 (@F.%.loc10_3.21) = splice_inst %.loc10_3.20 [template = %.loc10_3.22 (constants.%.9e9)]
+// CHECK:STDOUT:     %.loc10_3.5: @F.%.loc10_24.8 (%.535) = converted %.loc10_39.1, %.loc10_3.4 [template = %.loc10_3.22 (constants.%.9e9)]
+// CHECK:STDOUT:     %.loc10_3.6: @F.%.loc10_24.8 (%.535) = splice_inst %.loc10_3.23 [template = %.loc10_3.24 (constants.%.9f8)]
+// CHECK:STDOUT:     %.loc10_3.7: @F.%.loc10_24.8 (%.535) = splice_inst %.loc10_3.25 [template = %.loc10_3.26 (constants.%.073)]
+// CHECK:STDOUT:     assign %a.var, %.loc10_3.7
+// CHECK:STDOUT:     %.loc10_24.1: type = splice_block %.loc10_24.3 [template = %.loc10_24.8 (constants.%.535)] {
+// CHECK:STDOUT:       %Cpp.ref.loc10_17: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:       %A.ref.loc10_20: %A.type = name_ref A, imports.%A.template [concrete = constants.%A.template]
+// CHECK:STDOUT:       %T.ref.loc10_23: type = name_ref T, %T.loc9_15.2 [symbolic = %T.loc9_15.1 (constants.%T)]
+// CHECK:STDOUT:       %.loc10_24.2: @F.%.loc10_24.5 (@F.%.loc10_24.5) = splice_inst %.loc10_24.4 [template = %.loc10_24.6 (constants.%.ae6cd7.1)]
+// CHECK:STDOUT:       %.loc10_24.3: type = splice_inst %.loc10_24.7 [template = %.loc10_24.8 (constants.%.535)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %a: ref @F.%.loc10_24.8 (%.535) = wrapper_binding a, %a.var
+// CHECK:STDOUT:     name_binding_decl {
+// CHECK:STDOUT:       %a.patt.loc10_15.1: @F.%pattern_type (%pattern_type.281) = ref_binding_pattern a [template = %a.patt.loc10_15.2 (constants.%a.patt.44a)]
+// CHECK:STDOUT:       %a.var_patt.loc10_3.1: @F.%pattern_type (%pattern_type.281) = var_pattern %a.patt.loc10_15.1 [template = %a.var_patt.loc10_3.2 (constants.%a.var_patt.5fb)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %.loc10_3.8: @F.%.loc10_24.8 (%.535) = splice_inst %.loc10_3.27 [template = %.loc10_3.28 (constants.%.cb8)]
+// CHECK:STDOUT:     %.loc10_3.9: @F.%.loc10_3.30 (@F.%.loc10_3.30) = splice_inst %.loc10_3.29 [template = %.loc10_3.31 (constants.%.495)]
+// CHECK:STDOUT:     %.loc10_3.10: @F.%.loc10_3.33 (@F.%.loc10_3.33) = splice_inst %.loc10_3.32 [template = %.loc10_3.34 (constants.%.013)]
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%T) {
+// CHECK:STDOUT:   %T.patt.loc9_15.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc9_15.1 => constants.%T
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%i32) {
+// CHECK:STDOUT:   %T.patt.loc9_15.2 => constants.%T.patt
+// CHECK:STDOUT:   %T.loc9_15.1 => constants.%i32
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %.loc10_24.4 => constants.%inst.splice_block.72dff3.1
+// CHECK:STDOUT:   %.loc10_24.5 => type
+// CHECK:STDOUT:   %.loc10_24.6 => constants.%A
+// CHECK:STDOUT:   %.loc10_24.7 => constants.%inst.splice_block.c26
+// CHECK:STDOUT:   %.loc10_24.8 => constants.%A
+// CHECK:STDOUT:   %require_complete => constants.%complete_type.357
+// CHECK:STDOUT:   %pattern_type => constants.%pattern_type.b78
+// CHECK:STDOUT:   %a.patt.loc10_15.2 => constants.%a.patt.198
+// CHECK:STDOUT:   %a.var_patt.loc10_3.2 => constants.%a.var_patt.47b
+// CHECK:STDOUT:   %.loc10_35.2 => constants.%inst.splice_block.72dff3.2
+// CHECK:STDOUT:   %.loc10_35.3 => type
+// CHECK:STDOUT:   %.loc10_35.4 => constants.%A
+// CHECK:STDOUT:   %.loc10_36.2 => constants.%inst.name_ref
+// CHECK:STDOUT:   %.loc10_36.3 => constants.%A.A.cpp_overload_set.type
+// CHECK:STDOUT:   %.loc10_36.4 => constants.%A.A.cpp_overload_set.value
+// CHECK:STDOUT:   %.loc10_39.2 => constants.%inst.splice_block.76c
+// CHECK:STDOUT:   %.loc10_39.3 => constants.%A
+// CHECK:STDOUT:   %.loc10_39.4 => invalid
+// CHECK:STDOUT:   %.loc10_3.11 => constants.%.04f
+// CHECK:STDOUT:   %.loc10_3.12 => constants.%.5a1
+// CHECK:STDOUT:   %.loc10_3.13 => constants.%.847f2c.2
+// CHECK:STDOUT:   %.loc10_3.14 => constants.%.5d9
+// CHECK:STDOUT:   %.loc10_3.15 => constants.%.831
+// CHECK:STDOUT:   %.loc10_3.16 => constants.%.7fa0c8.2
+// CHECK:STDOUT:   %.loc10_3.17 => constants.%.98e
+// CHECK:STDOUT:   %.loc10_3.18 => constants.%.81d
+// CHECK:STDOUT:   %.loc10_3.19 => constants.%.472
+// CHECK:STDOUT:   %.loc10_3.20 => constants.%.6bc
+// CHECK:STDOUT:   %.loc10_3.21 => constants.%.133
+// CHECK:STDOUT:   %.loc10_3.22 => constants.%.da3
+// CHECK:STDOUT:   %.loc10_3.23 => constants.%inst.as_compatible.7b3
+// CHECK:STDOUT:   %.loc10_3.24 => constants.%.d73
+// CHECK:STDOUT:   %.loc10_3.25 => constants.%.33e
+// CHECK:STDOUT:   %.loc10_3.26 => constants.%.4ee
+// CHECK:STDOUT:   %.loc10_3.27 => constants.%inst.as_compatible.b4e
+// CHECK:STDOUT:   %.loc10_3.28 => invalid
+// CHECK:STDOUT:   %.loc10_3.29 => constants.%inst.splice_block.688
+// CHECK:STDOUT:   %.loc10_3.30 => <bound method>
+// CHECK:STDOUT:   %.loc10_3.31 => invalid
+// CHECK:STDOUT:   %.loc10_3.32 => constants.%inst.call
+// CHECK:STDOUT:   %.loc10_3.33 => constants.%empty_tuple.type
+// CHECK:STDOUT:   %.loc10_3.34 => invalid
 // CHECK:STDOUT: }
 // CHECK:STDOUT:

--- a/toolchain/check/testdata/interop/cpp/template/generic_call.carbon
+++ b/toolchain/check/testdata/interop/cpp/template/generic_call.carbon
@@ -17,23 +17,346 @@ struct X {};
 
 template<typename T> struct S {};
 
-// --- fail_todo_generic_call.carbon
+// --- generic_call.carbon
 
 library "[[@TEST_NAME]]";
 
 import Cpp library "header.h";
 
+//@dump-sem-ir-begin
 fn F[T: type](unused x: T) {
   var unused v: Cpp.S(T);
 }
+//@dump-sem-ir-end
 
 fn G() {
-  // CHECK:STDERR: fail_todo_generic_call.carbon:[[@LINE+7]]:3: error: unable to monomorphize specific `F(Cpp.X)` [ResolvingSpecificHere]
-  // CHECK:STDERR:   F({} as Cpp.X);
-  // CHECK:STDERR:   ^
-  // CHECK:STDERR: fail_todo_generic_call.carbon:[[@LINE-7]]:3: note: value of type `<bound method>` is not callable [CallToNonCallable]
-  // CHECK:STDERR:   var unused v: Cpp.S(T);
-  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~~~~~~
-  // CHECK:STDERR:
   F({} as Cpp.X);
 }
+
+// CHECK:STDOUT: --- generic_call.carbon
+// CHECK:STDOUT:
+// CHECK:STDOUT: constants {
+// CHECK:STDOUT:   %type: type = facet_type <type> [concrete]
+// CHECK:STDOUT:   %.Self.frozen: %type = symbolic_binding .Self [symbolic_self]
+// CHECK:STDOUT:   %pattern_type.98f: type = pattern_type type [concrete]
+// CHECK:STDOUT:   %T.patt.d47: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic]
+// CHECK:STDOUT:   %T.67d: type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %pattern_type.51d1c4.1: type = pattern_type %T.67d [symbolic]
+// CHECK:STDOUT:   %x.param_patt.91d: %pattern_type.51d1c4.1 = value_param_pattern [symbolic]
+// CHECK:STDOUT:   %x.patt.260: %pattern_type.51d1c4.1 = wrapper_binding_pattern x, %x.param_patt.91d [symbolic]
+// CHECK:STDOUT:   %F.type: type = fn_type @F [concrete]
+// CHECK:STDOUT:   %empty_tuple.type: type = tuple_type () [concrete]
+// CHECK:STDOUT:   %F: %F.type = struct_value () [concrete]
+// CHECK:STDOUT:   %require_complete.944: <witness> = require_complete_type %T.67d [symbolic]
+// CHECK:STDOUT:   %S.type: type = cpp_type_template_type S [concrete]
+// CHECK:STDOUT:   %S.template: %S.type = struct_value () [concrete]
+// CHECK:STDOUT:   %.ae6: @F.%.loc8_24.5 (@F.%.loc8_24.5) = splice_inst @F.%.loc8_24.4 [template]
+// CHECK:STDOUT:   %.535: type = splice_inst @F.%.loc8_24.7 [template]
+// CHECK:STDOUT:   %require_complete.01e: <witness> = require_complete_type %.535 [template]
+// CHECK:STDOUT:   %pattern_type.281: type = pattern_type %.535 [template]
+// CHECK:STDOUT:   %v.patt.1d5: %pattern_type.281 = ref_binding_pattern v [template]
+// CHECK:STDOUT:   %v.var_patt.367: %pattern_type.281 = var_pattern %v.patt.1d5 [template]
+// CHECK:STDOUT:   %DefaultOrUnformed.type: type = facet_type <@DefaultOrUnformed> [concrete]
+// CHECK:STDOUT:   %Self.935: %DefaultOrUnformed.type = symbolic_binding Self, 0 [symbolic]
+// CHECK:STDOUT:   %DefaultOrUnformed.WithSelf.Op.type.8f1: type = fn_type @DefaultOrUnformed.WithSelf.Op, @DefaultOrUnformed.WithSelf(%Self.935) [symbolic]
+// CHECK:STDOUT:   %DefaultOrUnformed.WithSelf.Op.ad7: %DefaultOrUnformed.WithSelf.Op.type.8f1 = struct_value () [symbolic]
+// CHECK:STDOUT:   %Default.type: type = facet_type <@Default> [concrete]
+// CHECK:STDOUT:   %T.b09: %Default.type = symbolic_binding T, 0 [symbolic]
+// CHECK:STDOUT:   %T.as_type.as.DefaultOrUnformed.impl.Op.type.0c9: type = fn_type @T.as_type.as.DefaultOrUnformed.impl.Op, @T.as_type.as.DefaultOrUnformed.impl(%T.b09) [symbolic]
+// CHECK:STDOUT:   %T.as_type.as.DefaultOrUnformed.impl.Op.cfe: %T.as_type.as.DefaultOrUnformed.impl.Op.type.0c9 = struct_value () [symbolic]
+// CHECK:STDOUT:   %DefaultOrUnformed.lookup_impl_witness: <witness> = lookup_impl_witness %.535, @DefaultOrUnformed [template]
+// CHECK:STDOUT:   %.6b4: require_specific_def_type = require_specific_def @T.as.DefaultOrUnformed.impl(%.535) [template]
+// CHECK:STDOUT:   %DefaultOrUnformed.facet.45f: %DefaultOrUnformed.type = facet_value %.535, (%DefaultOrUnformed.lookup_impl_witness) [template]
+// CHECK:STDOUT:   %.bb0: @F.%.loc8_25.6 (@F.%.loc8_25.6) = splice_inst @F.%.loc8_25.5 [template]
+// CHECK:STDOUT:   %.cde: @F.%.loc8_25.9 (@F.%.loc8_25.9) = splice_inst @F.%.loc8_25.8 [template]
+// CHECK:STDOUT:   %ImplicitAs.type.0ff: type = generic_interface_type @ImplicitAs [concrete]
+// CHECK:STDOUT:   %ImplicitAs.generic: %ImplicitAs.type.0ff = struct_value () [concrete]
+// CHECK:STDOUT:   %.847f2c.1: @F.%.loc8_3.12 (@F.%.loc8_3.12) = splice_inst @F.%.loc8_3.11 [template]
+// CHECK:STDOUT:   %.7fa0c8.1: @F.%.loc8_3.15 (@F.%.loc8_3.15) = splice_inst @F.%.loc8_3.14 [template]
+// CHECK:STDOUT:   %.178: @F.%.loc8_3.18 (@F.%.loc8_3.18) = splice_inst @F.%.loc8_3.17 [template]
+// CHECK:STDOUT:   %.852: @F.%.loc8_3.21 (@F.%.loc8_3.21) = splice_inst @F.%.loc8_3.20 [template]
+// CHECK:STDOUT:   %.7f5: %.535 = splice_inst @F.%.loc8_3.23 [template]
+// CHECK:STDOUT:   %.f22: %.535 = splice_inst @F.%.loc8_3.25 [template]
+// CHECK:STDOUT:   %Destroy.type: type = facet_type <@Destroy> [concrete]
+// CHECK:STDOUT:   %Self.0e7: %Destroy.type = symbolic_binding Self, 0 [symbolic]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.d3e: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Self.0e7) [symbolic]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.42b: %Destroy.WithSelf.Op.type.d3e = struct_value () [symbolic]
+// CHECK:STDOUT:   %Destroy.assoc_type: type = assoc_entity_type @Destroy [concrete]
+// CHECK:STDOUT:   %assoc0.ae8: %Destroy.assoc_type = assoc_entity element0, imports.%Core.import_ref.918 [concrete]
+// CHECK:STDOUT:   %.131: %.535 = splice_inst @F.%.loc8_3.27 [template]
+// CHECK:STDOUT:   %.8f8: @F.%.loc8_3.30 (@F.%.loc8_3.30) = splice_inst @F.%.loc8_3.29 [template]
+// CHECK:STDOUT:   %.763: @F.%.loc8_3.33 (@F.%.loc8_3.33) = splice_inst @F.%.loc8_3.32 [template]
+// CHECK:STDOUT:   %empty_struct_type: type = struct_type {} [concrete]
+// CHECK:STDOUT:   %X: type = class_type @X [concrete]
+// CHECK:STDOUT:   %complete_type: <witness> = complete_type_witness %empty_struct_type [concrete]
+// CHECK:STDOUT:   %pattern_type.fa7: type = pattern_type %X [concrete]
+// CHECK:STDOUT:   %x.param_patt.468: %pattern_type.fa7 = value_param_pattern [concrete]
+// CHECK:STDOUT:   %x.patt.af8: %pattern_type.fa7 = wrapper_binding_pattern x, %x.param_patt.468 [concrete]
+// CHECK:STDOUT:   %S: type = class_type @S [concrete]
+// CHECK:STDOUT:   %inst.splice_block.5af: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.788: type = splice_block imports.%S.decl [concrete = %S] {}
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.splice_block.c1e: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.895: type = splice_block %S [concrete = %S] {}
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %pattern_type.981: type = pattern_type %S [concrete]
+// CHECK:STDOUT:   %v.patt.5fa: %pattern_type.981 = ref_binding_pattern v [concrete]
+// CHECK:STDOUT:   %v.var_patt.e69: %pattern_type.981 = var_pattern %v.patt.5fa [concrete]
+// CHECK:STDOUT:   %.e53: require_specific_def_type = require_specific_def @T.as.DefaultOrUnformed.impl(%S) [concrete]
+// CHECK:STDOUT:   %S.Op.type.83af6e.1: type = fn_type @S.Op.1 [concrete]
+// CHECK:STDOUT:   %S.Op.4dca31.1: %S.Op.type.83af6e.1 = struct_value () [concrete]
+// CHECK:STDOUT:   %custom_witness.9b4: <witness> = custom_witness (%S.Op.4dca31.1), @Default [concrete]
+// CHECK:STDOUT:   %Default.facet.602: %Default.type = facet_value %S, (%custom_witness.9b4) [concrete]
+// CHECK:STDOUT:   %DefaultOrUnformed.impl_witness.1ff: <witness> = impl_witness imports.%DefaultOrUnformed.impl_witness_table.162, @T.as_type.as.DefaultOrUnformed.impl(%Default.facet.602) [concrete]
+// CHECK:STDOUT:   %T.as_type.as.DefaultOrUnformed.impl.Op.type.c7b: type = fn_type @T.as_type.as.DefaultOrUnformed.impl.Op, @T.as_type.as.DefaultOrUnformed.impl(%Default.facet.602) [concrete]
+// CHECK:STDOUT:   %T.as_type.as.DefaultOrUnformed.impl.Op.83d: %T.as_type.as.DefaultOrUnformed.impl.Op.type.c7b = struct_value () [concrete]
+// CHECK:STDOUT:   %DefaultOrUnformed.facet.ba3: %DefaultOrUnformed.type = facet_value %S, (%DefaultOrUnformed.impl_witness.1ff) [concrete]
+// CHECK:STDOUT:   %DefaultOrUnformed.WithSelf.Op.type.483: type = fn_type @DefaultOrUnformed.WithSelf.Op, @DefaultOrUnformed.WithSelf(%DefaultOrUnformed.facet.ba3) [concrete]
+// CHECK:STDOUT:   %DefaultOrUnformed.assoc_type: type = assoc_entity_type @DefaultOrUnformed [concrete]
+// CHECK:STDOUT:   %assoc0.b81: %DefaultOrUnformed.assoc_type = assoc_entity element0, imports.%Core.import_ref.d14 [concrete]
+// CHECK:STDOUT:   %.805: type = fn_type_with_self_type %DefaultOrUnformed.WithSelf.Op.type.483, %DefaultOrUnformed.facet.ba3 [concrete]
+// CHECK:STDOUT:   %inst.splice_block.9d9: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.64e: %.805 = splice_block %impl.elem0.9ae [concrete = %T.as_type.as.DefaultOrUnformed.impl.Op.83d] {
+// CHECK:STDOUT:       %as_type: type = facet_access_type %DefaultOrUnformed.facet.ba3 [concrete = %S]
+// CHECK:STDOUT:       %.bcbe: type = converted %DefaultOrUnformed.facet.ba3, %as_type [concrete = %S]
+// CHECK:STDOUT:       %Op.ref.f8c: %DefaultOrUnformed.assoc_type = name_ref Op, imports.%Core.import_ref.6dc [concrete = %assoc0.b81]
+// CHECK:STDOUT:       %impl.elem0.9ae: %.805 = impl_witness_access %DefaultOrUnformed.impl_witness.1ff, element0 [concrete = %T.as_type.as.DefaultOrUnformed.impl.Op.83d]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.splice_block.7e5: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.cc7: init %S = splice_block %T.as_type.as.DefaultOrUnformed.impl.Op.call {
+// CHECK:STDOUT:       <elided>
+// CHECK:STDOUT:       %.746: ref %S = temporary_storage
+// CHECK:STDOUT:       %T.as_type.as.DefaultOrUnformed.impl.Op.call: init %S to %.746 = call %T.as_type.as.DefaultOrUnformed.impl.Op.specific_fn.e6b3f4.2()
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.04f: <instruction> = call_action (%ImplicitAs.generic, %.535), false [template]
+// CHECK:STDOUT:   %.5a1a: type = type_of_inst %.04f [template]
+// CHECK:STDOUT:   %.847f2c.2: %.5a1a = splice_inst %.04f [template]
+// CHECK:STDOUT:   %.5d9: <instruction> = access_member_action %.847f2c.2, Convert [template]
+// CHECK:STDOUT:   %.831: type = type_of_inst %.5d9 [template]
+// CHECK:STDOUT:   %.7fa0c8.2: %.831 = splice_inst %.5d9 [template]
+// CHECK:STDOUT:   %.fba: <instruction> = compound_member_access_action %.cc7, %.7fa0c8.2 [template]
+// CHECK:STDOUT:   %.5a14: type = type_of_inst %.fba [template]
+// CHECK:STDOUT:   %.cb9: %.5a14 = splice_inst %.fba [template]
+// CHECK:STDOUT:   %.c0e: <instruction> = call_action (%.cb9), true [template]
+// CHECK:STDOUT:   %.e96: type = type_of_inst %.c0e [template]
+// CHECK:STDOUT:   %.296: %.e96 = splice_inst %.c0e [template]
+// CHECK:STDOUT:   %.dd8: %S = splice_inst %.c0e [template]
+// CHECK:STDOUT:   %inst.as_compatible.276: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.dfb: %S = as_compatible %.296 [template = %.dd8]
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %.23d: <instruction> = convert_to_category_action %.dd8, element10 [template]
+// CHECK:STDOUT:   %.a98: %S = splice_inst %.23d [template]
+// CHECK:STDOUT:   %inst.as_compatible.c08: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.37f: ref %S = as_compatible @F.%v.var
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %S.cpp_destructor.type: type = fn_type @S.cpp_destructor [concrete]
+// CHECK:STDOUT:   %S.cpp_destructor: %S.cpp_destructor.type = struct_value () [concrete]
+// CHECK:STDOUT:   %S.Op.type.83af6e.2: type = fn_type @S.Op.2 [concrete]
+// CHECK:STDOUT:   %S.Op.4dca31.2: %S.Op.type.83af6e.2 = struct_value () [concrete]
+// CHECK:STDOUT:   %custom_witness.e7a31c.2: <witness> = custom_witness (%S.Op.4dca31.2), @Destroy [concrete]
+// CHECK:STDOUT:   %Destroy.facet.2e5: %Destroy.type = facet_value %S, (%custom_witness.e7a31c.2) [concrete]
+// CHECK:STDOUT:   %Destroy.WithSelf.Op.type.5df: type = fn_type @Destroy.WithSelf.Op, @Destroy.WithSelf(%Destroy.facet.2e5) [concrete]
+// CHECK:STDOUT:   %.670: type = fn_type_with_self_type %Destroy.WithSelf.Op.type.5df, %Destroy.facet.2e5 [concrete]
+// CHECK:STDOUT:   %inst.splice_block.603: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.fe0: <bound method> = splice_block %bound_method {
+// CHECK:STDOUT:       <elided>
+// CHECK:STDOUT:       %impl.elem0.c3e: %.670 = impl_witness_access %custom_witness.e7a31c.2, element0 [concrete = %S.Op.4dca31.2]
+// CHECK:STDOUT:       %bound_method: <bound method> = bound_method %.37f, %impl.elem0.c3e
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %inst.splice_block.35a: <instruction> = inst_value [concrete] {
+// CHECK:STDOUT:     %.f30: init %empty_tuple.type = splice_block %S.cpp_destructor.call {
+// CHECK:STDOUT:       %Op.ref.6a0: %S.cpp_destructor.type = name_ref Op, imports.%S.cpp_destructor.decl [concrete = %S.cpp_destructor]
+// CHECK:STDOUT:       %S.cpp_destructor.bound: <bound method> = bound_method %.37f, %Op.ref.6a0
+// CHECK:STDOUT:       %S.cpp_destructor.call: init %empty_tuple.type = call %S.cpp_destructor.bound(%.37f)
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: imports {
+// CHECK:STDOUT:   %Cpp: <namespace> = namespace file.%Cpp.import_cpp, [concrete] {
+// CHECK:STDOUT:     .S = %S.template
+// CHECK:STDOUT:     .X = %X.decl
+// CHECK:STDOUT:     import Cpp//...
+// CHECK:STDOUT:   }
+// CHECK:STDOUT:   %S.template: %S.type = struct_value () [concrete = constants.%S.template]
+// CHECK:STDOUT:   %Core.import_ref.6dc: %DefaultOrUnformed.assoc_type = import_ref Core//prelude/parts/default, loc{{\d+_\d+}}, loaded [concrete = constants.%assoc0.b81]
+// CHECK:STDOUT:   %Core.import_ref.c2f: @T.as_type.as.DefaultOrUnformed.impl.%T.as_type.as.DefaultOrUnformed.impl.Op.type (%T.as_type.as.DefaultOrUnformed.impl.Op.type.0c9) = import_ref Core//prelude/parts/default, loc{{\d+_\d+}}, loaded [symbolic = @T.as_type.as.DefaultOrUnformed.impl.%T.as_type.as.DefaultOrUnformed.impl.Op (constants.%T.as_type.as.DefaultOrUnformed.impl.Op.cfe)]
+// CHECK:STDOUT:   %DefaultOrUnformed.impl_witness_table.162 = impl_witness_table (%Core.import_ref.c2f), @T.as_type.as.DefaultOrUnformed.impl [concrete]
+// CHECK:STDOUT:   %Core.import_ref.918: @Destroy.WithSelf.%Destroy.WithSelf.Op.type (%Destroy.WithSelf.Op.type.d3e) = import_ref Core//prelude/parts/destroy, loc{{\d+_\d+}}, loaded [symbolic = @Destroy.WithSelf.%Destroy.WithSelf.Op (constants.%Destroy.WithSelf.Op.42b)]
+// CHECK:STDOUT:   %X.decl: type = class_decl @X [concrete = constants.%X] {} {}
+// CHECK:STDOUT:   %S.decl: type = class_decl @S [concrete = constants.%S] {} {}
+// CHECK:STDOUT:   %Core.import_ref.d14: @DefaultOrUnformed.WithSelf.%DefaultOrUnformed.WithSelf.Op.type (%DefaultOrUnformed.WithSelf.Op.type.8f1) = import_ref Core//prelude/parts/default, loc{{\d+_\d+}}, loaded [symbolic = @DefaultOrUnformed.WithSelf.%DefaultOrUnformed.WithSelf.Op (constants.%DefaultOrUnformed.WithSelf.Op.ad7)]
+// CHECK:STDOUT:   %S.cpp_destructor.decl: %S.cpp_destructor.type = fn_decl @S.cpp_destructor [concrete = constants.%S.cpp_destructor] {
+// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     <elided>
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: file {
+// CHECK:STDOUT:   %F.decl: %F.type = fn_decl @F [concrete = constants.%F] {
+// CHECK:STDOUT:     %T.patt.loc7_7.1: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_7.2 (constants.%T.patt.d47)]
+// CHECK:STDOUT:     %x.param_patt.loc7_23.1: @F.%pattern_type.loc7 (%pattern_type.51d1c4.1) = value_param_pattern [symbolic = %x.param_patt.loc7_23.2 (constants.%x.param_patt.91d)]
+// CHECK:STDOUT:     %x.patt.loc7_23.1: @F.%pattern_type.loc7 (%pattern_type.51d1c4.1) = wrapper_binding_pattern x, %x.param_patt.loc7_23.1 [symbolic = %x.patt.loc7_23.2 (constants.%x.patt.260)]
+// CHECK:STDOUT:   } {
+// CHECK:STDOUT:     %.loc7_9.1: type = splice_block %.loc7_9.2 [concrete = type] {
+// CHECK:STDOUT:       %.Self.frozen: %type = symbolic_binding .Self [symbolic_self = constants.%.Self.frozen]
+// CHECK:STDOUT:       %.loc7_9.2: type = type_literal type [concrete = type]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %T.loc7_7.2: type = symbolic_binding T, 0 [symbolic = %T.loc7_7.1 (constants.%T.67d)]
+// CHECK:STDOUT:     %x.param: @F.%T.loc7_7.1 (%T.67d) = value_param call_param0
+// CHECK:STDOUT:     %T.ref.loc7: type = name_ref T, %T.loc7_7.2 [symbolic = %T.loc7_7.1 (constants.%T.67d)]
+// CHECK:STDOUT:     %x: @F.%T.loc7_7.1 (%T.67d) = wrapper_binding x, %x.param
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: generic fn @F(%T.loc7_7.2: type) {
+// CHECK:STDOUT:   %T.patt.loc7_7.2: %pattern_type.98f = symbolic_binding_pattern T, 0 [symbolic = %T.patt.loc7_7.2 (constants.%T.patt.d47)]
+// CHECK:STDOUT:   %T.loc7_7.1: type = symbolic_binding T, 0 [symbolic = %T.loc7_7.1 (constants.%T.67d)]
+// CHECK:STDOUT:   %pattern_type.loc7: type = pattern_type %T.loc7_7.1 [symbolic = %pattern_type.loc7 (constants.%pattern_type.51d1c4.1)]
+// CHECK:STDOUT:   %x.param_patt.loc7_23.2: @F.%pattern_type.loc7 (%pattern_type.51d1c4.1) = value_param_pattern [symbolic = %x.param_patt.loc7_23.2 (constants.%x.param_patt.91d)]
+// CHECK:STDOUT:   %x.patt.loc7_23.2: @F.%pattern_type.loc7 (%pattern_type.51d1c4.1) = wrapper_binding_pattern x, %x.param_patt.loc7_23.2 [symbolic = %x.patt.loc7_23.2 (constants.%x.patt.260)]
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete.loc7: <witness> = require_complete_type %T.loc7_7.1 [symbolic = %require_complete.loc7 (constants.%require_complete.944)]
+// CHECK:STDOUT:   %.loc8_24.4: <instruction> = call_template_action clang_decl_id78000002, (%T.loc7_7.1) [template]
+// CHECK:STDOUT:   %.loc8_24.5: type = type_of_inst %.loc8_24.4 [template]
+// CHECK:STDOUT:   %.loc8_24.6: @F.%.loc8_24.5 (@F.%.loc8_24.5) = splice_inst %.loc8_24.4 [template = %.loc8_24.6 (constants.%.ae6)]
+// CHECK:STDOUT:   %.loc8_24.7: <instruction> = convert_to_value_action %.loc8_24.2, type [template]
+// CHECK:STDOUT:   %.loc8_24.8: type = splice_inst %.loc8_24.7 [template = %.loc8_24.8 (constants.%.535)]
+// CHECK:STDOUT:   %require_complete.loc8: <witness> = require_complete_type %.loc8_24.8 [template = %require_complete.loc8 (constants.%require_complete.01e)]
+// CHECK:STDOUT:   %pattern_type.loc8: type = pattern_type %.loc8_24.8 [template = %pattern_type.loc8 (constants.%pattern_type.281)]
+// CHECK:STDOUT:   %v.patt.loc8_15.2: @F.%pattern_type.loc8 (%pattern_type.281) = ref_binding_pattern v [template = %v.patt.loc8_15.2 (constants.%v.patt.1d5)]
+// CHECK:STDOUT:   %v.var_patt.loc8_3.2: @F.%pattern_type.loc8 (%pattern_type.281) = var_pattern %v.patt.loc8_15.2 [template = %v.var_patt.loc8_3.2 (constants.%v.var_patt.367)]
+// CHECK:STDOUT:   %.loc8_25.4: require_specific_def_type = require_specific_def @T.as.DefaultOrUnformed.impl(%.loc8_24.8) [template = %.loc8_25.4 (constants.%.6b4)]
+// CHECK:STDOUT:   %DefaultOrUnformed.lookup_impl_witness: <witness> = lookup_impl_witness %.loc8_24.8, @DefaultOrUnformed [template = %DefaultOrUnformed.lookup_impl_witness (constants.%DefaultOrUnformed.lookup_impl_witness)]
+// CHECK:STDOUT:   %DefaultOrUnformed.facet.loc8_25.2: %DefaultOrUnformed.type = facet_value %.loc8_24.8, (%DefaultOrUnformed.lookup_impl_witness) [template = %DefaultOrUnformed.facet.loc8_25.2 (constants.%DefaultOrUnformed.facet.45f)]
+// CHECK:STDOUT:   %.loc8_25.5: <instruction> = access_member_action %.loc8_25.1, Op [template]
+// CHECK:STDOUT:   %.loc8_25.6: type = type_of_inst %.loc8_25.5 [template]
+// CHECK:STDOUT:   %.loc8_25.7: @F.%.loc8_25.6 (@F.%.loc8_25.6) = splice_inst %.loc8_25.5 [template = %.loc8_25.7 (constants.%.bb0)]
+// CHECK:STDOUT:   %.loc8_25.8: <instruction> = call_action (%.loc8_25.2), false [template]
+// CHECK:STDOUT:   %.loc8_25.9: type = type_of_inst %.loc8_25.8 [template]
+// CHECK:STDOUT:   %.loc8_25.10: @F.%.loc8_25.9 (@F.%.loc8_25.9) = splice_inst %.loc8_25.8 [template = %.loc8_25.10 (constants.%.cde)]
+// CHECK:STDOUT:   %.loc8_3.11: <instruction> = call_action (constants.%ImplicitAs.generic, constants.%.535), false [template]
+// CHECK:STDOUT:   %.loc8_3.12: type = type_of_inst %.loc8_3.11 [template]
+// CHECK:STDOUT:   %.loc8_3.13: @F.%.loc8_3.12 (@F.%.loc8_3.12) = splice_inst %.loc8_3.11 [template = %.loc8_3.13 (constants.%.847f2c.1)]
+// CHECK:STDOUT:   %.loc8_3.14: <instruction> = access_member_action %.loc8_3.1, Convert [template]
+// CHECK:STDOUT:   %.loc8_3.15: type = type_of_inst %.loc8_3.14 [template]
+// CHECK:STDOUT:   %.loc8_3.16: @F.%.loc8_3.15 (@F.%.loc8_3.15) = splice_inst %.loc8_3.14 [template = %.loc8_3.16 (constants.%.7fa0c8.1)]
+// CHECK:STDOUT:   %.loc8_3.17: <instruction> = compound_member_access_action %.loc8_25.3, %.loc8_3.2 [template]
+// CHECK:STDOUT:   %.loc8_3.18: type = type_of_inst %.loc8_3.17 [template]
+// CHECK:STDOUT:   %.loc8_3.19: @F.%.loc8_3.18 (@F.%.loc8_3.18) = splice_inst %.loc8_3.17 [template = %.loc8_3.19 (constants.%.178)]
+// CHECK:STDOUT:   %.loc8_3.20: <instruction> = call_action (%.loc8_3.3), true [template]
+// CHECK:STDOUT:   %.loc8_3.21: type = type_of_inst %.loc8_3.20 [template]
+// CHECK:STDOUT:   %.loc8_3.22: @F.%.loc8_3.21 (@F.%.loc8_3.21) = splice_inst %.loc8_3.20 [template = %.loc8_3.22 (constants.%.852)]
+// CHECK:STDOUT:   %.loc8_3.23: <instruction> = refine_type_action %.loc8_3.5, %.loc8_24.8 [template]
+// CHECK:STDOUT:   %.loc8_3.24: @F.%.loc8_24.8 (%.535) = splice_inst %.loc8_3.23 [template = %.loc8_3.24 (constants.%.7f5)]
+// CHECK:STDOUT:   %.loc8_3.25: <instruction> = convert_to_category_action %.loc8_3.6, element10 [template]
+// CHECK:STDOUT:   %.loc8_3.26: @F.%.loc8_24.8 (%.535) = splice_inst %.loc8_3.25 [template = %.loc8_3.26 (constants.%.f22)]
+// CHECK:STDOUT:   %.loc8_3.27: <instruction> = refine_type_action %v.var, %.loc8_24.8 [template]
+// CHECK:STDOUT:   %.loc8_3.28: @F.%.loc8_24.8 (%.535) = splice_inst %.loc8_3.27 [template = %.loc8_3.28 (constants.%.131)]
+// CHECK:STDOUT:   %.loc8_3.29: <instruction> = compound_member_access_action %.loc8_3.8, constants.%assoc0.ae8 [template]
+// CHECK:STDOUT:   %.loc8_3.30: type = type_of_inst %.loc8_3.29 [template]
+// CHECK:STDOUT:   %.loc8_3.31: @F.%.loc8_3.30 (@F.%.loc8_3.30) = splice_inst %.loc8_3.29 [template = %.loc8_3.31 (constants.%.8f8)]
+// CHECK:STDOUT:   %.loc8_3.32: <instruction> = call_action (%.loc8_3.9), true [template]
+// CHECK:STDOUT:   %.loc8_3.33: type = type_of_inst %.loc8_3.32 [template]
+// CHECK:STDOUT:   %.loc8_3.34: @F.%.loc8_3.33 (@F.%.loc8_3.33) = splice_inst %.loc8_3.32 [template = %.loc8_3.34 (constants.%.763)]
+// CHECK:STDOUT:
+// CHECK:STDOUT:   fn(%x.param: @F.%T.loc7_7.1 (%T.67d)) {
+// CHECK:STDOUT:   !entry:
+// CHECK:STDOUT:     %v.var: ref @F.%.loc8_24.8 (%.535) = var_storage %v.var_patt.loc8_3.1
+// CHECK:STDOUT:     %DefaultOrUnformed.facet.loc8_25.1: %DefaultOrUnformed.type = facet_value constants.%.535, (constants.%DefaultOrUnformed.lookup_impl_witness) [template = %DefaultOrUnformed.facet.loc8_25.2 (constants.%DefaultOrUnformed.facet.45f)]
+// CHECK:STDOUT:     %.loc8_25.1: %DefaultOrUnformed.type = converted constants.%.535, %DefaultOrUnformed.facet.loc8_25.1 [template = %DefaultOrUnformed.facet.loc8_25.2 (constants.%DefaultOrUnformed.facet.45f)]
+// CHECK:STDOUT:     %.loc8_25.2: @F.%.loc8_25.6 (@F.%.loc8_25.6) = splice_inst %.loc8_25.5 [template = %.loc8_25.7 (constants.%.bb0)]
+// CHECK:STDOUT:     %.loc8_25.3: @F.%.loc8_25.9 (@F.%.loc8_25.9) = splice_inst %.loc8_25.8 [template = %.loc8_25.10 (constants.%.cde)]
+// CHECK:STDOUT:     %.loc8_3.1: @F.%.loc8_3.12 (@F.%.loc8_3.12) = splice_inst %.loc8_3.11 [template = %.loc8_3.13 (constants.%.847f2c.1)]
+// CHECK:STDOUT:     %.loc8_3.2: @F.%.loc8_3.15 (@F.%.loc8_3.15) = splice_inst %.loc8_3.14 [template = %.loc8_3.16 (constants.%.7fa0c8.1)]
+// CHECK:STDOUT:     %.loc8_3.3: @F.%.loc8_3.18 (@F.%.loc8_3.18) = splice_inst %.loc8_3.17 [template = %.loc8_3.19 (constants.%.178)]
+// CHECK:STDOUT:     %.loc8_3.4: @F.%.loc8_3.21 (@F.%.loc8_3.21) = splice_inst %.loc8_3.20 [template = %.loc8_3.22 (constants.%.852)]
+// CHECK:STDOUT:     %.loc8_3.5: @F.%.loc8_24.8 (%.535) = converted %.loc8_25.3, %.loc8_3.4 [template = %.loc8_3.22 (constants.%.852)]
+// CHECK:STDOUT:     %.loc8_3.6: @F.%.loc8_24.8 (%.535) = splice_inst %.loc8_3.23 [template = %.loc8_3.24 (constants.%.7f5)]
+// CHECK:STDOUT:     %.loc8_3.7: @F.%.loc8_24.8 (%.535) = splice_inst %.loc8_3.25 [template = %.loc8_3.26 (constants.%.f22)]
+// CHECK:STDOUT:     assign %v.var, %.loc8_3.7
+// CHECK:STDOUT:     %.loc8_24.1: type = splice_block %.loc8_24.3 [template = %.loc8_24.8 (constants.%.535)] {
+// CHECK:STDOUT:       %Cpp.ref: <namespace> = name_ref Cpp, imports.%Cpp [concrete = imports.%Cpp]
+// CHECK:STDOUT:       %S.ref: %S.type = name_ref S, imports.%S.template [concrete = constants.%S.template]
+// CHECK:STDOUT:       %T.ref.loc8: type = name_ref T, %T.loc7_7.2 [symbolic = %T.loc7_7.1 (constants.%T.67d)]
+// CHECK:STDOUT:       %.loc8_24.2: @F.%.loc8_24.5 (@F.%.loc8_24.5) = splice_inst %.loc8_24.4 [template = %.loc8_24.6 (constants.%.ae6)]
+// CHECK:STDOUT:       %.loc8_24.3: type = splice_inst %.loc8_24.7 [template = %.loc8_24.8 (constants.%.535)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %v: ref @F.%.loc8_24.8 (%.535) = wrapper_binding v, %v.var
+// CHECK:STDOUT:     name_binding_decl {
+// CHECK:STDOUT:       %v.patt.loc8_15.1: @F.%pattern_type.loc8 (%pattern_type.281) = ref_binding_pattern v [template = %v.patt.loc8_15.2 (constants.%v.patt.1d5)]
+// CHECK:STDOUT:       %v.var_patt.loc8_3.1: @F.%pattern_type.loc8 (%pattern_type.281) = var_pattern %v.patt.loc8_15.1 [template = %v.var_patt.loc8_3.2 (constants.%v.var_patt.367)]
+// CHECK:STDOUT:     }
+// CHECK:STDOUT:     %.loc8_3.8: @F.%.loc8_24.8 (%.535) = splice_inst %.loc8_3.27 [template = %.loc8_3.28 (constants.%.131)]
+// CHECK:STDOUT:     %.loc8_3.9: @F.%.loc8_3.30 (@F.%.loc8_3.30) = splice_inst %.loc8_3.29 [template = %.loc8_3.31 (constants.%.8f8)]
+// CHECK:STDOUT:     %.loc8_3.10: @F.%.loc8_3.33 (@F.%.loc8_3.33) = splice_inst %.loc8_3.32 [template = %.loc8_3.34 (constants.%.763)]
+// CHECK:STDOUT:     return
+// CHECK:STDOUT:   }
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%T.67d) {
+// CHECK:STDOUT:   %T.patt.loc7_7.2 => constants.%T.patt.d47
+// CHECK:STDOUT:   %T.loc7_7.1 => constants.%T.67d
+// CHECK:STDOUT:   %pattern_type.loc7 => constants.%pattern_type.51d1c4.1
+// CHECK:STDOUT:   %x.param_patt.loc7_23.2 => constants.%x.param_patt.91d
+// CHECK:STDOUT:   %x.patt.loc7_23.2 => constants.%x.patt.260
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: specific @F(constants.%X) {
+// CHECK:STDOUT:   %T.patt.loc7_7.2 => constants.%T.patt.d47
+// CHECK:STDOUT:   %T.loc7_7.1 => constants.%X
+// CHECK:STDOUT:   %pattern_type.loc7 => constants.%pattern_type.fa7
+// CHECK:STDOUT:   %x.param_patt.loc7_23.2 => constants.%x.param_patt.468
+// CHECK:STDOUT:   %x.patt.loc7_23.2 => constants.%x.patt.af8
+// CHECK:STDOUT:
+// CHECK:STDOUT: !definition:
+// CHECK:STDOUT:   %require_complete.loc7 => constants.%complete_type
+// CHECK:STDOUT:   %.loc8_24.4 => constants.%inst.splice_block.5af
+// CHECK:STDOUT:   %.loc8_24.5 => type
+// CHECK:STDOUT:   %.loc8_24.6 => constants.%S
+// CHECK:STDOUT:   %.loc8_24.7 => constants.%inst.splice_block.c1e
+// CHECK:STDOUT:   %.loc8_24.8 => constants.%S
+// CHECK:STDOUT:   %require_complete.loc8 => constants.%complete_type
+// CHECK:STDOUT:   %pattern_type.loc8 => constants.%pattern_type.981
+// CHECK:STDOUT:   %v.patt.loc8_15.2 => constants.%v.patt.5fa
+// CHECK:STDOUT:   %v.var_patt.loc8_3.2 => constants.%v.var_patt.e69
+// CHECK:STDOUT:   %.loc8_25.4 => constants.%.e53
+// CHECK:STDOUT:   %DefaultOrUnformed.lookup_impl_witness => constants.%DefaultOrUnformed.impl_witness.1ff
+// CHECK:STDOUT:   %DefaultOrUnformed.facet.loc8_25.2 => constants.%DefaultOrUnformed.facet.ba3
+// CHECK:STDOUT:   %.loc8_25.5 => constants.%inst.splice_block.9d9
+// CHECK:STDOUT:   %.loc8_25.6 => constants.%.805
+// CHECK:STDOUT:   %.loc8_25.7 => constants.%T.as_type.as.DefaultOrUnformed.impl.Op.83d
+// CHECK:STDOUT:   %.loc8_25.8 => constants.%inst.splice_block.7e5
+// CHECK:STDOUT:   %.loc8_25.9 => constants.%S
+// CHECK:STDOUT:   %.loc8_25.10 => invalid
+// CHECK:STDOUT:   %.loc8_3.11 => constants.%.04f
+// CHECK:STDOUT:   %.loc8_3.12 => constants.%.5a1a
+// CHECK:STDOUT:   %.loc8_3.13 => constants.%.847f2c.2
+// CHECK:STDOUT:   %.loc8_3.14 => constants.%.5d9
+// CHECK:STDOUT:   %.loc8_3.15 => constants.%.831
+// CHECK:STDOUT:   %.loc8_3.16 => constants.%.7fa0c8.2
+// CHECK:STDOUT:   %.loc8_3.17 => constants.%.fba
+// CHECK:STDOUT:   %.loc8_3.18 => constants.%.5a14
+// CHECK:STDOUT:   %.loc8_3.19 => constants.%.cb9
+// CHECK:STDOUT:   %.loc8_3.20 => constants.%.c0e
+// CHECK:STDOUT:   %.loc8_3.21 => constants.%.e96
+// CHECK:STDOUT:   %.loc8_3.22 => constants.%.296
+// CHECK:STDOUT:   %.loc8_3.23 => constants.%inst.as_compatible.276
+// CHECK:STDOUT:   %.loc8_3.24 => constants.%.dd8
+// CHECK:STDOUT:   %.loc8_3.25 => constants.%.23d
+// CHECK:STDOUT:   %.loc8_3.26 => constants.%.a98
+// CHECK:STDOUT:   %.loc8_3.27 => constants.%inst.as_compatible.c08
+// CHECK:STDOUT:   %.loc8_3.28 => invalid
+// CHECK:STDOUT:   %.loc8_3.29 => constants.%inst.splice_block.603
+// CHECK:STDOUT:   %.loc8_3.30 => <bound method>
+// CHECK:STDOUT:   %.loc8_3.31 => invalid
+// CHECK:STDOUT:   %.loc8_3.32 => constants.%inst.splice_block.35a
+// CHECK:STDOUT:   %.loc8_3.33 => constants.%empty_tuple.type
+// CHECK:STDOUT:   %.loc8_3.34 => invalid
+// CHECK:STDOUT: }
+// CHECK:STDOUT:

--- a/toolchain/sem_ir/function.cpp
+++ b/toolchain/sem_ir/function.cpp
@@ -16,6 +16,33 @@
 
 namespace Carbon::SemIR {
 
+auto TryGetCalleeAsBoundMethod(const File& sem_ir, InstId callee_id,
+                               SpecificId caller_specific_id)
+    -> std::optional<BoundMethod> {
+  // Step through splices before checking for a bound method. Unfortunately we
+  // can't just look at the constant value of callee_id here, because bound
+  // methods are non-constant if their `self` is, so we do a mini-eval here.
+  while (true) {
+    auto inst = sem_ir.insts().Get(callee_id);
+    if (auto splice_inst = inst.TryAs<SpliceInst>()) {
+      auto inst_value_id = GetConstantValueInSpecific(
+          sem_ir, caller_specific_id, splice_inst->inst_id);
+      if (!inst_value_id.is_concrete()) {
+        break;
+      }
+      callee_id = sem_ir.constant_values()
+                      .GetInstAs<SemIR::InstValue>(inst_value_id)
+                      .inst_id;
+    } else if (auto splice_block = inst.TryAs<SpliceBlock>()) {
+      callee_id = splice_block->result_id;
+    } else {
+      break;
+    }
+  }
+
+  return sem_ir.insts().TryGetAs<BoundMethod>(callee_id);
+}
+
 auto GetCallee(const File& sem_ir, InstId callee_id,
                SpecificId caller_specific_id) -> Callee {
   CalleeFunction fn = {.function_id = FunctionId::None,
@@ -23,7 +50,8 @@ auto GetCallee(const File& sem_ir, InstId callee_id,
                        .resolved_specific_id = SpecificId::None,
                        .self_type_id = InstId::None,
                        .self_id = InstId::None};
-  if (auto bound_method = sem_ir.insts().TryGetAs<BoundMethod>(callee_id)) {
+  if (auto bound_method =
+          TryGetCalleeAsBoundMethod(sem_ir, callee_id, caller_specific_id)) {
     fn.self_id = bound_method->object_id;
     callee_id = bound_method->function_decl_id;
   }

--- a/toolchain/sem_ir/function.h
+++ b/toolchain/sem_ir/function.h
@@ -411,6 +411,12 @@ struct CalleeNonFunction {};
 using Callee = std::variant<CalleeCppOverloadSet, CalleeError, CalleeFunction,
                             CalleeNonFunction>;
 
+// Given a callee expression in a function call, attempt to convert the callee
+// to a `BoundMethod`, minimally unwrapping it while doing so.
+auto TryGetCalleeAsBoundMethod(const File& sem_ir, InstId callee_id,
+                               SpecificId caller_specific_id)
+    -> std::optional<BoundMethod>;
+
 // Returns information for the function corresponding to callee_id in
 // caller_specific_id.
 auto GetCallee(const File& sem_ir, InstId callee_id,


### PR DESCRIPTION
`GetCallee` is sometimes called on a spliced instruction, and is checking its exact inst operand to see if it's a `BoundMethod`. This fails if the `BoundMethod` is wrapped in another instruction, such as a splice. Normally our approach for such a situation would be to constant-evaluate the operand, but that doesn't work here because the `BoundMethod` will be non-constant if its bound `self` is. So instead we now step through splice instructions manually when looking for the `BoundMethod`.