### PR TITLE
Exclude `.clang-tidy` from rumdl checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,6 +41,8 @@ Checks:
   # Warns when we have multiple empty cases in switches, which we do for comment
   # reasons.
   - '-bugprone-branch-clone'
+  # We shadow methods with CRTP, instead of using virtual, such as for Print().
+  - '-bugprone-derived-method-shadowing-base-method'
   # Frequently warns on multiple parameters of the same type.
   - '-bugprone-easily-swappable-parameters'
   # Finds issues like out-of-memory in main(). We don't use exceptions, so it's

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -4,6 +4,7 @@
 
 [global]
 exclude = [
+  ".clang-tidy",
   ".git",
   ".jj",
   "CHANGELOG.md",

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -150,12 +150,12 @@ class StringFingerprintStore {
     bool first = true;
     for (const auto& item : contents_) {
       if (!first) {
-        result += ",";
+        result.push_back(',');
       }
       first = false;
       result += item;
     }
-    result += "}";
+    result.push_back('}');
     return SaveString(std::move(result));
   }
 

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -409,7 +409,7 @@ auto InstNamer::Namespace::AllocateName(
   }
 
   // Append numbers until we find an available name.
-  name += ".";
+  name.push_back('.');
   auto name_size_without_counter = name.size();
   for (int counter = 1;; ++counter) {
     name.resize(name_size_without_counter);


### PR DESCRIPTION
Basically the whole file is an error and the formatting is not how we want to write the file, so just exclude it.