### PR TITLE
Move to clang 21 as mininum version and use it in CI

### DIFF
--- a/.github/actions/build-setup-macos/action.yml
+++ b/.github/actions/build-setup-macos/action.yml
@@ -23,7 +23,7 @@ runs:
           xcrun simctl delete all
         sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/*
 
-    # Install and cache LLVM 19 from Homebrew. Some runners may have LLVM 19,
+    # Install and cache LLVM 21 from Homebrew. Some runners may have LLVM 21,
     # but this is reliable (including with libc++), and gives us testing at the
     # minimum supported LLVM version.
     - name: Cache Homebrew
@@ -46,7 +46,7 @@ runs:
           }}
         # Note the key needs to include all the packages we're adding.
         key:
-          Homebrew-Cache-${{ inputs.matrix_runner }}-${{ runner.arch }}-llvm@19
+          Homebrew-Cache-${{ inputs.matrix_runner }}-${{ runner.arch }}-llvm@21
 
     - name: Install LLVM and Clang with Homebrew
       if: steps.cache-homebrew-macos.outputs.cache-hit != 'true'
@@ -60,11 +60,11 @@ runs:
         LEAVES=$(brew leaves | egrep -v '^(bazelisk|gh|git|git-lfs|gnu-tar|go@.*|jq|pipx|node@.*|openssl@.*|wget|yq|zlib)$')
         brew uninstall -f --ignore-dependencies $LEAVES
         echo '*** Installing LLVM deps'
-        brew install --force-bottle --only-dependencies llvm@19
+        brew install --force-bottle --only-dependencies llvm@21
         echo '*** Installing LLVM itself'
-        brew install --force-bottle --force --verbose llvm@19
-        echo '*** brew info llvm@19'
-        brew info llvm@19
+        brew install --force-bottle --force --verbose llvm@21
+        echo '*** brew info llvm@21'
+        brew info llvm@21
         echo '*** brew autoremove'
         brew autoremove
         echo '*** brew info'
@@ -77,7 +77,7 @@ runs:
     - name: Setup LLVM and Clang
       shell: bash
       run: |
-        LLVM_PATH="$(brew --prefix llvm@19)"
+        LLVM_PATH="$(brew --prefix llvm@21)"
         echo "Using ${LLVM_PATH}"
         echo "${LLVM_PATH}/bin" >> $GITHUB_PATH
         echo '*** ls "${LLVM_PATH}"'

--- a/.github/actions/build-setup-ubuntu/action.yml
+++ b/.github/actions/build-setup-ubuntu/action.yml
@@ -23,17 +23,13 @@ runs:
         large-packages: false
 
     # Select the LLVM release - by the cache key and the download.
-    #
-    # x86-64 uses the LLVM 19 monolithic package. That release only
-    # published a smaller community build for Linux AArch64, so AArch64 uses
-    # the official monolithic package, first available in LLVM 20.
     - name: Select LLVM release
       shell: bash
       run: |
         if [[ "${{ runner.arch }}" == "ARM64" ]]; then
-          echo "LLVM_RELEASE=20.1.8" >> "$GITHUB_ENV"
+          echo "LLVM_RELEASE=21.1.8" >> "$GITHUB_ENV"
         else
-          echo "LLVM_RELEASE=19.1.7" >> "$GITHUB_ENV"
+          echo "LLVM_RELEASE=21.1.8" >> "$GITHUB_ENV"
         fi
 
     # Cache and install a recent version of LLVM. This uses the GitHub action

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -307,7 +307,7 @@
   "moduleExtensions": {
     "//bazel/cc_toolchains:clang_configuration.bzl%clang_toolchain_extension": {
       "general": {
-        "bzlTransitiveDigest": "DyUCJOgQYb+hGTTTtitbFytne29L1JZ2UsbwLpdkMKM=",
+        "bzlTransitiveDigest": "IGxGFknaFQQo7RudzfwIOuxREEsnEXwlM9KuPiNQYBM=",
         "usagesDigest": "lTxkeAFhR0iBEa3dg5hWvtd2HFCr5zCJx/fl27A+IKA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/cc_toolchains/clang_configuration.bzl
+++ b/bazel/cc_toolchains/clang_configuration.bzl
@@ -188,9 +188,9 @@ def _configure_clang_toolchain_impl(repository_ctx):
     (clang, clang_version, clang_version_for_cache) = _detect_system_clang(
         repository_ctx,
     )
-    if clang_version and clang_version < 19:
+    if clang_version and clang_version < 21:
         fail("Found clang {0}. ".format(clang_version) +
-             "Carbon requires clang >=19. See " +
+             "Carbon requires clang >=21. See " +
              "https://github.com/carbon-language/carbon-lang/blob/trunk/docs/project/contribution_tools.md#old-llvm-versions")
 
     clang_cpp = clang.dirname.get_child("clang++")

--- a/docs/project/contribution_tools.md
+++ b/docs/project/contribution_tools.md
@@ -49,8 +49,8 @@ These commands should help set up a development environment on your machine.
 # Update apt.
 sudo apt update
 
-# Check that the `clang` version is at least 19, our minimum version. That needs
-# the number of the `:` in the output to be over 19. For example, `1:19.0-1`.
+# Check that the `clang` version is at least 21, our minimum version. That needs
+# the number of the `:` in the output to be over 21. For example, `1:21.0-1`.
 apt-cache show clang | grep 'Version:'
 
 # Install tools. Use the same version as the Clang version you found above. Do
@@ -88,28 +88,28 @@ it to your `$PATH`, and aliasing `bazel` to it.
 
 #### Old `clang` versions
 
-If the version of `clang` is earlier than 19, you may still have version 19
+If the version of `clang` is earlier than 21, you may still have version 21
 available. You can use the following install instead:
 
 ```shell
 # Install explicitly versioned Clang tools.
 sudo apt install \
-  clang-19 \
-  libc++-19-dev \
-  libc++abi-19-dev \
-  lld-19 \
-  lldb-19
+  clang-21 \
+  libc++-21-dev \
+  libc++abi-21-dev \
+  lld-21 \
+  lldb-21
 
 # In your Carbon checkout, tell Bazel where to find `clang`. You can also
 # export this path as the `CC` environment variable, or add it directly to
 # your `PATH`.
-echo "build --repo_env=CC=$(readlink -f $(which clang-19))" >> user.bazelrc
+echo "build --repo_env=CC=$(readlink -f $(which clang-21))" >> user.bazelrc
 ```
 
 And if it's not available directly from the distribution, you can install Clang
 tools on Debian/Ubuntu from <https://apt.llvm.org>.
 
-> NOTE: Most LLVM 19+ installs should build Carbon. If you're having issues, see
+> NOTE: Most LLVM 21+ installs should build Carbon. If you're having issues, see
 > [troubleshooting build issues](#troubleshooting-build-issues).
 
 ### macOS
@@ -203,7 +203,7 @@ These tools are essential for work on Carbon.
         -   [Bazelisk](https://docs.bazel.build/versions/master/install-bazelisk.html):
             Downloads and runs the [configured Bazel version](/.bazelversion).
     -   [Clang](https://clang.llvm.org/) and [LLVM](https://llvm.org/)
-        -   NOTE: Most LLVM 19+ installs should build Carbon. If you're having
+        -   NOTE: Most LLVM 21+ installs should build Carbon. If you're having
             issues, see
             [troubleshooting build issues](#troubleshooting-build-issues).
     -   [gh CLI](https://github.com/cli/cli): Helps with GitHub.
@@ -419,8 +419,8 @@ includes things such as changing LLVM versions, or installing libc++. Running
 
 Many build issues result from the particular options `clang` and `llvm` have
 been built with, particularly when it comes to system-installed versions. If you
-run `clang --version`, you should see at least version 19. If you see an older
-version, please update, or use the special `clang-19` instructions above.
+run `clang --version`, you should see at least version 21. If you see an older
+version, please update, or use the special `clang-21` instructions above.
 
 System installs of macOS typically won't work, for example being an old LLVM
 version or missing llvm-ar; [setup commands](#setup-commands) includes LLVM from
@@ -442,7 +442,7 @@ providing the output of the following diagnostic commands:
 ```shell
 echo $CC
 which clang
-which clang-19
+which clang-21
 clang --version
 grep llvm_bindir $(bazel info workspace)/bazel-execroot/external/+clang_toolchain_extension+bazel_cc_toolchain/clang_detected_variables.bzl
 


### PR DESCRIPTION
Clang 21 is now the latest version available in Ubuntu LTS, so we can move to it.