### PR TITLE
Broken: use Optional in advent day 3

### DIFF
--- a/examples/advent2024/day3_common.carbon
+++ b/examples/advent2024/day3_common.carbon
@@ -8,40 +8,39 @@ library "day3_common";
 
 import library "io_utils";
 
-// Reads "mul(a,b)", and returns (true, a, b).
-// On error, stops before the first invalid character and returns (false, 0, 0).
-// TODO: -> Optional((i32, i32))
-fn ReadMul() -> (bool, i32, i32) {
+// Reads "mul(a,b)", and returns Some((a, b)).
+// On error, stops before the first invalid character and returns None.
+fn ReadMul() -> Core.Optional((i32, i32)) {
   var a: i32;
   var b: i32;
   if (ConsumeChar('m') and ConsumeChar('u') and ConsumeChar('l') and
       ConsumeChar('(') and ReadInt(ref a) and ConsumeChar(',') and
       ReadInt(ref b) and ConsumeChar(')')) {
-    return (true, a, b);
+    return (a, b);
   }
-  return (false, 0, 0);
+  return Core.Optional((i32, i32)).None();
 }
 
-// Reads "do()" or "don't()", and returns (true, was_do).
-// On error, stops before the first invalid character and returns (false, false).
-fn ReadDoOrDont() -> (bool, bool) {
+// Reads "do()" or "don't()", and returns Some(was_do).
+// On error, stops before the first invalid character and returns None.
+fn ReadDoOrDont() -> Core.Optional(bool) {
   // "do"
   if (not ConsumeChar('d') or not ConsumeChar('o')) {
-    return (false, false);
+    return Core.Optional(bool).None();
   }
 
   var do: bool = true;
   // "n't"
   if (ConsumeChar('n')) {
     if (not ConsumeChar('\'') or not ConsumeChar('t')) {
-      return (false, false);
+      return Core.Optional(bool).None();
     }
     do = false;
   }
 
   // "()"
   if (not ConsumeChar('(') or not ConsumeChar(')')) {
-    return (false, false);
+    return Core.Optional(bool).None();
   }
-  return (true, do);
+  return do;
 }

--- a/examples/advent2024/day3_part1.carbon
+++ b/examples/advent2024/day3_part1.carbon
@@ -14,9 +14,9 @@ fn Run() {
   while (PeekChar() != CharOrEOF.EOF()) {
     if (PeekChar() == 'm') {
       // TODO: Use `if let` when available.
-      let result: (bool, i32, i32) = ReadMul();
-      if (result.0) {
-        total += result.1 * result.2;
+      let result: Core.Optional((i32, i32)) = ReadMul();
+      if (result.HasValue()) {
+        total += result.Get().0 * result.Get().1;
       }
     } else {
       ReadChar();

--- a/examples/advent2024/day3_part2.carbon
+++ b/examples/advent2024/day3_part2.carbon
@@ -15,15 +15,15 @@ fn Run() {
   while (PeekChar() != CharOrEOF.EOF()) {
     if (PeekChar() == 'm') {
       // TODO: Use `if let` when available.
-      let result: (bool, i32, i32) = ReadMul();
-      if (result.0 and enabled) {
-        total += result.1 * result.2;
+      let result: Core.Optional((i32, i32)) = ReadMul();
+      if (result.HasValue() and enabled) {
+        total += result.Get().0 * result.Get().1;
       }
     } else if (PeekChar() == 'd') {
       // TODO: Use `if let` when available.
-      let result: (bool, bool) = ReadDoOrDont();
-      if (result.0) {
-        enabled = result.1;
+      let result: Core.Optional(bool) = ReadDoOrDont();
+      if (result.HasValue()) {
+        enabled = result.Get();
       }
     } else {
       ReadChar();


### PR DESCRIPTION
Produces a bogus error:
```
examples/advent2024/day3_part1.carbon:17:47: error: cannot implicitly convert expression of type `Core.Optional((i32, i32) as Core.OptionalStorage)` to `Core.Optional((i32, i32) as Core.OptionalStorage)`
      let result: Core.Optional((i32, i32)) = ReadMul();
                                              ^~~~~~~~~
examples/advent2024/day3_part1.carbon:17:47: note: type `Core.Optional((i32, i32) as Core.OptionalStorage)` does not implement interface `Core.ImplicitAs(Core.Optional((i32, i32) as Core.OptionalStorage))`
      let result: Core.Optional((i32, i32)) = ReadMul();
                                              ^~~~~~~~~
```