### PR TITLE
Replace C-style variadic with a concept

### DIFF
--- a/common/struct_reflection.h
+++ b/common/struct_reflection.h
@@ -55,15 +55,7 @@ struct AnyField {
 
 // Detector for whether we can list-initialize T from the given list of fields.
 template <typename T, typename... Fields>
-constexpr auto CanListInitialize(decltype(T{Fields()...})* /*unused*/) -> bool {
-  return true;
-}
-template <typename T, typename... Fields>
-// Intentionally using a C-style variadic function as a catch-all.
-// NOLINTNEXTLINE(modernize-avoid-variadic-functions)
-constexpr auto CanListInitialize(...) -> bool {
-  return false;
-}
+concept CanListInitialize = requires { T{Fields()...}; };
 
 #pragma clang diagnostic pop
 
@@ -74,7 +66,7 @@ constexpr auto CanListInitialize(...) -> bool {
 // 2) Add more AnyField<T>s until we can't initialize any more.
 template <typename T, bool AnyWorkedSoFar = false, typename... Fields>
 constexpr auto CountFields() -> int {
-  if constexpr (CanListInitialize<T, Fields...>(nullptr)) {
+  if constexpr (CanListInitialize<T, Fields...>) {
     return CountFields<T, true, Fields..., AnyField<T>>();
   } else if constexpr (AnyWorkedSoFar) {
     constexpr int NumFields = sizeof...(Fields) - 1;

--- a/common/struct_reflection.h
+++ b/common/struct_reflection.h
@@ -59,6 +59,8 @@ constexpr auto CanListInitialize(decltype(T{Fields()...})* /*unused*/) -> bool {
   return true;
 }
 template <typename T, typename... Fields>
+// Intentionally using a C-style variadic function as a catch-all.
+// NOLINTNEXTLINE(modernize-avoid-variadic-functions)
 constexpr auto CanListInitialize(...) -> bool {
   return false;
 }

--- a/common/struct_reflection_test.cpp
+++ b/common/struct_reflection_test.cpp
@@ -53,17 +53,17 @@ TEST(StructReflectionTest, CanListInitialize) {
   {
     using Type = OneField;
     using Field = Internal::AnyField<Type>;
-    static_assert(Internal::CanListInitialize<Type>(nullptr));
-    static_assert(Internal::CanListInitialize<Type, Field>(nullptr));
-    static_assert(!Internal::CanListInitialize<Type, Field, Field>(0));
+    static_assert(Internal::CanListInitialize<Type>);
+    static_assert(Internal::CanListInitialize<Type, Field>);
+    static_assert(!Internal::CanListInitialize<Type, Field, Field>);
   }
 
   {
     using Type = OneFieldNoDefaultConstructor;
     using Field = Internal::AnyField<Type>;
-    static_assert(!Internal::CanListInitialize<Type>(0));
-    static_assert(Internal::CanListInitialize<Type, Field>(nullptr));
-    static_assert(!Internal::CanListInitialize<Type, Field, Field>(0));
+    static_assert(!Internal::CanListInitialize<Type>);
+    static_assert(Internal::CanListInitialize<Type, Field>);
+    static_assert(!Internal::CanListInitialize<Type, Field, Field>);
   }
 }
 


### PR DESCRIPTION
clang-tidy 24 warns on C-style variadics, and we don't need to use one here anymore. Instead of a function call with an argument list, use a concept to determine if a type can be list initialized.