### PR TITLE
Disable readability-inconsistent-ifelse-braces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -95,6 +95,9 @@ Checks:
   - '-readability-enum-initial-value'
   # Warns too frequently.
   - '-readability-function-cognitive-complexity'
+  # Warns on use of CARBON_KIND() and can't use NOLINT effectively inside a
+  # macro.
+  - '-readability-inconsistent-ifelse-braces'
   # Warns in reasonably documented situations.
   - '-readability-magic-numbers'
   # Warns on `= {}` which is also used to indicate which fields do not need to


### PR DESCRIPTION
This produces a warning on every use of CARBON_KIND() with clang 24.

I tried putting NOLINT comments into the macro on the else to no avail. It seems that comments are stripped from the macro output when it's performing the check.

We already require {} on every if/else (outside of these weird macro cases) so this doesn't seem like a problem to disable.