### PR TITLE
Disable readability-use-concise-preprocessor-directives in clang-tidy 24

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -111,6 +111,9 @@ Checks:
   - '-readability-redundant-parentheses'
   # Warns when callers use similar names as different parameters.
   - '-readability-suspicious-call-argument'
+  # Low value check, and it's a stylistic choice to use `#if defined(...)` when
+  # paired with `#elif defined(...)`.
+  - '-readability-use-concise-preprocessor-directives'
 
 CheckOptions:
   # Don't warn on structs; done by ignoring when there are only public members.


### PR DESCRIPTION
While we do adhere to its expectations most of the time, we don't always. This is a low value check, and it's a stylistic choice to use `#if defined(...)` when paired with `#elif defined(...)`.
