### PR TITLE
Cache SemIR::Mangler in FileContext

### DIFF
--- a/toolchain/lower/file_context.cpp
+++ b/toolchain/lower/file_context.cpp
@@ -62,7 +62,9 @@ FileContext::FileContext(Context& context, const SemIR::File& sem_ir,
                          llvm::SmallVector<SemIR::SpecificId>()),
       coalescer_(vlog_stream_, sem_ir.specifics()),
       vtables_(decltype(vtables_)::MakeForOverwrite(sem_ir.vtables())),
-      specific_vtables_(sem_ir.specifics(), nullptr) {
+      specific_vtables_(sem_ir.specifics(), nullptr),
+      mangler_(sem_ir, context.total_ir_count(),
+               context.mangle_string_fingerprint()) {
   CARBON_CHECK(!sem_ir.has_errors(),
                "Generating LLVM IR from invalid SemIR::File is unsupported.");
 }
@@ -365,9 +367,7 @@ auto FileContext::GetOrCreateLLVMFunction(
     }
   }
 
-  SemIR::Mangler m(sem_ir(), context().total_ir_count(),
-                   context().mangle_string_fingerprint());
-  std::string mangled_name = m.Mangle(function_id, specific_id);
+  std::string mangled_name = mangler_.Mangle(function_id, specific_id);
   if (auto* existing = llvm_module().getFunction(mangled_name)) {
     // We might have already lowered this function while lowering a different
     // file. That's OK.
@@ -741,9 +741,7 @@ auto FileContext::BuildGlobalVariableDecl(SemIR::VarStorage var_storage)
 
 auto FileContext::BuildNonCppGlobalVariableDecl(SemIR::VarStorage var_storage)
     -> llvm::GlobalVariable* {
-  SemIR::Mangler m(sem_ir(), context().total_ir_count(),
-                   context().mangle_string_fingerprint());
-  auto mangled_name = m.MangleGlobalVariable(var_storage.pattern_id);
+  auto mangled_name = mangler_.MangleGlobalVariable(var_storage.pattern_id);
   auto linkage = llvm::GlobalVariable::ExternalLinkage;
 
   // If the variable doesn't have an externally-visible name, demote it to
@@ -784,9 +782,7 @@ auto FileContext::BuildVtable(const SemIR::Vtable& vtable,
         cxx_record_decl);
   }
 
-  SemIR::Mangler m(sem_ir(), context().total_ir_count(),
-                   context().mangle_string_fingerprint());
-  std::string mangled_name = m.MangleVTable(class_info, specific_id);
+  std::string mangled_name = mangler_.MangleVTable(class_info, specific_id);
 
   if (sem_ir()
           .insts()

--- a/toolchain/lower/file_context.h
+++ b/toolchain/lower/file_context.h
@@ -12,6 +12,7 @@
 #include "toolchain/sem_ir/file.h"
 #include "toolchain/sem_ir/ids.h"
 #include "toolchain/sem_ir/inst_namer.h"
+#include "toolchain/sem_ir/mangler.h"
 
 namespace clang {
 class CodeGenerator;
@@ -169,6 +170,7 @@ class FileContext {
   auto sem_ir() const -> const SemIR::File& { return *sem_ir_; }
   auto cpp_file() -> const SemIR::CppFile* { return sem_ir().cpp_file(); }
   auto inst_namer() -> const SemIR::InstNamer* { return inst_namer_; }
+  auto mangler() -> SemIR::Mangler& { return mangler_; }
   auto global_variables() -> const Map<SemIR::InstId, llvm::GlobalVariable*>& {
     return global_variables_;
   }
@@ -311,6 +313,8 @@ class FileContext {
       vtables_;
   FixedSizeValueStore<SemIR::SpecificId, llvm::Constant*, Tag<SemIR::CheckIRId>>
       specific_vtables_;
+
+  SemIR::Mangler mangler_;
 };
 
 }  // namespace Carbon::Lower


### PR DESCRIPTION
### Description
When lowering symbols (functions, global variables, and vtables), a new `SemIR::Mangler` was being created on each call. Each `Mangler` creates its own `InstFingerprinter` with a fresh store, preventing any fingerprint computations from being reused across manglings.

This PR caches a single `SemIR::Mangler` instance in `FileContext` so that the underlying fingerprint cache is preserved and reused across all symbol manglings within the file.
