### PR TITLE
Disable the bugprone-crtp-constructor-accessibility warning in clang-tidy 24

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,6 +41,9 @@ Checks:
   # Warns when we have multiple empty cases in switches, which we do for comment
   # reasons.
   - '-bugprone-branch-clone'
+  # We use CRTP inheritence widely and across distant areas of the codebase,
+  # which makes maintaining friend lists for the constructors frustrating.
+  - '-bugprone-crtp-constructor-accessibility'
   # We shadow methods with CRTP, instead of using virtual, such as for Print().
   - '-bugprone-derived-method-shadowing-base-method'
   # Frequently warns on multiple parameters of the same type.


### PR DESCRIPTION
The warning wants all classes inherited as CRTP base classes to hide all their constrcuctors and friend all uses of them. We use CRTP quite a lot and across different components of the toolchain, which would make maintaining friend lists frustrating.