### PR TITLE
Gracefully handle member access on a runtime type value

### DIFF
--- a/toolchain/check/testdata/facet/runtime_value.carbon
+++ b/toolchain/check/testdata/facet/runtime_value.carbon
@@ -129,6 +129,32 @@ fn F(T: Z) {
   T.G();
 }
 
+// --- fail_member_access_runtime_facet.carbon
+library "[[@TEST_NAME]]";
+
+interface Z {
+  fn G();
+}
+
+fn F(T: Z) {
+  // CHECK:STDERR: fail_member_access_runtime_facet.carbon:[[@LINE+4]]:3: error: cannot access member of interface `Z` in type `Z` that does not implement that interface [MissingImplInMemberAccess]
+  // CHECK:STDERR:   T.G();
+  // CHECK:STDERR:   ^~~
+  // CHECK:STDERR:
+  T.G();
+}
+
+// --- fail_member_access_runtime_type.carbon
+library "[[@TEST_NAME]]";
+
+fn F(T: type) {
+  // CHECK:STDERR: fail_member_access_runtime_type.carbon:[[@LINE+4]]:3: error: type `type` does not support qualified expressions [QualifiedExprUnsupported]
+  // CHECK:STDERR:   T.G();
+  // CHECK:STDERR:   ^~~
+  // CHECK:STDERR:
+  T.G();
+}
+
 // CHECK:STDOUT: --- facet_value_copy_from_reference.carbon
 // CHECK:STDOUT:
 // CHECK:STDOUT: constants {

--- a/toolchain/check/type.cpp
+++ b/toolchain/check/type.cpp
@@ -304,10 +304,15 @@ auto GetCanonicalFacetOrTypeValue(Context& context, SemIR::ConstantId const_id)
 
 auto TryGetCanonicalFacetValue(Context& context, SemIR::InstId inst_id)
     -> SemIR::InstId {
-  if (context.insts().Get(inst_id).type_id() == SemIR::TypeType::TypeId) {
-    return GetCanonicalFacetOrTypeValue(context, inst_id);
+  if (context.insts().Get(inst_id).type_id() != SemIR::TypeType::TypeId) {
+    return SemIR::InstId::None;
   }
-  return SemIR::InstId::None;
+  auto const_id = context.constant_values().Get(inst_id);
+  if (!const_id.is_constant()) {
+    return SemIR::InstId::None;
+  }
+  return context.constant_values().GetInstId(
+      GetCanonicalFacetOrTypeValue(context, const_id));
 }
 
 }  // namespace Carbon::Check


### PR DESCRIPTION
Avoid CHECK failure when performing member access on a runtime type value. We will just fail to find the CanonicalFacetOrTypeValue and then fail lookup.