### PR TITLE
Passthrough the StringRef to mapRequired instead of just the data() pointer

### DIFF
--- a/toolchain/base/yaml.h
+++ b/toolchain/base/yaml.h
@@ -68,7 +68,7 @@ class OutputMapping {
     // letting mapRequired take `&value`.
     template <typename T>
     auto Add(llvm::StringRef key, T value) -> void {
-      io_->mapRequired(key.data(), value);
+      io_->mapRequired(key, value);
     }
 
    private:


### PR DESCRIPTION
The StringRef represents a bounded region of a string, but using data() drops the end bound, and makes LLVM construct a new StringRef starting in the same position and going until a nul terminator. If this worked correctly before, it was because the StringRef was always pointing to a full `std::string` or the tail of one.