### PR TITLE
Disable bugprone-return-const-ref-from-parameter in clang tidy 24

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,6 +54,8 @@ Checks:
   - '-bugprone-macro-parentheses'
   # Conflicts with integer type C++ style.
   - '-bugprone-narrowing-conversions'
+  # We return const references from value stores.
+  - '-bugprone-return-const-ref-from-parameter'
   # Complains about reasonable code like `1 << 20` and would push us away from
   # our integer type C++ style rules.
   - '-bugprone-signed-bitwise'


### PR DESCRIPTION
We intentionally return const references from stable containers like value stores.