### PR TITLE
Disable `-Wunused-template` in clangd-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,6 +41,8 @@ Checks:
   # Warns when we have multiple empty cases in switches, which we do for comment
   # reasons.
   - '-bugprone-branch-clone'
+  # We shadow methods with CRTP, instead of using virtual, such as for Print().
+  - '-bugprone-derived-method-shadowing-base-method'
   # Frequently warns on multiple parameters of the same type.
   - '-bugprone-easily-swappable-parameters'
   # Finds issues like out-of-memory in main(). We don't use exceptions, so it's

--- a/.clangd
+++ b/.clangd
@@ -11,7 +11,8 @@ Diagnostics:
   #   compiler.
   # `unused-includes`: has false positives, reporting includes unused when
   #   they are used. Probably the same root cause as unused-function.
-  Suppress: [unused-function, unused-includes]
+  # `unused-template`: has false positives, which we see in eval.cpp.
+  Suppress: [unused-function, unused-includes, unused-template]
 
 ---
 

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -4,6 +4,7 @@
 
 [global]
 exclude = [
+  ".clang-tidy",
   ".git",
   ".jj",
   "CHANGELOG.md",

--- a/bazel/cc_toolchains/cc_toolchain_cpp_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_cpp_features.bzl
@@ -249,9 +249,6 @@ clang_warnings_feature = feature(
             # TODO: Regression that warns on anonymous unions; remove depending
             # on fix.
             "-Wno-missing-designated-field-initializers",
-
-            # False positives in eval.cpp.
-            "-Wno-unused-template",
         ])],
     )],
 )

--- a/bazel/cc_toolchains/cc_toolchain_cpp_features.bzl
+++ b/bazel/cc_toolchains/cc_toolchain_cpp_features.bzl
@@ -249,6 +249,9 @@ clang_warnings_feature = feature(
             # TODO: Regression that warns on anonymous unions; remove depending
             # on fix.
             "-Wno-missing-designated-field-initializers",
+
+            # False positives in eval.cpp.
+            "-Wno-unused-template",
         ])],
     )],
 )

--- a/toolchain/check/eval.cpp
+++ b/toolchain/check/eval.cpp
@@ -878,12 +878,8 @@ static auto ReplaceFieldWithConstantValue(EvalContext& eval_context,
 
 // Function template that can be called with an argument of type `T`. Used below
 // to detect which overloads of `GetConstantValue` exist.
-//
-// Marked as maybe unused at it seems the use in a requires isn't tracked by the
-// latest version of Clang's `-Wunused-template`.
-// https://github.com/llvm/llvm-project/issues/218429
 template <typename T>
-[[maybe_unused]] static auto Accept(T /*arg*/) -> void {}
+static auto Accept(T /*arg*/) -> void {}
 
 // Determines whether a `GetConstantValue` overload exists for a given ID type.
 // Note that we do not check whether `GetConstantValue` is *callable* with a

--- a/toolchain/sem_ir/inst_fingerprinter.cpp
+++ b/toolchain/sem_ir/inst_fingerprinter.cpp
@@ -150,12 +150,12 @@ class StringFingerprintStore {
     bool first = true;
     for (const auto& item : contents_) {
       if (!first) {
-        result += ",";
+        result.push_back(',');
       }
       first = false;
       result += item;
     }
-    result += "}";
+    result.push_back('}');
     return SaveString(std::move(result));
   }
 

--- a/toolchain/sem_ir/inst_namer.cpp
+++ b/toolchain/sem_ir/inst_namer.cpp
@@ -409,7 +409,7 @@ auto InstNamer::Namespace::AllocateName(
   }
 
   // Append numbers until we find an available name.
-  name += ".";
+  name.push_back('.');
   auto name_size_without_counter = name.size();
   for (int counter = 1;; ++counter) {
     name.resize(name_size_without_counter);


### PR DESCRIPTION
This is firing on some of our _used_ templates in eval.cpp in clang-tidy 24

It was coming to `-Wall` for clang as well (https://github.com/llvm/llvm-project/issues/202945) but was reverted due to issues like false positives (https://github.com/llvm/llvm-project/pull/218638). Some fixes were applied to try enable in `-Wall` in clang 23 (https://github.com/llvm/llvm-project/pull/222336) but it still remains disabled by default for clang.