### PR TITLE
Move diagnostic emit functions to protected to match their base class

### DIFF
--- a/toolchain/sem_ir/diagnostic_loc_converter.cpp
+++ b/toolchain/sem_ir/diagnostic_loc_converter.cpp
@@ -49,6 +49,7 @@ class ClangImportCollector : public clang::DiagnosticRenderer {
                            const_cast<clang::DiagnosticOptions&>(diag_opts)),
         imports_(imports) {}
 
+ protected:
   void emitDiagnosticMessage(clang::FullSourceLoc loc, clang::PresumedLoc ploc,
                              clang::DiagnosticsEngine::Level /*level*/,
                              llvm::StringRef message,


### PR DESCRIPTION
The  emit functions are inherited from a base class as protected, and clang-tidy warns if we then expose them as public.