### PR TITLE
Start to preserve type sugar in diagnostics.

### DIFF
--- a/toolchain/check/diagnostic_emitter.cpp
+++ b/toolchain/check/diagnostic_emitter.cpp
@@ -92,14 +92,7 @@ auto DiagnosticEmitter::ConvertArg(llvm::Any arg) const -> llvm::Any {
     if (!type_of_expr->inst_id.has_value()) {
       return "<none>";
     }
-    // TODO: Where possible, produce a better description of the type based on
-    // the expression.
-    return "`" +
-           StringifyConstantInst(
-               *sem_ir_,
-               sem_ir_->types().GetTypeInstId(
-                   sem_ir_->insts().Get(type_of_expr->inst_id).type_id())) +
-           "`";
+    return "`" + StringifyTypeOfInst(*sem_ir_, type_of_expr->inst_id) + "`";
   }
   if (auto* expr = llvm::any_cast<InstIdAsConstant>(&arg)) {
     return "`" + StringifyConstantInst(*sem_ir_, expr->inst_id) + "`";

--- a/toolchain/check/testdata/alias/preserve_in_type_printing.carbon
+++ b/toolchain/check/testdata/alias/preserve_in_type_printing.carbon
@@ -51,3 +51,31 @@ fn H() -> const A* { return; }
 // CHECK:STDERR:           ^~~~~~~~~~~~
 // CHECK:STDERR:
 fn I() -> array(A, 42) { return; }
+
+// --- fail_alias_in_type_of_expr.carbon
+
+library "[[@TEST_NAME]]";
+
+class C {}
+alias A = C;
+
+fn MakePtr() -> A*;
+
+// The diagnostics below should describe the types of the expressions using the
+// spelling `A` from the declaration of the callee, not the canonical `C`.
+
+fn F() {
+  // The type of a call is the declared return type of the callee.
+  // CHECK:STDERR: fail_alias_in_type_of_expr.carbon:[[@LINE+4]]:3: error: type `A*` does not support qualified expressions [QualifiedExprUnsupported]
+  // CHECK:STDERR:   MakePtr().missing;
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  MakePtr().missing;
+
+  // The type of a dereference is the pointee type of the pointer's type.
+  // CHECK:STDERR: fail_alias_in_type_of_expr.carbon:[[@LINE+4]]:3: error: value of type `A` is not callable [CallToNonCallable]
+  // CHECK:STDERR:   (*MakePtr())();
+  // CHECK:STDERR:   ^~~~~~~~~~~~~~
+  // CHECK:STDERR:
+  (*MakePtr())();
+}

--- a/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
+++ b/toolchain/check/testdata/impl/fail_impl_bad_assoc_fn.carbon
@@ -179,7 +179,8 @@ class FDifferentImplicitParamType {
 
 class FDifferentReturnType {
   impl as J {
-    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+12]]:5: error: cannot implicitly convert expression of type `FDifferentReturnType` to `bool` [ConversionFailure]
+    // TODO: Include an "aka" in this diagnostic to explain that the type `Self` is `FDifferentReturnType`.
+    // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+12]]:5: error: cannot implicitly convert expression of type `Self` to `bool` [ConversionFailure]
     // CHECK:STDERR:     fn F(self: bool, b: bool) -> Self;
     // CHECK:STDERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // CHECK:STDERR: fail_impl_bad_assoc_fn.carbon:[[@LINE+9]]:5: note: type `FDifferentReturnType` does not implement interface `Core.ImplicitAs(bool)` [MissingImplInMemberAccessInContext]

--- a/toolchain/language_server/handle_position.cpp
+++ b/toolchain/language_server/handle_position.cpp
@@ -20,18 +20,16 @@ namespace Carbon::LanguageServer {
 // if it has no type. Instructions that aren't values, such as declarations of
 // namespaces, have no type to show.
 //
-// TODO: `StringifyConstantInst` renders some types as placeholders such as
+// TODO: `StringifyTypeOfInst` renders some types as placeholders such as
 // `<type of F>` for a function and `<pattern for i32>` for a binding pattern,
 // which is unhelpful as hover text. Show the signature for a function, and the
 // bound type rather than the pattern type for a binding.
-static auto StringifyTypeOfInst(const SemIR::File& sem_ir,
-                                SemIR::InstId inst_id) -> std::string {
-  auto type_id = sem_ir.insts().Get(inst_id).type_id();
-  if (!type_id.has_value()) {
+static auto StringifyTypeForHover(const SemIR::File& sem_ir,
+                                  SemIR::InstId inst_id) -> std::string {
+  if (!sem_ir.insts().Get(inst_id).type_id().has_value()) {
     return "";
   }
-  return SemIR::StringifyConstantInst(sem_ir,
-                                      sem_ir.types().GetTypeInstId(type_id));
+  return SemIR::StringifyTypeOfInst(sem_ir, inst_id);
 }
 
 // Given a position-based query, returns the corresponding position information.
@@ -78,7 +76,7 @@ auto HandleHover(
   const auto& sem_ir = *info.file->sem_ir();
   RawStringOstream text;
   text << "```carbon\n" << info.file->tokens().GetTokenText(info.token);
-  if (auto type = StringifyTypeOfInst(sem_ir, info.inst_id); !type.empty()) {
+  if (auto type = StringifyTypeForHover(sem_ir, info.inst_id); !type.empty()) {
     text << ": " << type;
   }
   text << "\n```";

--- a/toolchain/sem_ir/BUILD
+++ b/toolchain/sem_ir/BUILD
@@ -202,11 +202,25 @@ cc_library(
 )
 
 cc_library(
+    name = "sugared_type",
+    srcs = ["sugared_type.cpp"],
+    hdrs = ["sugared_type.h"],
+    deps = [
+        ":file",
+        ":typed_insts",
+        "//common:check",
+        "//toolchain/base:kind_switch",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "stringify",
     srcs = ["stringify.cpp"],
     hdrs = ["stringify.h"],
     deps = [
         ":file",
+        ":sugared_type",
         ":typed_insts",
         "//common:check",
         "//common:concepts",

--- a/toolchain/sem_ir/stringify.cpp
+++ b/toolchain/sem_ir/stringify.cpp
@@ -19,6 +19,7 @@
 #include "toolchain/sem_ir/singleton_insts.h"
 #include "toolchain/sem_ir/specific_interface.h"
 #include "toolchain/sem_ir/struct_type_field.h"
+#include "toolchain/sem_ir/sugared_type.h"
 #include "toolchain/sem_ir/type_info.h"
 #include "toolchain/sem_ir/typed_insts.h"
 
@@ -874,6 +875,10 @@ auto StringifyConstantInst(const File& sem_ir, InstId outer_inst_id)
   StepStack step_stack(&sem_ir);
   step_stack.PushInstId(outer_inst_id);
   return Stringify(sem_ir, step_stack);
+}
+
+auto StringifyTypeOfInst(const File& sem_ir, InstId inst_id) -> std::string {
+  return StringifyConstantInst(sem_ir, GetSugaredTypeOfInst(sem_ir, inst_id));
 }
 
 auto StringifySpecific(const File& sem_ir, SpecificId specific_id)

--- a/toolchain/sem_ir/stringify.h
+++ b/toolchain/sem_ir/stringify.h
@@ -19,6 +19,12 @@ namespace Carbon::SemIR {
 auto StringifyConstantInst(const File& sem_ir, InstId outer_inst_id)
     -> std::string;
 
+// Produces a string version of the type of an instruction, describing the type
+// the way it was written in the source where we can determine that. Generally,
+// this should not be called directly. To format the type of an expression into
+// a diagnostic, use a diagnostic parameter of type `TypeOfInstId`.
+auto StringifyTypeOfInst(const File& sem_ir, InstId inst_id) -> std::string;
+
 // Produces a string version of the name of a specific. Generally, this should
 // not be called directly. To format a string into a diagnostic, use a
 // diagnostic parameter of type `SpecificId`.

--- a/toolchain/sem_ir/sugared_type.cpp
+++ b/toolchain/sem_ir/sugared_type.cpp
@@ -1,0 +1,209 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "toolchain/sem_ir/sugared_type.h"
+
+#include <variant>
+
+#include "common/check.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "toolchain/base/kind_switch.h"
+#include "toolchain/sem_ir/function.h"
+#include "toolchain/sem_ir/ids.h"
+#include "toolchain/sem_ir/inst.h"
+#include "toolchain/sem_ir/inst_categories.h"
+#include "toolchain/sem_ir/typed_insts.h"
+
+namespace Carbon::SemIR {
+
+namespace {
+
+// Searches for an instruction that describes how the type of a given
+// instruction was written. See `GetSugaredTypeOfInst`.
+class SugaredTypeFinder {
+ public:
+  explicit SugaredTypeFinder(const File* sem_ir) : sem_ir_(sem_ir) {}
+
+  // Finds the best spelling we can for the type of `inst_id`.
+  auto Find(InstId inst_id) -> TypeInstId;
+
+ private:
+  // A transformation that is applied to a type that we find in order to produce
+  // the type of the instruction that the search started from.
+  enum class Step {
+    // Replace a pointer type `T*` with its pointee type `T`.
+    Pointee,
+  };
+
+  // Walks from `inst_id` towards the instructions that determined its type,
+  // until we find an instruction that tracks how its type was written, adding
+  // to `steps_` as we go. Returns `None` if no such instruction is found.
+  auto FindSpelledType(InstId inst_id) -> TypeInstId;
+
+  // Finds the declared return type of `call`, as written.
+  auto FindCallReturnType(Call call) -> TypeInstId;
+
+  // Applies `step` to `type_inst_id`, desugaring it if necessary. Returns
+  // `None` if the step can't be applied.
+  auto ApplyStep(Step step, TypeInstId type_inst_id) -> TypeInstId;
+
+  // Returns `operand_id` if it has type `type_id`, and `None` otherwise. This
+  // is used when looking through an instruction that is expected to have the
+  // same type as one of its operands: if that turns out not to hold, we stop
+  // the search rather than describing the wrong type.
+  auto LookThrough(TypeId type_id, InstId operand_id) -> InstId;
+
+  const File* sem_ir_;
+
+  // The steps to apply to the type that we find, in reverse order.
+  llvm::SmallVector<Step> steps_;
+};
+
+auto SugaredTypeFinder::LookThrough(TypeId type_id, InstId operand_id)
+    -> InstId {
+  if (!operand_id.has_value() ||
+      sem_ir_->insts().Get(operand_id).type_id() != type_id) {
+    return InstId::None;
+  }
+  return operand_id;
+}
+
+auto SugaredTypeFinder::FindCallReturnType(Call call) -> TypeInstId {
+  auto callee = GetCallee(*sem_ir_, call.callee_id);
+  auto* function_callee = std::get_if<CalleeFunction>(&callee);
+  if (!function_callee) {
+    return TypeInstId::None;
+  }
+
+  // TODO: For a call to a generic function, substitute the call's arguments
+  // into the declared return type so that we can describe how it was written.
+  if (function_callee->enclosing_specific_id.has_value() ||
+      function_callee->resolved_specific_id.has_value()) {
+    return TypeInstId::None;
+  }
+
+  // This is `None` if no return type was declared, in which case we have no
+  // spelling to offer.
+  return sem_ir_->functions()
+      .Get(function_callee->function_id)
+      .return_type_inst_id;
+}
+
+auto SugaredTypeFinder::ApplyStep(Step step, TypeInstId type_inst_id)
+    -> TypeInstId {
+  switch (step) {
+    case Step::Pointee: {
+      auto pointer_type = sem_ir_->insts().TryGetAs<PointerType>(type_inst_id);
+      if (!pointer_type) {
+        // The spelling we found isn't syntactically a pointer type, for example
+        // because the pointer type was named by an alias. Desugar it and try
+        // again: the canonical instruction for a pointer type is a
+        // `PointerType`.
+        type_inst_id = sem_ir_->types().GetTypeInstId(
+            sem_ir_->types().GetTypeIdForTypeInstId(type_inst_id));
+        pointer_type = sem_ir_->insts().TryGetAs<PointerType>(type_inst_id);
+        if (!pointer_type) {
+          return TypeInstId::None;
+        }
+      }
+      return pointer_type->pointee_id;
+    }
+  }
+}
+
+auto SugaredTypeFinder::FindSpelledType(InstId inst_id) -> TypeInstId {
+  while (inst_id.has_value()) {
+    auto inst = sem_ir_->insts().Get(inst_id);
+    CARBON_KIND_SWITCH(inst) {
+      // The type of a call is the declared return type of the callee.
+      case CARBON_KIND(Call call): {
+        return FindCallReturnType(call);
+      }
+
+      // The type of a dereference is the pointee type of the pointer.
+      case CARBON_KIND(Deref deref): {
+        steps_.push_back(Step::Pointee);
+        inst_id = deref.pointer_id;
+        continue;
+      }
+
+      // The following instructions have the same type as one of their operands,
+      // so look through them to that operand.
+      case CARBON_KIND(NameRef name_ref): {
+        inst_id = LookThrough(inst.type_id(), name_ref.value_id);
+        continue;
+      }
+      case CARBON_KIND_ANY(AnyBinding, binding): {
+        inst_id = LookThrough(inst.type_id(), binding.value_id);
+        continue;
+      }
+      case CARBON_KIND(AcquireValue acquire_value): {
+        inst_id = LookThrough(inst.type_id(), acquire_value.value_id);
+        continue;
+      }
+      case CARBON_KIND(Converted converted): {
+        inst_id = LookThrough(inst.type_id(), converted.result_id);
+        continue;
+      }
+      case CARBON_KIND(SpliceBlock splice_block): {
+        inst_id = LookThrough(inst.type_id(), splice_block.result_id);
+        continue;
+      }
+      case CARBON_KIND(Temporary temporary): {
+        inst_id = LookThrough(inst.type_id(), temporary.init_id);
+        continue;
+      }
+      case CARBON_KIND(ValueOfInitializer value_of_initializer): {
+        inst_id = LookThrough(inst.type_id(), value_of_initializer.init_id);
+        continue;
+      }
+
+      default: {
+        // TODO: Handle more cases here. For example, the type of a name
+        // reference to a binding or field should use the type as written in
+        // the declaration of that binding or field, and the type of an index
+        // into an array should be the element type as written in the array
+        // type.
+        return TypeInstId::None;
+      }
+    }
+  }
+  return TypeInstId::None;
+}
+
+auto SugaredTypeFinder::Find(InstId inst_id) -> TypeInstId {
+  auto type_id = sem_ir_->insts().Get(inst_id).type_id();
+  if (!type_id.has_value()) {
+    return TypeInstId::None;
+  }
+
+  auto result = FindSpelledType(inst_id);
+  for (auto step : llvm::reverse(steps_)) {
+    if (!result.has_value()) {
+      break;
+    }
+    result = ApplyStep(step, result);
+  }
+
+  if (!result.has_value()) {
+    // We've no better spelling for this type, so use the canonical one.
+    return sem_ir_->types().GetTypeInstId(type_id);
+  }
+
+  CARBON_CHECK(sem_ir_->types().GetTypeIdForTypeInstId(result) == type_id,
+               "Spelling {0} found for the type of {1} describes type {2}, but "
+               "its type is {3}",
+               result, inst_id, sem_ir_->types().GetTypeIdForTypeInstId(result),
+               type_id);
+  return result;
+}
+
+}  // namespace
+
+auto GetSugaredTypeOfInst(const File& sem_ir, InstId inst_id) -> TypeInstId {
+  return SugaredTypeFinder(&sem_ir).Find(inst_id);
+}
+
+}  // namespace Carbon::SemIR

--- a/toolchain/sem_ir/sugared_type.h
+++ b/toolchain/sem_ir/sugared_type.h
@@ -1,0 +1,35 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef CARBON_TOOLCHAIN_SEM_IR_SUGARED_TYPE_H_
+#define CARBON_TOOLCHAIN_SEM_IR_SUGARED_TYPE_H_
+
+#include "toolchain/sem_ir/file.h"
+#include "toolchain/sem_ir/ids.h"
+
+namespace Carbon::SemIR {
+
+// Returns an instruction describing the type of `inst_id`, preferring an
+// instruction that reflects how the type was written in the source over the
+// canonical instruction for the type.
+//
+// The type of an instruction is tracked as a `TypeId`, which is canonical, and
+// so says nothing about how the type was spelled: for example, a type named by
+// an alias is indistinguishable from the type that the alias names. However,
+// the instructions that formed the type as written are usually still present,
+// and can often be found by looking at the instruction that has the type,
+// rather than at the type itself. For example, the type of a call to a
+// non-generic function is the declared return type of that function, and the
+// function tracks the instruction for its return type as written.
+//
+// This process is opportunistic: where we can't do better, the canonical type
+// instruction is returned. The result always describes the same type as
+// `sem_ir.insts().Get(inst_id).type_id()`; only the spelling can differ.
+//
+// Returns `None` if `inst_id` has no type.
+auto GetSugaredTypeOfInst(const File& sem_ir, InstId inst_id) -> TypeInstId;
+
+}  // namespace Carbon::SemIR
+
+#endif  // CARBON_TOOLCHAIN_SEM_IR_SUGARED_TYPE_H_


### PR DESCRIPTION
Instead of always printing types as canonical, attempt to find a sugared type where possible, and include that type in the diagnostic. We can only do this when given the instruction whose type is being printed (`TypeOfInstId`) rather than the canonical type ID.

Initial support here is intentionally minimal: just looking through calls to the callee's declared return type, and looking through pointer dereferences and corresponding pointer types, to build out the initial infrastructure. More cases can be added later; this degrades gracefully to using the canonical type if a better type can't be found.

Assisted-by: Claude Opus 5 via Antigravity