### PR TITLE
NOLINT an initializer list construction that clang-tidy warns on

### DIFF
--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -483,7 +483,8 @@ namespace Internal {
 
 // Storage for `internal_allowed_node_kinds` where there's a list of kinds.
 template <Parse::NodeKind::RawEnumType... T>
-// NOLINTNEXTLINE(google-readability-casting): Initializer list is not a cast.
+// False positive: https://github.com/llvm/llvm-project/issues/222793
+// NOLINTNEXTLINE(google-readability-casting)
 constexpr std::array<Parse::NodeKind::RawEnumType, sizeof...(T)> Kinds = {T...};
 
 // `NoneNodeId` uses should never have a node associated; it's mainly for

--- a/toolchain/sem_ir/inst_kind.h
+++ b/toolchain/sem_ir/inst_kind.h
@@ -483,6 +483,7 @@ namespace Internal {
 
 // Storage for `internal_allowed_node_kinds` where there's a list of kinds.
 template <Parse::NodeKind::RawEnumType... T>
+// NOLINTNEXTLINE(google-readability-casting): Initializer list is not a cast.
 constexpr std::array<Parse::NodeKind::RawEnumType, sizeof...(T)> Kinds = {T...};
 
 // `NoneNodeId` uses should never have a node associated; it's mainly for


### PR DESCRIPTION
Clang is synthesizing a cast when using an enum value from a template parameter, and then clang-tidy is finding and reporting that cast. Upstream bug: https://github.com/llvm/llvm-project/issues/222793