### PR TITLE
Disable readability-identifier-naming in clang-tidy 24

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -97,6 +97,9 @@ Checks:
   - '-readability-enum-initial-value'
   # Warns too frequently.
   - '-readability-function-cognitive-complexity'
+  # Allows naming styles we don't use, and has errors on our use of `_1`, `_2`
+  # to have multiple unnamed vars in a destructuring declaration.
+  - '-readability-identifier-naming'
   # Warns on use of CARBON_KIND() and can't use NOLINT effectively inside a
   # macro.
   - '-readability-inconsistent-ifelse-braces'


### PR DESCRIPTION
This check allows styles that we don't use so it's not really useful for enforcing our style guide. And prevents the use of `_1` or similar in destructuring declarations where want to use `_` for multiple variables, such as `auto [_1, _2, foo] = bar()`.
