### PR TITLE
Remove empty lambda parameter lists

### DIFF
--- a/toolchain/check/cpp/generate_ast.cpp
+++ b/toolchain/check/cpp/generate_ast.cpp
@@ -942,7 +942,7 @@ auto InitializeCppDomain(
   // Ensure any diagnostics emitted in this function are flushed before we
   // return.
   auto on_exit =
-      llvm::scope_exit([&]() { FlushDiagnosticConsumer(*diags->getClient()); });
+      llvm::scope_exit([&] { FlushDiagnosticConsumer(*diags->getClient()); });
 
   // Extract the input from the frontend invocation and make sure it makes
   // sense.

--- a/toolchain/check/cpp/import.cpp
+++ b/toolchain/check/cpp/import.cpp
@@ -108,7 +108,7 @@ static auto AddNamespace(Context& context, PackageNameId cpp_package_id,
              SemIR::NameId::ForPackageName(cpp_package_id),
              SemIR::NameScopeId::Package,
              /*diagnose_duplicate_namespace=*/false,
-             [&]() {
+             [&] {
                return AddInst<SemIR::ImportCppDecl>(
                    context,
                    context.parse_tree().As<Parse::ImportDeclId>(


### PR DESCRIPTION
clang-tidy 24 warns about these being redundant