### PR TITLE
Remove redundant use of `typename`

### DIFF
--- a/common/find.h
+++ b/common/find.h
@@ -15,11 +15,11 @@ namespace Carbon {
 namespace Internal {
 
 template <typename Range>
-using RangePointerType = typename std::iterator_traits<decltype(std::begin(
-    std::declval<Range>()))>::pointer;
+using RangePointerType =
+    std::iterator_traits<decltype(std::begin(std::declval<Range>()))>::pointer;
 
 template <typename Range>
-using RangeValueType = typename std::iterator_traits<decltype(std::begin(
+using RangeValueType = std::iterator_traits<decltype(std::begin(
     std::declval<Range>()))>::value_type;
 
 template <typename Range, typename Pred>

--- a/common/hashing_test.cpp
+++ b/common/hashing_test.cpp
@@ -736,8 +736,8 @@ struct SparseHashTestParamRanges {
 
 template <typename ParamRanges>
 struct SparseHashTest : ::testing::Test {
-  using ByteCount = typename ParamRanges::ByteCount;
-  using SetBitCount = typename ParamRanges::SetBitCount;
+  using ByteCount = ParamRanges::ByteCount;
+  using SetBitCount = ParamRanges::SetBitCount;
 
   static auto GetHashedByteStrings() {
     llvm::SmallVector<HashedString> hashes;

--- a/common/map.h
+++ b/common/map.h
@@ -61,13 +61,13 @@ class MapView
     : RawHashtable::ViewImpl<InputKeyT, InputValueT, InputKeyContextT> {
   using ImplT =
       RawHashtable::ViewImpl<InputKeyT, InputValueT, InputKeyContextT>;
-  using EntryT = typename ImplT::EntryT;
+  using EntryT = ImplT::EntryT;
 
  public:
-  using KeyT = typename ImplT::KeyT;
-  using ValueT = typename ImplT::ValueT;
-  using KeyContextT = typename ImplT::KeyContextT;
-  using MetricsT = typename ImplT::MetricsT;
+  using KeyT = ImplT::KeyT;
+  using ValueT = ImplT::ValueT;
+  using KeyContextT = ImplT::KeyContextT;
+  using MetricsT = ImplT::MetricsT;
 
   // This type represents the result of lookup operations. It encodes whether
   // the lookup was a success as well as accessors for the key and value.
@@ -160,15 +160,15 @@ class MapBase : protected RawHashtable::BaseImpl<InputKeyT, InputValueT,
  protected:
   using ImplT =
       RawHashtable::BaseImpl<InputKeyT, InputValueT, InputKeyContextT>;
-  using EntryT = typename ImplT::EntryT;
+  using EntryT = ImplT::EntryT;
 
  public:
-  using KeyT = typename ImplT::KeyT;
-  using ValueT = typename ImplT::ValueT;
-  using KeyContextT = typename ImplT::KeyContextT;
+  using KeyT = ImplT::KeyT;
+  using ValueT = ImplT::ValueT;
+  using KeyContextT = ImplT::KeyContextT;
   using ViewT = MapView<KeyT, ValueT, KeyContextT>;
-  using LookupKVResult = typename ViewT::LookupKVResult;
-  using MetricsT = typename ImplT::MetricsT;
+  using LookupKVResult = ViewT::LookupKVResult;
+  using MetricsT = ImplT::MetricsT;
 
   // The result type for insertion operations both indicates whether an insert
   // was needed (as opposed to finding an existing element), and provides access
@@ -385,8 +385,8 @@ class Map : public RawHashtable::TableImpl<
   using ImplT = RawHashtable::TableImpl<BaseT, SmallSize>;
 
  public:
-  using KeyT = typename BaseT::KeyT;
-  using ValueT = typename BaseT::ValueT;
+  using KeyT = BaseT::KeyT;
+  using ValueT = BaseT::ValueT;
 
   Map() = default;
   Map(const Map& arg) = default;

--- a/common/map_benchmark.cpp
+++ b/common/map_benchmark.cpp
@@ -66,8 +66,8 @@ static constexpr bool IsCarbonMap =
 template <typename InMapT>
 struct MapWrapperImpl {
   using MapT = InMapT;
-  using KeyT = typename MapT::key_type;
-  using ValueT = typename MapT::mapped_type;
+  using KeyT = MapT::key_type;
+  using ValueT = MapT::mapped_type;
 
   MapT m;
 
@@ -218,8 +218,8 @@ auto ReportMetrics(const MapWrapper<MapT>& m_wrapper, benchmark::State& state)
 template <typename MapT>
 static void BM_MapContainsHit(benchmark::State& state) {
   using MapWrapperT = MapWrapper<MapT>;
-  using KT = typename MapWrapperT::KeyT;
-  using VT = typename MapWrapperT::ValueT;
+  using KT = MapWrapperT::KeyT;
+  using VT = MapWrapperT::ValueT;
   MapWrapperT m;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), state.range(1));
@@ -254,8 +254,8 @@ MAP_BENCHMARK_ONE_OP(BM_MapContainsHit, HitArgs);
 template <typename MapT>
 static void BM_MapContainsMiss(benchmark::State& state) {
   using MapWrapperT = MapWrapper<MapT>;
-  using KT = typename MapWrapperT::KeyT;
-  using VT = typename MapWrapperT::ValueT;
+  using KT = MapWrapperT::KeyT;
+  using VT = MapWrapperT::ValueT;
   MapWrapperT m;
   auto [keys, lookup_keys] = GetKeysAndMissKeys<KT>(state.range(0));
   for (auto k : keys) {
@@ -307,8 +307,8 @@ MAP_BENCHMARK_ONE_OP(BM_MapContainsMiss, SizeArgs);
 template <typename MapT>
 static void BM_MapLookupHit(benchmark::State& state) {
   using MapWrapperT = MapWrapper<MapT>;
-  using KT = typename MapWrapperT::KeyT;
-  using VT = typename MapWrapperT::ValueT;
+  using KT = MapWrapperT::KeyT;
+  using VT = MapWrapperT::ValueT;
   MapWrapperT m;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), state.range(1));
@@ -363,8 +363,8 @@ MAP_BENCHMARK_ONE_OP_SIZE(BM_MapLookupHit, HitArgs, LowZeroBitInt<32>, int);
 template <typename MapT>
 static void BM_MapUpdateHit(benchmark::State& state) {
   using MapWrapperT = MapWrapper<MapT>;
-  using KT = typename MapWrapperT::KeyT;
-  using VT = typename MapWrapperT::ValueT;
+  using KT = MapWrapperT::KeyT;
+  using VT = MapWrapperT::ValueT;
   MapWrapperT m;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), state.range(1));
@@ -405,8 +405,8 @@ MAP_BENCHMARK_ONE_OP(BM_MapUpdateHit, HitArgs);
 template <typename MapT>
 static void BM_MapEraseUpdateHit(benchmark::State& state) {
   using MapWrapperT = MapWrapper<MapT>;
-  using KT = typename MapWrapperT::KeyT;
-  using VT = typename MapWrapperT::ValueT;
+  using KT = MapWrapperT::KeyT;
+  using VT = MapWrapperT::ValueT;
   MapWrapperT m;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), state.range(1));
@@ -463,8 +463,8 @@ MAP_BENCHMARK_ONE_OP(BM_MapEraseUpdateHit, HitArgs);
 template <typename MapT>
 static void BM_MapInsertSeq(benchmark::State& state) {
   using MapWrapperT = MapWrapper<MapT>;
-  using KT = typename MapWrapperT::KeyT;
-  using VT = typename MapWrapperT::ValueT;
+  using KT = MapWrapperT::KeyT;
+  using VT = MapWrapperT::ValueT;
   constexpr ssize_t LookupKeysSize = 1 << 8;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), LookupKeysSize);

--- a/common/map_test.cpp
+++ b/common/map_test.cpp
@@ -42,8 +42,8 @@ using ::testing::UnorderedElementsAreArray;
 template <typename MapT, typename MatcherRangeT>
 auto ExpectMapElementsAre(MapT&& m, MatcherRangeT element_matchers) -> void {
   // Now collect the elements into a container.
-  using KeyT = typename std::remove_reference<MapT>::type::KeyT;
-  using ValueT = typename std::remove_reference<MapT>::type::ValueT;
+  using KeyT = std::remove_reference<MapT>::type::KeyT;
+  using ValueT = std::remove_reference<MapT>::type::ValueT;
   std::vector<
       std::pair<std::reference_wrapper<KeyT>, std::reference_wrapper<ValueT>>>
       map_entries;
@@ -68,7 +68,7 @@ auto ExpectMapElementsAre(MapT&& m,
 template <typename ValueCB, typename RangeT, typename... RangeTs>
 auto MakeKeyValues(ValueCB value_cb, RangeT&& range, RangeTs&&... ranges)
     -> auto {
-  using KeyT = typename RangeT::value_type;
+  using KeyT = RangeT::value_type;
   using ValueT = decltype(value_cb(std::declval<KeyT>()));
   std::vector<std::pair<KeyT, ValueT>> elements;
   auto add_range = [&](RangeT&& r) {

--- a/common/raw_hashtable.h
+++ b/common/raw_hashtable.h
@@ -474,8 +474,8 @@ class BaseImpl {
   using ValueT = InputValueT;
   using KeyContextT = InputKeyContextT;
   using ViewImplT = ViewImpl<KeyT, ValueT, KeyContextT>;
-  using EntryT = typename ViewImplT::EntryT;
-  using MetricsT = typename ViewImplT::MetricsT;
+  using EntryT = ViewImplT::EntryT;
+  using MetricsT = ViewImplT::MetricsT;
 
   BaseImpl(int small_alloc_size, Storage* small_storage)
       : small_alloc_size_(small_alloc_size) {

--- a/common/set.h
+++ b/common/set.h
@@ -56,9 +56,9 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
   using ImplT = RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT>;
 
  public:
-  using KeyT = typename ImplT::KeyT;
-  using KeyContextT = typename ImplT::KeyContextT;
-  using MetricsT = typename ImplT::MetricsT;
+  using KeyT = ImplT::KeyT;
+  using KeyContextT = ImplT::KeyContextT;
+  using MetricsT = ImplT::MetricsT;
 
   // This type represents the result of lookup operations. It encodes whether
   // the lookup was a success as well as accessors for the key.
@@ -110,7 +110,7 @@ class SetView : RawHashtable::ViewImpl<InputKeyT, void, InputKeyContextT> {
   friend class SetBase<KeyT, KeyContextT>;
   friend class SetView<const KeyT, KeyContextT>;
 
-  using EntryT = typename ImplT::EntryT;
+  using EntryT = ImplT::EntryT;
 
   SetView() = default;
   explicit(false) SetView(ImplT base) : ImplT(base) {}
@@ -138,11 +138,11 @@ class SetBase
   using ImplT = RawHashtable::BaseImpl<InputKeyT, void, InputKeyContextT>;
 
  public:
-  using KeyT = typename ImplT::KeyT;
-  using KeyContextT = typename ImplT::KeyContextT;
+  using KeyT = ImplT::KeyT;
+  using KeyContextT = ImplT::KeyContextT;
   using ViewT = SetView<KeyT, KeyContextT>;
-  using LookupResult = typename ViewT::LookupResult;
-  using MetricsT = typename ImplT::MetricsT;
+  using LookupResult = ViewT::LookupResult;
+  using MetricsT = ImplT::MetricsT;
 
   // The result type for insertion operations both indicates whether an insert
   // was needed (as opposed to the key already being in the set), and provides
@@ -299,7 +299,7 @@ class Set : public RawHashtable::TableImpl<SetBase<InputKeyT, InputKeyContextT>,
   using ImplT = RawHashtable::TableImpl<BaseT, SmallSize>;
 
  public:
-  using KeyT = typename BaseT::KeyT;
+  using KeyT = BaseT::KeyT;
 
   Set() = default;
   Set(const Set& arg) = default;

--- a/common/set_benchmark.cpp
+++ b/common/set_benchmark.cpp
@@ -37,7 +37,7 @@ static constexpr bool IsCarbonSet = IsCarbonSetImpl<SetT>::value;
 // supported through specializations.
 template <typename SetT>
 struct SetWrapperImpl {
-  using KeyT = typename SetT::key_type;
+  using KeyT = SetT::key_type;
 
   SetT s;
 
@@ -158,7 +158,7 @@ using SetWrapper =
 template <typename SetT>
 static void BM_SetContainsHitPtr(benchmark::State& state) {
   using SetWrapperT = SetWrapper<SetT>;
-  using KT = typename SetWrapperT::KeyT;
+  using KT = SetWrapperT::KeyT;
   SetWrapperT s;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), state.range(1));
@@ -190,7 +190,7 @@ MAP_BENCHMARK_ONE_OP(BM_SetContainsHitPtr, HitArgs);
 template <typename SetT>
 static void BM_SetContainsMissPtr(benchmark::State& state) {
   using SetWrapperT = SetWrapper<SetT>;
-  using KT = typename SetWrapperT::KeyT;
+  using KT = SetWrapperT::KeyT;
   SetWrapperT s;
   auto [keys, lookup_keys] = GetKeysAndMissKeys<KT>(state.range(0));
   for (auto k : keys) {
@@ -225,7 +225,7 @@ MAP_BENCHMARK_ONE_OP(BM_SetContainsMissPtr, SizeArgs);
 template <typename SetT>
 static void BM_SetLookupHitPtr(benchmark::State& state) {
   using SetWrapperT = SetWrapper<SetT>;
-  using KT = typename SetWrapperT::KeyT;
+  using KT = SetWrapperT::KeyT;
   SetWrapperT s;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), state.range(1));
@@ -265,7 +265,7 @@ MAP_BENCHMARK_ONE_OP(BM_SetLookupHitPtr, HitArgs);
 template <typename SetT>
 static void BM_SetEraseInsertHitPtr(benchmark::State& state) {
   using SetWrapperT = SetWrapper<SetT>;
-  using KT = typename SetWrapperT::KeyT;
+  using KT = SetWrapperT::KeyT;
   SetWrapperT s;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), state.range(1));
@@ -324,7 +324,7 @@ MAP_BENCHMARK_ONE_OP(BM_SetEraseInsertHitPtr, HitArgs);
 template <typename SetT>
 static void BM_SetInsertSeq(benchmark::State& state) {
   using SetWrapperT = SetWrapper<SetT>;
-  using KT = typename SetWrapperT::KeyT;
+  using KT = SetWrapperT::KeyT;
   constexpr ssize_t LookupKeysSize = 1 << 8;
   auto [keys, lookup_keys] =
       GetKeysAndHitKeys<KT>(state.range(0), LookupKeysSize);

--- a/common/set_test.cpp
+++ b/common/set_test.cpp
@@ -24,7 +24,7 @@ using ::testing::UnorderedElementsAreArray;
 template <typename SetT, typename MatcherRangeT>
 auto ExpectSetElementsAre(SetT&& s, MatcherRangeT element_matchers) -> void {
   // Collect the elements into a container.
-  using KeyT = typename std::remove_reference<SetT>::type::KeyT;
+  using KeyT = std::remove_reference<SetT>::type::KeyT;
   std::vector<std::reference_wrapper<KeyT>> entries;
   s.ForEach([&entries](KeyT& k) { entries.push_back(std::ref(k)); });
 

--- a/toolchain/base/canonical_value_store_impl.h
+++ b/toolchain/base/canonical_value_store_impl.h
@@ -16,7 +16,7 @@ CanonicalValueStore<IdT, KeyT, TagIdT, ValueT>::CanonicalValueStore()
 
 template <typename IdT, typename KeyT, typename TagIdT, typename ValueT>
 CanonicalValueStore<IdT, KeyT, TagIdT, ValueT>::CanonicalValueStore(
-    typename IdTagType::TagIdType id, int32_t initial_reserved_ids)
+    IdTagType::TagIdType id, int32_t initial_reserved_ids)
   requires(!IdTagIsUntagged<IdTag<IdT, TagIdT>>)
     : values_(id, initial_reserved_ids) {}
 

--- a/toolchain/base/value_store.h
+++ b/toolchain/base/value_store.h
@@ -125,8 +125,8 @@ class ValueStoreEnumerateIterator
           std::pair<typename ValueStoreT::IdType,
                     typename ValueStoreT::ConstRefType>> {
  public:
-  using IdType = typename ValueStoreT::IdType;
-  using ConstRefType = typename ValueStoreT::ConstRefType;
+  using IdType = ValueStoreT::IdType;
+  using ConstRefType = ValueStoreT::ConstRefType;
   using ValueType = std::pair<IdType, ConstRefType>;
 
   auto operator*() const -> ValueType {

--- a/toolchain/base/value_store_impl.h
+++ b/toolchain/base/value_store_impl.h
@@ -21,7 +21,7 @@ ValueStore<IdT, ValueT, TagIdT>::ValueStore(IdTagType tag)
 
 template <typename IdT, typename ValueT, typename TagIdT>
 ValueStore<IdT, ValueT, TagIdT>::ValueStore(
-    typename ValueStore<IdT, ValueT, TagIdT>::IdTagType::TagIdType id,
+    ValueStore<IdT, ValueT, TagIdT>::IdTagType::TagIdType id,
     int32_t initial_reserved_ids)
   requires(!IdTagIsUntagged<IdTagType>)
     : tag_(id, initial_reserved_ids) {}
@@ -73,8 +73,7 @@ auto ValueStore<IdT, ValueT, TagIdT>::Resize(int32_t size,
 template <typename IdT, typename ValueT, typename TagIdT>
 auto ValueStore<IdT, ValueT, TagIdT>::Chunk::UninitializedFill(
     int32_t fill_count,
-    typename ValueStore<IdT, ValueT, TagIdT>::ConstRefType default_value)
-    -> void
+    ValueStore<IdT, ValueT, TagIdT>::ConstRefType default_value) -> void
   requires(std::is_copy_constructible_v<ValueT>)
 {
   CARBON_DCHECK(num_ + fill_count <= Capacity());

--- a/toolchain/check/eval_inst.h
+++ b/toolchain/check/eval_inst.h
@@ -140,11 +140,10 @@ struct FunctionTypeForEvalConstantInstImpl<InstT, true, true> {
       -> ConstantEvalResult;
 };
 template <typename InstT>
-using FunctionTypeForEvalConstantInst =
-    typename FunctionTypeForEvalConstantInstImpl<
-        InstT, ConstantKindHasEvalConstantInst(InstT::Kind.constant_kind()),
-        InstT::Kind.constant_needs_inst_id() !=
-            SemIR::InstConstantNeedsInstIdKind::No>::Type;
+using FunctionTypeForEvalConstantInst = FunctionTypeForEvalConstantInstImpl<
+    InstT, ConstantKindHasEvalConstantInst(InstT::Kind.constant_kind()),
+    InstT::Kind.constant_needs_inst_id() !=
+        SemIR::InstConstantNeedsInstIdKind::No>::Type;
 
 }  // namespace Internal
 

--- a/toolchain/parse/tree.h
+++ b/toolchain/parse/tree.h
@@ -134,7 +134,7 @@ class Tree : public Printable<Tree> {
 
   template <typename IdT>
   auto IsValid(IdT id) const -> bool {
-    using T = typename NodeForId<IdT>::TypedNode;
+    using T = NodeForId<IdT>::TypedNode;
     CARBON_DCHECK(node_kind(id) == T::Kind);
     return !node_has_error(id);
   }

--- a/toolchain/parse/tree_and_subtrees.h
+++ b/toolchain/parse/tree_and_subtrees.h
@@ -309,7 +309,7 @@ auto TreeAndSubtrees::Extract(IdT id) const
     return std::nullopt;
   }
 
-  using T = typename NodeForId<IdT>::TypedNode;
+  using T = NodeForId<IdT>::TypedNode;
   return ExtractNodeFromChildren<T>(id, children(id));
 }
 

--- a/toolchain/sem_ir/mangler.h
+++ b/toolchain/sem_ir/mangler.h
@@ -97,7 +97,7 @@ class Mangler {
       -> void {
     std::visit(
         [&](auto& f) -> void {
-          using ResultT = typename std::decay_t<decltype(f)>::ResultType;
+          using ResultT = std::decay_t<decltype(f)>::ResultType;
           if constexpr (std::is_same_v<ResultT, llvm::StringRef>) {
             os << f.GetOrCompute(file, id);
           } else {


### PR DESCRIPTION
clang-tidy 24 warns about these