### PR TITLE
NOLINT the use of sizeof() on a pointer if a pointer is hashed

### DIFF
--- a/common/hashing.h
+++ b/common/hashing.h
@@ -822,6 +822,9 @@ inline auto Hasher::Hash(const Ts&... values) -> void {
       return static_cast<uint64_t>(HashValue(value));
     } else if constexpr (CanHashAsRawDataType<T>) {
       auto raw_value = MapToRawDataType(value);
+      // If we are hashing a pointer, then `raw_value` is a pointer, but that
+      // is what we want the size of.
+      // NOLINTNEXTLINE(bugprone-sizeof-expression)
       if constexpr (sizeof(raw_value) <= 8) {
         return ReadSmall(raw_value);
       } else {


### PR DESCRIPTION
The hashing code is generic over the type of the value being given to sizeof() so ideally this warning would not happen at all, but it does. Possibly because the value is the return of an overload set, so it's not obvious that it's the templated type. One of those overloads returns `const void*` but change that to an integer does not remove the warning still.