### PR TITLE
NOLINT an assignment in a complex boolean statement

### DIFF
--- a/toolchain/parse/extract.h
+++ b/toolchain/parse/extract.h
@@ -273,10 +273,10 @@ auto NodeExtractor::ExtractTupleLikeType(
   // Use a fold over the `=` operator to parse fields from right to left.
   [[maybe_unused]] int unused;
   bool ok = true;
-  static_cast<void>(
-      ((ok && (ok = (std::get<Index>(fields) = Extractable<U>::Extract(*this))
-                        .has_value()),
-        unused) = ... = 0));
+  // NOLINTNEXTLINE(bugprone-assignment-in-selection-statement)
+  ((ok && (ok = (std::get<Index>(fields) = Extractable<U>::Extract(*this))
+                    .has_value()),
+    unused) = ... = 0);
   if (!ok) {
     MaybeTrace("Aggregate {0}: error\n", llvm::getTypeName<T>());
     return std::nullopt;


### PR DESCRIPTION
We use a complex fold statement over `operator=`, with an assignment to a variable earlier in the folded-over expression, which is intentional.