### PR TITLE
jj_prek: snapshot the working copy

### DIFF
--- a/scripts/jj_prek.sh
+++ b/scripts/jj_prek.sh
@@ -9,9 +9,15 @@
 
 set -eu
 
-# Find the .git directory, and map `@` to a git commit.
+# Map `@` to a git commit. This deliberately doesn't pass
+# `--ignore-working-copy`, so that jj first snapshots the files on disk into `@`;
+# otherwise the index built below can describe stale file contents, and hooks
+# both check the wrong thing and fail to write back their fixes.
+HEAD="$(jj show --no-patch -r @ --template 'commit_id')"
+
+# Find the .git directory. The working copy was snapshotted above, so this
+# doesn't need to do so again.
 export GIT_DIR="$(jj git root --ignore-working-copy)"
-HEAD="$(jj show --no-patch --ignore-working-copy -r @ --template 'commit_id')"
 
 # Create a git index file describing `@`.
 export GIT_INDEX_FILE="$(mktemp)"


### PR DESCRIPTION
Instead of running on the "current" `@` (the state at which the previous `jj` command happened to be run), intentionally trigger a working copy snapshot from `jj_prek`.

Assisted-by: Claude Opus 5 via Antigravity