### PR TITLE
Disable clang-tidy misc-multiple-inheritance for clang 24

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -73,6 +73,8 @@ Checks:
   # Extremely slow. TODO: Re-enable once
   # https://github.com/llvm/llvm-project/issues/128797 is fixed.
   - '-misc-confusable-identifiers'
+  # We use multiple inheritence without virtual extensively.
+  - '-misc-multiple-inheritance'
   # Overlaps with `-Wno-missing-prototypes`.
   - '-misc-use-internal-linkage'
   # Suggests `std::array`, which we could migrate to, but conflicts with the


### PR DESCRIPTION
We use multiple inheritance extensively, such as with our EntityWithParamsBase subclasses. But we don't do this for vtables/virtual, we do it for composing fields.