### PR TITLE
Remove a comment that looks to be left behind from a refactoring

### DIFF
--- a/toolchain/check/custom_witness.cpp
+++ b/toolchain/check/custom_witness.cpp
@@ -77,8 +77,6 @@ auto MakeBuiltinOperatorFunction(Context& context,
   return decl_id;
 }
 
-// Returns the body for `Destroy.Op`. This will return `None` if using the
-// builtin `NoOp` is appropriate.
 // Returns a FacetType that contains only the query interface.
 static auto GetFacetTypeForQuerySpecificInterface(
     Context& context, SemIR::LocId loc_id,


### PR DESCRIPTION
The GetFacetTypeForQuerySpecificInterface function has two comments on top of it. The second one actually refers to what the function does.